### PR TITLE
Made a role class mismatch show the appropriate error

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -31,6 +31,7 @@ import copy
 import discord.abc
 
 from . import utils
+from .role import Role
 from .user import BaseUser, User
 from .activity import create_activity
 from .permissions import Permissions
@@ -447,7 +448,12 @@ class Member(discord.abc.Messageable, _BaseUser):
         except KeyError:
             pass
         else:
-            payload['roles'] = tuple(r.id for r in roles)
+            id_list = []
+            for r in roles:
+                if not isinstance(r, Role):
+                    raise TypeError('Expected discord.Role but received %s instead.' % r.__class__.__name__)
+                id_list.append(r.id)
+            payload['roles'] = tuple(id_list)
 
         yield from http.edit_member(guild_id, self.id, reason=reason, **payload)
 


### PR DESCRIPTION
This shows a good error for lets say a nonetype or a user trying to put for example a guild into the role list.