### PR TITLE
avoid potential bug when creating new private msgs

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -178,9 +178,8 @@ class Client:
             found = utils.find(lambda pm: pm.user == destination, self.private_channels)
             if found is None:
                 # Couldn't find the user, so start a PM with them first.
-                yield from self.start_private_message(destination)
-                channel_id = self.private_channels[-1].id
-                return channel_id
+                channel = yield from self.start_private_message(destination)
+                return channel.id
             else:
                 return found.id
         elif isinstance(destination, Object):
@@ -690,7 +689,9 @@ class Client:
         yield from utils._verify_successful_response(r)
         data = yield from r.json()
         log.debug(request_success_log.format(response=r, json=payload, data=data))
-        self.private_channels.append(PrivateChannel(id=data['id'], user=user))
+        channel = PrivateChannel(id=data['id'], user=user)
+        self.private_channels.append(channel)
+        return channel
 
     @asyncio.coroutine
     def _rate_limit_helper(self, name, method, url, data):

--- a/discord/state.py
+++ b/discord/state.py
@@ -55,6 +55,7 @@ class ConnectionState:
     def _add_server(self, guild):
         server = Server(**guild)
         self.servers.append(server)
+        return server
 
     def parse_ready(self, data):
         self.user = User(**data['user'])
@@ -220,8 +221,8 @@ class ConnectionState:
             # unavailable during the READY event and is now
             # available, so it isn't in the cache...
 
-        self._add_server(data)
-        self.dispatch('server_join', self.servers[-1])
+        server = self._add_server(data)
+        self.dispatch('server_join', server)
 
     def parse_guild_update(self, data):
         server = self._get_server(data.get('id'))


### PR DESCRIPTION
It probably isn't good to rely on an item that was added to a list to
still be the last item, especially if we could have other async
coroutines modify the list. This may not be an actual issue, but having
the function explicitly return the object that it just added to the list
should guarantee that we don't accidentally pull the wrong item from the
end of the list later.