### PR TITLE
Fix unquoted Route params leading to `add_reaction` failing on some emoji

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -53,7 +53,7 @@ class Route:
         self.method = method
         url = (self.BASE + self.path)
         if parameters:
-            self.url = url.format(**parameters)
+            self.url = url.format(**{k: _uriquote(v) for k, v in parameters.items()})
         else:
             self.url = url
 


### PR DESCRIPTION
Usually raw should work anyway, but the hash emoji (#⃣) fails with a NotFound.
Since the official client quotes (and suffers no issues, although apparently this is an aiohttp issue with raws) we might as well do so as well, since it doesn't appear to break anything but fixes the hash emoji and any other potential emoji that suffer from this.