### PR TITLE
Use local version identifer for SHA

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if version.endswith(('a', 'b', 'rc')):
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate()
         if out:
-            version += '-' + out.decode('utf-8').strip()
+            version += '+' + out.decode('utf-8').strip()
     except Exception:
         pass
 


### PR DESCRIPTION
local version identifier seems to be the only PEP440
way to add arbitrary string to the version. Makes
pip stop complaining about invalid version label.