### PR TITLE
example: Fixed an issue where there is no default channel and causes a crash.

### DIFF
--- a/examples/new_member.py
+++ b/examples/new_member.py
@@ -9,7 +9,7 @@ class MyClient(discord.Client):
 
     async def on_member_join(self, member):
         guild = member.guild
-        await guild.default_channel.send('Welcome {0.mention} to {1.name}!'.format(member, guild))
+        await guild.system_channel.send('Welcome {0.mention} to {1.name}!'.format(member, guild))
 
 client = MyClient()
 client.run('token')

--- a/examples/new_member.py
+++ b/examples/new_member.py
@@ -9,7 +9,7 @@ class MyClient(discord.Client):
 
     async def on_member_join(self, member):
         guild = member.guild
-        await guild.system_channel.send('Welcome {0.mention} to {1.name}!'.format(member, guild))
+        await guild.channels[1].send('Welcome {0.mention} to {1.name}!'.format(member, guild))
 
 client = MyClient()
 client.run('token')


### PR DESCRIPTION
Made a PR before but noticed, it only works when a join channel is set.

Now, instead of ``guild.default_channel``, ``guilds.channels[1]`` would get the job done.