### PR TITLE
Added Client.task decorator method and Client.tasks

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -899,16 +899,16 @@ class Client:
                         asyncio.TimeoutError,
                         websockets.InvalidHandshake,
                         websockets.WebSocketProtocolError) as e:
-                    restart = all(isinstance(e, asyncio.CancelledError),
+                    restart = all((isinstance(e, asyncio.CancelledError),
                                   restart_check is not None, restart_check(),
                                   # check if task has been overwritten
-                                  self.tasks['name'] is asyncio.Task.current_task()
-                    restart_on_resume = any(not self.is_closed(),
+                                  self.tasks['name'] is asyncio.Task.current_task()))
+                    restart_on_resume = any((not self.is_closed(),
                         # clean disconnect
                         isinstance(e, ConnectionClosed) and
-                        e.code = 1000) or
+                        e.code == 1000) or
                         # connection issue
-                        not isinstance(e, (ConnectionClosed, asyncio.CancelledError))
+                        not isinstance(e, (ConnectionClosed, asyncio.CancelledError)))
 
                     if restart or restart_on_resume:
                         if restart_on_resume:
@@ -921,7 +921,7 @@ class Client:
                 else:
                     return result
 
-        self.tasks[name] = self.loop.create_task(task_coro(), loop=self.loop)
+        self.tasks[name] = self.loop.create_task(task_coro())
         return coro
 
     def async_task(self, coro, name=None, overwrite=False, restart_check=None):


### PR DESCRIPTION
This should make it a lot easier and more straightforward for people to create tasks that run in the background. Additionally, those tasks will be able to continue where they left off, as they receive a dict called `state` (is that a good name?) that contains the state those tasks had when the connection was interrupted. For that to work, the tasks written by users would just need to store variables in the `state` dict. The Client.task decorator takes care of possible connection issues; when there are any, it will wait for the Client to reconnect, and restart the tasks, passing them the state they had when the connection issue occured.

Tasks decorated with Client.task will be stored in the Client's `tasks` attribute.