### PR TITLE
Make Client.delete_message use _rate_limit_helper.

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -973,7 +973,7 @@ class Client:
         """
 
         url = '{}/{}/messages/{}'.format(endpoints.CHANNELS, message.channel.id, message.id)
-        response = yield from self.session.delete(url, headers=self.headers)
+        response = yield from self._rate_limit_helper('delete_message', 'DELETE', url, None)
         log.debug(request_logging_format.format(method='DELETE', response=response))
         yield from utils._verify_successful_response(response)
         yield from response.release()


### PR DESCRIPTION
In response to the new message-deletion rate limit.

This should prevent HTTP 429 errors from propagating to user code when deleting messages.

N.B. `fgrep self.session. discord/client.py` reveals several other places where the rate limit helper is not used, and I've no clue whether such non-usage is intentional.