### PR TITLE
Default invoke_without_command to True instead of False

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -874,10 +874,10 @@ class Group(GroupMixin, Command):
         in case no subcommand was found. If this is ``False``, then
         the group callback will always be invoked first. This means
         that the checks and the parsing dictated by its parameters
-        will be executed. Defaults to ``False``.
+        will be executed. Defaults to ``True``.
     """
     def __init__(self, **attrs):
-        self.invoke_without_command = attrs.pop('invoke_without_command', False)
+        self.invoke_without_command = attrs.pop('invoke_without_command', True)
         super().__init__(**attrs)
 
     @asyncio.coroutine


### PR DESCRIPTION
The current implementation is at best kind of unexpected for how one would expect subcommands to work- if the second arg of a command is a subcommand, it's natural to assume that it will invoke the subcommand instead of being passed as an arg to the root command. The default option also seems to be a more specialty option, with less total usage by the average user. 

Furthermore, the naming `invoke_without_command` is... confusing at best. I'm still not completely sure what this means. This change should eliminate some minor confusion for new users.