### PR TITLE
Remove accept_invite & references

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -2701,40 +2701,13 @@ class Client:
         return result
 
     @asyncio.coroutine
-    def accept_invite(self, invite):
-        """|coro|
-
-        Accepts an :class:`Invite`, URL or ID to an invite.
-
-        The URL must be a discord.gg URL. e.g. "http://discord.gg/codehere".
-        An ID for the invite is just the "codehere" portion of the invite URL.
-
-        Parameters
-        -----------
-        invite
-            The :class:`Invite` or URL to an invite to accept.
-
-        Raises
-        -------
-        HTTPException
-            Accepting the invite failed.
-        NotFound
-            The invite is invalid or expired.
-        Forbidden
-            You are a bot user and cannot use this endpoint.
-        """
-
-        invite_id = self._resolve_invite(invite)
-        yield from self.http.accept_invite(invite_id)
-
-    @asyncio.coroutine
     def delete_invite(self, invite):
         """|coro|
 
         Revokes an :class:`Invite`, URL, or ID to an invite.
 
-        The ``invite`` parameter follows the same rules as
-        :meth:`accept_invite`.
+        The URL must be a discord.gg URL. e.g. "http://discord.gg/codehere".
+-       An ID for the invite is just the "codehere" portion of the invite URL.
 
         Parameters
         ----------

--- a/discord/client.py
+++ b/discord/client.py
@@ -2707,7 +2707,7 @@ class Client:
         Revokes an :class:`Invite`, URL, or ID to an invite.
 
         The URL must be a discord.gg URL. e.g. "http://discord.gg/codehere".
--       An ID for the invite is just the "codehere" portion of the invite URL.
+        An ID for the invite is just the "codehere" portion of the invite URL.
 
         Parameters
         ----------

--- a/discord/http.py
+++ b/discord/http.py
@@ -562,9 +562,6 @@ class HTTPClient:
     def invites_from_channel(self, channel_id):
         return self.request(Route('GET', '/channels/{channel_id}/invites', channel_id=channel_id))
 
-    def accept_invite(self, invite_id):
-        return self.request(Route('POST', '/invite/{invite_id}', invite_id=invite_id))
-
     def delete_invite(self, invite_id):
         return self.request(Route('DELETE', '/invite/{invite_id}', invite_id=invite_id))
 


### PR DESCRIPTION
Bot accounts can't accept invites anyway and the endpoint no longer works on user/selfbots.
Also amended `delete_invite` docstring to no longer rely on the invite param explanation in `accept_invite`.