### PR TITLE
Support the definition of commands' arguments' separators.

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -161,7 +161,7 @@ class Context(discord.abc.Messageable):
             raise ValueError('This context is not valid.')
 
         # some state to revert to when we're done
-        index, previous = view.index, view.previous
+        index, previous, separator = view.index, view.previous, view.separator
         invoked_with = self.invoked_with
         invoked_subcommand = self.invoked_subcommand
         subcommand_passed = self.subcommand_passed
@@ -170,6 +170,7 @@ class Context(discord.abc.Messageable):
             to_call = cmd.root_parent or cmd
             view.index = len(self.prefix) + 1
             view.previous = 0
+            view.separator = None
         else:
             to_call = cmd
 
@@ -179,6 +180,7 @@ class Context(discord.abc.Messageable):
             self.command = cmd
             view.index = index
             view.previous = previous
+            view.separator = separator
             self.invoked_with = invoked_with
             self.invoked_subcommand = invoked_subcommand
             self.subcommand_passed = subcommand_passed

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -868,7 +868,10 @@ class Group(GroupMixin, Command):
         view = ctx.view
         previous = view.index
         view.skip_ws()
+        sep = view.separator
+        view.separator = None
         trigger = view.get_word()
+        view.separator = sep
 
         if trigger:
             ctx.subcommand_passed = trigger
@@ -900,7 +903,10 @@ class Group(GroupMixin, Command):
         view = ctx.view
         previous = view.index
         view.skip_ws()
+        sep = view.separator
+        view.separator = None
         trigger = view.get_word()
+        view.separator = sep
 
         if trigger:
             ctx.subcommand_passed = trigger


### PR DESCRIPTION
This adds the kwarg `separator` to the construction of the class `Command` to allow people to define any character as a separator when parsing the command's arguments before its invocation.

Example to consider in the notes that follow :
```py
bot = commands.Bot('$')

@bot.command()
async def foo(ctx, *things):
    await ctx.send('\n'.join(map(lambda s: f'"{s}"', things)))

@bot.command(separator='|')
async def bar(ctx, *things):
    await ctx.send('\n'.join(map(lambda s: f'"{s}"', things)))

@bot.command(separator=',')
async def baz(ctx, thing1, thing2):
    pass

bot.run('token')
```
Those 2 commands invocations provide the same output :
```
$foo "hello world" "this is a long second argument" "and a third"
$bar hello world | this is a long second argument | and a third
```

A few things to note :
- This only support the definition of one separator, it can easily be changed to accept several with either a list or characters or a string of more than one characters
- Spaces around the separator are stripped for readability on use (`$bar hello | world` vs `$foo hello|world`
Quoted strings are the way to bypass this. e.g `$bar hello | " world " | !`
- Separators can now be escaped, e.g `$bar hello \|world` will result in only 1 argument
This is a change from the current behavior as `$foo hello\ world` now results in one arguments too instead of two.
This is also easily revertable or can be applied only to the non default separators.
- The commands' POSIX like signature includes the separator with surrounding spaces, as I didn't know how to specify in a readable manner the spaces are optional. It can result in some signature which divert from the wanted behavior, e.g `$help baz` provides the following output : `$baz <thing1> , <thing2>` when one would want to use it like so : `$baz a thing, another thing`
