### PR TITLE
Fix changing own nickname without manage_nicknames

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -1424,7 +1424,12 @@ class Client:
             Editing the channel failed.
         """
 
-        url = '{0}/{1.server.id}/members/{1.id}'.format(endpoints.SERVERS, member)
+        if member == self.user:
+            fmt = '{0}/{1.server.id}/members/@me/nick'
+        else:
+            fmt = '{0}/{1.server.id}/members/{1.id}'
+
+        url = fmt.format(endpoints.SERVERS, member)
 
         payload = {
             # oddly enough, this endpoint requires '' to clear the nickname


### PR DESCRIPTION
Use @me/nick rather than id when changing own nickname - this only
requires change_nicknames rather than manage.