### PR TITLE
Actually resume on opcode RECONNECT

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -447,9 +447,8 @@ class Client:
             try:
                 yield from self.ws.poll_event()
             except (ReconnectWebSocket, ResumeWebSocket) as e:
-                resume = type(e) is ResumeWebSocket
                 log.info('Got ' + type(e).__name__)
-                self.ws = yield from DiscordWebSocket.from_client(self, resume=resume)
+                self.ws = yield from DiscordWebSocket.from_client(self, resume=True)
             except ConnectionClosed as e:
                 yield from self.close()
                 if e.code != 1000:

--- a/discord/client.py
+++ b/discord/client.py
@@ -446,8 +446,8 @@ class Client:
         while not self.is_closed:
             try:
                 yield from self.ws.poll_event()
-            except (ReconnectWebSocket, ResumeWebSocket) as e:
-                log.info('Got ' + type(e).__name__)
+            except ResumeWebSocket:
+                log.info('Got ResumeWebsocket')
                 self.ws = yield from DiscordWebSocket.from_client(self, resume=True)
             except ConnectionClosed as e:
                 yield from self.close()

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -45,10 +45,6 @@ __all__ = [ 'ReconnectWebSocket', 'DiscordWebSocket',
             'KeepAliveHandler', 'VoiceKeepAliveHandler',
             'DiscordVoiceWebSocket', 'ResumeWebSocket' ]
 
-class ReconnectWebSocket(Exception):
-    """Signals to handle the RECONNECT opcode."""
-    pass
-
 class ResumeWebSocket(Exception):
     """Signals to initialise via RESUME opcode instead of IDENTIFY."""
     pass
@@ -339,7 +335,7 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
             # internal exception signalling to reconnect.
             log.info('Received RECONNECT opcode.')
             yield from self.close()
-            raise ReconnectWebSocket()
+            raise ResumeWebsocket()
 
         if op == self.HEARTBEAT_ACK:
             self._keep_alive.ack()


### PR DESCRIPTION
As stipulated in discord's gateway doc, we should resume when receiving an opcode RECONNECT.