### PR TITLE
get_channel accepts strings not integers

### DIFF
--- a/examples/background_task.py
+++ b/examples/background_task.py
@@ -17,7 +17,7 @@ class MyClient(discord.Client):
     async def my_background_task(self):
         await self.wait_until_ready()
         counter = 0
-        channel = self.get_channel(1234567) # channel ID goes here
+        channel = self.get_channel('1234567') # channel ID goes here
         while not self.is_closed():
             counter += 1
             await channel.send(counter)


### PR DESCRIPTION
Misleading confused me for a tad, minor fix.