### PR TITLE
Drop code utilizing the now-blacklisted relationships endpoint

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -678,29 +678,6 @@ class HTTPClient:
     def move_member(self, user_id, guild_id, channel_id, *, reason=None):
         return self.edit_member(guild_id=guild_id, user_id=user_id, channel_id=channel_id, reason=reason)
 
-
-    # Relationship related
-
-    def remove_relationship(self, user_id):
-        r = Route('DELETE', '/users/@me/relationships/{user_id}', user_id=user_id)
-        return self.request(r)
-
-    def add_relationship(self, user_id, type=None):
-        r = Route('PUT', '/users/@me/relationships/{user_id}', user_id=user_id)
-        payload = {}
-        if type is not None:
-            payload['type'] = type
-
-        return self.request(r, json=payload)
-
-    def send_friend_request(self, username, discriminator):
-        r = Route('POST', '/users/@me/relationships')
-        payload = {
-            'username': username,
-            'discriminator': int(discriminator)
-        }
-        return self.request(r, json=payload)
-
     # Misc
 
     def application_info(self):

--- a/discord/relationship.py
+++ b/discord/relationship.py
@@ -52,31 +52,3 @@ class Relationship:
     def __repr__(self):
         return '<Relationship user={0.user!r} type={0.type!r}>'.format(self)
 
-    @asyncio.coroutine
-    def delete(self):
-        """|coro|
-
-        Deletes the relationship.
-
-        Raises
-        ------
-        HTTPException
-            Deleting the relationship failed.
-        """
-
-        yield from self._state.http.remove_relationship(self.user.id)
-
-    @asyncio.coroutine
-    def accept(self):
-        """|coro|
-
-        Accepts the relationship request. e.g. accepting a
-        friend request.
-
-        Raises
-        -------
-        HTTPException
-            Accepting the relationship failed.
-        """
-
-        yield from self._state.http.add_relationship(self.user.id)

--- a/discord/user.py
+++ b/discord/user.py
@@ -523,67 +523,6 @@ class User(BaseUser, discord.abc.Messageable):
         return r.type is RelationshipType.blocked
 
     @asyncio.coroutine
-    def block(self):
-        """|coro|
-
-        Blocks the user.
-
-        Raises
-        -------
-        Forbidden
-            Not allowed to block this user.
-        HTTPException
-            Blocking the user failed.
-        """
-
-        yield from self._state.http.add_relationship(self.id, type=RelationshipType.blocked.value)
-
-    @asyncio.coroutine
-    def unblock(self):
-        """|coro|
-
-        Unblocks the user.
-
-        Raises
-        -------
-        Forbidden
-            Not allowed to unblock this user.
-        HTTPException
-            Unblocking the user failed.
-        """
-        yield from self._state.http.remove_relationship(self.id)
-
-    @asyncio.coroutine
-    def remove_friend(self):
-        """|coro|
-
-        Removes the user as a friend.
-
-        Raises
-        -------
-        Forbidden
-            Not allowed to remove this user as a friend.
-        HTTPException
-            Removing the user as a friend failed.
-        """
-        yield from self._state.http.remove_relationship(self.id)
-
-    @asyncio.coroutine
-    def send_friend_request(self):
-        """|coro|
-
-        Sends the user a friend request.
-
-        Raises
-        -------
-        Forbidden
-            Not allowed to send a friend request to the user.
-        HTTPException
-            Sending the friend request failed.
-        """
-        yield from self._state.http.send_friend_request(username=self.name, discriminator=self.discriminator)
-
-    @asyncio.coroutine
     def profile(self):
         """|coro|
 


### PR DESCRIPTION
`/users/@me/relationships` now unverifies user accounts so keeping them in will just confuse users seeing them in the documentation and expecting them to work.