### PR TITLE
Add the ability to reset a cooldown on a command

### DIFF
--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -74,6 +74,7 @@ class Cooldown:
             self._window = current
     
     def reset(self):
+        """Resets our token so a new rate limit window will be started"""
         self._tokens = self.rate
         self._last = 0
         

--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -43,6 +43,7 @@ class Cooldown:
         self.type = type
         self._window = 0.0
         self._tokens = self.rate
+        self._last = 0
 
         if not isinstance(self.type, BucketType):
             raise TypeError('Cooldown type must be a BucketType')
@@ -74,6 +75,7 @@ class Cooldown:
     
     def reset(self):
         self._tokens = self.rate
+        self._last = 0
         
     def copy(self):
         return Cooldown(self.rate, self.per, self.type)

--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -71,7 +71,10 @@ class Cooldown:
         # so update the window to point to our current time frame
         if self._tokens == 0:
             self._window = current
-
+    
+    def reset(self):
+        self._tokens = self.rate
+        
     def copy(self):
         return Cooldown(self.rate, self.per, self.type)
 

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -338,6 +338,7 @@ class Command:
                 raise CommandOnCooldown(bucket, retry_after)
 
     def reset_cooldown(self, ctx):
+        """A method used to reset the cooldown on this command"""
         if self._buckets.valid:
             bucket = self._buckets.get_bucket(ctx)
             bucket.reset()

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -337,11 +337,9 @@ class Command:
             if retry_after:
                 raise CommandOnCooldown(bucket, retry_after)
 
-
     def reset_cooldown(self, ctx):
         if self._buckets.valid:
             bucket = self._buckets.get_bucket(ctx)
-            bucket.is_rate_limited()
             bucket.reset()
 
     @asyncio.coroutine

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -337,6 +337,13 @@ class Command:
             if retry_after:
                 raise CommandOnCooldown(bucket, retry_after)
 
+
+    def reset_cooldown(self, ctx):
+        if self._buckets.valid:
+            bucket = self._buckets.get_bucket(ctx)
+            bucket.is_rate_limited()
+            bucket.reset()
+
     @asyncio.coroutine
     def invoke(self, ctx):
         ctx.command = self


### PR DESCRIPTION
Currently the only way to do so is accessing private members, which is a "nono", so this should be added at the command level.