### PR TITLE
[commands] Make HelpFormatter ignore hidden commands for max_width

### DIFF
--- a/discord/ext/commands/formatter.py
+++ b/discord/ext/commands/formatter.py
@@ -160,7 +160,7 @@ class HelpFormatter:
         try:
             commands = self.command.commands if not self.is_cog() else self.context.bot.commands
             if commands:
-                return max(map(lambda c: len(c.name), commands.values()))
+                return max(map(lambda c: len(c.name) if self.show_hidden or not c.hidden else 0, commands.values()))
             return 0
         except AttributeError:
             return len(self.command.name)


### PR DESCRIPTION
2 weeks later, realised there was no description :clap: 

```py
from discord.ext import commands

def setup(bot):
    bot.add_cog(Trains(bot))


class Trains:
    def __init__(self, bot):
        self.bot = bot

    @commands.command()
    async def choo(self):
        """Yay trains !"""
        await self.bot.say('I like trains.')

    @commands.command(hidden=True)
    async def choochoochoochoochoochoochoochoochoochoo(self):
        """Rip help message."""
        await self.bot.say('I FREAKING LOVE TRAINS !!!')

```
Produces:
![capture](https://cloud.githubusercontent.com/assets/18576662/17248990/1e52318c-559e-11e6-97b5-f1c1dea0d4a2.PNG)
