### PR TITLE
Fix so "@everyone" isn't triggered when mentioning someone named "@everyone"

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -173,7 +173,7 @@ class Message:
         }
 
         transformations.update(mention_transforms)
-        transformations[re.escape('@everyone')] = '@\u200beveryone'
+        transformations[re.escape('@')] = '@\u200b'
 
         def repl(obj):
             return transformations.get(re.escape(obj.group(0)), '')


### PR DESCRIPTION
http://i.imgur.com/3lDwe5Y.png

this seemed like the easiest fix for a really rare but possibly annoying way to abuse bots