### PR TITLE
Added an enum representing the valid activity types.

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -212,6 +212,20 @@ class UserFlags(Enum):
     partner = 2
     hypesquad = 4
 
+
+class ActivityType(IntEnum):
+    """An enum that defines valid flags for the ``type`` parameter
+    used when creating an instance of ``discord.game.Game``.
+
+    Correct for v6 of the gateway API, as of 4th Jan 2018.
+    See: https://discordapp.com/developers/docs/topics/gateway#game-object
+    """
+    game = 0,       # e.g. `Playing {name}`
+    streaming = 1,  # e.g. `Streaming {name}`; requires a valid twitch URL.
+    listening = 2,  # e.g. `Listening to {name}`
+    watching = 3    # e.g. `Watching {name}`
+
+
 def try_enum(cls, val):
     """A function that tries to turn the value into enum ``cls``.
 

--- a/discord/game.py
+++ b/discord/game.py
@@ -52,7 +52,10 @@ class Game:
     url: str
         The game's URL. Usually used for twitch streaming.
     type: int
-        The type of game being played. 1 indicates "Streaming".
+        The type of game being played. See ``discord.enums.ActivityType`` for
+        the valid options. Defaults to ``0``, denoting a game.
+        Note that ``1`` (streaming) requires a VALID twitch URL to work,
+        otherwise the bot user will appear to not be doing anything.
     """
 
     __slots__ = ('name', 'type', 'url')


### PR DESCRIPTION
I have added this, as it does not seem to be defined anywhere else
in this API wrapper. I have grepped all the files to try and find
a match, but as yet can not find anything.

Currently, the existing values for the game activity types are not
very clear. There does not seem to be anything in the dpy
documentation regarding this (at least, not in the docstrings in
the source code).

The docstring in discord.Game seems to imply that there is only
the option of playing a game, or streaming a twitch URL. As of
4th Jan 2018, this is incorrect. There is also the ability to
be "listening to" something, or "watching" something. Both have
been tested and work running under a standard discord bot account.

I have tweaked the docstring in discord.Game to reflect this change.