### PR TITLE
Fix issue with author changing type

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -244,7 +244,7 @@ class Client(object):
                 message = copy.deepcopy(older_message)
                 # update the new update
                 for attr in data:
-                    if attr == 'channel_id':
+                    if attr == 'channel_id' or attr == 'author':
                         continue
                     value = data[attr]
                     if 'time' in attr:


### PR DESCRIPTION
When cycling through the attributes of the data json 'author' within 'message' which was previously a user object is overwritten with a dictionary. This causes an AttributeError to be thrown ( and silently swallowed... thanks except: pass) whenever any of its attributes are referenced in the form message.author.x. User data should change in this step and the user object should not be modified for any reason so its safe to skip updating it.