### PR TITLE
Quick Fix/Question

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -678,6 +678,6 @@ class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
         if self._keep_alive:
             self._keep_alive.stop()
 
-        yield from super().close_connection(force=force)
+        yield from super().close_connection()
 
 


### PR DESCRIPTION
Hello,
I was playing around with having a bot leave a discord voice channel and I noticed I constantly recieved the error:

Traceback (most recent call last): File "F:\Git Hub\Bugisoft.DMC\venv\lib\site-packages\discord\client.py", line 307, in _run_event yield from getattr(self, event)(*args, **kwargs) File "F:/Git Hub/Bugisoft.DMC/Bugisoft.py", line 63, in on_message await VoiceConnector.leave() File "F:\Git Hub\Bugisoft.DMC\voiceCommands\VoiceConnecter.py", line 14, in leave await VoiceConnector.voice.disconnect() File "F:\Git Hub\Bugisoft.DMC\venv\lib\site-packages\discord\voice_client.py", line 297, in disconnect yield from self.ws.close() File "F:\Git Hub\Bugisoft.DMC\venv\lib\site-packages\websockets\protocol.py", line 396, in close yield from asyncio.shield(self.close_connection_task) File "F:\Git Hub\Bugisoft.DMC\venv\lib\site-packages\discord\gateway.py", line 686, in close_connection yield from super().close_connection(force=force) TypeError: close_connection() got an unexpected keyword argument 'force'

I played around a bit and found out that in this line:

discord.py/discord/gateway.py

Line 681 in gateway.py
 yield from super().close_connection(force=force) 

Removing the force=force fixed the issue that I was experiencing above, and I was just wondering if I was actually just messing something else up the line. I do not know too much about the discord API, and I am probably making a mistake.

Thanks!