### PR TITLE
added nick_mention function

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -101,6 +101,11 @@ class User:
     def mention(self):
         """Returns a string that allows you to mention the given user."""
         return '<@{0.id}>'.format(self)
+    
+    @property
+    def nick_mention(self):
+        """Returns a string that allows you to mention the given user."""
+        return '<@!{0.id}>'.format(self)
 
     def permissions_in(self, channel):
         """An alias for :meth:`Channel.permissions_for`.


### PR DESCRIPTION
The reason I added this is because a line that goes:
   
```py
if message.content == client.user.mention:
```   



doesn't detect nickname mentions