### PR TITLE
Allowing a function to execute right before a command is invoked

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -821,7 +821,7 @@ class Bot(GroupMixin, discord.Client):
         if invoker in self.commands:
             command = self.commands[invoker]
             if before_invoke is not None:
-                if asyncio.iscoroutine(before_invoke):
+                if asyncio.iscoroutinefunction(before_invoke):
                     yield from before_invoke()
                 else:
                     before_invoke()

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -762,7 +762,7 @@ class Bot(GroupMixin, discord.Client):
     # command processing
 
     @asyncio.coroutine
-    def process_commands(self, message):
+    def process_commands(self, message, before_invoke=None):
         """|coro|
 
         This function processes the commands that have been registered
@@ -784,6 +784,9 @@ class Bot(GroupMixin, discord.Client):
         -----------
         message : discord.Message
             The message to process commands for.
+        before_invoke : Optional[function]
+            A function to execute right before the command is invoked.
+            Can also be a coroutine.
         """
         _internal_channel = message.channel
         _internal_author = message.author
@@ -817,6 +820,11 @@ class Bot(GroupMixin, discord.Client):
 
         if invoker in self.commands:
             command = self.commands[invoker]
+            if before_invoke is not None:
+                if asyncio.iscoroutine(before_invoke):
+                    yield from before_invoke()
+                else:
+                    before_invoke()
             self.dispatch('command', command, ctx)
             try:
                 yield from command.invoke(ctx)


### PR DESCRIPTION
This adds an optional parameter `before_invoke` of the type `function` to the `process_commands` coroutine. If `before_invoke` is given as an argument to `process_commands`, it will execute that function before a command is invoked (if `message` contains a command). This is useful because listening to `on_command` doesn't guarantee that the code that should be executed `on_command` is actually executed before the command is invoked.