### PR TITLE
Enable FEC/PLR

### DIFF
--- a/discord/opus.py
+++ b/discord/opus.py
@@ -156,6 +156,8 @@ APPLICATION_VOIP     = 2048
 APPLICATION_LOWDELAY = 2051
 CTL_SET_BITRATE      = 4002
 CTL_SET_BANDWIDTH    = 4008
+CTL_SET_FEC          = 4012
+CTL_SET_PLP          = 4014
 
 band_ctl = {
     'narrow': 1101,
@@ -181,6 +183,8 @@ class Encoder:
 
         self._state = self._create_state()
         self.set_bitrate(128)
+        self.set_fec(True)
+        self.set_expected_packet_loss_percent(0.15)
         self.set_bandwidth('full')
 
     def __del__(self):
@@ -217,6 +221,20 @@ class Encoder:
 
         if ret < 0:
             log.info('error has happened in set_bandwidth')
+            raise OpusError(ret)
+            
+    def set_fec(self, enabled=True):
+        ret = _lib.opus_encoder_ctl(self._state, CTL_SET_FEC, 1 if enabled else 0)
+        
+        if ret < 0:
+            log.info('error has happened in set_fec')
+            raise OpusError(ret)
+            
+    def set_expected_packet_loss_percent(self, percentage):
+        ret = _lib.opus_encoder_ctl(self._state, CTL_SET_PLP, min(100, max(0, int(percentage * 100))))
+        
+        if ret < 0:
+            log.info('error has happened in set_expected_packet_loss_percent')
             raise OpusError(ret)
 
     def encode(self, pcm, frame_size):


### PR DESCRIPTION
Enable forward error correction + packet loss percent tuning in opus encoder. Additionally, use some sane defaults. This should fix people hearing robo in music when packet loss is happening.