### PR TITLE
added proper handling of my_background_task future

### DIFF
--- a/examples/background_task.py
+++ b/examples/background_task.py
@@ -1,5 +1,6 @@
 import discord
 import asyncio
+from asyncio.futures import CancelledError
 
 client = discord.Client()
 
@@ -7,10 +8,13 @@ async def my_background_task():
     await client.wait_until_ready()
     counter = 0
     channel = discord.Object(id='channel_id_here')
-    while not client.is_closed:
-        counter += 1
-        await client.send_message(channel, counter)
-        await asyncio.sleep(60) # task runs every 60 seconds
+    try:
+        while not client.is_closed:
+            counter += 1
+            await client.send_message(channel, counter)
+            await asyncio.sleep(60) # task runs every 60 seconds
+    except CancelledError:
+        pass
 
 @client.event
 async def on_ready():
@@ -22,10 +26,19 @@ async def on_ready():
 loop = asyncio.get_event_loop()
 
 try:
-    loop.create_task(my_background_task())
+    my_background_task_future = loop.create_task(my_background_task())
     loop.run_until_complete(client.login('email', 'password'))
     loop.run_until_complete(client.connect())
 except Exception:
+    my_background_task_future.cancel()
     loop.run_until_complete(client.close())
+    pending = asyncio.Task.all_tasks()
+    gathered = asyncio.gather(*pending)
+    try:
+        gathered.cancel()
+        loop.run_forever()
+        gathered.exception()
+    except:
+        pass
 finally:
     loop.close()


### PR DESCRIPTION
my_background_task future wasn't stored and couldn't be properly canceled leaving the task running after termination.

my_background_task also has to catch CancelledError to properly handle the Future's cancel() call.

Also, not all client tasks were terminated until loop.close() was called. Added the pending tasks gather code from Client's run().