### PR TITLE
Add documentation for new_member system messages

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -683,6 +683,10 @@ All enumerations are subclasses of `enum`_.
 
         The system message denoting that a pinned message has been added to a channel.
 
+    .. attribute:: new_member
+
+        The system message denoting that a new member has joined a Guild.
+
 .. class:: VoiceRegion
 
     Specifies the region a voice server belongs to.


### PR DESCRIPTION
This documents the `new_member` attribute of the MessageType enum, as it's missing.