### PR TITLE
Implement custom help category names

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -109,8 +109,15 @@ def _default_help_command(ctx, *commands : str):
         command = None
         if name in bot.cogs:
             command = bot.cogs[name]
+        elif name in bot.all_commands:
+            command = bot.all_commands[name]
         else:
-            command = bot.all_commands.get(name)
+            for cog in bot.cogs.values():
+                category_name = getattr(cog, '_{0.__class__.__name__}__category_name'.format(cog), None)
+                if category_name == name:
+                    command = cog
+                    break
+
             if command is None:
                 yield from destination.send(bot.command_not_found.format(name))
                 return

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -590,6 +590,13 @@ class Command:
         return type(self.instance).__name__ if self.instance is not None else None
 
     @property
+    def category_name(self):
+        """A custom override name for the cog this belongs to. None otherwise."""
+        cog = self.instance
+        if cog is not None:
+            return getattr(cog, '_{0.__class__.__name__}__category_name'.format(cog), None)
+
+    @property
     def short_doc(self):
         """Gets the "short" documentation of a command.
 

--- a/discord/ext/commands/formatter.py
+++ b/discord/ext/commands/formatter.py
@@ -318,7 +318,7 @@ class HelpFormatter:
         max_width = self.max_name_size
 
         def category(tup):
-            cog = tup[1].cog_name
+            cog = tup[1].category_name or tup[1].cog_name
             # we insert the zero width space there to give it approximate
             # last place sorting position.
             return cog + ':' if cog is not None else '\u200bNo Category:'


### PR DESCRIPTION
This PR allows cogs to have custom category names when they appear in help.

For example:
```py
class MyClassName:
    __category_name = "Cool Commands"
    ...
```
produces default help like the following:
```
Description

Cool Commands:
  smile   :)
​No Category:
  help    Shows this message.

Type ?help command for more info on a command.
You can also type ?help category for more info on a category.
```

~~Main issue with this impl:~~
- ~~`?help category` no longer works on renamed categories (they still work on non-renamed); you must know the cog's actual name and it isn't displayed~~
    - ~~To search this would require a cache or an O(n) lookup every time the help command is used~~
    - ~~Multiple cogs sharing a category name would present even more problems~~