### PR TITLE
Add "rollback strategy" to Client.join_voice_channel

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -3185,9 +3185,9 @@ class Client:
         try:
             session_id_data = yield from asyncio.wait_for(session_id_future, timeout=10.0, loop=self.loop)
             data = yield from asyncio.wait_for(voice_data_future, timeout=10.0, loop=self.loop)
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as e:
             yield from self.ws.voice_state(server.id, None, self_mute=True)
-            return None
+            raise e
 
         kwargs = {
             'user': self.user,

--- a/discord/client.py
+++ b/discord/client.py
@@ -3181,8 +3181,13 @@ class Client:
 
         # request joining
         yield from self.ws.voice_state(server.id, channel.id)
-        session_id_data = yield from asyncio.wait_for(session_id_future, timeout=10.0, loop=self.loop)
-        data = yield from asyncio.wait_for(voice_data_future, timeout=10.0, loop=self.loop)
+
+        try:
+            session_id_data = yield from asyncio.wait_for(session_id_future, timeout=10.0, loop=self.loop)
+            data = yield from asyncio.wait_for(voice_data_future, timeout=10.0, loop=self.loop)
+        except asyncio.TimeoutError:
+            yield from self.ws.voice_state(server.id, None, self_mute=True)
+            return None
 
         kwargs = {
             'user': self.user,


### PR DESCRIPTION
I observed that `yield from asyncio.wait_for(voice_data_future, timeout=10.0, loop=self.loop)` frequently times out. The only way to disconnect the bot from the vc is to use `voice_client.leave`. But since there's no voice_client, why not just disconnect if that code times out.

Other possible solution is to add a `leave_voice_channel` to Client?