### PR TITLE
Add get_role for Guild object

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -314,6 +314,11 @@ class Guild(Hashable):
         """Returns a :class:`Member` with the given ID. If not found, returns None."""
         return self._members.get(user_id)
 
+    def get_role(self, role_id):
+        """Returns a :class:`Role` with the given ID. If not found, returns None."""
+        found = [r for r in self.roles if r.id == role_id]
+        return found[0] if found else None
+
     @utils.cached_slot_property('_default_role')
     def default_role(self):
         """Gets the @everyone role that all members have by default."""


### PR DESCRIPTION
Takes a role ID, gets the role using a list comprehension and returns the found role (or None if the resulting list from the comprehension is not found to be True). Suggesting this because `Role` seems to be left out in terms of getting an object based on the ID. I've tested this too and it works as written