### PR TITLE
Remove reference to "whitelisted" bots for emoji endpoints

### DIFF
--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -193,8 +193,6 @@ class Emoji(Hashable):
         You must have :attr:`~Permissions.manage_emojis` permission to
         do this.
 
-        Guild local emotes can only be deleted by user bots.
-
         Parameters
         -----------
         reason: Optional[str]
@@ -218,8 +216,6 @@ class Emoji(Hashable):
 
         You must have :attr:`~Permissions.manage_emojis` permission to
         do this.
-
-        Guild local emotes can only be edited by user bots.
 
         Parameters
         -----------

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -193,6 +193,8 @@ class Emoji(Hashable):
         You must have :attr:`~Permissions.manage_emojis` permission to
         do this.
 
+        Note that bot accounts can only delete custom emojis they own.
+
         Parameters
         -----------
         reason: Optional[str]
@@ -216,6 +218,8 @@ class Emoji(Hashable):
 
         You must have :attr:`~Permissions.manage_emojis` permission to
         do this.
+
+        Note that bot accounts can only edit custom emojis they own.
 
         Parameters
         -----------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -971,6 +971,8 @@ class Guild(Hashable):
 
         There is currently a limit of 50 local emotes per guild.
 
+        Note that bot accounts can only edit and delete emojis they have created.
+
         Parameters
         -----------
         name: str

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -969,11 +969,6 @@ class Guild(Hashable):
 
         Creates a custom :class:`Emoji` for the guild.
 
-        This endpoint is only allowed for user bots or white listed
-        bots. If this is done by a user bot then this is a local
-        emoji that can only be used inside the guild. If done by
-        a whitelisted bot, then this emoji is "global".
-
         There is currently a limit of 50 local emotes per guild.
 
         Parameters


### PR DESCRIPTION
Due to a recent change in the Discord API, bots can now create guild-specific emoji, so I've removed the parts of the documentation referencing this restriction.