### PR TITLE
Get created Objects from cache

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -1773,7 +1773,7 @@ class Client:
 
         data = yield from self.http.create_channel(server.id, name, str(type), permission_overwrites=perms)
         channel = Channel(server=server, **data)
-        return channel
+        return utils.get(server.channels, id=channel.id)
 
     @asyncio.coroutine
     def delete_channel(self, channel):
@@ -1886,7 +1886,8 @@ class Client:
             region = region.name
 
         data = yield from self.http.create_server(name, region, icon)
-        return Server(**data)
+        server = Server(**data)
+        return utils.get(self.servers, id=server.id)
 
     @asyncio.coroutine
     def edit_server(self, server, **fields):
@@ -2411,7 +2412,7 @@ class Client:
         # we have to call edit because you can't pass a payload to the
         # http request currently.
         yield from self.edit_role(server, role, **fields)
-        return role
+        return utils.get(server.roles, id=role.id)
 
     @asyncio.coroutine
     def edit_channel_permissions(self, channel, target, overwrite=None):


### PR DESCRIPTION
Get created Objects from cache rather than use objects that are useless if you wish to check values from them.