### PR TITLE
Examples for AsyncIterator, change_presence & some minor changes

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -335,7 +335,6 @@ class GuildChannel:
         - Guild roles
         - Channel overrides
         - Member overrides
-        - Whether the channel is the default channel.
 
         Parameters
         ----------
@@ -764,7 +763,7 @@ class Messageable(metaclass=abc.ABCMeta):
 
         Example Usage: ::
 
-            with channel.typing():
+            async with channel.typing():
                 # do expensive stuff here
                 await channel.send('done!')
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -753,6 +753,11 @@ class Client:
         The game parameter is a Game object (not a string) that represents
         a game being played currently.
 
+        Example: ::
+
+            game = discord.Game(name="with the API")
+            await client.change_presence(status=discord.Status.idle, game=game)
+
         Parameters
         ----------
         game: Optional[:class:`Game`]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1351,12 +1351,6 @@ Certain utilities make working with async iterators easier, detailed below.
 
         Flattens the async iterator into a ``list`` with all the elements.
 
-        Getting the most recent message in a channel: ::
-
-            message_list = await channel.history().flatten()
-
-            last_message = message_list[0]
-
         :return: A list of every element in the async iterator.
         :rtype: list
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1324,8 +1324,8 @@ Certain utilities make working with async iterators easier, detailed below.
 
         Example: ::
 
-            msg = await channel.history().get(author__name='Dave')
             # msg is the last message by a user named 'Dave' or None
+            msg = await channel.history().get(author__name='Dave')
 
     .. comethod:: find(predicate)
 
@@ -1341,8 +1341,8 @@ Certain utilities make working with async iterators easier, detailed below.
             def predicate(event):
                 return event.reason is not None
 
-            event = await guild.audit_logs().find(predicate)
             # event is the last event that had a reason or None
+            event = await guild.audit_logs().find(predicate)
 
         :param predicate: The predicate to use. Can be a coroutine.
         :return: The first element that returns ``True`` for the predicate or ``None``.
@@ -1357,8 +1357,8 @@ Certain utilities make working with async iterators easier, detailed below.
 
             message_list = await channel.history().flatten()
 
-            last_message = message_list[0]
             # last_message is the last message seen in that channel
+            last_message = message_list[0]
 
         :return: A list of every element in the async iterator.
         :rtype: list

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1322,9 +1322,8 @@ Certain utilities make working with async iterators easier, detailed below.
 
         Similar to :func:`utils.get` except run over the async iterator.
 
-        Example: ::
+        Getting the last message by a user named 'Dave' or ``None``: ::
 
-            # msg is the last message by a user named 'Dave' or None
             msg = await channel.history().get(author__name='Dave')
 
     .. comethod:: find(predicate)
@@ -1336,12 +1335,11 @@ Certain utilities make working with async iterators easier, detailed below.
         Unlike :func:`utils.find`\, the predicate provided can be a
         coroutine.
 
-        Example: ::
+        Getting the last audit log with a reason or ``None``: ::
 
             def predicate(event):
                 return event.reason is not None
 
-            # event is the last event that had a reason or None
             event = await guild.audit_logs().find(predicate)
 
         :param predicate: The predicate to use. Can be a coroutine.
@@ -1353,11 +1351,10 @@ Certain utilities make working with async iterators easier, detailed below.
 
         Flattens the async iterator into a ``list`` with all the elements.
 
-        Example: ::
+        Getting the most recent message in a channel: ::
 
             message_list = await channel.history().flatten()
 
-            # last_message is the last message seen in that channel
             last_message = message_list[0]
 
         :return: A list of every element in the async iterator.
@@ -1370,13 +1367,13 @@ Certain utilities make working with async iterators easier, detailed below.
         every element it is iterating over. This function can either be a
         regular function or a coroutine.
 
-        Example: ::
+        Creating a content iterator: ::
 
             def transform(message):
-                return message.clean_content
+                return message.content
 
-            async for elem in channel.history().map(transform):
-                # elem is the clean_content of the message
+            async for content in channel.history().map(transform):
+                message_length = len(content)
 
         :param func: The function to call on every element. Could be a coroutine.
         :return: An async iterator.
@@ -1387,13 +1384,13 @@ Certain utilities make working with async iterators easier, detailed below.
         :class:`AsyncIterator` is returned that filters over the original
         async iterator. This predicate can be a regular function or a coroutine.
 
-        Example: ::
+        Getting messages by non-bot accounts: ::
 
             def predicate(message):
                 return not message.author.bot
 
             async for elem in channel.history().filter(predicate):
-                # elem will never be a message from a bot account
+                ...
 
         :param predicate: The predicate to call on every element. Could be a coroutine.
         :return: An async iterator.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1322,6 +1322,11 @@ Certain utilities make working with async iterators easier, detailed below.
 
         Similar to :func:`utils.get` except run over the async iterator.
 
+        Example: ::
+
+            msg = await channel.history().get(author__name='Dave')
+            # msg is the last message by a user named 'Dave' or None
+
     .. comethod:: find(predicate)
 
         |coro|
@@ -1331,6 +1336,14 @@ Certain utilities make working with async iterators easier, detailed below.
         Unlike :func:`utils.find`\, the predicate provided can be a
         coroutine.
 
+        Example: ::
+
+            def predicate(event):
+                return event.reason is not None
+
+            event = await guild.audit_logs().find(predicate)
+            # event is the last event that had a reason or None
+
         :param predicate: The predicate to use. Can be a coroutine.
         :return: The first element that returns ``True`` for the predicate or ``None``.
 
@@ -1339,6 +1352,13 @@ Certain utilities make working with async iterators easier, detailed below.
         |coro|
 
         Flattens the async iterator into a ``list`` with all the elements.
+
+        Example: ::
+
+            message_list = await channel.history().flatten()
+
+            last_message = message_list[0]
+            # last_message is the last message seen in that channel
 
         :return: A list of every element in the async iterator.
         :rtype: list
@@ -1350,6 +1370,14 @@ Certain utilities make working with async iterators easier, detailed below.
         every element it is iterating over. This function can either be a
         regular function or a coroutine.
 
+        Example: ::
+
+            def transform(message):
+                return message.clean_content
+
+            async for elem in channel.history().map(transform):
+                # elem is the clean_content of the message
+
         :param func: The function to call on every element. Could be a coroutine.
         :return: An async iterator.
 
@@ -1358,6 +1386,14 @@ Certain utilities make working with async iterators easier, detailed below.
         This is similar to the built-in ``filter`` function. Another
         :class:`AsyncIterator` is returned that filters over the original
         async iterator. This predicate can be a regular function or a coroutine.
+
+        Example: ::
+
+            def predicate(message):
+                return not message.author.bot
+
+            async for elem in channel.history().filter(predicate):
+                # elem will never be a message from a bot account
 
         :param predicate: The predicate to call on every element. Could be a coroutine.
         :return: An async iterator.


### PR DESCRIPTION
Examples as in title, changing example on `typing()` to use the more desirable `async with` and removing a mention of dropped default guild channel