### PR TITLE
Allow Object in start_private_message

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -238,13 +238,8 @@ class Client:
         elif isinstance(destination, Server):
             return destination.id, destination.id
         elif isinstance(destination, User):
-            found = self.connection._get_private_channel_by_user(destination.id)
-            if found is None:
-                # Couldn't find the user, so start a PM with them first.
-                channel = yield from self.start_private_message(destination)
-                return channel.id, None
-            else:
-                return found.id, None
+            channel = yield from self.start_private_message(destination)
+            return channel.id, None
         elif isinstance(destination, Object):
             found = self.get_channel(destination.id)
             if found is not None:
@@ -766,16 +761,19 @@ class Client:
         HTTPException
             The request failed.
         InvalidArgument
-            The user argument was not of :class:`User`.
+            The user argument was not of :class:`User` or :class:`Object`.
         """
 
-        if not isinstance(user, User):
-            raise InvalidArgument('user argument must be a User')
+        if not isinstance(user, User) and not isinstance(user, Object):
+            raise InvalidArgument('user argument must be a User or Object')
 
-        data = yield from self.http.start_private_message(user.id)
-        channel = PrivateChannel(me=self.user, **data)
-        self.connection._add_private_channel(channel)
-        return channel
+        found = self.connection._get_private_channel_by_user(user.id)
+        if found is None:
+            data = yield from self.http.start_private_message(user.id)
+            channel = PrivateChannel(me=self.user, **data)
+            self.connection._add_private_channel(channel)
+            return channel
+        return found
 
     @asyncio.coroutine
     def send_message(self, destination, content, *, tts=False):


### PR DESCRIPTION
**What**
Change the `Client.start_private_message` function to accept a `discord.Object` and improve it's use outside of `Client.send_message`.

**Why**
Because `Client.send_message` expects that a `discord.Object` passed as destination contains a channel (and not a user) id, sending a DM to an user when you only have the user id requires you to search that user first.
Since the  `Client.start_private_message` only requires the user id to create a private channel, this will allow users to bypass the search for the User object.

``` python
channel = await client.start_private_message(discord.Object(user.id))
await client.send_message(channel, content)
```

A currently possible workaround  is to construct an User object directly to pass to `Client.start_private_message` or `Client.send_message`, however the docs state that data classes should not be created manually.
