### PR TITLE
Raise on add_cog being passed a class instead of an instance.

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -541,7 +541,15 @@ class BotBase(GroupMixin):
         -----------
         cog
             The cog to register to the bot.
+
+        Raises
+        --------
+        ClientException
+            The cog passed was a class instead of an instance.
         """
+
+        if inspect.isclass(cog):
+            raise discord.ClientException('cog passed to add_cog is a class instead of an instance')
 
         self.cogs[type(cog).__name__] = cog
 

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -549,7 +549,7 @@ class BotBase(GroupMixin):
         """
 
         if inspect.isclass(cog):
-            raise discord.ClientException('cog passed to add_cog is a class instead of an instance')
+            raise discord.ClientException('cog passed is a class instead of an instance')
 
         self.cogs[type(cog).__name__] = cog
 


### PR DESCRIPTION
Minor issue, but at the moment `add_cog` accepts both instances and classes being passed to it.

This can create errors that are hard to trace the source of when someone accidentally passes a class instead of an instance, as command and event handler functions will be registered using the unbound methods.

I can't think of a good reason why someone would intentionally want to use a class instead of an instance, so this could potentially prevent some headaches.

I was thinking of using `TypeError` over `ClientException`, but ended up deciding on `ClientException` to align with `load_extension` raising on lack of a `setup` function. Feel free to suggest changes if you think differently or have a better implementation of this.