### PR TITLE
Disallow setting non-permission attributes

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -530,7 +530,7 @@ class PermissionOverwrite:
     """
 
     def __init__(self, **kwargs):
-        super().__setattr__('_values', {})
+        self.__dict__['_values'] = {}
 
         for key, value in kwargs.items():
             setattr(self, key, value)

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -533,14 +533,11 @@ class PermissionOverwrite:
         super().__setattr__('_values', {})
 
         for key, value in kwargs.items():
-            if key not in self.VALID_NAMES:
-                raise ValueError('no permission called {0}.'.format(key))
-
             setattr(self, key, value)
 
     def __setattr__(self, name, value):
         if name not in self.VALID_NAMES:
-            raise ValueError('{} is not a valid permission.'.format(name))
+            raise ValueError('no permission called {0}'.format(name))
         super().__setattr__(name, value)
 
     def _set(self, key, value):

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -530,7 +530,7 @@ class PermissionOverwrite:
     """
 
     def __init__(self, **kwargs):
-        self._values = {}
+        super().__setattr__('_values', {})
 
         for key, value in kwargs.items():
             if key not in self.VALID_NAMES:

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -538,6 +538,11 @@ class PermissionOverwrite:
 
             setattr(self, key, value)
 
+    def __setattr__(self, name, value):
+        if name not in self.VALID_NAMES:
+            raise ValueError('{} is not a valid permission.'.format(name))
+        super().__setattr__(name, value)
+
     def _set(self, key, value):
         if value not in (True, None, False):
             raise TypeError('Expected bool or NoneType, received {0.__class__.__name__}'.format(value))


### PR DESCRIPTION
This will avoid issues where someone makes a mistake typing the name of a permission, or thinks the name is something else.