### PR TITLE
Rename `Game` to `Activity`

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -19,7 +19,7 @@ __version__ = '1.0.0a'
 
 from .client import Client, AppInfo
 from .user import User, ClientUser, Profile
-from .game import Game
+from .activity import Activity
 from .emoji import Emoji, PartialEmoji
 from .channel import *
 from .guild import Guild

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -24,35 +24,37 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-class Game:
-    """Represents a Discord game.
+from .enums import ActivityType, try_enum
+
+class Activity:
+    """Represents a Discord activity.
 
     .. container:: operations
 
         .. describe:: x == y
 
-            Checks if two games are equal.
+            Checks if two activities are equal.
 
         .. describe:: x != y
 
-            Checks if two games are not equal.
+            Checks if two activities are not equal.
 
         .. describe:: hash(x)
 
-            Returns the game's hash.
+            Returns the activity's hash.
 
         .. describe:: str(x)
 
-            Returns the game's name.
+            Returns the activity's name.
 
     Attributes
     -----------
     name: :class:`str`
-        The game's name.
+        The activity's name.
     url: :class:`str`
-        The game's URL. Usually used for twitch streaming.
-    type: :class:`int`
-        The type of game being played. 1 indicates "Streaming".
+        The activity's URL. Usually used for twitch streaming.
+    type: :class:`ActivityType`
+        The type of activity being played.
     """
 
     __slots__ = ('name', 'type', 'url')
@@ -60,13 +62,13 @@ class Game:
     def __init__(self, **kwargs):
         self.name = kwargs.get('name')
         self.url = kwargs.get('url')
-        self.type = kwargs.get('type', 0)
+        self.type = try_enum(ActivityType, kwargs.get('type', 0))
 
     def __str__(self):
         return str(self.name)
 
     def __repr__(self):
-        return '<Game name={0.name!r} type={0.type!r} url={0.url!r}>'.format(self)
+        return '<Activity name={0.name!r} type={0.type!r} url={0.url!r}>'.format(self)
 
     def _iterator(self):
         for attr in self.__slots__:
@@ -78,7 +80,7 @@ class Game:
         return self._iterator()
 
     def __eq__(self, other):
-        return isinstance(other, Game) and other.name == self.name
+        return isinstance(other, Activity) and other.name == self.name
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/discord/client.py
+++ b/discord/client.py
@@ -95,8 +95,8 @@ class Client:
         members from the guilds the bot belongs to. If this is ``False``\, then
         no offline members are received and :meth:`request_offline_members`
         must be used to fetch the offline members of the guild.
-    game: Optional[:class:`Game`]
-        A game to start your presence with upon logging on to Discord.
+    activity: Optional[:class:`Activity`]
+        An activity to start your presence with upon logging on to Discord.
     status: Optional[:class:`Status`]
         A status to start your presence with upon logging on to Discord.
     heartbeat_timeout: float
@@ -794,23 +794,23 @@ class Client:
         return self.event(coro)
 
     @asyncio.coroutine
-    def change_presence(self, *, game=None, status=None, afk=False):
+    def change_presence(self, *, activity=None, status=None, afk=False):
         """|coro|
 
         Changes the client's presence.
 
-        The game parameter is a Game object (not a string) that represents
-        a game being played currently.
+        The activity parameter is an Activity object (not a string) that represents
+        an activity being played currently.
 
         Example: ::
 
-            game = discord.Game(name="with the API")
-            await client.change_presence(status=discord.Status.idle, game=game)
+            acitivity = discord.Activity(name="with the API")
+            await client.change_presence(status=discord.Status.idle, activity=activity)
 
         Parameters
         ----------
-        game: Optional[:class:`Game`]
-            The game being played. None if no game is being played.
+        activity: Optional[:class:`Activity`]
+            The activity being played. None if no activity is being played.
         status: Optional[:class:`Status`]
             Indicates what status to change to. If None, then
             :attr:`Status.online` is used.
@@ -822,7 +822,7 @@ class Client:
         Raises
         ------
         InvalidArgument
-            If the ``game`` parameter is not :class:`Game` or None.
+            If the ``activity`` parameter is not :class:`Activity` or None.
         """
 
         if status is None:
@@ -835,14 +835,14 @@ class Client:
             status_enum = status
             status = str(status)
 
-        yield from self.ws.change_presence(game=game, status=status, afk=afk)
+        yield from self.ws.change_presence(activity=activity, status=status, afk=afk)
 
         for guild in self._connection.guilds:
             me = guild.me
             if me is None:
                 continue
 
-            me.game = game
+            me.activity = activity
             me.status = status_enum
 
     # Guild stuff

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -29,7 +29,7 @@ from enum import Enum, IntEnum
 __all__ = ['ChannelType', 'MessageType', 'VoiceRegion', 'VerificationLevel',
            'ContentFilter', 'Status', 'DefaultAvatar', 'RelationshipType',
            'AuditLogAction', 'AuditLogActionCategory', 'UserFlags',
-           'ActivityType']
+           'ActivityType', ]
 
 class ChannelType(Enum):
     text     = 0

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -28,7 +28,8 @@ from enum import Enum, IntEnum
 
 __all__ = ['ChannelType', 'MessageType', 'VoiceRegion', 'VerificationLevel',
            'ContentFilter', 'Status', 'DefaultAvatar', 'RelationshipType',
-           'AuditLogAction', 'AuditLogActionCategory', 'UserFlags', ]
+           'AuditLogAction', 'AuditLogActionCategory', 'UserFlags',
+           'ActivityType']
 
 class ChannelType(Enum):
     text     = 0
@@ -119,6 +120,15 @@ class RelationshipType(Enum):
     blocked          = 2
     incoming_request = 3
     outgoing_request = 4
+
+class ActivityType(IntEnum):
+    playing   = 0
+    streaming = 1
+    listening = 2
+    watching  = 3
+
+    def __str__(self):
+        return self.name
 
 class AuditLogActionCategory(Enum):
     create = 1

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -34,7 +34,7 @@ from .view import StringView
 
 __all__ = [ 'Converter', 'MemberConverter', 'UserConverter',
             'TextChannelConverter', 'InviteConverter', 'RoleConverter',
-            'GameConverter', 'ColourConverter', 'VoiceChannelConverter',
+            'ActivityConverter', 'ColourConverter', 'VoiceChannelConverter',
             'EmojiConverter', 'PartialEmojiConverter', 'CategoryChannelConverter',
             'IDConverter', 'clean_content' ]
 
@@ -336,11 +336,11 @@ class RoleConverter(IDConverter):
             raise BadArgument('Role "{}" not found.'.format(argument))
         return result
 
-class GameConverter(Converter):
-    """Converts to :class:`Game`."""
+class ActivityConverter(Converter):
+    """Converts to :class:`Activity`."""
     @asyncio.coroutine
     def convert(self, ctx, argument):
-        return discord.Game(name=argument)
+        return discord.Activity(name=argument)
 
 class InviteConverter(Converter):
     """Converts to a :class:`Invite`.

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -30,7 +30,7 @@ import websockets
 import asyncio
 
 from . import utils, compat
-from .game import Game
+from .activity import Activity
 from .errors import ConnectionClosed, InvalidArgument
 import logging
 import zlib, json
@@ -283,10 +283,10 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
             payload['d']['shard'] = [self.shard_id, self.shard_count]
 
         state = self._connection
-        if state._game is not None or state._status is not None:
+        if state._activity is not None or state._status is not None:
             payload['d']['presence'] = {
                 'status': state._status,
-                'game': state._game,
+                'game': state._activity,
                 'since': 0,
                 'afk': False
             }
@@ -469,19 +469,19 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
                 raise ConnectionClosed(e, shard_id=self.shard_id) from e
 
     @asyncio.coroutine
-    def change_presence(self, *, game=None, status=None, afk=False, since=0.0):
-        if game is not None and not isinstance(game, Game):
-            raise InvalidArgument('game must be of type Game or None')
+    def change_presence(self, *, activity=None, status=None, afk=False, since=0.0):
+        if activity is not None and not isinstance(activity, Activity):
+            raise InvalidArgument('activity must be of type Activity or None')
 
         if status == 'idle':
             since = int(time.time() * 1000)
 
-        sent_game = dict(game) if game else None
+        sent_activity = dict(activity) if activity else None
 
         payload = {
             'op': self.PRESENCE,
             'd': {
-                'game': sent_game,
+                'game': sent_activity,
                 'afk': afk,
                 'since': since,
                 'status': status

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -32,7 +32,7 @@ from collections import namedtuple, defaultdict
 from . import utils
 from .role import Role
 from .member import Member, VoiceState
-from .game import Game
+from .activity import Activity
 from .permissions import PermissionOverwrite
 from .colour import Colour
 from .errors import InvalidArgument, ClientException
@@ -243,8 +243,8 @@ class Guild(Hashable):
             member = self.get_member(user_id)
             if member is not None:
                 member.status = try_enum(Status, presence['status'])
-                game = presence.get('game', {})
-                member.game = Game(**game) if game else None
+                activity = presence.get('game', {})
+                member.activity = Activity(**activity) if activity else None
 
         if 'channels' in data:
             channels = data['channels']

--- a/discord/member.py
+++ b/discord/member.py
@@ -32,7 +32,7 @@ import discord.abc
 
 from . import utils
 from .user import BaseUser, User
-from .game import Game
+from .activity import Activity
 from .permissions import Permissions
 from .enums import Status, try_enum
 from .colour import Colour
@@ -147,15 +147,15 @@ class Member(discord.abc.Messageable, _BaseUser):
     status : :class:`Status`
         The member's status. There is a chance that the status will be a :class:`str`
         if it is a value that is not recognised by the enumerator.
-    game : :class:`Game`
-        The game that the user is currently playing. Could be None if no game is being played.
+    activity : :class:`Activity`
+        The activity that the user is currently playing. Could be None if no activity is being played.
     guild : :class:`Guild`
         The guild that the member belongs to.
     nick : Optional[:class:`str`]
         The guild specific nickname of the user.
     """
 
-    __slots__ = ('roles', 'joined_at', 'status', 'game', 'guild', 'nick', '_user', '_state')
+    __slots__ = ('roles', 'joined_at', 'status', 'activity', 'guild', 'nick', '_user', '_state')
 
     def __init__(self, *, data, guild, state):
         self._state = state
@@ -164,8 +164,8 @@ class Member(discord.abc.Messageable, _BaseUser):
         self.joined_at = utils.parse_time(data.get('joined_at'))
         self._update_roles(data)
         self.status = Status.offline
-        game = data.get('game', {})
-        self.game = Game(**game) if game else None
+        activity = data.get('game', {})
+        self.activity = Activity(**activity) if activity else None
         self.nick = data.get('nick', None)
 
     def __str__(self):
@@ -218,8 +218,8 @@ class Member(discord.abc.Messageable, _BaseUser):
 
     def _presence_update(self, data, user):
         self.status = try_enum(Status, data['status'])
-        game = data.get('game', {})
-        self.game = Game(**game) if game else None
+        activity = data.get('game', {})
+        self.activity = Activity(**activity) if activity else None
         u = self._user
         u.name = user.get('username', u.name)
         u.avatar = user.get('avatar', u.avatar)

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -307,18 +307,18 @@ class AutoShardedClient(Client):
         yield from self.http.close()
 
     @asyncio.coroutine
-    def change_presence(self, *, game=None, status=None, afk=False, shard_id=None):
+    def change_presence(self, *, activity=None, status=None, afk=False, shard_id=None):
         """|coro|
 
         Changes the client's presence.
 
-        The game parameter is a Game object (not a string) that represents
-        a game being played currently.
+        The activity parameter is an Activity object (not a string) that represents
+        an activity being played currently.
 
         Parameters
         ----------
-        game: Optional[:class:`Game`]
-            The game being played. None if no game is being played.
+        activity: Optional[:class:`Activity`]
+            The activity being played. None if no activity is being played.
         status: Optional[:class:`Status`]
             Indicates what status to change to. If None, then
             :attr:`Status.online` is used.
@@ -334,7 +334,7 @@ class AutoShardedClient(Client):
         Raises
         ------
         InvalidArgument
-            If the ``game`` parameter is not :class:`Game` or None.
+            If the ``activity`` parameter is not :class:`Activity` or None.
         """
 
         if status is None:
@@ -349,12 +349,12 @@ class AutoShardedClient(Client):
 
         if shard_id is None:
             for shard in self.shards.values():
-                yield from shard.ws.change_presence(game=game, status=status, afk=afk)
+                yield from shard.ws.change_presence(activity=activity, status=status, afk=afk)
 
             guilds = self._connection.guilds
         else:
             shard = self.shards[shard_id]
-            yield from shard.ws.change_presence(game=game, status=status, afk=afk)
+            yield from shard.ws.change_presence(activity=activity, status=status, afk=afk)
             guilds = [g for g in self._connection.guilds if g.shard_id == shard_id]
 
         for guild in guilds:
@@ -362,5 +362,5 @@ class AutoShardedClient(Client):
             if me is None:
                 continue
 
-            me.game = game
+            me.activity = activity
             me.status = status_enum

--- a/discord/state.py
+++ b/discord/state.py
@@ -67,9 +67,9 @@ class ConnectionState:
         self.heartbeat_timeout = options.get('heartbeat_timeout', 60.0)
         self._listeners = []
 
-        game = options.get('game', None)
-        if game:
-            game = dict(game)
+        activity = options.get('activity', None)
+        if activity:
+            activity = dict(activity)
 
         status = options.get('status', None)
         if status:
@@ -78,7 +78,7 @@ class ConnectionState:
             else:
                 status = str(status)
 
-        self._game = game
+        self._activity = activity
         self._status = status
 
         self.clear()

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -872,6 +872,25 @@ All enumerations are subclasses of `enum`_.
         You have sent a friend request to this user.
 
 
+.. class:: ActivityType
+
+    Represents the possible activity types that can be passed for the type
+    parameter of an :class:`Activity`.
+
+    .. attribute:: playing
+
+        The activity type is playing
+    .. attribute:: streaming
+
+        The activity type is streaming
+    .. attribute:: listening
+
+        The activity type is listening
+    .. attribute:: watching
+
+        The activity type is watching
+
+
 .. class:: AuditLogAction
 
     Represents the type of action being done for a :class:`AuditLogEntry`\,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -410,7 +410,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     This is called when one or more of the following things change:
 
     - status
-    - game playing
+    - current activity
     - avatar
     - nickname
     - roles
@@ -2007,10 +2007,10 @@ Colour
 .. autoclass:: Colour
     :members:
 
-Game
+Activity
 ~~~~
 
-.. autoclass:: Game
+.. autoclass:: Activity
     :members:
 
 Permissions

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -164,7 +164,7 @@ Converters
 .. autoclass:: discord.ext.commands.RoleConverter
     :members:
 
-.. autoclass:: discord.ext.commands.GameConverter
+.. autoclass:: discord.ext.commands.ActivityConverter
     :members:
 
 .. autoclass:: discord.ext.commands.ColourConverter

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -308,7 +308,7 @@ A lot of discord models work out of the gate as a parameter:
 - :class:`CategoryChannel`
 - :class:`Role`
 - :class:`Invite`
-- :class:`Game`
+- :class:`Activity`
 - :class:`Emoji`
 - :class:`PartialEmoji`
 - :class:`Colour`
@@ -336,7 +336,7 @@ converter is given below:
 +-----------------------+-------------------------------------------------+
 | :class:`Invite`       | :class:`~ext.commands.InviteConverter`          |
 +-----------------------+-------------------------------------------------+
-| :class:`Game`         | :class:`~ext.commands.GameConverter`            |
+| :class:`Activity`         | :class:`~ext.commands.ActivityConverter`    |
 +-----------------------+-------------------------------------------------+
 | :class:`Emoji`        | :class:`~ext.commands.EmojiConverter`           |
 +-----------------------+-------------------------------------------------+

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -96,10 +96,10 @@ How do I set the "Playing" status?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 There is a method for this under :class:`Client` called :meth:`Client.change_presence`. The relevant aspect of this is its
-``game`` keyword argument which takes in a :class:`Game` object. Putting both of these pieces of info together, you get the
+``activity`` keyword argument which takes in a :class:`Activity` object. Putting both of these pieces of info together, you get the
 following: ::
 
-    await client.change_presence(game=discord.Game(name='my game'))
+    await client.change_presence(activity=discord.Activity(name='my activity'))
 
 How do I send a message to a specific channel?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -329,7 +329,7 @@ New Features
 - Added a way to remove the messages of the user that just got banned in :meth:`Client.ban`.
 - Added :meth:`Client.wait_until_ready` to facilitate easy creation of tasks that require the client cache to be ready.
 - Added :meth:`Client.wait_until_login` to facilitate easy creation of tasks that require the client to be logged in.
-- Add :class:`discord.Game` to represent any game with custom text to send to :meth:`Client.change_status`.
+- Add :class:`discord.Activity` to represent any activity with custom text to send to :meth:`Client.change_status`.
 - Add :attr:`Message.nonce` attribute.
 - Add :meth:`Member.permissions_in` as another way of doing :meth:`Channel.permissions_for`.
 - Add :meth:`Client.move_member` to move a member to another voice channel.


### PR DESCRIPTION
This pull request:
* Universally refactors Game to Activity, both the class and all parameters referencing it
* Adds the ActivityType enum.
* Documentation has been updated.

Resolves issue https://github.com/Rapptz/discord.py/issues/393. Both Documentation and Code tested locally, seem to be working fine. Change is breaking, of course.