### PR TITLE
logs_from improvements

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -51,6 +51,7 @@ import logging, traceback
 import sys, re
 import tempfile, os, hashlib
 import itertools
+import datetime
 from random import randint as random_integer
 
 PY35 = sys.version_info >= (3, 5)
@@ -1165,10 +1166,12 @@ class Client:
             The channel to obtain the logs from.
         limit : int
             The number of messages to retrieve.
-        before : :class:`Message`
-            The message before which all returned messages must be.
-        after : :class:`Message`
-            The message after which all returned messages must be.
+        before : :class:`Message` or `datetime`
+            The message or date before which all returned messages must be.
+            If a date is provided it must be a timezone-naive datetime representing UTC time.
+        after : :class:`Message` or `datetime`
+            The message or date after which all returned messages must be.
+            If a date is provided it must be a timezone-naive datetime representing UTC time.
 
         Raises
         ------
@@ -1208,9 +1211,15 @@ class Client:
         }
 
         if before:
-            params['before'] = before.id
+            if isinstance(before, datetime.datetime):
+                params['before'] = utils.time_snowflake(before, high=False)
+            else:
+                params['before'] = before.id
         if after:
-            params['after'] = after.id
+            if isinstance(after, datetime.datetime):
+                params['after'] = utils.time_snowflake(after, high=True)
+            else:
+                params['after'] = after.id
 
         response = yield from self.session.get(url, params=params, headers=self.headers)
         log.debug(request_logging_format.format(method='GET', response=response))

--- a/discord/client.py
+++ b/discord/client.py
@@ -1211,15 +1211,9 @@ class Client:
         }
 
         if before:
-            if isinstance(before, datetime.datetime):
-                params['before'] = utils.time_snowflake(before, high=False)
-            else:
-                params['before'] = before.id
+            params['before'] = before.id
         if after:
-            if isinstance(after, datetime.datetime):
-                params['after'] = utils.time_snowflake(after, high=True)
-            else:
-                params['after'] = after.id
+            params['after'] = after.id
 
         response = yield from self.session.get(url, params=params, headers=self.headers)
         log.debug(request_logging_format.format(method='GET', response=response))
@@ -1229,10 +1223,20 @@ class Client:
 
     if PY35:
         def logs_from(self, channel, limit=100, *, before=None, after=None, reverse=False):
+            if isinstance(before, datetime.datetime):
+                before = Object(utils.time_snowflake(before, high=False))
+            if isinstance(after, datetime.datetime):
+                after = Object(utils.time_snowflake(after, high=True))
+
             return LogsFromIterator.create(self, channel, limit, before=before, after=after, reverse=reverse)
     else:
         @asyncio.coroutine
         def logs_from(self, channel, limit=100, *, before=None, after=None):
+            if isinstance(before, datetime.datetime):
+                before = Object(utils.time_snowflake(before, high=False))
+            if isinstance(after, datetime.datetime):
+                after = Object(utils.time_snowflake(after, high=True))
+
             def generator(data):
                 for message in data:
                     yield Message(channel=channel, **message)

--- a/discord/client.py
+++ b/discord/client.py
@@ -1228,8 +1228,8 @@ class Client:
         return messages
 
     if PY35:
-        def logs_from(self, channel, limit=100, *, before=None, after=None):
-            return LogsFromIterator(self, channel, limit, before, after)
+        def logs_from(self, channel, limit=100, *, before=None, after=None, reverse=False):
+            return LogsFromIterator.create(self, channel, limit, before=before, after=after, reverse=reverse)
     else:
         @asyncio.coroutine
         def logs_from(self, channel, limit=100, *, before=None, after=None):

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -33,24 +33,49 @@ from .object import Object
 PY35 = sys.version_info >= (3, 5)
 
 class LogsFromIterator:
-    def __init__(self, client, channel, limit, before, after):
+    @staticmethod
+    def create(client, channel, limit, *, before=None, after=None, reverse=False):
+        """Create a proper iterator depending on parameters.
+
+        The messages endpoint has two behaviors:
+            If `before` is specified, it returns the `limit` newest messages before `before`, sorted with newest first.
+              - Fill strategy - update 'before' to oldest message
+            If `after` is specified, it returns the `limit` oldest messages after `after`, sorted with newest first.
+              - Fill strategy - update 'after' to newest message
+              - If messages are not reversed, they will be out of order (99-0, 199-100, so on)
+
+        A note that if both before and after are specified, before is ignored by the messages endpoint.
+
+        Parameters
+        -----------
+        client : class:`Client`
+        channel : class:`Channel`
+            Channel from which to request logs
+        limit : int
+            Maximum number of messages to retrieve
+        before : :class:`Message` or id-like
+            Message before which all messages must be.
+        after : :class:`Message` or id-like
+            Message after which all messages must be.
+        reverse : bool
+            If set to true, return messages in oldest->newest order. Recommended when using with "after" queries,
+            otherwise messages will be out of order. Defaults to False for backwards compatability.
+        """
+        if before and after:
+            if reverse:
+                return LogsFromBeforeAfterReversedIterator(client, channel, limit, before, after)
+            else:
+                return LogsFromBeforeAfterIterator(client, channel, limit, before, after)
+        elif after:
+            return LogsFromAfterIterator(client, channel, limit, after, reverse=reverse)
+        else:
+            return LogsFromBeforeIterator(client, channel, limit, before)
+
+    def __init__(self, client, channel, limit):
         self.client = client
         self.channel = channel
         self.limit = limit
-        self.before = before
-        self.after = after
         self.messages = asyncio.Queue()
-
-    @asyncio.coroutine
-    def fill_messages(self):
-        if self.limit > 0:
-            retrieve = self.limit if self.limit <= 100 else 100
-            data = yield from self.client._logs_from(self.channel, retrieve, self.before, self.after)
-            if len(data):
-                self.limit -= retrieve
-                self.before = Object(id=data[-1]['id'])
-                for element in data:
-                    yield from self.messages.put(Message(channel=self.channel, **element))
 
     @asyncio.coroutine
     def iterate(self):
@@ -73,3 +98,82 @@ class LogsFromIterator:
                 # if we're still empty at this point...
                 # we didn't get any new messages so stop looping
                 raise StopAsyncIteration()
+
+class LogsFromBeforeIterator(LogsFromIterator):
+    def __init__(self, client, channel, limit, before):
+        super().__init__(client, channel, limit)
+        self.before = before
+
+    @asyncio.coroutine
+    def fill_messages(self):
+        if self.limit > 0:
+            retrieve = self.limit if self.limit <= 100 else 100
+
+            data = yield from self.client._logs_from(self.channel, retrieve, before=self.before)
+            if len(data):
+                self.limit -= retrieve
+                self.before = Object(id=data[-1]['id'])
+                for element in data:
+                    yield from self.messages.put(Message(channel=self.channel, **element))
+
+class LogsFromAfterIterator(LogsFromIterator):
+    """Iterator for retrieving "after" style responses.
+
+    Recommended to use with reverse=True - this will return messages oldest to newest.
+    With reverse=False, you'll recieve messages 99-0, 199-100, etc."""
+    def __init__(self, client, channel, limit, after, *, reverse=False):
+        super().__init__(client, channel, limit)
+        self.after = after
+        self.reverse = reverse
+
+    @asyncio.coroutine
+    def fill_messages(self):
+        if self.limit > 0:
+            retrieve = self.limit if self.limit <= 100 else 100
+
+            data = yield from self.client._logs_from(self.channel, retrieve, after=self.after)
+            if len(data):
+                self.limit -= retrieve
+                self.after = Object(id=data[0]['id'])
+                for element in (data if not self.reverse else reversed(data)):
+                    yield from self.messages.put(Message(channel=self.channel, **element))
+
+class LogsFromBeforeAfterIterator(LogsFromIterator):
+    """Newest -> Oldest."""
+    def __init__(self, client, channel, limit, before, after):
+        super().__init__(client, channel, limit)
+        self.before = before
+        self.after = after
+
+    @asyncio.coroutine
+    def fill_messages(self):
+        if self.limit > 0:
+            retrieve = self.limit if self.limit <= 100 else 100
+
+            data = yield from self.client._logs_from(self.channel, retrieve, before=self.before)
+            if len(data):
+                self.limit -= retrieve
+                self.before = Object(id=data[-1]['id'])
+                for element in data:
+                    if int(element['id']) > int(self.after.id):
+                        yield from self.messages.put(Message(channel=self.channel, **element))
+
+class LogsFromBeforeAfterReversedIterator(LogsFromIterator):
+    """Oldest -> Newest."""
+    def __init__(self, client, channel, limit, before, after):
+        super().__init__(client, channel, limit)
+        self.before = before
+        self.after = after
+
+    @asyncio.coroutine
+    def fill_messages(self):
+        if self.limit > 0:
+            retrieve = self.limit if self.limit <= 100 else 100
+
+            data = yield from self.client._logs_from(self.channel, retrieve, after=self.after)
+            if len(data):
+                self.limit -= retrieve
+                self.after = Object(id=data[0]['id'])
+                for element in reversed(data):
+                    if int(element['id']) < int(self.before.id):
+                        yield from self.messages.put(Message(channel=self.channel, **element))

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -29,8 +29,6 @@ import asyncio
 import aiohttp
 from .message import Message
 from .object import Object
-from . import utils
-import datetime
 
 PY35 = sys.version_info >= (3, 5)
 
@@ -147,15 +145,6 @@ class LogsFromBeforeAfterIterator(LogsFromIterator):
         self.before = before
         self.after = after
 
-        if isinstance(before, datetime.datetime):
-            self.before = Object(utils.time_snowflake(before, high=False))
-        else:
-            self.before = before
-        if isinstance(after, datetime.datetime):
-            self.after = Object(utils.time_snowflake(after, high=True))
-        else:
-            self.after = after
-
     @asyncio.coroutine
     def fill_messages(self):
         if self.limit > 0:
@@ -171,8 +160,13 @@ class LogsFromBeforeAfterIterator(LogsFromIterator):
                 for element in data:
                         yield from self.messages.put(Message(channel=self.channel, **element))
 
-class LogsFromBeforeAfterReversedIterator(LogsFromBeforeAfterIterator):
+class LogsFromBeforeAfterReversedIterator(LogsFromIterator):
     """Oldest -> Newest."""
+    def __init__(self, client, channel, limit, before, after):
+        super().__init__(client, channel, limit)
+        self.before = before
+        self.after = after
+
     @asyncio.coroutine
     def fill_messages(self):
         if self.limit > 0:

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -106,6 +106,24 @@ def snowflake_time(id):
     """Returns the creation date in UTC of a discord id."""
     return datetime.datetime.utcfromtimestamp(((int(id) >> 22) + DISCORD_EPOCH) / 1000)
 
+def time_snowflake(datetime_obj, high=False):
+    """Returns a numeric snowflake pretending to be created at the given date.
+
+    When using as the lower end of a range, use time_snowflake(high=False) - 1 to be inclusive, high=True to be exclusive
+    When using as the higher end of a range, use time_snowflake(high=True) + 1 to be inclusive, high=False to be exclusive
+
+    Parameters
+    -----------
+    datetime_obj
+        A timezone-naive datetime object representing UTC time.
+    high
+        Whether or not to set the lower 22 bit to high or low.
+    """
+    unix_seconds = (datetime_obj - type(datetime_obj)(1970, 1, 1)).total_seconds()
+    discord_millis = int(unix_seconds * 1000 - DISCORD_EPOCH)
+
+    return (discord_millis << 22) + (2**22-1 if high else 0)
+
 def find(predicate, seq):
     """A helper to return the first element found in the sequence
     that meets the predicate. For example: ::


### PR DESCRIPTION
Allow datetime objects to be used in logs_from.
Add time_snowflake to convert a datetime to a "snowflake".
Fix logs_from returning incorrect results when retrieving more than 100 messages and only specifying "after".
Fix logs_from returning incorrect results when retrieving and specifying both "before" and "after".
Add option to return messages in oldest->newest order when specifying only "after" or specifying both "before" and "after". (Recommended when only specifying "after" and retrieving over 100 messages)