### PR TITLE
change server members to a dict

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -126,7 +126,7 @@ class Message(object):
         if self.channel is not None:
             for mention in mentions:
                 id_search = mention.get('id')
-                member = utils.find(lambda m: m.id == id_search, self.server.members)
+                member = self.server.get_member(id_search)
                 if member is not None:
                     self.mentions.append(member)
 
@@ -165,7 +165,7 @@ class Message(object):
 
         if not self.channel.is_private:
             self.server = self.channel.server
-            found = utils.find(lambda m: m.id == self.author.id, self.server.members)
+            found = self.server.get_member(self.author.id)
             if found is not None:
                 self.author = found
 

--- a/discord/server.py
+++ b/discord/server.py
@@ -28,6 +28,7 @@ from . import utils
 from .role import Role
 from .member import Member
 from .channel import Channel
+from collections import OrderedDict
 
 class Server(object):
     """Represents a Discord server.
@@ -97,7 +98,7 @@ class Server(object):
         self.roles = [Role(everyone=(self.id == r['id']), **r) for r in guild['roles']]
         default_role = self.get_default_role()
 
-        self._members = {}
+        self._members = OrderedDict()
         self.owner = guild['owner_id']
 
         for data in guild['members']:
@@ -132,7 +133,7 @@ class Server(object):
 
     @property
     def members(self):
-        return self._members.values()
+        return list(self._members.values())
 
     def get_member(self, user_id):
         """Gets a specific :class:`Member` for the given :attr:`User.id` efficiently."""


### PR DESCRIPTION
Considering that we frequently find members by their ID, it makes sense
to store this as a dict where the keys are the IDs so we can look them
up (and add and remove them) in O(1) time instead of O(N) time.

Keeps backwards compatibility so you can still do server.members and
get a list (it just stores it as a dict internally).