### PR TITLE
Changed discord.Client.event to debug log success instead of info log.

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -773,7 +773,7 @@ class Client:
             raise ClientException('event registered must be a coroutine function')
 
         setattr(self, coro.__name__, coro)
-        log.info('%s has successfully been registered as an event', coro.__name__)
+        log.debug('%s has successfully been registered as an event', coro.__name__)
         return coro
 
     def async_event(self, coro):


### PR DESCRIPTION
I am proposing a change to the chosen verbosity of logging this message when registering an event:

https://github.com/Rapptz/discord.py/blob/54f2c71e71f20bdc18231eed2083f1464b499764/discord/client.py#L776

changing it to

```python
log.debug('%s has successfully been registered as an event', coro.__name__)
```

The simple reason for this is that, when subscribing to a large number of events, and having verbosity set to `INFO`, it can lead to a large number of messages being output to the console. Whilst this may be of interest to the developer, taking into account the bot being packaged as a finished product and a user using it, I do not believe this message can be of any real use or importance to the user running the bot. 

![image](https://user-images.githubusercontent.com/30690359/30773033-02440b6a-a060-11e7-8d7b-d98adc37a964.png)

If this was changed to DEBUG, then the information could still be obtained when required.

## Why do I think this is an issue?

The INFO verbosity is meant to be used for information of interest, but not information regarding the specifics of the underlying workings necessarily. A large amount of output just makes other information unreadable or difficult to find in logs, and for the sake of changing five characters in the source, it would be a benefit.

## Other possible work arounds

The developer could, if registering events in bulk, check the verbosity of the `discord` logger, and if the verbosity is set to INFO, temporarily change the verbosity to WARNING before switching it back to INFO afterwards.

*However* the issue with this is that, if any other messages are logged under `INFO` in the mean time, we will end up discarding them.

The other potential work around that ~~I have not tested, but~~ has been suggested would be to use filters, however, for the sake of this, it would be easier to just change it here. My question is that "should adding filters be necessary to begin with?"

(Edit) I have tested adding a filter, and yes, this does appear to be a work around:

```python
import logging
...
    discordpy_logger = logging.getLogger('discord.client')
    discordpy_logger.addFilter(lambda rec: rec.levelno != logging.INFO or
                               'has successfully been registered as an event' not in rec.msg)
```

---

If there are any other ways around this, then I would appreciate them being explained, or if not, the reasoning behind this design choice. I have inquired about it on the discord guild in the `#python_discord-py` channel, however, I was not able to find a resolution, and whilst this isn't a breaking issue, it is kind of annoying.

Thank you, any feedback whatsoever would be awesome :)

(This is the first time I have put a PR in on a fork, so if I have messed up anywhere, or forgot anything important, please let me know!)
