### PR TITLE
sphinxcontrib-napoleon => sphinx.ext.napoleon

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
   requirements = f.read().splitlines()
 
 if on_rtd:
-  requirements.append('sphinxcontrib-napoleon')
+  requirements.append('sphinx.ext.napoleon')
   requirements.append('sphinxcontrib-asyncio')
   requirements.append('sphinx==1.6.3')
 


### PR DESCRIPTION
Quoting https://pypi.python.org/pypi/sphinxcontrib-napoleon, 
"As of Sphinx 1.3, the napoleon extension will come packaged with Sphinx under sphinx.ext.napoleon. The sphinxcontrib.napoleon extension will continue to work with Sphinx <= 1.2."