### PR TITLE
Add the ability to add an embed object to file uploads

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -1174,7 +1174,7 @@ class Client:
         yield from self.http.send_typing(channel_id)
 
     @asyncio.coroutine
-    def send_file(self, destination, fp, *, filename=None, content=None, tts=False):
+    def send_file(self, destination, fp, *, filename=None, content=None, tts=False, embed=None):
         """|coro|
 
         Sends a message to the destination given with the file given.
@@ -1208,6 +1208,8 @@ class Client:
             forced into a string by a ``str(content)`` call.
         tts : bool
             If the content of the message should be sent with TTS enabled.
+        embed: :class:`Embed`
+            The rich embed for the content.
 
         Raises
         -------
@@ -1231,7 +1233,7 @@ class Client:
             buffer = fp
 
         data = yield from self.http.send_file(channel_id, buffer, guild_id=guild_id,
-                                              filename=filename, content=content, tts=tts)
+                                              filename=filename, content=content, tts=tts, embed=embed)
         channel = self.get_channel(data.get('channel_id'))
         message = self.connection._create_message(channel=channel, **data)
         return message

--- a/discord/http.py
+++ b/discord/http.py
@@ -234,12 +234,15 @@ class HTTPClient:
         url = '{0.CHANNELS}/{1}/typing'.format(self, channel_id)
         return self.post(url, bucket=_func_())
 
-    def send_file(self, channel_id, buffer, *, guild_id=None, filename=None, content=None, tts=False):
+    def send_file(self, channel_id, buffer, *, guild_id=None, filename=None, content=None, tts=False, embed=None):
         url = '{0.CHANNELS}/{1}/messages'.format(self, channel_id)
         form = aiohttp.FormData()
 
         if content is not None:
             form.add_field('content', str(content))
+
+        if embed is not None:
+            form.add_field('payload_json', utils.to_json({'embed': embed.to_dict()}))
 
         form.add_field('tts', 'true' if tts else 'false')
         form.add_field('file', buffer, filename=filename, content_type='application/octet-stream')


### PR DESCRIPTION
Add the ability to add an embed object to file uploads - this allows you to link to the uploaded file in the embed using attachment://filename - json_payload is documented here: https://discordapp.com/developers/docs/resources/channel#create-message