### PR TITLE
Fixed a zero division error when accessing latencies

### DIFF
--- a/discord/shard.py
+++ b/discord/shard.py
@@ -175,8 +175,10 @@ class AutoShardedClient(Client):
 
         This operates similarly to :meth:`.Client.latency` except it uses the average
         latency of every shard's latency. To get a list of shard latency, check the
-        :attr:`latencies` property.
+        :attr:`latencies` property. Returns ``None`` if there are no shards ready.
         """
+        if not self.shards:
+            return None
         return sum(latency for _, latency in self.latencies) / len(self.shards)
 
     @property

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -175,10 +175,10 @@ class AutoShardedClient(Client):
 
         This operates similarly to :meth:`.Client.latency` except it uses the average
         latency of every shard's latency. To get a list of shard latency, check the
-        :attr:`latencies` property. Returns ``None`` if there are no shards ready.
+        :attr:`latencies` property. Returns ``nan`` if there are no shards ready.
         """
         if not self.shards:
-            return None
+            return float('nan')
         return sum(latency for _, latency in self.latencies) / len(self.shards)
 
     @property


### PR DESCRIPTION
When accessing the latencies property on an AutoShardedClient when none of shards are ready, we get a ZeroDivisionError. An example of this can be seen here.
```py
class StatsBot(commands.AutoShardedBot):
    def __init__(self):
        super().__init__(command_prefix=None)
        self._add_commands()

    def _add_commands(self):
        '''Adds commands automatically'''
        for name, attr in inspect.getmembers(self):
            if isinstance(attr, commands.Command):
                self.add_command(attr)
```

When iterating through this custom client's it accesses the latencies property when no shards are ready, therefore it raises the error. A quick fix for this would be to return something (in this case nan) if no shards are ready.