### PR TITLE
[Rewrite] Help formatter: handle nick mentions

### DIFF
--- a/discord/ext/commands/formatter.py
+++ b/discord/ext/commands/formatter.py
@@ -181,12 +181,12 @@ class HelpFormatter:
     @property
     def clean_prefix(self):
         """The cleaned up invoke prefix. i.e. mentions are ``@name`` instead of ``<@id>``."""
-        user = self.context.bot.user
+        user = self.context.guild.me if self.context.guild else self.context.bot.user
         # this breaks if the prefix mention is not the bot itself but I
         # consider this to be an *incredibly* strange use case. I'd rather go
         # for this common use case rather than waste performance for the
         # odd one.
-        return self.context.prefix.replace(user.mention, '@' + user.name)
+        return self.context.prefix.replace(user.mention, '@' + user.display_name)
 
     def get_command_signature(self):
         """Retrieves the signature portion of the help page."""


### PR DESCRIPTION
Modifies the help formatter to handle nicknamed bot users for mentions in clean_prefix