### PR TITLE
Add Spotify intergration colour

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -186,7 +186,7 @@ class Activity(_ActivityTag):
         except KeyError:
             return None
         else:
-            return 'htps://cdn.discordapp.com/app-assets/{0}/{1}.png'.format(self.application_id, large_image)
+            return 'https://cdn.discordapp.com/app-assets/{0}/{1}.png'.format(self.application_id, large_image)
 
     @property
     def small_image_url(self):
@@ -199,7 +199,7 @@ class Activity(_ActivityTag):
         except KeyError:
             return None
         else:
-            return 'htps://cdn.discordapp.com/app-assets/{0}/{1}.png'.format(self.application_id, small_image)
+            return 'https://cdn.discordapp.com/app-assets/{0}/{1}.png'.format(self.application_id, small_image)
     @property
     def large_image_text(self):
         """Optional[:class:`str`]: Returns the large image asset hover text of this activity if applicable."""

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -438,7 +438,7 @@ class Spotify:
             Returns the string 'Spotify'.
     """
 
-    __slots__ = ('_state', '_details', '_timestamps', '_assets', '_party', '_sync_id', '_session_id', '_colour')
+    __slots__ = ('_state', '_details', '_timestamps', '_assets', '_party', '_sync_id', '_session_id')
 
     def __init__(self, **data):
         self._state = data.pop('state', None)
@@ -448,7 +448,6 @@ class Spotify:
         self._party = data.pop('party', {})
         self._sync_id = data.pop('sync_id')
         self._session_id = data.pop('session_id')
-        self._colour = Colour(0x1db954)
 
     @property
     def type(self):
@@ -463,14 +462,14 @@ class Spotify:
         """Returns the Spotify integration colour, as a :class:`Colour`.
 
         There is an alias for this named :meth:`color`"""
-        return self._colour
+        return Colour(0x1db954)
 
     @property
     def color(self):
         """Returns the Spotify integration colour, as a :class:`Colour`.
 
         There is an alias for this named :meth:`colour`"""
-        return self._colour
+        return self.colour
 
     def to_dict(self):
         return {

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -25,6 +25,7 @@ DEALINGS IN THE SOFTWARE.
 """
 
 from .enums import ActivityType, try_enum
+from .colour import Colour
 import datetime
 
 __all__ = ('Activity', 'Streaming', 'Game', 'Spotify')
@@ -437,7 +438,7 @@ class Spotify:
             Returns the string 'Spotify'.
     """
 
-    __slots__ = ('_state', '_details', '_timestamps', '_assets', '_party', '_sync_id', '_session_id')
+    __slots__ = ('_state', '_details', '_timestamps', '_assets', '_party', '_sync_id', '_session_id', '_colour')
 
     def __init__(self, **data):
         self._state = data.pop('state', None)
@@ -447,6 +448,7 @@ class Spotify:
         self._party = data.pop('party', {})
         self._sync_id = data.pop('sync_id')
         self._session_id = data.pop('session_id')
+        self._colour = Colour(0x1db954)
 
     @property
     def type(self):
@@ -455,6 +457,20 @@ class Spotify:
         It always returns :attr:`ActivityType.listening`.
         """
         return ActivityType.listening
+
+    @property
+    def colour(self):
+        """Returns the Spotify integration colour, as a :class:`Colour`.
+
+        There is an alias for this named :meth:`color`"""
+        return self._colour
+
+    @property
+    def color(self):
+        """Returns the Spotify integration colour, as a :class:`Colour`.
+
+        There is an alias for this named :meth:`colour`"""
+        return self._colour
 
     def to_dict(self):
         return {


### PR DESCRIPTION
Added property `colour` and alias `color` which returns the Spotify integration colour (#1db954).

Technically Discord uses both (#1cb050 and #1db954) but it appears #1db954 is an official Spotify colour.