### PR TITLE
Fix handling of message update in MESSAGE_UPDATE

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -175,17 +175,16 @@ class ConnectionState:
             self.messages.remove(found)
 
     def parse_message_update(self, data):
-        older_message = self._get_message(data.get('id'))
-        if older_message is not None:
+        message = self._get_message(data.get('id'))
+        if message is not None:
+            older_message = copy.copy(message)
             if 'content' not in data:
                 # embed only edit
-                message = copy.copy(older_message)
                 message.embeds = data['embeds']
             else:
-                message = Message(channel=older_message.channel, **data)
+                message._update(channel=message.channel, **data)
+
             self.dispatch('message_edit', older_message, message)
-            # update the older message
-            older_message = message
 
     def parse_presence_update(self, data):
         server = self._get_server(data.get('guild_id'))


### PR DESCRIPTION
There is a bug where message doesn't actually get updated in local store, thus subsequent edits reveal contents of original message rather the one after the `(n-1)`th edit.

This PR fixes that.

Also `clean_content` caching had to be removed due to limitations of slots editing them after creation was impossible, instead method renamed to `_clean_content` and in `_update` `clean_content` is set.

