### PR TITLE
[commands] unload cog submodules

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -768,6 +768,9 @@ class BotBase(GroupMixin):
             del lib
             del self.extensions[name]
             del sys.modules[name]
+            for module in list(sys.modules.keys()):
+                if _is_submodule(lib_name, module):
+                    del sys.modules[module]
 
     # command processing
 


### PR DESCRIPTION
When unloading cogs, currently we do not remove submodules from
sys.modules, meaning they will not be reloaded. Removing here
makes new imports reload from file. Of course, any already imported
modules will still hold a reference to the old module, since they
will not re-import it, and will not be forcably unloaded.


This still does not account for the case if e.g. some outside module imports cogs, or cogs import each other, etc., as those modules will not be reloaded in this case and will still hold a reference to the old module. In any case, since we support unload_extension with submodules (e.g. for commands and such), we should force reloading of submodules. This fixes the case where unloading foo.bar would not unload foo.bar.baz.