### PR TITLE
Fix 3.7 asyncio compatibility error with websockets library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp>=2.0.0,<2.3.0
-websockets>=4.0,<5.0
+https://github.com/aaugustin/websockets/archive/master.zip


### PR DESCRIPTION
The websockets library supports 3.4+ and it doesn't look like they plan to drop support for older versions soon. The latest version on PyPi since November has been 4.0.1. 

However, this pip build version causes an error on 3.7, which was fixed in December but the versioning has not changed. This fixes that error by just pulling from master and maintains support for older versions.

```py

 File "/usr/local/lib/python3.7/dist-packages/websockets/compatibility.py", line 15
    asyncio_ensure_future = asyncio.async           # Python < 3.5
                                        ^
SyntaxError: invalid syntax
```

The relevant fix was deployed in December (but no new release has been deployed): https://github.com/aaugustin/websockets/commit/9f566c5d12eae1258aa6f1991fe8cf0a7d390f97

