### PR TITLE
[commands] Fix infinite recursion on subgroups without a command

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -572,7 +572,7 @@ class Group(GroupMixin, Command):
             injected = inject_context(ctx, self.callback)
             yield from injected(*ctx.args, **ctx.kwargs)
 
-        if ctx.invoked_subcommand:
+        if trigger and ctx.invoked_subcommand:
             ctx.invoked_with = trigger
             yield from ctx.invoked_subcommand.invoke(ctx)
         elif not early_invoke:


### PR DESCRIPTION
Just as an FYI, ctx.invoked_subcommand will end up being an instance of commands.Group!

Example of issue:

Calling `!group subgroup` will cause infinite recursion.

```
@commands.group()
async def group(self):
    pass

@group.group()
async def subgroup(self):
    pass

@subgroup.command()
async def do_something(self):
    pass
```