### PR TITLE
[commands] add `usage` argument to Command to allow overriding the ar…

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -93,6 +93,8 @@ class Command:
     brief : str
         The short help text for the command. If this is not specified
         then the first line of the long help text is used instead.
+    usage : str
+        A replacement for arguments in the default help text.
     aliases : list
         The list of aliases the command can be invoked under.
     pass_context : bool
@@ -145,6 +147,7 @@ class Command:
         self.enabled = kwargs.get('enabled', True)
         self.help = kwargs.get('help')
         self.brief = kwargs.get('brief')
+        self.usage = kwargs.get('usage')
         self.rest_is_raw = kwargs.get('rest_is_raw', False)
         self.aliases = kwargs.get('aliases', [])
         self.pass_context = kwargs.get('pass_context', True)

--- a/discord/ext/commands/formatter.py
+++ b/discord/ext/commands/formatter.py
@@ -203,7 +203,7 @@ class HelpFormatter:
             result.append(name)
 
         params = cmd.clean_params
-        if cmd.usage is not None:
+        if cmd.usage:
             result.append(cmd.usage)
         elif len(params) > 0:
             for name, param in params.items():

--- a/discord/ext/commands/formatter.py
+++ b/discord/ext/commands/formatter.py
@@ -203,7 +203,9 @@ class HelpFormatter:
             result.append(name)
 
         params = cmd.clean_params
-        if len(params) > 0:
+        if cmd.usage is not None:
+            result.append(cmd.usage)
+        elif len(params) > 0:
             for name, param in params.items():
                 if param.default is not param.empty:
                     # We don't want None or '' to trigger the [name=value] case and instead it should


### PR DESCRIPTION
…gument list in the default help command

One use case being unordered arguments, but still "named" on the users' end.
Example:
```py
@bot.command(usage='[a] [b]')
async def com(ctx, *args):
    ...
```
Shows as `!com [a] [b]` in the help command instead of `!com [args...]`