### PR TITLE
Discord.py Resume support.

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -612,7 +612,7 @@ class Client:
                     raise ClientException('Unexpected websocket closure received')
                 elif self.ws.close_code != 1000:
                     log.info("Websocket closed on us. Reconnecting.")
-                    self.keep_alive_handler.cancel()
+                    self.keep_alive.cancel()
                     try:
                         yield from asyncio.wait_for(self._ws_graceful_reconnect(), timeout=None, loop=self.loop)
                     except Exception:

--- a/discord/client.py
+++ b/discord/client.py
@@ -118,10 +118,12 @@ class Client:
         self.gateway = None
         self.voice = None
         self.session_id = None
+        self.keep_alive = None
         self.sequence = 0
         self.loop = asyncio.get_event_loop() if loop is None else loop
         self._listeners = []
         self.cache_auth = options.get('cache_auth', True)
+        self.reconnect_times = 0
 
         max_messages = options.get('max_messages')
         if max_messages is None or max_messages < 100:
@@ -159,6 +161,22 @@ class Client:
     def _send_ws(self, data):
         self.dispatch('socket_raw_send', data)
         yield from self.ws.send(data)
+
+    @asyncio.coroutine
+    def _ws_graceful_reconnect(self):
+        self.reconnect_times += 1
+        try:
+            yield from asyncio.wait_for(self._make_websocket(initial=False), timeout=None, loop=self.loop)
+        except Exception:
+            self.gateway = self._get_gateway()
+            try:
+                yield from asyncio.wait_for(self._make_websocket(initial=False), timeout=None, loop=self.loop)
+            except Exception:
+                yield from asyncio.wait_for(asyncio.sleep(15), timeout=None, loop=self.loop)
+                try:
+                    yield from asyncio.wait_for(self._make_websocket(initial=False), timeout=None, loop=self.loop)
+                except Exception:
+                    raise asyncio.CancelledError
 
     @asyncio.coroutine
     def _login_via_cache(self, email, password):
@@ -342,6 +360,27 @@ class Client:
             log.info('Unhandled op {}'.format(op))
             return
 
+        if op == 9:
+            log.info("Asked to identify on resume.")
+            payload = {
+                'op': 2,
+                'd': {
+                    'token': self.token,
+                    'properties': {
+                        '$os': sys.platform,
+                        '$browser': 'discord.py',
+                        '$device': 'discord.py',
+                        '$referrer': '',
+                        '$referring_domain': ''
+                    },
+                    'compress': True,
+                    'large_threshold': 250,
+                    'v': 3
+                }
+            }
+            yield from self._send_ws(utils.to_json(payload))
+            return
+
         event = msg.get('t')
         is_ready = event == 'READY'
 
@@ -429,6 +468,7 @@ class Client:
         payload = {
             'op': 6,
             'd': {
+                'token': self.token,
                 'session_id': self.session_id,
                 'seq': self.sequence
             }
@@ -570,9 +610,28 @@ class Client:
                     continue
                 elif not self._is_ready.is_set():
                     raise ClientException('Unexpected websocket closure received')
-                else:
-                    yield from self.close()
-                    break
+                elif self.ws.close_code != 1000:
+                    log.info("Websocket closed on us. Reconnecting.")
+                    try:
+                        yield from asyncio.wait_for(self._ws_graceful_reconnect(), timeout=None, loop=self.loop)
+                    except Exception:
+                        log.info("Failed reconnecting Websocket. Closing.")
+                        yield from self.close()
+                        break
+                    else:
+                        if self.is_closed and self.ws.open:
+                            log.info("Mismatch between client state and Websocket state. Correcting.")
+                            yield from self._closed.clear()
+                            yield from self._reconnect_ws()
+                            continue
+                        elif self.is_closed:
+                            log.info("Websocket was created but did not connect to gateway.")
+                            yield from self.close()
+                            break
+                        else:
+                            log.info("Reconnected to gateway.")
+                            yield from self._reconnect_ws()
+                            continue
 
             yield from self.received_message(msg)
 
@@ -589,12 +648,13 @@ class Client:
             yield from self.voice.disconnect()
             self.voice = None
 
-        if self.ws.open:
+        if self.ws is not None and self.ws.open:
             yield from self.ws.close()
 
+        if self.keep_alive is not None:
+            self.keep_alive.cancel()
 
         yield from self.session.close()
-        self.keep_alive.cancel()
         self._closed.set()
         self._is_ready.clear()
 

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -155,7 +155,7 @@ class Command:
         return result
 
     def _convert_member(self, bot, message, argument):
-        match = re.match(r'<@([0-9]+)>', argument)
+        match = re.match(r'<@([0-9]+)>$', argument)
         server = message.server
         result = None
         if match is None:
@@ -179,7 +179,7 @@ class Command:
     _convert_user = _convert_member
 
     def _convert_channel(self, bot, message, argument):
-        match = re.match(r'<#([0-9]+)>', argument)
+        match = re.match(r'<#([0-9]+)>$', argument)
         result = None
         server = message.server
         if match is None:

--- a/discord/message.py
+++ b/discord/message.py
@@ -198,7 +198,17 @@ class Message:
 
         pattern = re.compile('|'.join(transformations.keys()))
         result = pattern.sub(repl, self.content)
-        return result.replace('@everyone', '@\u200beveryone')
+
+        transformations = {
+            '@everyone': '@\u200beveryone',
+            '@here': '@\u200bhere'
+        }
+
+        def repl2(obj):
+            return transformations.get(obj.group(0), '')
+
+        pattern = re.compile('|'.join(transformations.keys()))
+        return pattern.sub(repl2, result)
 
     def _handle_upgrades(self, channel_id):
         self.server = None


### PR DESCRIPTION
Made changes so that the library supports resumes. Fixed the resume packet to send the token (It was the only thing missing). Shouldn't interfere with anything else as it blocks all other threads until the reconnect happens (Which is necessary because otherwise everything implodes as things try to write to a dead websocket). Also successfully gets the pending missed events. Works good. Tested on my side in a custom build. Working good so far. Left in the reconnect_times variable, can be removed, but might be useful to someone somewhere.