### PR TITLE
fix some broken dependencies on legacy libs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp>=2.0.0,<2.3.0
 websockets>=3.0,<4.0
+yarl==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiohttp>=2.0.0,<2.3.0
 websockets>=3.0,<4.0
-yarl==1.1.1
+yarl<1.2


### PR DESCRIPTION
This feels like a really ugly fix and I dont really like it. But yarl has made some breaking changes recently and aiohttp 2.2 looks for 'yarl>=0.11' so it installs the latest version, 1.2.1 which causes the below traceback when importing discord.

Newer versions of aiohttp pin yarl to 1.1.1 so I have made that change here. My understanding is that aiohttp doesn't do back ports, so there is no point trying to fix the issue as the source.

This feels inelegant but it stops an error when you import discord
```
 Traceback (most recent call last):
  File "main.py", line 1, in <module>
    from constants import *
  File "/root/working/discord/spacebot/constants.py", line 2, in <module>
    import discord
  File "/usr/local/lib/python3.6/site-packages/discord/__init__.py", line 20, in <module>
    from .client import Client, AppInfo
  File "/usr/local/lib/python3.6/site-packages/discord/client.py", line 30, in <module>
    from .guild import Guild
  File "/usr/local/lib/python3.6/site-packages/discord/guild.py", line 39, in <module>
    from .channel import *
  File "/usr/local/lib/python3.6/site-packages/discord/channel.py", line 31, in <module>
    from .webhook import Webhook
  File "/usr/local/lib/python3.6/site-packages/discord/webhook.py", line 27, in <module>
    import aiohttp
  File "/usr/local/lib/python3.6/site-packages/aiohttp/__init__.py", line 6, in <module>
    from .client import *  # noqa
  File "/usr/local/lib/python3.6/site-packages/aiohttp/client.py", line 15, in <module>
    from . import connector as connector_mod
  File "/usr/local/lib/python3.6/site-packages/aiohttp/connector.py", line 17, in <module>
    from .client_proto import ResponseHandler
  File "/usr/local/lib/python3.6/site-packages/aiohttp/client_proto.py", line 6, in <module>
    from .http import HttpResponseParser, StreamWriter
  File "/usr/local/lib/python3.6/site-packages/aiohttp/http.py", line 8, in <module>
    from .http_parser import (HttpParser, HttpRequestParser, HttpResponseParser,
  File "/usr/local/lib/python3.6/site-packages/aiohttp/http_parser.py", line 15, in <module>
    from .http_writer import HttpVersion, HttpVersion10
  File "/usr/local/lib/python3.6/site-packages/aiohttp/http_writer.py", line 304, in <module>
    class URL(yarl.URL):
  File "/usr/local/lib/python3.6/site-packages/yarl/__init__.py", line 230, in __init_subclass__
    "is forbidden".format(cls))
TypeError: Inheritance a class <class 'aiohttp.http_writer.URL'> from URL is forbidden
```

resolves #1280