### PR TITLE
added cooldown BucketType for members

### DIFF
--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -31,8 +31,9 @@ __all__ = ['BucketType', 'Cooldown', 'CooldownMapping']
 class BucketType(enum.Enum):
     default = 0
     user    = 1
-    guild  = 2
+    guild   = 2
     channel = 3
+    member  = 4
 
 class Cooldown:
     __slots__ = ('rate', 'per', 'type', '_window', '_tokens', '_last')
@@ -111,6 +112,8 @@ class CooldownMapping:
             return (msg.guild or msg.author).id
         elif bucket_type is BucketType.channel:
             return msg.channel.id
+        elif bucket_type is BucketType.member:
+            return ((msg.guild or msg.author).id, msg.author.id)
 
     def _verify_cache_integrity(self):
         # we want to delete all cache objects that haven't been used

--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -113,7 +113,7 @@ class CooldownMapping:
         elif bucket_type is BucketType.channel:
             return msg.channel.id
         elif bucket_type is BucketType.member:
-            return ((msg.guild or msg.author).id, msg.author.id)
+            return ((msg.guild and msg.guild.id), msg.author.id)
 
     def _verify_cache_integrity(self):
         # we want to delete all cache objects that haven't been used

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1284,6 +1284,7 @@ def cooldown(rate, per, type=BucketType.default):
     - ``BucketType.user`` for a per-user basis.
     - ``BucketType.guild`` for a per-guild basis.
     - ``BucketType.channel`` for a per-channel basis.
+    - ``BucketType.member`` for a per-member basis.
 
     If a cooldown is triggered, then :exc:`.CommandOnCooldown` is triggered in
     :func:`.on_command_error` and the local error handler.


### PR DESCRIPTION
as the title says, this adds a cooldown for member objects using an user id and a guild id. This means that the cooldown will only be specific to a member (so only on cooldown for that user in that guild). This means they are free to use the command in another guild. This can be useful for commands that change guild specific user data.