### PR TITLE
 Add support for getting individual ban entries

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -799,6 +799,36 @@ class Guild(Hashable):
 
         yield from http.edit_guild(self.id, reason=reason, **fields)
 
+    @asyncio.coroutine
+    def get_ban(self, user):
+        """|coro|
+
+        Retrieves the :class:`BanEntry` for a user, which is a namedtuple
+        with a ``user`` and ``reason`` field. See :meth:`bans` for more
+        information.
+
+        You must have :attr:`~Permissions.ban_members` permission
+        to get this information.
+
+        Raises
+        ------
+        Forbidden
+            You do not have proper permissions to get the information.
+        NotFound
+            This user is not banned.
+        HTTPException
+            An error occurred while fetching the information.
+
+        Returns
+        -------
+        BanEntry
+            The BanEntry object for the specified user.
+        """
+        data = yield from self._state.http.get_ban(user.id, self.id)
+        return BanEntry(
+            user=User(state=self._state, data=data['user']),
+            reason=data['reason']
+        )
 
     @asyncio.coroutine
     def bans(self):

--- a/discord/http.py
+++ b/discord/http.py
@@ -589,6 +589,9 @@ class HTTPClient:
     def get_bans(self, guild_id):
         return self.request(Route('GET', '/guilds/{guild_id}/bans', guild_id=guild_id))
 
+    def get_ban(self, user_id, guild_id):
+        return self.request(Route('GET', '/guilds/{guild_id}/bans/{user_id}', guild_id=guild_id, user_id=user_id))
+
     def get_vanity_code(self, guild_id):
         return self.request(Route('GET', '/guilds/{guild_id}/vanity-url', guild_id=guild_id))
 


### PR DESCRIPTION
This PR introduces support for fetching individual ban entries. Works just like `guild.bans()`.

```py
entry = await guild.get_ban(user)  # type: BanEntry
entry.user  # type: User
entry.reason  # type: Optional[str]
```

See: https://github.com/discordapp/discord-api-docs/commit/bc75f80993498b427f55b48ff6cbf7feb4aa7147