### PR TITLE
Add PresenceType enum

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -28,7 +28,8 @@ from enum import Enum, IntEnum
 
 __all__ = ['ChannelType', 'MessageType', 'VoiceRegion', 'VerificationLevel',
            'ContentFilter', 'Status', 'DefaultAvatar', 'RelationshipType',
-           'AuditLogAction', 'AuditLogActionCategory', 'UserFlags', ]
+           'AuditLogAction', 'AuditLogActionCategory', 'UserFlags',
+           'PresenceType', ]
 
 class ChannelType(Enum):
     text     = 0
@@ -211,6 +212,15 @@ class UserFlags(Enum):
     staff = 1
     partner = 2
     hypesquad = 4
+
+class PresenceType(IntEnum):
+    playing   = 0
+    streaming = 1
+    listening = 2
+    watching  = 3
+
+    def __str__(self):
+        return self.name
 
 def try_enum(cls, val):
     """A function that tries to turn the value into enum ``cls``.

--- a/discord/game.py
+++ b/discord/game.py
@@ -53,8 +53,8 @@ class Game:
         The game's name.
     url: str
         The game's URL. Usually used for twitch streaming.
-    type: int
-        The type of game being played. 1 indicates "Streaming".
+    type: Union[:class:`PresenceType`, int]
+        The displayed presence type.
     """
 
     __slots__ = ('name', 'type', 'url')

--- a/discord/game.py
+++ b/discord/game.py
@@ -24,6 +24,8 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
+from .enums import try_enum, PresenceType
+
 class Game:
     """Represents a Discord game.
 
@@ -60,7 +62,7 @@ class Game:
     def __init__(self, **kwargs):
         self.name = kwargs.get('name')
         self.url = kwargs.get('url')
-        self.type = kwargs.get('type', 0)
+        self.type = try_enum(PresenceType, kwargs.get('type', 0))
 
     def __str__(self):
         return str(self.name)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1280,6 +1280,27 @@ All enumerations are subclasses of `enum`_.
         The action is the update of something.
 
 
+.. class:: PresenceType
+
+    Represents the type of presence being shown with a :class:`Game`. This affects how it displays in Discord.
+
+    .. attribute:: playing
+
+        Shows "Playing .." in Discord.
+
+    .. attribute:: streaming
+
+        Shows "Streaming .." in Discord. When this type is used, a URL is included linking to the stream page.
+
+    .. attribute:: listening
+
+        Shows "Listening to .." in Discord.
+
+    .. attribute:: watching
+
+        Shows "Watching .." in Discord.
+
+
 
 Async Iterator
 ----------------


### PR DESCRIPTION
As Discord had added 2 new presences (and may add more in the future) I think it's now more justifiable to have an enum available for this so people don't have to remember numbers.

This uses IntEnum to avoid breaking changes when comparing with `int`s alone, and `try_enum` in case Discord adds any more presence types.