### PR TITLE
Correct ServerRegion Strings (minor discrepancy)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -503,19 +503,19 @@ All enumerations are subclasses of `enum`_.
 
     Specifies the region a :class:`Server`'s voice server belongs to.
 
-    .. attribute:: us_west
+    .. attribute:: us-west
 
         The US West region.
-    .. attribute:: us_east
+    .. attribute:: us-east
 
         The US East region.
-    .. attribute:: us_central
+    .. attribute:: us-central
 
         The US Central region.
-    .. attribute:: eu_west
+    .. attribute:: eu-west
 
         The EU West region.
-    .. attribute:: eu_central
+    .. attribute:: eu-central
 
         The EU Central region.
     .. attribute:: singapore
@@ -537,13 +537,13 @@ All enumerations are subclasses of `enum`_.
     .. attribute:: brazil
 
         The Brazil region.
-    .. attribute:: vip_us_east
+    .. attribute:: vip-us-east
 
         The US East region for VIP servers.
-    .. attribute:: vip_us_west
+    .. attribute:: vip-us-west
 
         The US West region for VIP servers.
-    .. attribute:: vip_amsterdam
+    .. attribute:: vip-amsterdam
 
         The Amsterdam region for VIP servers.
 


### PR DESCRIPTION
us_east, us_west, etc (with '_') causes 400 BAD REQUEST exception:

Ignoring exception in on_message
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/discord/client.py", line 307, in _run_event
    yield from getattr(self, event)(*args, **kwargs)
  File "bot.py", line 294, in on_message
    await client.edit_server( cur_serv.me, region=req_reg )
  File "/usr/lib/python3.6/site-packages/discord/client.py", line 2381, in edit_server
    yield from self.http.edit_server(server.id, **fields)
  File "/usr/lib/python3.6/site-packages/discord/http.py", line 200, in request
    raise HTTPException(r, data)
discord.errors.HTTPException: BAD REQUEST (status code: 400)

Replacing '_' with '-' causes the call to return successfully and correctly update the region.