### PR TITLE
Clarified a detail about .subcommand_passed

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -62,7 +62,10 @@ class Context:
         The string that was attempted to call a subcommand. This does not have
         to point to a valid registered subcommand and could just point to a
         nonsense string. If nothing was passed to attempt a call to a
-        subcommand then this is set to `None`.
+        subcommand then this is set to `None`. Subcommand processing is only
+        performed after the command is invoked, so something like 
+        `(await bot.get_context(message)).subcommand_passed` will evaluate to
+        `None`.
     """
 
     def __init__(self, **attrs):


### PR DESCRIPTION
Specifically, it doesn't work on a context retrieved through `bot.get_context(msg)`.