### PR TITLE
Control execution of cog events

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -228,7 +228,6 @@ class Bot(GroupMixin, discord.Client):
 
     def dispatch(self, event_name, *args, **kwargs):
         super().dispatch(event_name, *args, **kwargs)
-        ev = 'on_' + event_name
         if ev in self.extra_events:
             for event in self.extra_events[ev]:
                 coro = self._run_extra(event, event_name, *args, **kwargs)
@@ -609,6 +608,15 @@ class Bot(GroupMixin, discord.Client):
         else:
             exc = CommandNotFound('Command "{}" is not found'.format(invoker))
             self.dispatch('command_error', exc, ctx)
+
+    async def process_events(self,*args,**kwargs):
+        ev = inspect.stack()[1][3]
+        #ev = 'on_' + event_name
+        print(ev)
+        '''if ev in self.extra_events:
+            for event in self.extra_events[ev]:
+                coro = self._run_extra(event, event_name, *args, **kwargs)
+                discord.utils.create_task(coro, loop=self.loop)'''
 
     @asyncio.coroutine
     def on_message(self, message):

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -178,7 +178,8 @@ class Bot(GroupMixin, discord.Client):
         ``"Command {0.name} has no subcommands."``. The first format argument is the
         :class:`Command` attempted to get a subcommand and the second is the name.
     """
-    def __init__(self, command_prefix, formatter=None, description=None, pm_help=False, **options):
+    def __init__(self, command_prefix, formatter=None, description=None,
+                 pm_help=False, override_event_control=False, **options):
         super().__init__(**options)
         self.command_prefix = command_prefix
         self.extra_events = {}
@@ -186,6 +187,7 @@ class Bot(GroupMixin, discord.Client):
         self.extensions = {}
         self.description = inspect.cleandoc(description) if description else ''
         self.pm_help = pm_help
+        self.override_event_control = override_event_control
         self.command_not_found = options.pop('command_not_found', 'No command called "{}" found.')
         self.command_has_no_subcommands = options.pop('command_has_no_subcommands', 'Command {0.name} has no subcommands.')
 
@@ -229,7 +231,7 @@ class Bot(GroupMixin, discord.Client):
     def dispatch(self, event_name, *args, **kwargs):
         super().dispatch(event_name, *args, **kwargs)
         ev = 'on_' + event_name
-        if not hasattr(self,ev):
+        if not self.override_event_control or not hasattr(self,ev):
             discord.utils.create_task(self.process_events(*args,event=ev,**kwargs))
 
     # utility "send_*" functions

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -230,9 +230,7 @@ class Bot(GroupMixin, discord.Client):
         super().dispatch(event_name, *args, **kwargs)
         ev = 'on_' + event_name
         if not hasattr(self,ev):
-            discord.utils.create_task(
-                self.process_events(*args,event=ev,**kwargs))
-            )
+            discord.utils.create_task(self.process_events(*args,event=ev,**kwargs)))
 
     # utility "send_*" functions
 

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -228,6 +228,7 @@ class Bot(GroupMixin, discord.Client):
 
     def dispatch(self, event_name, *args, **kwargs):
         super().dispatch(event_name, *args, **kwargs)
+        ev = 'on_'+event_name
         if ev in self.extra_events:
             for event in self.extra_events[ev]:
                 coro = self._run_extra(event, event_name, *args, **kwargs)

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -620,4 +620,4 @@ class Bot(GroupMixin, discord.Client):
     @asyncio.coroutine
     def on_message(self, message):
         yield from self.process_commands(message)
-        await self.process_events(message)
+        yield from self.process_events(message)

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -230,7 +230,7 @@ class Bot(GroupMixin, discord.Client):
         super().dispatch(event_name, *args, **kwargs)
         ev = 'on_' + event_name
         if not hasattr(self,ev):
-            discord.utils.create_task(self.process_events(*args,event=ev,**kwargs)))
+            discord.utils.create_task(self.process_events(*args,event=ev,**kwargs))
 
     # utility "send_*" functions
 

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -622,4 +622,5 @@ class Bot(GroupMixin, discord.Client):
     @asyncio.coroutine
     def on_message(self, message):
         yield from self.process_commands(message)
-        yield from self.process_events(message)
+        if self.override_event_control:
+            yield from self.process_events(message)


### PR DESCRIPTION
This gives the _optional_ ability to control the execution of cog events by providing a `process_events` coroutine that acts in a similar manner to `process_commands`.

By default, no functionality changes. In order to enable control of cog events you must pass `override_event_control=True` in to the commands.Bot initializer. Then for any Client events that are "overridden" `await bot.process_events(*args)` must be called within that event with the same args. If client events are not overridden then cog events are called regardless of whether or not `override_event_control` is True.