### PR TITLE
handle Game.name being None

### DIFF
--- a/discord/game.py
+++ b/discord/game.py
@@ -63,7 +63,7 @@ class Game:
         self.type = kwargs.get('type')
 
     def __str__(self):
-        return self.name
+        return str(self.name)
 
     def __repr__(self):
         return '<Game name={0.name!r} type={0.type!r} url={0.url!r}>'.format(self)


### PR DESCRIPTION
re #221, Game.name can still be None, which will cause TypeError on
str(game).

Currently discord does not treat these weird statuses uniformly, with it
showing as playing a game on mobile, but not playing a game on desktop. It
may be useful to know users are in this weird state.