### PR TITLE
Update docstrings for channel.py

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -176,7 +176,10 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
 
         You cannot bulk delete more than 100 messages or messages that
         are older than 14 days old.
-
+        
+        You must have :attr:`Permissions.manage_messages` permission use 
+        this.
+        
         Usable only by bot accounts.
 
         Parameters


### PR DESCRIPTION
`delete_messages` requires `manage_messages`; the docs in here, nor on RTD reflect this. 
Small amendment at line 180, adding three additional.