### PR TITLE
Allow any iterable to be passed to `command_prefix`.

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -25,6 +25,7 @@ DEALINGS IN THE SOFTWARE.
 """
 
 import asyncio
+import collections
 import discord
 import inspect
 import importlib
@@ -666,6 +667,8 @@ class BotBase(GroupMixin):
             if asyncio.iscoroutine(ret):
                 ret = yield from ret
             return ret
+        elif isinstance(prefix, collections.Iterable) and not isinstance(prefix, str):
+            return list(prefix)
         else:
             return prefix
 


### PR DESCRIPTION
Flattens any iterable in `get_prefix`. This allows custom iterators to be passed.