### PR TITLE
Allow arguments before input in create_ffmpeg_player

### DIFF
--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -341,7 +341,7 @@ class VoiceClient:
         struct.pack_into('>I', buff, 8, self.ssrc)
         return buff
 
-    def create_ffmpeg_player(self, filename, *, use_avconv=False, pipe=False, options=None, headers=None, after=None):
+    def create_ffmpeg_player(self, filename, *, use_avconv=False, pipe=False, options=None, optBefore=None, headers=None, after=None):
         """Creates a stream player for ffmpeg that launches in a separate thread to play
         audio.
 
@@ -395,13 +395,15 @@ class VoiceClient:
         """
         command = 'ffmpeg' if not use_avconv else 'avconv'
         input_name = '-' if pipe else shlex.quote(filename)
+        if isinstance(optBefore, str):
+            before_input = ' ' + optBefore
         headers_arg = ""
         if isinstance(headers, dict):
             for key, value in headers.items():
                 headers_arg += "{}: {}\r\n".format(key, value)
             headers_arg = ' -headers ' + shlex.quote(headers_arg)
-        cmd = command + '{} -i {} -f s16le -ar {} -ac {} -loglevel warning'
-        cmd = cmd.format(headers_arg, input_name, self.encoder.sampling_rate, self.encoder.channels)
+        cmd = command + '{} {} -i {} -f s16le -ar {} -ac {} -loglevel warning'
+        cmd = cmd.format(headers_arg, before_input, input_name, self.encoder.sampling_rate, self.encoder.channels)
 
         if isinstance(options, str):
             cmd = cmd + ' ' + options

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -405,7 +405,8 @@ class VoiceClient:
         if isinstance(optBefore, str):
             before_input = optBefore
         cmd = command + '{} {} -i {} -f s16le -ar {} -ac {} -loglevel warning'
-        cmd = cmd.format(headers_arg, before_input, input_name, self.encoder.sampling_rate, self.encoder.channels)
+        cmd = cmd.format(headers_arg, before_input, input_name,
+                         self.encoder.sampling_rate, self.encoder.channels)
 
         if isinstance(options, str):
             cmd = cmd + ' ' + options

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -395,14 +395,15 @@ class VoiceClient:
         """
         command = 'ffmpeg' if not use_avconv else 'avconv'
         input_name = '-' if pipe else shlex.quote(filename)
-        before_input = ''
-        if isinstance(optBefore, str):
-            before_input = ' ' + optBefore
         headers_arg = ""
         if isinstance(headers, dict):
             for key, value in headers.items():
                 headers_arg += "{}: {}\r\n".format(key, value)
             headers_arg = ' -headers ' + shlex.quote(headers_arg)
+        
+        before_input = ''
+        if isinstance(optBefore, str):
+            before_input = optBefore
         cmd = command + '{} {} -i {} -f s16le -ar {} -ac {} -loglevel warning'
         cmd = cmd.format(headers_arg, before_input, input_name, self.encoder.sampling_rate, self.encoder.channels)
 

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -376,6 +376,8 @@ class VoiceClient:
             to the stdin of ffmpeg.
         options: str
             Extra command line flags to pass to ``ffmpeg``.
+        optBefore: str
+            Extra command line flags to pass to ``ffmpeg`` before the ``-i`` flag is called.
         headers: dict
             HTTP headers dictionary to pass to ``-headers`` command line option
         after : callable

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -395,6 +395,7 @@ class VoiceClient:
         """
         command = 'ffmpeg' if not use_avconv else 'avconv'
         input_name = '-' if pipe else shlex.quote(filename)
+        before_input = ''
         if isinstance(optBefore, str):
             before_input = ' ' + optBefore
         headers_arg = ""


### PR DESCRIPTION
Allows for arguments to be sent to ffmpeg in front of the input argument, using optBefore in the same way as options.