### PR TITLE
examples: default_channel -> system_channel

### DIFF
--- a/examples/new_member.py
+++ b/examples/new_member.py
@@ -9,7 +9,7 @@ class MyClient(discord.Client):
 
     async def on_member_join(self, member):
         guild = member.guild
-        await guild.default_channel.send('Welcome {0.mention} to {1.name}!'.format(member, guild))
+        await guild.system_channel.send('Welcome {0.mention} to {1.name}!'.format(member, guild))
 
 client = MyClient()
 client.run('token')


### PR DESCRIPTION
When i was learning the API, I ran into a slight issue. `default_channel` was replaced with `system_channel` and was not updated in the examples.