### PR TITLE
Fix member.top_role not accounting for role hierarchy changes

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -308,7 +308,7 @@ class Member(discord.abc.Messageable, _BaseUser):
         This is useful for figuring where a member stands in the role
         hierarchy chain.
         """
-        return self.roles[-1]
+        return sorted(self.roles, key=lambda r: r.position, reverse=True)[0]
 
     @property
     def guild_permissions(self):

--- a/discord/member.py
+++ b/discord/member.py
@@ -308,7 +308,7 @@ class Member(discord.abc.Messageable, _BaseUser):
         This is useful for figuring where a member stands in the role
         hierarchy chain.
         """
-        return sorted(self.roles, key=lambda r: r.position, reverse=True)[0]
+        return max(self.roles, key=lambda r: r.position)
 
     @property
     def guild_permissions(self):


### PR DESCRIPTION
Currently, changing the role hierarchy in server settings doesn't change the order of `member.roles`, leading to `member.top_role` being wrong. 
