### PR TITLE
Added ability to create categories and add channels under categories.

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -2062,7 +2062,7 @@ class Client:
         yield from self.http.move_channel_position(channel.server.id, payload)
 
     @asyncio.coroutine
-    def create_channel(self, server, name, *overwrites, type=None):
+    def create_channel(self, server, name, *overwrites, type=None,parent=None):
         """|coro|
 
         Creates a :class:`Channel` in the specified :class:`Server`.
@@ -2114,6 +2114,8 @@ class Client:
         overwrites:
             An argument list of channel specific overwrites to apply on the channel on
             creation. Useful for creating 'secret' channels.
+        parent: str
+            The parent channel's id. Used to create channels under categories. 
 
         Raises
         -------
@@ -2159,7 +2161,7 @@ class Client:
 
             perms.append(payload)
 
-        data = yield from self.http.create_channel(server.id, name, str(type), permission_overwrites=perms)
+        data = yield from self.http.create_channel(server.id, name, str(type),parent_id=parent, permission_overwrites=perms)
         channel = Channel(server=server, **data)
         return channel
 

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -27,10 +27,11 @@ DEALINGS IN THE SOFTWARE.
 from enum import Enum
 
 class ChannelType(Enum):
-    text    = 0
-    private = 1
-    voice   = 2
-    group   = 3
+    text     = 0
+    private  = 1
+    voice    = 2
+    group    = 3
+    category = 4
 
     def __str__(self):
         return self.name

--- a/discord/http.py
+++ b/discord/http.py
@@ -465,7 +465,7 @@ class HTTPClient:
         r = Route('PATCH', '/guilds/{guild_id}/channels', guild_id=guild_id)
         return self.request(r, json=positions)
 
-    def create_channel(self, guild_id, name, channe_type, permission_overwrites=None):
+    def create_channel(self, guild_id, name, channe_type, parent_id=None,permission_overwrites=None):
         payload = {
             'name': name,
             'type': channe_type
@@ -473,6 +473,8 @@ class HTTPClient:
 
         if permission_overwrites is not None:
             payload['permission_overwrites'] = permission_overwrites
+        if parent_id is not None:
+            payload['parent_id'] = parent_id
 
         return self.request(Route('POST', '/guilds/{guild_id}/channels', guild_id=guild_id), json=payload)
 


### PR DESCRIPTION
Needed this feature for personal use, so thought I could share :)
1.Added "category" type to ChannelTypes in enums 
2.Edited create_channel() in http.py and client.py so that users can create channels under categories.

PS: First pull request on github, please feel free to point our mistakes/suggestions.

Thank you!