### PR TITLE
Change VerificationLevel, ContentFilter to be IntEnums

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -24,7 +24,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-from enum import Enum
+from enum import Enum, IntEnum
 
 __all__ = ['ChannelType', 'MessageType', 'VoiceRegion', 'VerificationLevel',
            'ContentFilter', 'Status', 'DefaultAvatar', 'RelationshipType',
@@ -69,7 +69,7 @@ class VoiceRegion(Enum):
     def __str__(self):
         return self.value
 
-class VerificationLevel(Enum):
+class VerificationLevel(IntEnum):
     none              = 0
     low               = 1
     medium            = 2
@@ -81,7 +81,7 @@ class VerificationLevel(Enum):
     def __str__(self):
         return self.name
 
-class ContentFilter(Enum):
+class ContentFilter(IntEnum):
     disabled    = 0
     no_role     = 1
     all_members = 2

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -736,6 +736,27 @@ All enumerations are subclasses of `enum`_.
     Specifies a :class:`Guild`\'s verification level, which is the criteria in
     which a member must meet before being able to send messages to the guild.
 
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two verification levels are equal.
+        .. describe:: x != y
+
+            Checks if two verification levels are not equal.
+        .. describe:: x > y
+
+            Checks if a verification level is higher than another.
+        .. describe:: x < y
+
+            Checks if a verification level is lower than another.
+        .. describe:: x >= y
+
+            Checks if a verification level is higher or equal to another.
+        .. describe:: x <= y
+
+            Checks if a verification level is lower or equal to another.
+
     .. attribute:: none
 
         No criteria set.
@@ -767,6 +788,27 @@ All enumerations are subclasses of `enum`_.
     Specifies a :class:`Guild`\'s explicit content filter, which is the machine
     learning algorithms that Discord uses to detect if an image contains
     pornography or otherwise explicit content.
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two content filter levels are equal.
+        .. describe:: x != y
+
+            Checks if two content filter levels are not equal.
+        .. describe:: x > y
+
+            Checks if a content filter level is higher than another.
+        .. describe:: x < y
+
+            Checks if a content filter level is lower than another.
+        .. describe:: x >= y
+
+            Checks if a content filter level is higher or equal to another.
+        .. describe:: x <= y
+
+            Checks if a content filter level is lower or equal to another.
 
     .. attribute:: disabled
 


### PR DESCRIPTION
This allows comparisons like `guild.verification_level >= discord.VerificationLevel.low` and `guild.explicit_content_filter > discord.ContentFilter.disabled` to be done rather than needing to use the `value` attribute.