### PR TITLE
Fix Client.create_server.

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -2242,6 +2242,9 @@ class Client:
 
         Creates a :class:`Server`.
 
+        Bot accounts generally are not allowed to create servers.
+        See Discord's official documentation for more info.
+
         Parameters
         ----------
         name : str
@@ -2270,9 +2273,9 @@ class Client:
             icon = utils._bytes_to_base64_data(icon)
 
         if region is None:
-            region = ServerRegion.us_west.name
+            region = ServerRegion.us_west.value
         else:
-            region = region.name
+            region = region.value
 
         data = yield from self.http.create_server(name, region, icon)
         return Server(**data)


### PR DESCRIPTION
Client was using .name of enum instead of .value, resulting in
invalid requests being sent to discord.
edit_server region changing was not broken as the region field
was str()'d, which uses .value.

Also document that most bot accounts cannot use create_server.

Fixes issue discovered in https://github.com/Rapptz/discord.py/issues/458

Tested and confirmed to fix for user accounts, since I don't have a gamebridge account. However, it should work for gamebridge accounts as well.