### PR TITLE
Allowed one argument to be used for custom prefixes (message)

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -37,7 +37,6 @@ from .view import StringView
 from .context import Context
 from .errors import CommandNotFound, CommandError
 from .formatter import HelpFormatter
-from inspect import signature
 
 def _get_variable(name):
     stack = inspect.stack()
@@ -240,7 +239,7 @@ class Bot(GroupMixin, discord.Client):
     def _get_prefix(self, message):
         prefix = self.command_prefix
         if callable(prefix):
-            if len(signature(prefix).parameters) == 1:
+            if len(inspect.signature(prefix).parameters) == 1:
                 ret = prefix(message)
             else:
                 ret = prefix(self, message)

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -37,6 +37,7 @@ from .view import StringView
 from .context import Context
 from .errors import CommandNotFound, CommandError
 from .formatter import HelpFormatter
+from inspect import signature
 
 def _get_variable(name):
     stack = inspect.stack()
@@ -239,7 +240,10 @@ class Bot(GroupMixin, discord.Client):
     def _get_prefix(self, message):
         prefix = self.command_prefix
         if callable(prefix):
-            ret = prefix(self, message)
+            if len(signature(prefix).parameters) == 1:
+                ret = prefix(message)
+            else:
+                ret = prefix(self, message)
             if asyncio.iscoroutine(ret):
                 ret = yield from ret
             return ret


### PR DESCRIPTION
For instance, not all prefix calls need the bot so it is just a unused object in the definition.