### PR TITLE
Find the longest prefix match instead of the first

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -799,7 +799,8 @@ class Bot(GroupMixin, discord.Client):
             if not view.skip_string(prefix):
                 return
         else:
-            invoked_prefix = discord.utils.find(view.skip_string, prefix)
+            invoked_prefix = filter(view.skip_string, prefix)
+            invoked_prefix = max(invoked_prefix, lambda s: len(s))
             if invoked_prefix is None:
                 return
 


### PR DESCRIPTION
Simple fix for prefixes that start with other prefixes