### PR TITLE
Force RTD to use python 3.6 and the latest environment build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,11 @@
+formats:
+  - pdf
+
+build:
+  image: latest
+
+python:
+  version: 3.6
+  pip_install: true
+  extra_requirements:
+    - docs


### PR DESCRIPTION
This fixes the "missing" sphinxcontrib library.