### PR TITLE
Make the shard websocket publicly available

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -130,7 +130,7 @@ class Client:
         self._connection.shard_count = self.shard_count
         self._closed = asyncio.Event(loop=self.loop)
         self._ready = asyncio.Event(loop=self.loop)
-        self._connection._get_websocket = lambda g: self.ws
+        self._connection._get_websocket = self.get_websocket
 
         if VoiceClient.warn_nacl:
             VoiceClient.warn_nacl = False
@@ -172,6 +172,9 @@ class Client:
             if m:
                 return m.group(1)
         return invite
+
+    def get_websocket(self, guild_id):
+        return self.ws
 
     @property
     def latency(self):

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -143,11 +143,9 @@ class AutoShardedClient(Client):
         # the key is the shard_id
         self.shards = {}
 
-        def _get_websocket(guild_id):
-            i = (guild_id >> 22) % self.shard_count
-            return self.shards[i].ws
-
-        self._connection._get_websocket = _get_websocket
+    def get_websocket(self, guild_id):
+        i = (guild_id >> 22) % self.shard_count
+        return self.shards[i].ws
 
     @asyncio.coroutine
     def _chunker(self, guild, *, shard_id=None):


### PR DESCRIPTION
In the standard Client, the websocket is publicly available at `Client.ws`. However when you use `AutoShardedClient` you would have to use `Client._connection._get_websocket(guild_id)` in order to retrieve the websocket.

This PR adds a `get_websocket()` method to both `Client` and `AutoShardedClient` that will retrieve the correct websocket.