### PR TITLE
Remove GuildChannel.is_default

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -254,10 +254,6 @@ class GuildChannel:
             ret.append(role)
         return ret
 
-    def is_default(self):
-        """bool : Indicates if this is the default channel for the :class:`Guild` it belongs to."""
-        return self.guild.id == self.id
-
     @property
     def mention(self):
         """str : The string that allows you to mention the channel."""
@@ -335,7 +331,6 @@ class GuildChannel:
         - Guild roles
         - Channel overrides
         - Member overrides
-        - Whether the channel is the default channel.
 
         Parameters
         ----------
@@ -357,9 +352,7 @@ class GuildChannel:
         # have to take into effect.
         # After all that is done.. you have to do the following:
 
-        # If manage permissions is True, then all permissions are set to
-        # True. If the channel is the default channel then everyone gets
-        # read permissions regardless.
+        # If manage permissions is True, then all permissions are set to True.
 
         # The operation first takes into consideration the denied
         # and then the allowed.
@@ -408,10 +401,6 @@ class GuildChannel:
             if overwrite.type == 'member' and overwrite.id == member.id:
                 base.handle_overwrite(allow=overwrite.allow, deny=overwrite.deny)
                 break
-
-        # default channels can always be read
-        if self.is_default():
-            base.read_messages = True
 
         # if you can't send a message in a channel then you can't have certain
         # permissions as well

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -207,7 +207,6 @@ In order to be a bit more consistent, certain things that were properties were c
 
 The following are now methods instead of properties (requires parentheses):
 
-- :meth:`TextChannel.is_default`
 - :meth:`Role.is_default`
 - :meth:`Client.is_ready`
 - :meth:`Client.is_closed`
@@ -337,7 +336,7 @@ They will be enumerated here.
 
     - There is no replacement for this one. This functionality is deprecated API wise.
 
-- ``Guild.default_channel`` / ``Server.default_channel``
+- ``Guild.default_channel`` / ``Server.default_channel`` and ``Channel.is_default``
 
     - The concept of a default channel was removed from Discord.
       See `#329 <https://github.com/hammerandchisel/discord-api-docs/pull/329>`_.


### PR DESCRIPTION
To keep consistent with the previous default channel removals.

I wasn't sure how to document this in `migrating.rst` because it was originally in the `Channel` class, now it was in `GuildChannel`, but elsewhere it is documented as part of `TextChannel`:

```
The following are now methods instead of properties (requires parentheses):

- :meth:`TextChannel.is_default`
- :meth:`Role.is_default`
- :meth:`Client.is_ready`
- :meth:`Client.is_closed`
```