### PR TITLE
Log to root logger by default in on_error

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -478,8 +478,7 @@ class Client(object):
             raise InvalidDestination('Destination must be Channel, PrivateChannel, User, or str')
 
     def on_error(self, event_method, *args, **kwargs):
-        msg = 'Caught exception in {} with args (*{}, **{})'
-        log.exception(msg.format(event_method, args, kwargs))
+        logging.exception('Ignoring exception in {}'.format(event_method))
 
     # Compatibility shim
     def __getattr__(self, name):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,6 +5,14 @@ API Reference
 
 The following section outlines the API of discord.py.
 
+.. note::
+
+    This module uses the Python logging module to log diagnostic and errors
+    in an output independent way.  If the logging module is not configured,
+    these logs will not be output anywhere.  See :ref:`logging_setup` for
+    more information on how to set up and use the logging module with
+    discord.py.
+
 
 Client
 -------
@@ -36,13 +44,6 @@ to handle it, which defaults to log a traceback and ignore the exception.
 .. versionadded:: 0.7.0
     Subclassing to listen to events.
 
-.. note::
-
-    If the Python logging module is not configured, the logs will not be
-    output anywhere. Meaning that exceptions in handlers will be
-    silently ignored. See :ref:`logging_setup` for more information on how to
-    set up and use the logging module with discord.py.
-
 
 .. function:: on_ready()
 
@@ -56,6 +57,12 @@ to handle it, which defaults to log a traceback and ignore the exception.
     behaviour and handle the exception for whatever reason yourself,
     this event can be overridden. Which, when done, will supress the
     default logging done.
+
+    .. note::
+
+        The default ``on_error`` handler logs exception to the root logger
+        instead of a logger under the discord namespace.  This is to ensure
+        that exceptions are output somewhere if logging is not configured.
 
     The information of the exception rasied and the exception itself can
     be retreived with a standard call to ``sys.exc_info()``.


### PR DESCRIPTION
Change the default implementation of on_error to log to the root logger
instead of discord.client and clarify that the exception is being
ignored.  This ensures that a message will be output to standard error
in case the logging module has not been configured.

Also removes the argument printing for the default on_error, this is due
to them often being too long, that they could cause another exception to
be thrown, and because it sometimes causes sensitive information to be
output such as Discord tokens and session ids.  It was also possible for
the length to get in the megabyte range with exceptions thrown by
on_socket_raw_receive in READY events.