### PR TITLE
Resolves #1280

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp>=2.0.0,<2.3.0
 websockets>=3.0,<4.0
+yarl<1.2


### PR DESCRIPTION
Yarl 1.2 introduces breaking changes to aiohttp. This modification should resolve these issues by installing yarl 1.1 instead.