### PR TITLE
Allow builtins' unbound methods to be used as command converters

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -201,8 +201,13 @@ class Command:
         if converter is bool:
             return _convert_to_bool(argument)
 
-        if converter.__module__.startswith('discord.') and not converter.__module__.endswith('converter'):
-            converter = getattr(converters, converter.__name__ + 'Converter')
+        try:
+            module = converter.__module__
+        except:
+            pass
+        else:
+            if module.startswith('discord.') and not module.endswith('converter'):
+                converter = getattr(converters, converter.__name__ + 'Converter')
 
         if inspect.isclass(converter):
             if issubclass(converter, converters.Converter):


### PR DESCRIPTION
Currently when, for instance, `arg: str.upper` is attempted in a command definition, a conditional in ext/commands/core.py raises `AttributeError: 'method_descriptor' object has no attribute '__module__'` at `if converter.__module__.startswith(...)`.

PR adds a check for `hasattr(converter, '__module__')` before this so the conditional can short-circuit instead of erroring.