### PR TITLE
Encrypted audio working with PyNacl

### DIFF
--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -336,20 +336,20 @@ class VoiceClient:
         nonce = bytearray(24)
         box = nacl.secret.SecretBox(bytes(self.secret_key))
         
-        #Formulate header
+        # Formulate header
         header[0] = 0x80
         header[1] = 0x78
         struct.pack_into('>H', header, 2, self.sequence)
         struct.pack_into('>I', header, 4, self.timestamp)
         struct.pack_into('>I', header, 8, self.ssrc)
         
-        #Copy header to nonce's first 12 bytes
+        # Copy header to nonce's first 12 bytes
         for i in range(0, len(header)):
             nonce[i] = header[i]
         
-        #Encrypt the Opus data with the nonce
-        #This weird lib also prepends the nonce to the data
-        #So we extract the data after the 24th spot
+        # Encrypt the Opus data with the nonce
+        # This weird lib also prepends the nonce to the data
+        # So we extract the data after the 24th spot
         encrypted = box.encrypt(bytes(data), bytes(nonce))
         encrypted_ba = bytearray(encrypted[24:])
         return header + encrypted_ba

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -347,9 +347,9 @@ class VoiceClient:
         for i in range(0, len(header)):
             nonce[i] = header[i]
         
-		#Encrypt the Opus data with the nonce
-		#This weird lib also prepends the nonce to the data
-		#So we extract the data after the 24th spot
+        #Encrypt the Opus data with the nonce
+        #This weird lib also prepends the nonce to the data
+        #So we extract the data after the 24th spot
         encrypted = box.encrypt(bytes(data), bytes(nonce))
         encrypted_ba = bytearray(encrypted[24:])
         return header + encrypted_ba

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -344,8 +344,7 @@ class VoiceClient:
         struct.pack_into('>I', header, 8, self.ssrc)
 
         # Copy header to nonce's first 12 bytes
-        for i in range(0, len(header)):
-            nonce[i] = header[i]
+        nonce[:12] = header
 
         # Encrypt and return the data
         return header + box.encrypt(bytes(data), bytes(nonce)).ciphertext

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -335,24 +335,20 @@ class VoiceClient:
         header = bytearray(12)
         nonce = bytearray(24)
         box = nacl.secret.SecretBox(bytes(self.secret_key))
-        
+
         # Formulate header
         header[0] = 0x80
         header[1] = 0x78
         struct.pack_into('>H', header, 2, self.sequence)
         struct.pack_into('>I', header, 4, self.timestamp)
         struct.pack_into('>I', header, 8, self.ssrc)
-        
+
         # Copy header to nonce's first 12 bytes
         for i in range(0, len(header)):
             nonce[i] = header[i]
-        
-        # Encrypt the Opus data with the nonce
-        # This weird lib also prepends the nonce to the data
-        # So we extract the data after the 24th spot
-        encrypted = box.encrypt(bytes(data), bytes(nonce))
-        encrypted_ba = bytearray(encrypted[24:])
-        return header + encrypted_ba
+
+        # Encrypt and return the data
+        return header + box.encrypt(bytes(data), bytes(nonce)).ciphertext
 
     def create_ffmpeg_player(self, filename, *, use_avconv=False, pipe=False, options=None, headers=None, after=None):
         """Creates a stream player for ffmpeg that launches in a separate thread to play

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -50,6 +50,7 @@ import subprocess
 import shlex
 import functools
 import datetime
+import nacl.secret
 
 log = logging.getLogger(__name__)
 
@@ -170,6 +171,7 @@ class VoiceClient:
         self.sequence = 0
         self.timestamp = 0
         self.encoder = OpusEncoder(48000, 2)
+        self.secret_key = []
         log.info('created opus encoder with {0.__dict__}'.format(self.encoder))
 
     def checked_add(self, attr, value, limit):
@@ -236,7 +238,7 @@ class VoiceClient:
                 'data': {
                     'address': self.ip,
                     'port': self.port,
-                    'mode': 'plain'
+                    'mode': 'xsalsa20_poly1305'
                 }
             }
         }
@@ -248,6 +250,7 @@ class VoiceClient:
     @asyncio.coroutine
     def connection_ready(self, data):
         log.info('voice connection is now ready')
+        self.secret_key = data.get('secret_key')
         speaking = {
             'op': 5,
             'd': {
@@ -329,17 +332,27 @@ class VoiceClient:
     # audio related
 
     def _get_voice_packet(self, data):
-        buff = bytearray(len(data) + 12)
-        buff[0] = 0x80
-        buff[1] = 0x78
-
-        for i in range(0, len(data)):
-            buff[i + 12] = data[i]
-
-        struct.pack_into('>H', buff, 2, self.sequence)
-        struct.pack_into('>I', buff, 4, self.timestamp)
-        struct.pack_into('>I', buff, 8, self.ssrc)
-        return buff
+        header = bytearray(12)
+        nonce = bytearray(24)
+        box = nacl.secret.SecretBox(bytes(self.secret_key))
+        
+        #Formulate header
+        header[0] = 0x80
+        header[1] = 0x78
+        struct.pack_into('>H', header, 2, self.sequence)
+        struct.pack_into('>I', header, 4, self.timestamp)
+        struct.pack_into('>I', header, 8, self.ssrc)
+        
+        #Copy header to nonce's first 12 bytes
+        for i in range(0, len(header)):
+            nonce[i] = header[i]
+        
+		#Encrypt the Opus data with the nonce
+		#This weird lib also prepends the nonce to the data
+		#So we extract the data after the 24th spot
+        encrypted = box.encrypt(bytes(data), bytes(nonce))
+        encrypted_ba = bytearray(encrypted[24:])
+        return header + encrypted_ba
 
     def create_ffmpeg_player(self, filename, *, use_avconv=False, pipe=False, options=None, headers=None, after=None):
         """Creates a stream player for ffmpeg that launches in a separate thread to play


### PR DESCRIPTION
Volt mentioned the 'plain' method for sending and receiving audio may not be there in the future. We should all probably switch to the encrypted audio method soon.

It was a couple of lines of code here, I decided to go with PyNacl since the other Nacl lib required that the user had a pre-installed libsodium.so (or whatever on Windows) on their machine. I only tested this under Linux, so I don't know if it works under Windows / OSX, but I assume it'd work on the latter.

Edit: Tested the proposed changes under Windows, so it works there as well.