### PR TITLE
Allow uploading of GIF avatars.

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -246,6 +246,8 @@ def _get_mime_type_for_image(data):
         return 'image/png'
     elif data.startswith(b'\xFF\xD8') and data.endswith(b'\xFF\xD9'):
         return 'image/jpeg'
+    elif data.startswith(b'\x47\x49\x46\x38\x37\x61') or data.startswith(b'\x47\x49\x46\x38\x39\x61'):
+        return 'image/gif'
     else:
         raise InvalidArgument('Unsupported image type given')
 


### PR DESCRIPTION
Discord Nitro accounts can upload GIFs as avatars, so the image
mimetype checker code should check for the GIF magic number too.