### PR TITLE
Add commands ext docs

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -69,6 +69,8 @@ class Converter:
         raise NotImplementedError('Derived classes need to implement this.')
 
 class MemberConverter(Converter):
+    """The :class:`Converter` for a string argument to data class :class:`.Member`
+    """
     def convert(self):
         message = self.ctx.message
         bot = self.ctx.bot
@@ -97,6 +99,8 @@ class MemberConverter(Converter):
 UserConverter = MemberConverter
 
 class ChannelConverter(Converter):
+    """The :class:`Converter` for a string argument to data class :class:`.Channel`
+    """
     def convert(self):
         message = self.ctx.message
         bot = self.ctx.bot
@@ -123,6 +127,8 @@ class ChannelConverter(Converter):
         return result
 
 class ColourConverter(Converter):
+    """The :class:`Converter` for a string argument to data class :class:`.Colour`
+    """
     def convert(self):
         arg = self.argument.replace('0x', '').lower()
 
@@ -138,6 +144,8 @@ class ColourConverter(Converter):
             return method()
 
 class RoleConverter(Converter):
+    """The :class:`Converter` for a string argument to data class :class:`.Role`
+    """
     def convert(self):
         server = self.ctx.message.server
         if not server:
@@ -151,10 +159,14 @@ class RoleConverter(Converter):
         return result
 
 class GameConverter(Converter):
+    """The :class:`Converter` for a string argument to data class :class:`.Game`
+    """
     def convert(self):
         return discord.Game(name=self.argument)
 
 class InviteConverter(Converter):
+    """The :class:`Converter` for a string argument to data class :class:`.Invite`
+    """
     @asyncio.coroutine
     def convert(self):
         try:
@@ -164,6 +176,8 @@ class InviteConverter(Converter):
             raise BadArgument('Invite is invalid or expired') from e
 
 class EmojiConverter(Converter):
+    """The :class:`Converter` for a string argument to data class :class:`.Emoji`
+    """
     @asyncio.coroutine
     def convert(self):
         message = self.ctx.message

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -872,12 +872,7 @@ def cooldown(rate, per, type=BucketType.default):
     of times in a specific time frame. These cooldowns can be based
     either on a per-server, per-channel, per-user, or global basis.
     Denoted by the third argument of ``type`` which must be of enum
-    type ``BucketType`` which could be either:
-
-    - ``BucketType.default`` for a global basis.
-    - ``BucketType.user`` for a per-user basis.
-    - ``BucketType.server`` for a per-server basis.
-    - ``BucketType.channel`` for a per-channel basis.
+    type :class:`.BucketType`.
 
     If a cooldown is triggered, then :exc:`CommandOnCooldown` is triggered in
     :func:`on_command_error` and the local error handler.
@@ -890,7 +885,7 @@ def cooldown(rate, per, type=BucketType.default):
         The number of times a command can be used before triggering a cooldown.
     per: float
         The amount of seconds to wait for a cooldown when it's been triggered.
-    type: ``BucketType``
+    type: :class:`.BucketType`
         The type of cooldown to have.
     """
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -684,6 +684,8 @@ Example usage of it is as follows: ::
         """Adds two numbers together."""
         await bot.say(left + right)
 
+    bot.run('token')
+
 .. autofunction:: discord.ext.commands.when_mentioned
 
 .. autofunction:: discord.ext.commands.when_mentioned_or

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -667,13 +667,17 @@ Commands Ext
 
 The following section outlines the commands extension module.
 
-This module is designed to make it easier to create a bot that responds to commands.
-Example usage of it is as follows: ::
+Introduction
+~~~~~~~~~~~~
+
+The commands extension module was designed to be a rich and powerful extension to discord.py that allows you to quickly and easily create a Discord bot. In order to use it, you should first initialise the :class:`Bot` class by declaring it as a variable or subclassing it: ::
 
     import discord
     from discord.ext import commands
 
     bot = commands.Bot(command_prefix='?', description="My first bot")
+
+After doing that, you can register new event and command functions using the decorators :meth:`Client.event` and :meth:`command`. A basic example of usage of this is below. ::
 
     @bot.event
     async def on_ready():
@@ -686,15 +690,40 @@ Example usage of it is as follows: ::
 
     bot.run('token')
 
-.. autofunction:: discord.ext.commands.when_mentioned
+One of the last (if not the last) functions that should be called in your script is :meth:`discord.Client.run`, along with the login details of the account you want to run the bot on. For OAuth accounts, this is passed as a token.
 
-.. autofunction:: discord.ext.commands.when_mentioned_or
+Arguments for commands should be added in the order that they will be required in, and the type they will be converted to. In the example above, the command `add` takes two arguments, `left` and `right`, both of which will be converted to integers, and then added together and sent as a response using :meth:`Bot.say`.
+
+You can pass the :class:`Context` object associated with the invoked command by adding `pass_context=True` to the decorator. This will allow you to obtain, for example, the invoking :class:`discord.Message` object. It should be added as the first paramater of the function. ::
+
+    @bot.command(pass_context=True)
+    async def add(ctx, left : int, right : int):
+        """Adds two numbers together."""
+        print(ctx.message.author)
+        await bot.say(left + right)
+
+The code above gets the author of the :class:`discord.Message` object and prints it to stdout, as a basic example of its usage. Creating subcommands are easy enough too, by using the :meth:`group` decorator. It will act as the main command, and you can pass the context to that too to check if a subcommand was actually used or if the command was just used on its own. ::
+
+    @bot.group(pass_context=True)
+    async def foo(ctx):
+        """Base command."""
+        if ctx.invoked_subcommand is None:
+            await bot.say('Nope.')
+
+    @test.command()
+    async def bar():
+        """Subcommand."""
+        await bot.say('Yes.')
 
 Bot
 ~~~
 
 .. autoclass:: Bot
     :members:
+
+.. autofunction:: discord.ext.commands.when_mentioned
+
+.. autofunction:: discord.ext.commands.when_mentioned_or
 
 Context
 ~~~~~~~
@@ -753,23 +782,23 @@ Event Reference
 
 Utility Functions
 ~~~~~~~~~~~~~~~~~
-.. autofunction:: discord.ext.commands.core.command
+.. autofunction:: command
 
-.. autofunction:: discord.ext.commands.core.group
+.. autofunction:: group
 
-.. autofunction:: discord.ext.commands.core.check
+.. autofunction:: check
 
-.. autofunction:: discord.ext.commands.core.has_role
+.. autofunction:: has_role
 
-.. autofunction:: discord.ext.commands.core.has_any_role
+.. autofunction:: has_any_role
 
-.. autofunction:: discord.ext.commands.core.has_permissions
+.. autofunction:: has_permissions
 
-.. autofunction:: discord.ext.commands.core.bot_has_role
+.. autofunction:: bot_has_role
 
-.. autofunction:: discord.ext.commands.core.bot_has_any_role
+.. autofunction:: bot_has_any_role
 
-.. autofunction:: discord.ext.commands.core.cooldown
+.. autofunction:: cooldown
 
 Enumerations
 ~~~~~~~~~~~~

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -677,7 +677,7 @@ The commands extension module was designed to be a rich and powerful extension t
 
     bot = commands.Bot(command_prefix='?', description="My first bot")
 
-After doing that, you can register new event and command functions using the decorators :meth:`Client.event` and :meth:`command`. A basic example of usage of this is below. ::
+After doing that, you can register new event and command functions using the decorators :meth:`discord.Client.event` and :meth:`command`. A basic example of usage of this is below. ::
 
     @bot.event
     async def on_ready():
@@ -727,6 +727,11 @@ Bot
 
 Context
 ~~~~~~~
+
+    .. warning::
+
+        The invocation context of a command is passed using :attr:`Command.pass_context`.
+        You should never create this class manually.
 
 .. autoclass:: Context
     :members:
@@ -822,6 +827,10 @@ Enumerations
 
 Data Classes
 ~~~~~~~~~~~~
+
+    .. warning::
+
+        Data classes should never be created manually.
 
 Command
 *******

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -659,3 +659,163 @@ The following exceptions are thrown by the library.
 .. autoexception:: discord.opus.OpusError
 
 .. autoexception:: discord.opus.OpusNotLoaded
+
+.. currentmodule:: discord.ext.commands
+
+Commands Ext
+--------------
+
+The following section outlines the commands extension module.
+
+This module is designed to make it easier to create a bot that responds to commands.
+Example usage of it is as follows: ::
+
+    import discord
+    from discord.ext import commands
+
+    bot = commands.Bot(command_prefix='?', description="My first bot")
+
+    @bot.event
+    async def on_ready():
+        print('Logged in as {0.name} ({0.id})'.format(bot.user))
+
+    @bot.command()
+    async def add(left : int, right : int):
+        """Adds two numbers together."""
+        await bot.say(left + right)
+
+.. autofunction:: discord.ext.commands.when_mentioned
+
+.. autofunction:: discord.ext.commands.when_mentioned_or
+
+Bot
+~~~
+
+.. autoclass:: Bot
+    :members:
+
+Context
+~~~~~~~
+
+.. autoclass:: Context
+    :members:
+
+GroupMixin
+~~~~~~~~~~
+
+.. autoclass:: GroupMixin
+    :members:
+
+Converter
+~~~~~~~~~~
+
+.. autoclass:: Converter
+    :members:
+
+.. autoclass:: MemberConverter
+    :members:
+
+.. autoclass:: ChannelConverter
+    :members:
+
+.. autoclass:: ColourConverter
+    :members:
+
+.. autoclass:: RoleConverter
+    :members:
+
+.. autoclass:: GameConverter
+    :members:
+
+.. autoclass:: InviteConverter
+    :members:
+
+Event Reference
+~~~~~~~~~~~~~~~
+
+.. function:: on_command_error(exception, context)
+
+    Called when an error occurs within a :class:`Command`
+
+    :param exception: The `Exception` that occurred
+    :param context: The :class:`Context` associated with the error
+
+Utility Functions
+~~~~~~~~~~~~~~~~~
+.. autofunction:: discord.ext.commands.core.command
+
+.. autofunction:: discord.ext.commands.core.group
+
+.. autofunction:: discord.ext.commands.core.check
+
+.. autofunction:: discord.ext.commands.core.has_role
+
+.. autofunction:: discord.ext.commands.core.has_any_role
+
+.. autofunction:: discord.ext.commands.core.has_permissions
+
+.. autofunction:: discord.ext.commands.core.bot_has_role
+
+.. autofunction:: discord.ext.commands.core.bot_has_any_role
+
+.. autofunction:: discord.ext.commands.core.cooldown
+
+Enumerations
+~~~~~~~~~~~~
+
+.. class:: discord.ext.commands.cooldowns.BucketType
+
+    Specifies the type of bucket, used for cooldowns.
+
+    .. attribute:: default
+
+        Global basis.
+    .. attribute:: user
+
+        Per-user basis.
+    .. attribute:: server
+
+        Per-server basis.
+    .. attribute:: channel
+
+        Per-channel basis.
+
+Data Classes
+~~~~~~~~~~~~
+
+Command
+*******
+
+.. autoclass:: Command
+    :members:
+
+Group
+*****
+
+.. autoclass:: Group
+    :members:
+
+Exceptions
+~~~~~~~~~~~~
+
+.. autoexception:: CommandError
+
+.. autoexception:: UserInputError
+
+.. autoexception:: CommandNotFound
+
+.. autoexception:: MissingRequiredArgument
+
+.. autoexception:: TooManyArguments
+
+.. autoexception:: BadArgument
+
+.. autoexception:: NoPrivateMessage
+
+.. autoexception:: CheckFailure
+
+.. autoexception:: DisabledCommand
+
+.. autoexception:: CommandInvokeError
+
+.. autoexception:: CommandOnCooldown

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -730,6 +730,15 @@ Converter
 .. autoclass:: InviteConverter
     :members:
 
+Formatter
+~~~~~~~~~~
+
+.. autoclass:: Paginator
+    :members:
+
+.. autoclass:: HelpFormatter
+    :members:
+
 Event Reference
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Oh boy. As docs don't currently exist for the commands ext module, I made them myself. Basic, little explanation, temporary solution.

Resolves part of #27 
