### PR TITLE
Fix exception when handling login failure

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -189,13 +189,13 @@ class HTTPClient:
 
     @asyncio.coroutine
     def static_login(self, token, *, bot):
-        old_state = (self.token, self.bot_token)
+        old_token, old_bot = self.token, self.bot_token
         self._token(token, bot=bot)
 
         try:
             data = yield from self.get(self.ME)
         except HTTPException as e:
-            self._token(*old_state)
+            self._token(old_token, bot=old_bot)
             if e.response.status == 401:
                 raise LoginFailure('Improper token has been passed.') from e
             raise e


### PR DESCRIPTION
Logging in with an invalid token would throw a TypeError due to improper
passing of arguments to HTTPClient._token.  Fix by properly passing the
keyword only bot argument.