### PR TITLE
remove duplicate member searching in typing event

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -655,14 +655,7 @@ class ConnectionState:
         if channel is not None:
             member = None
             user_id = data.get('user_id')
-            is_private = getattr(channel, 'is_private', None)
-            if is_private == None:
-                return
-
-            if is_private:
-                member = channel.user
-            else:
-                member = channel.server.get_member(user_id)
+            member = self._get_member(channel, user_id)
 
             if member is not None:
                 timestamp = datetime.datetime.utcfromtimestamp(data.get('timestamp'))


### PR DESCRIPTION
This commit is only a thing because `on_typing` events from private group channels can use the `channel.user` value which isn't accurate for the user that is typing. Now we just switch to using the `_get_member()` function to handle searching through the `channel.recipients` for us along with the server member search.