### PR TITLE
fetch_message: use history endpoint for user accts 

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -930,12 +930,15 @@ class Messageable(metaclass=abc.ABCMeta):
         """
         return Typing(self)
 
+    @utils.deprecated('fetch_message_fast')
     async def fetch_message(self, id):
         """|coro|
 
         Retrieves a single :class:`~discord.Message` from the destination.
 
         This can only be used by bot accounts.
+
+        Prefer using :meth:`fetch_message_fast`.
 
         Parameters
         ------------
@@ -960,6 +963,40 @@ class Messageable(metaclass=abc.ABCMeta):
         channel = await self._get_channel()
         data = await self._state.http.get_message(channel.id, id)
         return self._state.create_message(channel=channel, data=data)
+
+    async def fetch_message_fast(self, id):
+        """|coro|
+
+        Retrieves a single :class:`~discord.Message` from the destination, using
+        the history endpoint.
+
+        .. versionadded:: 1.5
+
+        Parameters
+        ------------
+        id: :class:`int`
+            The message ID to look for.
+
+        Raises
+        --------
+        ~discord.NotFound
+            The specified channel was not found.
+        ~discord.Forbidden
+            You do not have permissions to get channel message history.
+        ~discord.HTTPException
+            The request to get message history failed.
+
+        Returns
+        --------
+        Optional[:class:`~discord.Message`]
+            The message asked for, or None if there is no match.
+        """
+
+        channel = await self._get_channel()
+        data = await self._state.http.logs_from(channel.id, limit=1, around=id)
+        if data and int(data[0]['id']) == id:
+            return self._state.create_message(channel=channel, data=data[0])
+        return None
 
     async def pins(self):
         """|coro|


### PR DESCRIPTION
- Try first to get message from local cache, save us a discord query
- If unable to use get_message, fallback to logs_from