### PR TITLE
Change PartialReactionEmoji to PartialEmoji, add a PartialEmojiConverter

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -20,7 +20,7 @@ __version__ = '1.0.0a'
 from .client import Client, AppInfo
 from .user import User, ClientUser, Profile
 from .game import Game
-from .emoji import Emoji, PartialReactionEmoji
+from .emoji import Emoji, PartialEmoji
 from .channel import *
 from .guild import Guild
 from .relationship import Relationship

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -30,8 +30,8 @@ from collections import namedtuple
 from . import utils
 from .mixins import Hashable
 
-class PartialReactionEmoji(namedtuple('PartialReactionEmoji', 'name id')):
-    """Represents a "partial" reaction emoji.
+class PartialEmoji(namedtuple('PartialEmoji', 'animated name id')):
+    """Represents a "partial" emoji.
 
     This model will be given in two scenarios:
 
@@ -58,6 +58,8 @@ class PartialReactionEmoji(namedtuple('PartialReactionEmoji', 'name id')):
 
     Attributes
     -----------
+    animated: bool
+        Whether the emoji is animated or not.
     name: str
         The custom emoji name, if applicable, or the unicode codepoint
         of the non-custom emoji.
@@ -70,7 +72,7 @@ class PartialReactionEmoji(namedtuple('PartialReactionEmoji', 'name id')):
     def __str__(self):
         if self.id is None:
             return self.name
-        return '<:%s:%s>' % (self.name, self.id)
+        return '<%s:%s:%s>' % ('a' if self.animated else '', self.name, self.id)
 
     def is_custom_emoji(self):
         """Checks if this is a custom non-Unicode emoji."""
@@ -84,6 +86,15 @@ class PartialReactionEmoji(namedtuple('PartialReactionEmoji', 'name id')):
         if self.id is None:
             return self.name
         return ':%s:%s' % (self.name, self.id)
+
+    @property
+    def url(self):
+        """Returns a URL version of the emoji, if it is custom."""
+        if self.is_unicode_emoji():
+            return None
+
+        _format = 'gif' if self.animated else 'png'
+        return "https://cdn.discordapp.com/emojis/{0.id}.{1}".format(self, _format)
 
 class Emoji(Hashable):
     """Represents a custom emoji.

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -35,8 +35,8 @@ from .view import StringView
 __all__ = [ 'Converter', 'MemberConverter', 'UserConverter',
             'TextChannelConverter', 'InviteConverter', 'RoleConverter',
             'GameConverter', 'ColourConverter', 'VoiceChannelConverter',
-            'EmojiConverter','CategoryChannelConverter', 'IDConverter',
-            'clean_content' ]
+            'EmojiConverter', 'PartialEmojiConverter', 'CategoryChannelConverter',
+            'IDConverter', 'clean_content' ]
 
 def _get_from_guilds(bot, getter, argument):
     result = None
@@ -396,6 +396,25 @@ class EmojiConverter(IDConverter):
             raise BadArgument('Emoji "{}" not found.'.format(argument))
 
         return result
+
+class PartialEmojiConverter(Converter):
+    """Converts to a :class:`PartialEmoji`.
+
+
+    This is done by extracting the animated flag, name and ID from the emoji.
+    """
+    @asyncio.coroutine
+    def convert(self, ctx, argument):
+        match = re.match(r'<(a?):([a-zA-Z0-9\_]+):([0-9]+)>$', argument)
+
+        if match:
+            emoji_animated = bool(match.group(1))
+            emoji_name = match.group(2)
+            emoji_id = int(match.group(3))
+
+            return discord.PartialEmoji(animated=emoji_animated, name=emoji_name, id=emoji_id)
+
+        raise BadArgument('Couldn\'t convert "{}" to PartialEmoji.'.format(argument))
 
 class clean_content(Converter):
     """Converts the argument to mention scrubbed version of

--- a/discord/message.py
+++ b/discord/message.py
@@ -29,7 +29,7 @@ import re
 
 from . import utils, compat
 from .reaction import Reaction
-from .emoji import Emoji, PartialReactionEmoji
+from .emoji import Emoji, PartialEmoji
 from .calls import CallMessage
 from .enums import MessageType, try_enum
 from .errors import InvalidArgument, ClientException, HTTPException, NotFound
@@ -627,7 +627,7 @@ class Message:
 
         Parameters
         ------------
-        emoji: Union[:class:`Emoji`, :class:`Reaction`, :class:`PartialReactionEmoji`, str]
+        emoji: Union[:class:`Emoji`, :class:`Reaction`, :class:`PartialEmoji`, str]
             The emoji to react with.
 
         Raises
@@ -647,7 +647,7 @@ class Message:
 
         if isinstance(emoji, Emoji):
             emoji = '%s:%s' % (emoji.name, emoji.id)
-        elif isinstance(emoji, PartialReactionEmoji):
+        elif isinstance(emoji, PartialEmoji):
             emoji = emoji._as_reaction()
         elif isinstance(emoji, str):
             pass # this is okay
@@ -672,7 +672,7 @@ class Message:
 
         Parameters
         ------------
-        emoji: Union[:class:`Emoji`, :class:`Reaction`, :class:`PartialReactionEmoji`, str]
+        emoji: Union[:class:`Emoji`, :class:`Reaction`, :class:`PartialEmoji`, str]
             The emoji to remove.
         member: :class:`abc.Snowflake`
             The member for which to remove the reaction.
@@ -694,7 +694,7 @@ class Message:
 
         if isinstance(emoji, Emoji):
             emoji = '%s:%s' % (emoji.name, emoji.id)
-        elif isinstance(emoji, PartialReactionEmoji):
+        elif isinstance(emoji, PartialEmoji):
             emoji = emoji._as_reaction()
         elif isinstance(emoji, str):
             pass # this is okay

--- a/discord/state.py
+++ b/discord/state.py
@@ -26,7 +26,7 @@ DEALINGS IN THE SOFTWARE.
 
 from .guild import Guild
 from .user import User, ClientUser
-from .emoji import Emoji, PartialReactionEmoji
+from .emoji import Emoji, PartialEmoji
 from .message import Message
 from .relationship import Relationship
 from .channel import *
@@ -372,7 +372,7 @@ class ConnectionState:
 
         emoji_data = data['emoji']
         emoji_id = utils._get_as_snowflake(emoji_data, 'id')
-        emoji = PartialReactionEmoji(id=emoji_id, name=emoji_data['name'])
+        emoji = PartialEmoji(animated=emoji_data['animated'], id=emoji_id, name=emoji_data['name'])
         self.dispatch('raw_reaction_add', emoji, message_id, channel_id, user_id)
 
         # rich interface here
@@ -402,7 +402,7 @@ class ConnectionState:
 
         emoji_data = data['emoji']
         emoji_id = utils._get_as_snowflake(emoji_data, 'id')
-        emoji = PartialReactionEmoji(id=emoji_id, name=emoji_data['name'])
+        emoji = PartialEmoji(animated=emoji_data['animated'], id=emoji_id, name=emoji_data['name'])
         self.dispatch('raw_reaction_remove', emoji, message_id, channel_id, user_id)
 
         message = self._get_message(message_id)
@@ -846,7 +846,7 @@ class ConnectionState:
         try:
             return self._emojis[emoji_id]
         except KeyError:
-            return PartialReactionEmoji(id=emoji_id, name=data['name'])
+            return PartialEmoji(animated=data['animated'], id=emoji_id, name=data['name'])
 
     def _upgrade_partial_emoji(self, emoji):
         emoji_id = emoji.id

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -304,7 +304,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     called regardless of the state of the internal message cache.
 
     :param emoji: The custom or unicode emoji being reacted to.
-    :type emoji: :class:`PartialReactionEmoji`
+    :type emoji: :class:`PartialEmoji`
     :param int message_id: The message ID of the message being reacted.
     :param int channel_id: The channel ID where the message belongs to.
     :param int user_id: The user ID of the user who did the reaction.
@@ -328,7 +328,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     called regardless of the state of the internal message cache.
 
     :param emoji: The custom or unicode emoji that got un-reacted.
-    :type emoji: :class:`PartialReactionEmoji`
+    :type emoji: :class:`PartialEmoji`
     :param int message_id: The message ID of the message being un-reacted.
     :param int channel_id: The channel ID where the message belongs to.
     :param int user_id: The user ID of the user who removed the reaction.
@@ -1888,10 +1888,10 @@ Emoji
 .. autoclass:: Emoji()
     :members:
 
-PartialReactionEmoji
+PartialEmoji
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: PartialReactionEmoji()
+.. autoclass:: PartialEmoji()
     :members:
 
 Role

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -173,6 +173,9 @@ Converters
 .. autoclass:: discord.ext.commands.EmojiConverter
     :members:
 
+.. autoclass:: discord.ext.commands.PartialEmojiConverter
+    :members:
+
 .. autoclass:: discord.ext.commands.clean_content
     :members:
 

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -310,6 +310,7 @@ A lot of discord models work out of the gate as a parameter:
 - :class:`Invite`
 - :class:`Game`
 - :class:`Emoji`
+- :class:`PartialEmoji`
 - :class:`Colour`
 
 Having any of these set as the converter will intelligently convert the argument to the appropriate target type you
@@ -338,6 +339,8 @@ converter is given below:
 | :class:`Game`         | :class:`~ext.commands.GameConverter`            |
 +-----------------------+-------------------------------------------------+
 | :class:`Emoji`        | :class:`~ext.commands.EmojiConverter`           |
++-----------------------+-------------------------------------------------+
+| :class:`PartialEmoji` | :class:`~ext.commands.PartialEmojiConverter`    |
 +-----------------------+-------------------------------------------------+
 | :class:`Colour`       | :class:`~ext.commands.ColourConverter`          |
 +-----------------------+-------------------------------------------------+


### PR DESCRIPTION
This change does a couple of things:
- Renames `PartialReactionEmoji` to PartialEmoji` (breaking)
- Adds `animated` field to PartialEmoji
- Updates `__str__` to reflect animated-ness
- Adds `url` property to PartialEmoji, dynamic to `animated`, returns `None` for unicode emoji.
- Adds PartialEmojiConverter that converts a `<a?:name:id>` tag into a PartialEmoji

Tested on own install including docs, everything seems to work fine. This shouldn't be too severe of a breaking change since nothing generally directly references PartialReactionEmoji; the only places I've seen it referenced are within typehints of `on_raw_reaction_add` etc.

Weird Discord bug I discovered while writing this: messages Discord doesn't dispatch (obtained via `.history` or `.get_message` etc) always have the reactions with animated=False. Affects the returned payload directly, so not much I can do about this, although if Discord fixes this should automatically work as well.