### PR TITLE
retry on 500 + raise once out of retries

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -193,8 +193,8 @@ class HTTPClient:
 
                         continue
 
-                    # we've received a 502, unconditional retry
-                    if r.status == 502 and tries <= 5:
+                    # we've received a 500 or 502, unconditional retry
+                    if r.status in {500, 502} and tries <= 5:
                         yield from asyncio.sleep(1 + tries * 2, loop=self.loop)
                         continue
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -194,7 +194,7 @@ class HTTPClient:
                         continue
 
                     # we've received a 500 or 502, unconditional retry
-                    if r.status in {500, 502} and tries <= 5:
+                    if r.status in {500, 502}:
                         yield from asyncio.sleep(1 + tries * 2, loop=self.loop)
                         continue
 
@@ -208,6 +208,8 @@ class HTTPClient:
                 finally:
                     # clean-up just in case
                     yield from r.release()
+            # We've run out of retries, raise.
+            raise HTTPException(r, data)
 
     def get_attachment(self, url):
         resp = yield from self._session.get(url)


### PR DESCRIPTION
Discord official client retries on 500, so worst case scenario, we're
not any worse than the official client which seriously outnumbers us.