### PR TITLE
Embed.set_image/author/thumbnail don't set None

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -218,6 +218,8 @@ class Embed:
 
     def set_image(self, *, url):
         """Sets the image for the embed content.
+        
+        If you pass in None, your request's image will not change.
 
         This function returns the class instance to allow for fluent-style
         chaining.
@@ -228,9 +230,10 @@ class Embed:
             The source URL for the image. Only HTTP(S) is supported.
         """
 
-        self._image = {
-            'url': str(url)
-        }
+        if url:
+            self._image = {
+                'url': str(url)
+            }
 
         return self
 
@@ -252,6 +255,8 @@ class Embed:
     def set_thumbnail(self, *, url):
         """Sets the thumbnail for the embed content.
 
+        If you pass in None, your request's thumbnail will not change.
+
         This function returns the class instance to allow for fluent-style
         chaining.
 
@@ -261,9 +266,10 @@ class Embed:
             The source URL for the thumbnail. Only HTTP(S) is supported.
         """
 
-        self._thumbnail = {
-            'url': str(url)
-        }
+        if url:
+            self._thumbnail = {
+                'url': str(url)
+            }
 
         return self
 
@@ -304,6 +310,8 @@ class Embed:
     def set_author(self, *, name, url=EmptyEmbed, icon_url=EmptyEmbed):
         """Sets the author for the embed content.
 
+        If you pass in None for name, your request's name will not change.
+
         This function returns the class instance to allow for fluent-style
         chaining.
 
@@ -317,9 +325,10 @@ class Embed:
             The URL of the author icon. Only HTTP(S) is supported.
         """
 
-        self._author = {
-            'name': str(name)
-        }
+        if name:
+            self._author = {
+                'name': str(name)
+            }
 
         if url is not EmptyEmbed:
             self._author['url'] = str(url)


### PR DESCRIPTION
Before this change Embed.set_image(None) would append the string 'None'
to the request, leading to an opaque 400 Bad Request error introduced by
discord.py, not the user. This change detects None entered for the URL
in set_image and set_thumbnail and does not append that string 'None'.
For consistency, it also changes set_author to ignore None as well,
although the Discord API accepts the string 'None' as the author in that
case and does not produce a 400 Error.

Example code:
```python
import discord

channel_id = 'DEFINE_ME'
token = 'DEFINE_ME'

client = discord.Client()
channel = discord.Object(id=channel_id)

def run():
    em = discord.Embed()

    #You can uncomment each of these to see the errors from None

    #em.set_image(url='https://placekitten.com/123/321/')
    em.set_image(url=None)
    #em.set_author(name=None)
    #em.set_thumbnail(url=None)

    async def send_em():
        await client.wait_until_ready()
        await client.send_message(channel, embed=em) 

    @client.event
    async def on_ready():
        print('online')

    client.loop.create_task(send_em())
    client.run(token)

run()
```
