### PR TITLE
add static_format parameter to avatar_url_as

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -39,9 +39,12 @@ from .errors import InvalidArgument, ClientException
 from .channel import *
 from .enums import VoiceRegion, Status, ChannelType, try_enum, VerificationLevel, ContentFilter
 from .mixins import Hashable
+from .utils import valid_icon_size
 from .user import User
 from .invite import Invite
 from .iterators import AuditLogIterator
+
+VALID_ICON_FORMATS = {"jpeg", "jpg", "webp", "png"}
 
 BanEntry = namedtuple('BanEntry', 'reason user')
 
@@ -332,9 +335,40 @@ class Guild(Hashable):
     @property
     def icon_url(self):
         """Returns the URL version of the guild's icon. Returns an empty string if it has no icon."""
+        return self.icon_url_as()
+
+    def icon_url_as(self, *, format='webp', size=1024):
+        """Returns a friendly URL version of the guild's icon. Returns and empty string if it has no icon.
+
+        The format must be one of 'webp', 'jpeg', 'jpg', or 'png'. The
+        size must be a power of 2 between 16 and 1024.
+
+        Parameters
+        -----------
+        format: str
+            The format to attempt to convert the icon to.
+        size: int
+            The size of the image to display.
+
+        Returns
+        --------
+        str
+            The resulting CDN URL.
+
+        Raises
+        ------
+        InvalidArgument
+            Bad image format passed to ``format`` or invalid ``size``.
+        """
+        if not valid_icon_size(size):
+            raise InvalidArgument("size must be a power of 2 between 16 and 1024")
+        if format not in VALID_ICON_FORMATS:
+            raise InvalidArgument("format must be one of {}".format(VALID_ICON_FORMATS))
+
         if self.icon is None:
             return ''
-        return 'https://cdn.discordapp.com/icons/{0.id}/{0.icon}.jpg'.format(self)
+
+        return 'https://cdn.discordapp.com/icons/{0.id}/{0.icon}.{1}?size={2}'.format(self, format, size)
 
     @property
     def splash_url(self):

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -281,3 +281,7 @@ def sane_wait_for(futures, *, timeout, loop):
 
     if len(pending) != 0:
         raise asyncio.TimeoutError()
+
+def valid_icon_size(size):
+    """Icons must be power of 2 within [16, 1024]."""
+    return ((size != 0) and not (size & (size - 1))) and size in range(16, 1025)


### PR DESCRIPTION
static_format will only apply to static (not animated) avatars. Makes
it easier to grab gif-or-'format' of an avatar. Defaults to 'webp'