### PR TITLE
Add events for sniffing WebSocket data

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -69,7 +69,7 @@ class KeepAliveHandler(threading.Thread):
 
             msg = 'Keeping websocket alive with timestamp {0}'
             log.debug(msg.format(payload['d']))
-            self.socket.send(json.dumps(payload))
+            self.socket.send(json.dumps(payload, separators=(',', ':')))
 
 class WebSocket(WebSocketBaseClient):
     def __init__(self, dispatch, url):
@@ -393,7 +393,7 @@ class Client(object):
                 }
             }
 
-            self.ws.send(json.dumps(second_payload))
+            self.ws.send(json.dumps(second_payload, separators=(',', ':')))
 
     def _resolve_mentions(self, content, mentions):
         if isinstance(mentions, list):

--- a/discord/client.py
+++ b/discord/client.py
@@ -92,7 +92,12 @@ class WebSocket(WebSocketBaseClient):
     def handshake_ok(self):
         pass
 
+    def send(self, payload, binary=False):
+        self.dispatch('socket_raw_send', payload, binary)
+        WebSocketBaseClient.send(self, payload, binary)
+
     def received_message(self, msg):
+        self.dispatch('socket_raw_receive', msg)
         response = json.loads(str(msg))
         log.debug('WebSocket Event: {}'.format(response))
         if response.get('op') != 0:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -102,6 +102,43 @@ to handle it, which defaults to log a traceback and ignore the exception.
 
     :param response: The received message response after gone through ``json.loads``.
 
+.. function:: on_socket_raw_receive(msg)
+
+    Called whenever a message is received from the websocket, before
+    it's processed. Unlike ``on_socket_response`` this event is always
+    dispatched when a message is received and the passed data is not
+    processed in any way.
+
+    This is only really useful for grabing the websocket stream and
+    debugging purposes.
+
+    :param msg: The message passed on from the ws4py library. Can be an
+        instance of either ws4py.messaging.TextMessage, or
+        ws4py.messaging.BinaryMessage.
+
+.. function:: on_socket_raw_send(payload, binary=False)
+
+    Called whenever a send operation is done on the websocket before the
+    message is sent. The passed parameter is the message that is to
+    sent to the websocket.
+
+    This is only really useful for grabing the websocket stream and
+    debugging purposes.
+
+    .. note::
+
+        If the ``payload`` parameter is mutable, and modified during the
+        execution of this event, then the actual data sent out on the
+        websocket will be mangled. This is especially true if
+        ``payload`` is a generator, as reading them modifies their
+        state.
+
+    :param payload: The message that is about to be passed on to the
+        ws4py library. It can be any of a string, a bytearray, an
+        instance of ws4py.message.Message and a generator.
+    :param bool binary: True if the message being sent out is marked as
+        binary.
+
 .. function:: on_message_delete(message)
               on_message_edit(before, after)
 


### PR DESCRIPTION
These events were needed in order to realize my Discord Logger bot.  Although quite a special case, they might be useful for debugging.

I've tacked on a small improvement in the json encoding I spotted while coding this as well.