### PR TITLE
docs/migrating.rst: CPython 3.5.2 is not supported!

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ You can find examples in the examples directory.
 Requirements
 ------------
 
-* Python 3.5.2+
+* Python 3.5.3+
 * ``aiohttp`` library
 * ``websockets`` library
 * ``PyNaCl`` library (optional, for voice only)

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -11,7 +11,7 @@ in creating applications that utilise the Discord API.
 Prerequisites
 ---------------
 
-discord.py works with Python 3.5.2 or higher. Support for earlier versions of Python
+discord.py works with Python 3.5.3 or higher. Support for earlier versions of Python
 is not provided. Python 2.7 or lower is not supported. Python 3.4 or lower is not supported
 due to one of the dependencies (``aiohttp``) not supporting Python 3.4.
 

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -18,7 +18,7 @@ Python Version Change
 -----------------------
 
 In order to make development easier and also to allow for our dependencies to upgrade to allow usage of 3.7 or higher,
-the library had to remove support for Python versions lower than 3.5.2, which essentially means that **support for Python 3.4
+the library had to remove support for Python versions lower than 3.5.3, which essentially means that **support for Python 3.4
 is dropped**.
 
 Major Model Changes


### PR DESCRIPTION
The minimum version supported by aiohttp is CPython 3.5.3, not 3.5.2.
Fixes #1344.