### PR TITLE
Changed new_member.py - no default channel

### DIFF
--- a/examples/new_member.py
+++ b/examples/new_member.py
@@ -9,7 +9,7 @@ class MyClient(discord.Client):
 
     async def on_member_join(self, member):
         guild = member.guild
-        await guild.default_channel.send('Welcome {0.mention} to {1.name}!'.format(member, guild))
+        await member.send('Welcome {0.mention} to {1.name}!'.format(member, guild))
 
 client = MyClient()
 client.run('token')


### PR DESCRIPTION
This example now sends the message to the member from `on_member_join`, since `default_channel` was removed recently.