### PR TITLE
Prefix sha to fix leading zeros being stripped

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if version.endswith(('a', 'b', 'rc')):
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate()
         if out:
-            version += '+' + out.decode('utf-8').strip()
+            version += '+g' + out.decode('utf-8').strip()
     except Exception:
         pass
 


### PR DESCRIPTION
/dist.py:352: UserWarning: Normalizing '1.0.0a1402+0965847' to '1.0.0a1402+965847'