### PR TITLE
Print to stderr in on_error

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -24,6 +24,8 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
+from __future__ import print_function
+
 from . import endpoints
 from .errors import InvalidEventName, InvalidDestination, GatewayNotFound
 from .user import User
@@ -34,6 +36,7 @@ from .message import Message
 from . import utils
 from .invite import Invite
 
+import traceback
 import requests
 import json, re, time, copy
 from collections import deque
@@ -482,7 +485,8 @@ class Client(object):
             raise InvalidDestination('Destination must be Channel, PrivateChannel, User, or str')
 
     def on_error(self, event_method, *args, **kwargs):
-        logging.exception('Ignoring exception in {}'.format(event_method))
+        print('Ignoring exception in {}'.format(event_method), file=sys.stderr)
+        traceback.print_exc()
 
     # Compatibility shim
     def __getattr__(self, name):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -39,7 +39,7 @@ overriding the specific events. For example: ::
 
 
 If an event handler raises an exception, :func:`on_error` will be called
-to handle it, which defaults to log a traceback and ignore the exception.
+to handle it, which defaults to print a traceback and ignore the exception.
 
 .. versionadded:: 0.7.0
     Subclassing to listen to events.
@@ -53,16 +53,10 @@ to handle it, which defaults to log a traceback and ignore the exception.
 .. function:: on_error(event, \*args, \*\*kwargs)
 
     Usually when an event raises an uncaught exception, a traceback is
-    logged and the exception is ignored. If you want to change this
-    behaviour and handle the exception for whatever reason yourself,
-    this event can be overridden. Which, when done, will supress the
-    default logging done.
-
-    .. note::
-
-        The default ``on_error`` handler logs exception to the root logger
-        instead of a logger under the discord namespace.  This is to ensure
-        that exceptions are output somewhere if logging is not configured.
+    printed to stderr and the exception is ignored. If you want to
+    change this behaviour and handle the exception for whatever reason
+    yourself, this event can be overridden. Which, when done, will
+    supress the default action of printing the traceback.
 
     The information of the exception rasied and the exception itself can
     be retreived with a standard call to ``sys.exc_info()``.

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -4,11 +4,10 @@
 Setting Up Logging
 ===================
 
-*discord.py* logs errors, exceptions, and debug information via the
-`logging`_ python module. It is strongly recommended that the logging
-module is configured, as no errors or warnings will be output at all if
-it is not set up. Configuration of the ``logging`` module can be as
-simple as::
+*discord.py* logs errors and debug information via the `logging`_ python
+module. It is strongly recommended that the logging module is
+configured, as no errors or warnings will be output if it is not set up.
+Configuration of the ``logging`` module can be as simple as::
 
     import logging
 


### PR DESCRIPTION
Apparently the clever hack for logging in on_error was not so clever
after all.  If logging isn't configured, by the logging modules
definition of not configured, which is root logger not having an
Handlers attached, it will call logging.basicConfig().  Which messes up
setups that define handlers for other loggers than the root logger.

Going directly to the root logger rather than using the broken
convenience methods for logger is not an option either, as logger before
Python 3.2 does not have lastResort on the root logger, and prints an
error when invoked without any handlers.

Resolve by printing tracebacks to stderr by default in on_error.