### PR TITLE
[fix] Exception in Daemon threads. (that are logged to console instead of somewhere else) & more fixes.

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -469,9 +469,9 @@ class Client:
         Roughly Equivalent to: ::
 
             try:
-                loop.run_until_complete(start(*args, **kwargs))
+                loop.run_forever(start(*args, **kwargs))
             except KeyboardInterrupt:
-                loop.run_until_complete(logout())
+                loop.run_forever(logout())
                 # cancel all tasks lingering
             finally:
                 loop.close()
@@ -484,14 +484,14 @@ class Client:
         """
 
         try:
-            self.loop.run_until_complete(self.start(*args, **kwargs))
+            self.loop.run_forever(self.start(*args, **kwargs))
         except KeyboardInterrupt:
-            self.loop.run_until_complete(self.logout())
+            self.loop.run_forever(self.logout())
             pending = asyncio.Task.all_tasks()
             gathered = asyncio.gather(*pending)
             try:
                 gathered.cancel()
-                self.loop.run_until_complete(gathered)
+                self.loop.run_forever(gathered)
 
                 # we want to retrieve any exceptions to make sure that
                 # they don't nag us about it being un-retrieved.

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -147,7 +147,10 @@ class ProcessPlayer(StreamPlayer):
         self.process = process
 
     def run(self):
-        super().run()
+        try:
+            super().run()  # Exceptions can happen here if so we log them instead of write them in console.
+        except Exception as err:
+            log.exception('Exception in Daemon Thread(s) {0}.'.format(str(err)))
 
         self.process.kill()
         if self.process.poll() is None:

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -148,7 +148,7 @@ class ProcessPlayer(StreamPlayer):
 
     def run(self):
         try:
-            super().run()  # Exceptions can happen here if so we log them instead of write them in console.
+            super().run()
         except Exception as err:
             log.exception('Exception in Daemon Thread(s) {0}.'.format(str(err)))
 


### PR DESCRIPTION
I am new to using discord.py and I only use it for voice related things. However it does get exception in Daemon threads if the Voice Server/Region was to crash while the bot is playing stuff which would result in spam city.

Edit:
Added a fix for some reconnecting logic due to ``run_until_complete`` being a pain in the arse in some of my other code I wrote before. The benefit of using ``run_forever`` is more than the reason for ``run_until_complete`` to exist.