### PR TITLE
accept_invite() doesn't exist on rewrite

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -878,9 +878,6 @@ class Client:
 
         Revokes an :class:`Invite`, URL, or ID to an invite.
 
-        The ``invite`` parameter follows the same rules as
-        :meth:`accept_invite`.
-
         Parameters
         ----------
         invite


### PR DESCRIPTION
The coroutine accept_invite() isn't present on the rewrite branch yet it's mentioned on delete_invite() function.