### PR TITLE
Support extension loading of already imported modules

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -498,11 +498,12 @@ class Bot(GroupMixin, discord.Client):
 
     # extensions
 
-    def load_extension(self, name):
+    def load_extension(self, name, lib=None):
         if name in self.extensions:
             return
 
-        lib = importlib.import_module(name)
+        if lib is None:
+            lib = importlib.import_module(name)
         if not hasattr(lib, 'setup'):
             raise discord.ClientException('extension does not have a setup function')
 


### PR DESCRIPTION
Not everything is going to have an easily found relative path from the main script. This allows for the usage of `imp.find_module` and `imp.load_module` to grab modules from any path.