### PR TITLE
[commands] allow expanded unicode numerals for id converter

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -78,7 +78,7 @@ class Converter:
 
 class IDConverter(Converter):
     def __init__(self):
-        self._id_regex = re.compile(r'([0-9]{15,21})$')
+        self._id_regex = re.compile(r'(\d{15,21})$')
         super().__init__()
 
     def _get_id_match(self, argument):


### PR DESCRIPTION
The other converters are discord specific formatting which
only accept ascii numerals