### PR TITLE
Makes bot.process_commands ignore commands from bots

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -917,6 +917,8 @@ class BotBase(GroupMixin):
 
     @asyncio.coroutine
     def on_message(self, message):
+        if message.author.bot:
+            return
         yield from self.process_commands(message)
 
 class Bot(BotBase, discord.Client):

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -906,12 +906,17 @@ class BotBase(GroupMixin):
 
         This is built using other low level tools, and is equivalent to a
         call to :meth:`~.Bot.get_context` followed by a call to :meth:`~.Bot.invoke`.
+        
+        This also checks if the message's author is a bot and doesn't
+        call :meth:`~.Bot.get_context` or :meth:`~.Bot.invoke` if so.
 
         Parameters
         -----------
         message : discord.Message
             The message to process commands for.
         """
+        if message.author.bot:
+            return
         ctx = yield from self.get_context(message)
         yield from self.invoke(ctx)
 

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -917,8 +917,6 @@ class BotBase(GroupMixin):
 
     @asyncio.coroutine
     def on_message(self, message):
-        if message.author.bot:
-            return
         yield from self.process_commands(message)
 
 class Bot(BotBase, discord.Client):


### PR DESCRIPTION
This follows recommended usage of discord bots, and removes the need to override
on_message for just this. If they don't want it to ignore the bot, just override it.