### PR TITLE
[commands] pass arguments from bot.load_extension to cog.setup

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -711,17 +711,17 @@ class Bot(GroupMixin, discord.Client):
 
     # extensions
 
-    def load_extension(self, name, *args, **kwargs):
+    def load_extension(self, name, *, _package=None, **kwargs):
         if name in self.extensions:
             return
 
-        lib = importlib.import_module(name)
+        lib = importlib.import_module(name, _package)
         if not hasattr(lib, 'setup'):
             del lib
             del sys.modules[name]
             raise discord.ClientException('extension does not have a setup function')
 
-        lib.setup(self, *args, **kwargs)
+        lib.setup(self, **kwargs)
         self.extensions[name] = lib
 
     def unload_extension(self, name):

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -711,7 +711,7 @@ class Bot(GroupMixin, discord.Client):
 
     # extensions
 
-    def load_extension(self, name):
+    def load_extension(self, name, *args, **kwargs):
         if name in self.extensions:
             return
 
@@ -721,7 +721,7 @@ class Bot(GroupMixin, discord.Client):
             del sys.modules[name]
             raise discord.ClientException('extension does not have a setup function')
 
-        lib.setup(self)
+        lib.setup(self, *args, **kwargs)
         self.extensions[name] = lib
 
     def unload_extension(self, name):


### PR DESCRIPTION
tl;dr:

``` diff
+    def load_extension(self, name, *, _package=None, **kwargs):
+        lib = importlib.import_module(name, _package)
+        lib.setup(self, **kwargs)
```

usecase:

``` python
somebot.load_extension('.cogs.something',
                       _package=__package__,
                       data_location=data_folder + '/cogs.something`
)
```

Cleaner than pinning random data to the bot itself (imo)
---

I'm willing to rm the `_package` special case, as it is a bit finnicky and lameo, I'm also willing to set up some introspection for the lib.setup stuff, so if the module is an older cog, it won't cause an exception from being fed random arguments from the main bot code
