### PR TITLE
Add __eq__ to Message

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -185,6 +185,11 @@ class Message:
         self.reactions = [Reaction(message=self, data=d) for d in data.get('reactions', [])]
         self._update(channel, data)
 
+    def __eq__(self, other):
+        if not isinstance(other, Message):
+            return NotImplemented
+        return self.id == other.id
+
     def __repr__(self):
         return '<Message id={0.id} pinned={0.pinned} author={0.author!r}>'.format(self)
 


### PR DESCRIPTION
This makes it more intuitive to compare ```Message``` objects, which you may want to do when, for example, waiting for a reaction, or a message edit.