### PR TITLE
Implement voice receive (again)

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -947,7 +947,7 @@ class Connectable(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @asyncio.coroutine
-    def connect(self, *, timeout=60.0, reconnect=True):
+    def connect(self, *, timeout=60.0, pad_silence=True, reconnect=True):
         """|coro|
 
         Connects to voice and creates a :class:`VoiceClient` to establish
@@ -961,6 +961,9 @@ class Connectable(metaclass=abc.ABCMeta):
             Whether the bot should automatically attempt
             a reconnect if a part of the handshake fails
             or the gateway goes down.
+        pad_silence: bool
+            Whether silence when a user is not speaking should be
+            padded with zeroes or just ignored.
 
         Raises
         -------
@@ -982,7 +985,8 @@ class Connectable(metaclass=abc.ABCMeta):
         if state._get_voice_client(key_id):
             raise ClientException('Already connected to a voice channel.')
 
-        voice = VoiceClient(state=state, timeout=timeout, channel=self)
+        voice = VoiceClient(state=state, timeout=timeout,
+                            pad_silence=pad_silence, channel=self)
         state._add_voice_client(key_id, voice)
 
         try:

--- a/discord/errors.py
+++ b/discord/errors.py
@@ -164,3 +164,9 @@ class ConnectionClosed(ClientException):
         self.reason = original.reason
         self.shard_id = shard_id
         super().__init__(str(original))
+
+class InvalidVoicePacket(DiscordException):
+    """Exception that's thrown when a raw UDP packet cannot be parsed
+    as a valid :class:`VoicePacket`.
+    """
+    pass

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -660,6 +660,15 @@ class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
             yield from self.identify()
         elif op == self.SESSION_DESCRIPTION:
             yield from self.load_secret_key(data)
+        elif op == self.SPEAKING:
+            user_id = int(data['user_id'])
+            ssrc = int(data['ssrc'])
+
+            if 'speaking' in data:
+                user = self._connection._state.get_user(user_id)
+
+                self._connection.decoders[ssrc].user = user
+                self._connection.decoders[ssrc].speaking_state(data['speaking'])
 
     @asyncio.coroutine
     def initial_connection(self, data):
@@ -706,5 +715,3 @@ class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
             self._keep_alive.stop()
 
         yield from super().close_connection(force=force)
-
-

--- a/discord/opus.py
+++ b/discord/opus.py
@@ -36,11 +36,16 @@ log = logging.getLogger(__name__)
 c_int_ptr = ctypes.POINTER(ctypes.c_int)
 c_int16_ptr = ctypes.POINTER(ctypes.c_int16)
 c_float_ptr = ctypes.POINTER(ctypes.c_float)
+c_ubyte_ptr = ctypes.POINTER(ctypes.c_ubyte)
 
 class EncoderStruct(ctypes.Structure):
     pass
 
+class DecoderStruct(ctypes.Structure):
+    pass
+
 EncoderStructPtr = ctypes.POINTER(EncoderStruct)
+DecoderStructPtr = ctypes.POINTER(DecoderStruct)
 
 def _err_lt(result, func, args):
     if result < 0:
@@ -73,6 +78,27 @@ exported_functions = [
         None, ctypes.c_int32, _err_lt),
     ('opus_encoder_destroy',
         [EncoderStructPtr], None, None),
+
+    ('opus_decoder_get_size',
+        [ctypes.c_int], ctypes.c_int, None),
+    ('opus_decoder_create',
+        [ctypes.c_int, ctypes.c_int, c_int_ptr], DecoderStructPtr, None),
+    ('opus_packet_get_bandwidth',
+        [ctypes.c_char_p], ctypes.c_int, None),
+    ('opus_packet_get_nb_channels',
+        [ctypes.c_char_p], ctypes.c_int, None),
+    ('opus_packet_get_nb_frames',
+        [ctypes.c_char_p, ctypes.c_int], ctypes.c_int, None),
+    ('opus_packet_get_samples_per_frame',
+        [ctypes.c_char_p, ctypes.c_int], ctypes.c_int, None),
+    ('opus_decoder_get_nb_samples',
+        [DecoderStructPtr, ctypes.c_char_p, ctypes.c_int32], ctypes.c_int, None),
+    ('opus_decode',
+        [DecoderStructPtr, ctypes.c_char_p, ctypes.c_int32, c_int16_ptr, ctypes.c_int, ctypes.c_int], ctypes.c_int, None),
+    ('opus_decode_float',
+        [DecoderStructPtr, ctypes.c_char_p, ctypes.c_int32, c_float_ptr, ctypes.c_int, ctypes.c_int], ctypes.c_int, None),
+    ('opus_decoder_destroy',
+        [DecoderStructPtr], None, None)
 ]
 
 def libopus_loader(name):
@@ -273,3 +299,83 @@ class Encoder:
         ret = _lib.opus_encode(self._state, pcm, frame_size, data, max_data_bytes)
 
         return array.array('b', data[:ret]).tobytes()
+
+class Decoder:
+    def __init__(self, sampling=48000, channels=2):
+        self.sampling_rate = sampling
+        self.channels = channels
+
+        self._state = self._create_state()
+
+    def __del__(self):
+        if hasattr(self, '_state'):
+            _lib.opus_decoder_destroy(self._state)
+            self._state = None
+
+    def _create_state(self):
+        ret = ctypes.c_int()
+        result = _lib.opus_decoder_create(self.sampling_rate, self.channels, ctypes.byref(ret))
+
+        if ret.value != 0:
+            log.info('error has happened in decoder state creation')
+            raise OpusError(ret.value)
+
+        return result
+
+    @classmethod
+    def _packet_get_nb_frames(cls, data):
+        """Gets the number of frames in an Opus packet"""
+        result = _lib.opus_packet_get_nb_frames(data, len(data))
+        if result < 0:
+            log.info('error has happened in packet_get_nb_frames')
+            raise OpusError(result)
+
+        return result
+
+    @classmethod
+    def _packet_get_nb_channels(cls, data):
+        """Gets the number of channels in an Opus packet"""
+        result = _lib.opus_packet_get_nb_channels(data)
+        if result < 0:
+            log.info('error has happened in packet_get_nb_channels')
+            raise OpusError(result)
+
+        return result
+
+    def _packet_get_samples_per_frame(self, data):
+        """Gets the number of samples per frame from an Opus packet"""
+        result = _lib.opus_packet_get_samples_per_frame(data, self.sampling_rate)
+        if result < 0:
+            log.info('error has happened in packet_get_samples_per_frame')
+            raise OpusError(result)
+
+        return result
+
+    def _decode(self, data, frame_size, decode_fec, decode_func, decode_ctype, arr_type):
+        if frame_size is None:
+            frames = self._packet_get_nb_frames(data)
+            samples_per_frame = self._packet_get_samples_per_frame(data)
+
+            channels = self._packet_get_nb_channels(data)
+            frame_size = frames * samples_per_frame
+            log.debug('detected frame_size %d (%d frames, %d samples per frame, %d channels)', frame_size, frames, samples_per_frame, channels)
+
+        pcm_size = frame_size * self.channels
+        pcm = (decode_ctype * pcm_size)()
+        pcm_ptr = ctypes.cast(pcm, ctypes.POINTER(decode_ctype))
+
+        decode_fec = 1 if decode_fec else 0
+
+        result = decode_func(self._state, data, len(data), pcm_ptr, frame_size, decode_fec)
+        if result < 0:
+            log.debug('error happened in decode')
+            raise OpusError(result)
+
+        log.debug('opus decode result: %d (total buf size: %d)', result, len(pcm))
+        return array.array(arr_type, pcm).tobytes()
+
+    def decode(self, data, frame_size=None, decode_fec=False):
+        return self._decode(data, frame_size, decode_fec, _lib.opus_decode, ctypes.c_int16, 'h')
+
+    def decode_float(self, data, frame_size=None, decode_fec=False):
+        return self._decode(data, frame_size, decode_fec, _lib.opus_decode_float, ctypes.c_float, 'f')

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -541,6 +541,48 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param before: The previous relationship status.
     :param after: The updated relationship status.
 
+.. function:: on_raw_voice_receive(voice_client, voice_packet)
+
+    Called when raw Opus data has been received, but before it has
+    been decoded.
+
+    :param voice_client: The :class:`VoiceClient` relating to the channel the
+                         user is talking in.
+    :param voice_packet: A :class:`VoicePacket` containing the raw data for
+                         the packet that has been received.
+
+.. function:: on_pcm_data_receive(voice_client, voice_packet)
+
+    Similar to the above function, but the Opus data has been
+    decoded to reveal the PCM data.
+
+    :param voice_client: The :class:`VoiceClient` relating to the channel the
+                         user is talking in.
+    :param voice_packet: A :class:`VoicePacket` containing the decoded data
+                         for the packet that has been received.
+
+.. function:: on_voice_receive(voice_client, user, data)
+
+    Called when a voice packet has been received and buffered.
+    Voice packets sent to this function will be reordered ensuring
+    that the audio is almost entirely intact.
+
+    :param voice_client: The :class:`VoiceClient` relating to the channel the
+                         user is talking in.
+    :param user: A :class:`User` relating to the user speaking.
+    :param data: The buffered PCM data, including padded silence when a user is
+                 not speaking unless `voice_client.pad_silence` is set to
+                 `False`.
+
+.. function:: on_voice_speaking_state(voice_client, user, speaking)
+
+    Called when a user starts or stops speaking in a voice channel.
+
+    :param voice_client: The :class:`VoiceClient` relating to the channel the
+                         user is currently in.
+    :param user: The :class:`User` converned.
+    :param speaking: A bool dictating if the user is now speaking or not.
+
 .. _discord-api-utils:
 
 Utility Functions
@@ -698,7 +740,7 @@ All enumerations are subclasses of `enum`_.
 
         The US East region.
     .. attribute:: us_south
-    
+
         The US South region.
     .. attribute:: us_central
 
@@ -729,10 +771,10 @@ All enumerations are subclasses of `enum`_.
 
         The Brazil region.
     .. attribute:: hongkong
-    
+
         The Hong Kong region.
     .. attribute:: russia
-    
+
         The Russia region.
     .. attribute:: vip_us_east
 


### PR DESCRIPTION
I've done it again, but this time I've actually implemented things like the RTP headers properly. I've also tried to take into account feedback, from Danny, b1nzy and Jake.

The functions added are documented in the `docs/api.rst` file, but an example usage could look something like this:
```py
TARGET = 161508165672763392
f = open('f.pcm', 'wb')
@client.event
async def on_voice_receive(vc, user, data):
    if user.id == TARGET:
        f.write(data)
```
and that would handle packet reordering, silence padding, etc.