### PR TITLE
Show sha1 for development versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,12 @@ if version.endswith(('a', 'b', 'rc')):
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate()
         if out:
-            version = version + out.decode('utf-8').strip()
+            version += out.decode('utf-8').strip()
+        p = subprocess.Popen(['git', 'rev-parse', '--short', 'HEAD'],
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = p.communicate()
+        if out:
+            version += '-' + out.decode('utf-8').strip()
     except Exception:
         pass
 


### PR DESCRIPTION
This is handy as you can more easily tell which recent commit you are on vs. just commit count.

git describe --tags might also work well for dev versions but requires more tagging