### PR TITLE
Fix the proxy support for aiohttp>=1.4.

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -80,8 +80,11 @@ class Client:
         The `event loop`_ to use for asynchronous operations. Defaults to ``None``,
         in which case the default event loop is used via ``asyncio.get_event_loop()``.
     connector : aiohttp.BaseConnector
-        The `connector`_ to use for connection pooling. Useful for proxies, e.g.
-        with a `ProxyConnector`_.
+        The `connector`_ to use for connection pooling.
+    proxy : Optional[str]
+        Proxy URL.
+    proxy_auth : Optional[aiohttp.BasicAuth]
+        An object that represents proxy HTTP Basic Authorization.
     shard_id : Optional[int]
         Integer starting at 0 and less than shard_count.
     shard_count : Optional[int]
@@ -116,7 +119,9 @@ class Client:
         self.shard_count = options.get('shard_count')
 
         connector = options.pop('connector', None)
-        self.http = HTTPClient(connector, loop=self.loop)
+        proxy = options.pop('proxy', None)
+        proxy_auth = options.pop('proxy_auth', None)
+        self.http = HTTPClient(connector, proxy=proxy, proxy_auth=proxy_auth, loop=self.loop)
 
         self._connection = ConnectionState(dispatch=self.dispatch, chunker=self._chunker,
                                            syncer=self._syncer, http=self.http, loop=self.loop, **options)

--- a/discord/http.py
+++ b/discord/http.py
@@ -88,7 +88,7 @@ class HTTPClient:
     SUCCESS_LOG = '{method} {url} has received {text}'
     REQUEST_LOG = '{method} {url} with {json} has returned {status}'
 
-    def __init__(self, connector=None, *, loop=None):
+    def __init__(self, connector=None, *, proxy=None, proxy_auth=None, loop=None):
         self.loop = asyncio.get_event_loop() if loop is None else loop
         self.connector = connector
         self._session = aiohttp.ClientSession(connector=connector, loop=self.loop)
@@ -97,6 +97,8 @@ class HTTPClient:
         self._global_over.set()
         self.token = None
         self.bot_token = False
+        self.proxy = proxy
+        self.proxy_auth = proxy_auth
 
         user_agent = 'DiscordBot (https://github.com/Rapptz/discord.py {0}) Python/{1[0]}.{1[1]} aiohttp/{2}'
         self.user_agent = user_agent.format(__version__, sys.version_info, aiohttp.__version__)
@@ -134,6 +136,12 @@ class HTTPClient:
                 headers['X-Audit-Log-Reason'] = _uriquote(reason, safe='/ ')
 
         kwargs['headers'] = headers
+
+        # Proxy support
+        if self.proxy is not None:
+            kwargs['proxy'] = self.proxy
+        if self.proxy_auth is not None:
+            kwargs['proxy_auth'] = self.proxy_auth
 
         if not self._global_over.is_set():
             # wait until the global lock is complete


### PR DESCRIPTION
Since aiohttp 1.4 (issue 1609), `aiohttp.ProxyConnector` has been dropped. This re-enables the proxy support by using the parameters of `ClientSession.request`