### PR TITLE
None author param in wait_for_message allows any author

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -590,7 +590,10 @@ class Client:
         """
 
         def predicate(message):
-            result = message.author == author
+            result = True
+            if author is not None:
+                result = result and message.author == author
+
             if content is not None:
                 result = result and message.content == content
 


### PR DESCRIPTION
Allows for e.g.:
```python

@client.async_event
def on_message(message):
    if message.content.startswith('$greet')
        yield from client.send_message(message.channel, 'First one to say hi wins!')
        msg = yield from client.wait_for_message(channel=message.channel, content='hi')
        yield from client.send_message(message.channel, '{} wins!'.format(msg.author.name))
```

(ok it's tested now it works)