### PR TITLE
Fixed being Rate limited on Delete messages.

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -972,10 +972,10 @@ class Client:
         """
 
         url = '{}/{}/messages/{}'.format(endpoints.CHANNELS, message.channel.id, message.id)
-        response = yield from self.session.delete(url, headers=self.headers)
-        log.debug(request_logging_format.format(method='DELETE', response=response))
-        yield from utils._verify_successful_response(response)
-        yield from response.release()
+        resp = yield from self._rate_limit_helper('delete_message', 'DELETE', url, None)
+        log.debug(request_logging_format.format(method='DELETE', response=resp))
+        yield from utils._verify_successful_response(resp)
+        yield from resp.release()
 
     @asyncio.coroutine
     def edit_message(self, message, new_content):

--- a/discord/errors.py
+++ b/discord/errors.py
@@ -119,3 +119,13 @@ class ConnectionClosed(ClientException):
         self.code = original.code
         self.reason = original.reason
         super().__init__(str(original))
+
+class RateLimitError(ClientException):
+    """Exception that's thrown when you send more requests to a discord
+    endpoint than that you can do per second.
+    
+    This essentially throws a Error saying you are being rate limited.
+    
+    Will be replaced with a rate limit helper that would allow it to be
+    retried when Danny gets to making it."""
+    pass

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -217,7 +217,12 @@ def _verify_successful_response(response):
             raise Forbidden(response, message, text)
         elif code == 404:
             raise NotFound(response, message, text)
-        raise HTTPException(response, message, text)
+        elif code == 429:
+            raise RateLimitError(message)
+        elif code == 502:
+            return
+        else:
+            raise HTTPException(response, message, text)
 
 def _get_mime_type_for_image(data):
     if data.startswith(b'\x89\x50\x4E\x47\x0D\x0A\x1A\x0A'):


### PR DESCRIPTION
When anyone prunes messages by mass because of the rate limit of 4~5 msgs per second being able to be deleted I decided to change it myself. This is working and I tested it myself. I would not be proposing this if it was not working at all.

It seems to take me like 15 sec or so now to delete 100 messages with this too.