### PR TITLE
Add voice receive capabilities.

### DIFF
--- a/discord/errors.py
+++ b/discord/errors.py
@@ -164,3 +164,9 @@ class ConnectionClosed(ClientException):
         self.reason = original.reason
         self.shard_id = shard_id
         super().__init__(str(original))
+
+class InvalidVoicePacket(DiscordException):
+    """Exception that's thrown when a raw UDP packet cannot be parsed
+    as a valid :class:`VoicePacket`.
+    """
+    pass

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -553,6 +553,7 @@ class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
         super().__init__(*args, **kwargs)
         self.max_size = None
         self._keep_alive = None
+        self._dispatch = lambda *args: None
 
     @asyncio.coroutine
     def send_as_json(self, data):
@@ -595,6 +596,7 @@ class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
         ws.gateway = gateway
         ws._connection = client
         ws._max_heartbeat_timeout = 60.0
+        ws._dispatch = client._state.dispatch
 
         if resume:
             yield from ws.resume()
@@ -649,6 +651,22 @@ class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
             yield from self.identify()
         elif op == self.SESSION_DESCRIPTION:
             yield from self.load_secret_key(data)
+        elif op == self.SPEAKING:
+            user_id = int(data['user_id'])
+            ssrc = int(data['ssrc'])
+
+            if 'speaking' in data:
+                user = self._connection._state.get_user(user_id)
+
+                self._dispatch('voice_speaking_state', self._connection, user, data['speaking'])
+
+                # Used for continuous streams
+                for f in self._connection._speaking_listeners:
+                    f(user, data['speaking'])
+
+                if self._connection.channel.id not in self._connection._ssrc_lookup:
+                    self._connection._ssrc_lookup[self._connection.channel.id] = {}
+                self._connection._ssrc_lookup[self._connection.channel.id][ssrc] = user_id
 
     @asyncio.coroutine
     def initial_connection(self, data):
@@ -695,5 +713,3 @@ class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
             self._keep_alive.stop()
 
         yield from super().close_connection(force=force)
-
-

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -661,12 +661,14 @@ class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
                 self._dispatch('voice_speaking_state', self._connection, user, data['speaking'])
 
                 # Used for continuous streams
-                for f in self._connection._speaking_listeners:
-                    f(user, data['speaking'])
+                for uid in self._connection._speaking_listeners:
+                    if uid == user_id:
+                        for f in self._connection._speaking_listeners[uid]:
+                            f(user, data['speaking'])
 
                 if self._connection.channel.id not in self._connection._ssrc_lookup:
-                    self._connection._ssrc_lookup[self._connection.channel.id] = {}
-                self._connection._ssrc_lookup[self._connection.channel.id][ssrc] = user_id
+                    self._connection._ssrc_lookup[self._connection.guild.id] = {}
+                self._connection._ssrc_lookup[self._connection.guild.id][ssrc] = user_id
 
     @asyncio.coroutine
     def initial_connection(self, data):

--- a/discord/opus.py
+++ b/discord/opus.py
@@ -36,11 +36,17 @@ log = logging.getLogger(__name__)
 c_int_ptr = ctypes.POINTER(ctypes.c_int)
 c_int16_ptr = ctypes.POINTER(ctypes.c_int16)
 c_float_ptr = ctypes.POINTER(ctypes.c_float)
+c_ubyte_ptr = ctypes.POINTER(ctypes.c_ubyte)
 
 class EncoderStruct(ctypes.Structure):
     pass
 
+class DecoderStruct(ctypes.Structure):
+    pass
+
 EncoderStructPtr = ctypes.POINTER(EncoderStruct)
+
+DecoderStructPtr = ctypes.POINTER(DecoderStruct)
 
 # A list of exported functions.
 # The first argument is obviously the name.
@@ -52,7 +58,18 @@ exported_functions = [
     ('opus_encoder_create', [ctypes.c_int, ctypes.c_int, ctypes.c_int, c_int_ptr], EncoderStructPtr),
     ('opus_encode', [EncoderStructPtr, c_int16_ptr, ctypes.c_int, ctypes.c_char_p, ctypes.c_int32], ctypes.c_int32),
     ('opus_encoder_ctl', None, ctypes.c_int32),
-    ('opus_encoder_destroy', [EncoderStructPtr], None)
+    ('opus_encoder_destroy', [EncoderStructPtr], None),
+
+    ('opus_decoder_get_size', [ctypes.c_int], ctypes.c_int),
+    ('opus_decoder_create', [ctypes.c_int, ctypes.c_int, c_int_ptr], DecoderStructPtr),
+    ('opus_packet_get_bandwidth', [ctypes.c_char_p], ctypes.c_int),
+    ('opus_packet_get_nb_channels', [ctypes.c_char_p], ctypes.c_int),
+    ('opus_packet_get_nb_frames', [ctypes.c_char_p, ctypes.c_int], ctypes.c_int),
+    ('opus_packet_get_samples_per_frame', [ctypes.c_char_p, ctypes.c_int], ctypes.c_int),
+    ('opus_decoder_get_nb_samples', [DecoderStructPtr, ctypes.c_char_p, ctypes.c_int32], ctypes.c_int),
+    ('opus_decode', [DecoderStructPtr, ctypes.c_char_p, ctypes.c_int32, c_int16_ptr, ctypes.c_int, ctypes.c_int], ctypes.c_int),
+    ('opus_decode_float', [DecoderStructPtr, ctypes.c_char_p, ctypes.c_int32, c_float_ptr, ctypes.c_int, ctypes.c_int], ctypes.c_int),
+    ('opus_decoder_destroy', [DecoderStructPtr], None)
 ]
 
 def libopus_loader(name):
@@ -146,10 +163,11 @@ class OpusError(DiscordException):
         The error code returned.
     """
 
-    def __init__(self, code):
+    def __init__(self, code, verbose=True):
         self.code = code
         msg = _lib.opus_strerror(self.code).decode('utf-8')
-        log.info('"%s" has happened', msg)
+        if verbose:
+            log.info('"%s" has happened', msg)
         super().__init__(msg)
 
 class OpusNotLoaded(DiscordException):
@@ -276,3 +294,93 @@ class Encoder:
             raise OpusError(ret)
 
         return array.array('b', data[:ret]).tobytes()
+
+class Decoder:
+    def __init__(self, sampling=48000, channels=2):
+        self.sampling_rate = sampling
+        self.channels = channels
+
+        self._state = self._create_state()
+
+    def __del__(self):
+        if hasattr(self, '_state'):
+            _lib.opus_decoder_destroy(self._state)
+            self._state = None
+
+    def _create_state(self):
+        ret = ctypes.c_int()
+        result = _lib.opus_decoder_create(self.sampling_rate, self.channels, ctypes.byref(ret))
+
+        if ret.value != 0:
+            log.info('error has happened in decoder state creation')
+            raise OpusError(ret.value)
+
+        return result
+
+    @classmethod
+    def _packet_get_nb_frames(cls, data):
+        """Gets the number of frames in an Opus packet"""
+        result = _lib.opus_packet_get_nb_frames(data, len(data))
+        if result < 0:
+            log.info('error has happened in packet_get_nb_frames')
+            raise OpusError(result)
+
+        return result
+
+    @classmethod
+    def _packet_get_nb_channels(cls, data):
+        """Gets the number of channels in an Opus packet"""
+        result = _lib.opus_packet_get_nb_channels(data)
+        if result < 0:
+            log.info('error has happened in packet_get_nb_channels')
+            raise OpusError(result)
+
+        return result
+
+    def _packet_get_samples_per_frame(self, data):
+        """Gets the number of samples per frame from an Opus packet"""
+        result = _lib.opus_packet_get_samples_per_frame(data, self.sampling_rate)
+        if result < 0:
+            log.info('error has happened in packet_get_samples_per_frame')
+            raise OpusError(result)
+
+        return result
+
+    def _decode(self, data, frame_size, decode_fec, decode_func, decode_ctype, arr_type):
+        if frame_size is None:
+            frames = self._packet_get_nb_frames(data)
+            samples_per_frame = self._packet_get_samples_per_frame(data)
+            # note: channels could be different from self.channels
+            # this doesn't actually get used in frame_size, but we get
+            # the value for debugging
+            channels = self._packet_get_nb_channels(data)
+            frame_size = frames * samples_per_frame
+            log.debug('detected frame_size {} ({} frames, {} samples per frame, {} channels)'.format(frame_size, frames, samples_per_frame, channels))
+
+        # note: python-opus also multiplies this value by
+        # ctypes.sizeof(decode_ctype) but that appears to be wrong
+        pcm_size = frame_size * self.channels
+        pcm = (decode_ctype * pcm_size)()
+        pcm_ptr = ctypes.cast(pcm, ctypes.POINTER(decode_ctype))
+
+        decode_fec = int(bool(decode_fec))
+
+        result = decode_func(self._state, data, len(data), pcm_ptr, frame_size, decode_fec)
+        if result < 0:
+            log.debug('error happened in decode')
+            raise OpusError(result, verbose=False)
+
+        # note: I'm not sure exactly how to interpret result. It appears to be
+        # the number of samples decoded, but if the packet was only 1 channel
+        # and the decoder was created with 2 channels, the actual output
+        # appears to be 2 * result samples (same audio on each channel).
+        # Regardless, the way we've created the pcm buffer, it should be
+        # completely filled.
+        log.debug('opus decode result: {} (total buf size: {})'.format(result, len(pcm)))
+        return array.array(arr_type, pcm).tobytes()
+
+    def decode(self, data, frame_size=None, decode_fec=False):
+        return self._decode(data, frame_size, decode_fec, _lib.opus_decode, ctypes.c_int16, 'h')
+
+    def decode_float(self, data, frame_size=None, decode_fec=False):
+        return self._decode(data, frame_size, decode_fec, _lib.opus_decode_float, ctypes.c_float, 'f')

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -44,6 +44,8 @@ import socket
 import logging
 import struct
 import threading
+import heapq
+import time
 
 log = logging.getLogger(__name__)
 
@@ -56,8 +58,88 @@ except ImportError:
 from . import opus
 from .backoff import ExponentialBackoff
 from .gateway import *
-from .errors import ClientException, ConnectionClosed
+from .errors import ClientException, ConnectionClosed,  InvalidVoicePacket
 from .player import AudioPlayer, AudioSource
+
+class VoicePacket:
+    """Represents a packet of voice data.
+
+    You should not construct these yourself, they will be constructed from
+    incoming UDP packets on the socket used for voice data.
+
+    Attributes
+    ----------
+    sequence : int
+        The sequence id for the packet. Must be between 0 and 65535. Each
+        packet has a value of 1 greater than the previous packet from the
+        same source. After the sequence reaches the maximum value (65535),
+        the next packet has a sequence value of 0.
+    timestamp : int
+        The timestamp for the packet.
+    ssrc : int
+        The id of the user (or source) of this voice packet.
+    buff : bytes
+        The Opus packet (as bytes).
+    user : Optional[:class:`abc.User`]
+        The user who the packet belongs to
+    pcm : Optional[bytes]
+        The decoded PCM data.
+    """
+    # Struct format of the packet metadata
+    _FORMAT = '>HHII'
+    # Packets should start with b'\x80\x78' (32888 as a big endian ushort)
+    _CHECK = 32888
+    # Some packets will start with b'\x90\x78' (36984)
+    _CHECK2 = 36984
+
+    def __init__(self, sequence=None, timestamp=None, ssrc=None, buff=None, user=None):
+        self.sequence = sequence
+        self.timestamp = timestamp
+        self.ssrc = ssrc
+        self.buff = buff
+        self.user = user
+
+    @classmethod
+    def unpack(cls, packet, voice_client):
+        if len(packet) < 13:
+            raise InvalidVoicePacket('packet is too small: {}'.format(packet))
+
+        # Unpack header
+        check, seq, ts, ssrc = struct.unpack_from(cls._FORMAT, packet)
+        header = packet[:12]
+        buff = packet[12:]
+
+        # Check the packet is valid
+        if check != cls._CHECK and check != cls._CHECK2:
+            fmt = 'packet has invalid check bytes: {}'
+            raise InvalidVoicePacket(fmt.format(packet))
+
+        # Decrypt data
+        nonce = bytearray(24)
+        nonce[:12] = header
+        box = nacl.secret.SecretBox(bytes(voice_client.secret_key))
+        buff = box.decrypt(bytes(buff), bytes(nonce))
+
+        # Packets starting with b'\x90' need the first 8 bytes ignored
+        if check == cls._CHECK2:
+            buff = buff[8:]
+
+        # Lookup the SSRC and then get the user
+        user_id = 0
+        if voice_client.channel.id in voice_client._ssrc_lookup:
+            if ssrc in voice_client._ssrc_lookup[voice_client.channel.id]:
+                user_id = int(voice_client._ssrc_lookup[voice_client.channel.id][ssrc])
+        user = voice_client._state.get_user(user_id)
+
+        # Create a `VoicePacket` instance and return it.
+        return cls(seq, ts, ssrc, buff, user)
+
+    def __str__(self):
+        fmt = '<VoicePacket sequence={0.sequence}, timestamp={0.timestamp}, ssrc={0.ssrc}, buff=bytes({1})>'
+        return fmt.format(self, len(self.buff))
+
+    def __repr__(self):
+        return str(self)
 
 class VoiceClient:
     """Represents a Discord voice connection.
@@ -67,11 +149,11 @@ class VoiceClient:
 
     Warning
     --------
-    In order to play audio, you must have loaded the opus library
-    through :func:`opus.load_opus`.
+    In order to play or receive audio, you must have loaded the opus
+    library through :func:`opus.load_opus`.
 
     If you don't do this then the library will not be able to
-    transmit audio.
+    transmit or receive audio.
 
     Attributes
     -----------
@@ -107,6 +189,12 @@ class VoiceClient:
         self._runner = None
         self._player = None
         self.encoder = opus.Encoder()
+        self.decoders = {}
+        self._ssrc_lookup = {}
+        self._voice_receiver = None
+
+        self._pcm_listeners = []
+        self._speaking_listeners = []
 
     warn_nacl = not has_nacl
 
@@ -212,6 +300,11 @@ class VoiceClient:
             while not hasattr(self, 'secret_key'):
                 yield from self.ws.poll_event()
             self._connected.set()
+
+            self._voice_receiver = self.loop.create_task(self._voice_receive_loop())
+            #receive_thread = threading.Thread(target=self._voice_receive_loop)
+            #receive_thread.deamon = True
+            #receive_thread.start()
         except (ConnectionClosed, asyncio.TimeoutError):
             if reconnect and _tries < 5:
                 log.exception('Failed to connect to voice... Retrying...')
@@ -262,6 +355,13 @@ class VoiceClient:
             return
 
         self.stop()
+
+        if self._voice_receiver is not None:
+            self._voice_receiver.cancel()
+            self._voice_receiver = None
+        self.decoders.clear()
+        self._pcm_listeners = []
+
         self._connected.clear()
 
         try:
@@ -293,23 +393,180 @@ class VoiceClient:
 
     # audio related
 
-    def _get_voice_packet(self, data):
-        header = bytearray(12)
-        nonce = bytearray(24)
-        box = nacl.secret.SecretBox(bytes(self.secret_key))
+    @asyncio.coroutine
+    def get_voice_data(self, user, timeout=0.4):
+        """|coro|
 
-        # Formulate header
-        header[0] = 0x80
-        header[1] = 0x78
-        struct.pack_into('>H', header, 2, self.sequence)
-        struct.pack_into('>I', header, 4, self.timestamp)
-        struct.pack_into('>I', header, 8, self.ssrc)
+        Receive voice data from a user until they are silent for
+        `timeout` s.
 
-        # Copy header to nonce's first 12 bytes
-        nonce[:12] = header
+        Parameters
+        -----------
+        user: :class:`abc.User`
+            The user to listen for audio from.
+        timeout: Optional[float]
+            The time in ms of silence after which to stop listening.
 
-        # Encrypt and return the data
-        return header + box.encrypt(bytes(data), bytes(nonce)).ciphertext
+        Returns
+        -----------
+        `bytearray`
+            The received voice data from the user.
+
+        Note
+        -----------
+        The returned data is stereo 48kHz audio in raw PCM. You will have to
+        add your own headers if you want to save it as a `.wav` file.
+        """
+        buffer = []
+        last_packet = 0
+        user_id = user.id
+
+        def listener(vc, vp):
+            nonlocal buffer, user_id, last_packet
+            if user_id == (None if vp.user is None else vp.user.id):
+                last_packet = time.time()
+                heapq.heappush(buffer, (vp.timestamp, vp))
+
+        self._pcm_listeners.append(listener)
+
+        while time.time() - last_packet < timeout or last_packet == 0:
+            yield from asyncio.sleep(0.1)  # Continue to fill up the buffer.
+        self._pcm_listeners.remove(listener)
+
+        buffer.sort()
+        data = bytearray()
+        current_timestamp = 0
+        for key, value in buffer:
+            if current_timestamp == 0:
+                delta = 0
+            else:
+                delta = (key - current_timestamp) - 960
+                delta = max(delta, 0)  # Just to be safe
+
+            padding = bytearray([0] * delta * 4)
+            data += padding
+            data += value.pcm
+
+            current_timestamp = key
+
+        return data
+
+    @asyncio.coroutine
+    def pipe_voice_into_file(self, user, file_object, buffer_size=0.2):
+        """|coro|
+
+        Constantly receive data from a user and pipe it into a file-like
+        object. Packets will be reordered and any silence or missed packets
+        will be accounted for.
+
+        Parameters
+        -----------
+        user: :class:`abc.User`
+            The user to listen for audio from.
+        file_object: File-like
+            The file-like object to pipe the voice data into. This object just
+            has to have a `.write` method that takes bytes.
+        buffer_size: Optional[float]
+            The number of seconds to bufffer the audio for before writing to
+            the `file_object`. The larger this value, the less likely you are
+            to miss a packet, but the longer you have to wait before the data
+            is in the `file_object`.
+
+        Note
+        -----------
+        This function, although a co-routine, is not blocking.
+
+        Note
+        -----------
+        The returned data is stereo 48kHz audio in raw PCM. You will have to
+        add your own headers if you want to save it as a `.wav` file.
+        """
+
+        # Convert buffer_size from seconds to packets.
+        buffer_size = int(round((buffer_size * 1000) / 20))
+
+        SAMPLE_RATE = 48000
+        SAMPLE_SIZE = 2
+
+        last_packet = 0
+        user_id = user.id
+        voice_buffer = []
+        last_speaking = 0
+
+        def listener(vc, vp):
+            nonlocal voice_buffer, user_id, last_packet
+            if user_id == (None if vp.user is None else vp.user.id):
+                last_packet = vp.timestamp
+                heapq.heappush(voice_buffer, (vp.timestamp, vp))
+
+                if len(voice_buffer) > buffer_size:
+                    packet = heapq.heappop(voice_buffer)[1]
+
+                    if last_packet == 0:
+                        delta = 0
+                    else:
+                        delta = (packet.timestamp - last_packet) - 960
+
+                    if delta > 0:  # Ignore skipped packets
+                        data = bytearray([0] * delta * 4)
+                        data += packet.pcm
+
+                        file_object.write(data)
+
+                        last_packet = packet.timestamp
+
+        def speaking_listener(user, speaking):
+            nonlocal last_speaking, user_id
+            if user.id == user_id:
+                if speaking:
+                    if last_speaking != 0:
+                        delta = time.time() - last_speaking
+                        padding = bytearray([0] * int(delta * SAMPLE_RATE) * SAMPLE_SIZE)
+                        file_object.write(padding)
+
+                        last_speaking = 0
+                else:
+                    last_speaking = time.time()
+
+        self._pcm_listeners.append(listener)
+        self._speaking_listeners.append(speaking_listener)
+
+    @asyncio.coroutine
+    def _voice_receive_loop(self):
+        """
+        Listener loop.
+        This loop will receive data from `self.socket` then it will create a
+        `VoicePckaet` object that handles the decryption and decoding then
+        dispatch two client events so the user can tap into the data.
+        """
+
+        try:
+            while self.is_connected():
+                packet = yield from self.loop.sock_recv(self.socket, 65536)
+                log.debug('Received Voice Packet of {} bytes'.format(len(packet)))
+
+                vp = VoicePacket.unpack(packet, self)
+                log.debug('Decoded Voice Packet: {}'.format(vp))
+
+                if vp.ssrc not in self.decoders:
+                    self.decoders[vp.ssrc] = opus.Decoder()
+
+                # Dispatch event
+                self._state.dispatch('receive_opus', self, vp)
+
+                # TODO: re-order packets
+
+                pcm = self.decoders[vp.ssrc].decode(vp.buff)
+                log.debug('Opus decoded {} bytes of pcm data'.format(len(pcm)))
+
+                vp.pcm = pcm
+                self._state.dispatch('receive_pcm', self, vp)
+
+                # Send PCM data to `get_voice_data`(s):
+                for f in self._pcm_listeners:
+                    f(self, vp)
+        except asyncio.CancelledError:
+            pass
 
     def play(self, source, *, after=None):
         """Plays an :class:`AudioSource`.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -541,6 +541,34 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param before: The previous relationship status.
     :param after: The updated relationship status.
 
+.. function:: on_receive_opus(voice_client, voice_packet)
+
+    Called before decoding the audio when a user speaks in a voice channel that
+    you are connected to.
+    
+    :param voice_client: The :class:`VoiceClient` relating to the channel the
+                         user is talking in.
+    :param voice_packet: The :class:`VoicePacket` containing the raw opus data.
+
+.. function:: on_receive_pcm(voice_client, voice_packet)
+
+    Called when a user speaks in a voice channel that you are connected to.
+    
+    :param voice_client: The :class:`VoiceClient` relating to the channel the
+                         user is talking in.
+    :param voice_packet: The :class:`VoicePacket` containing the decoded PCM
+                         data in a sterio, 48kHz, signed, 16 bit format.
+
+.. function:: on_voice_speaking_state(voice_client, user, speaking)
+
+    Called when a user starts or stops speaking in a voice channel that you are
+    connected to.
+
+    :param voice_client: The :class:`VoiceClient` relating to the channel the
+                         user is in.
+    :param user: The :class:`User` who has started or stopped speaking.
+    :param speaking: A `bool` representing if the user is now speaking or not.
+
 .. _discord-api-utils:
 
 Utility Functions

--- a/examples/basic_voice_receive.py
+++ b/examples/basic_voice_receive.py
@@ -1,0 +1,40 @@
+import asyncio
+
+import discord
+
+from discord.ext import commands
+
+# The user to record audio from
+TARGET_USER_ID = 161508165672763392
+
+class Recorder:
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command()
+    async def die(self, ctx):
+        await self.bot.logout()
+
+    @commands.command()
+    async def join(self, ctx, *, channel: discord.VoiceChannel):
+        """Joins a voice channel"""
+
+        if ctx.voice_client is not None:
+            return await ctx.voice_client.move_to(channel)
+
+        voice_client = await channel.connect()
+        
+        target = bot.get_user(TARGET_USER_ID)
+        file_ = open('audio.pcm', 'wb')
+        await voice_client.pipe_voice_into_file(target, file_)
+
+bot = commands.Bot(command_prefix=commands.when_mentioned_or("!"),
+                   description='Record audio from a voice channel.')
+
+@bot.event
+async def on_ready():
+    print('Logged in as {0.id}/{0}'.format(bot.user))
+    print('------')
+
+bot.add_cog(Recorder(bot))
+bot.run('token')


### PR DESCRIPTION
The API is as follows:

1. Create your `VoiceClient` object (usually from a `.connect()`)
2. Register your voice events using `@client.event` or `@bot.event` (see the documentation for the individual events)
3. That's it. The voice data or user speaking events will be sent to those callbacks.

You can also use `await voice_client.get_voice_data` to listen for audio from a user, then return it all once the user stops talking. This has the added side effect of reordering all the packets for you before compiling them into a `bytearray` object and returning it for you.

If you're _really_ lazy, you can do `await voice_client.pipe_voice_into_file` which will listen to a user and pip all of their voice data into a file-like object for you all reordered and accounting for missed packets and silence.

See `examples/basic_voice_receive.py` to have a look at what it might look like in reality.