### PR TITLE
Fix Member.display_name returning None

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -133,5 +133,5 @@ class User:
         if they have a server specific nickname then that
         is returned instead.
         """
-        return getattr(self, 'nick', self.name)
+        return getattr(self, 'nick', None) or self.name
 


### PR DESCRIPTION
If Member.nick was None, getattr would happily return None, not the
default value.