### PR TITLE
Compatibility with websockets 4.0

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -516,11 +516,11 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
         yield from self.send_as_json(payload)
 
     @asyncio.coroutine
-    def close_connection(self, force=False):
+    def close_connection(self, *args, **kwargs):
         if self._keep_alive:
             self._keep_alive.stop()
 
-        yield from super().close_connection(force=force)
+        yield from super().close_connection(*args, **kwargs)
 
 class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
     """Implements the websocket protocol for handling voice connections.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp>=2.0.0,<2.3.0
-websockets>=3.1,<4.0
+websockets>=4.0,<5.0


### PR DESCRIPTION
Making the method signature use `*args` and `**kwargs` means that the library can change pretty much however it wants and it won't break. Since all we do in `close_connection` is stop the keep-alive task, I'm pretty confident that we don't really care what the specific arguments are.