### PR TITLE
Remove all asyncio.coroutine calls

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -787,13 +787,6 @@ class Client:
         log.debug('%s has successfully been registered as an event', coro.__name__)
         return coro
 
-    def async_event(self, coro):
-        """A shorthand decorator for :func:`asyncio.coroutine` + :meth:`event`."""
-        if not asyncio.iscoroutinefunction(coro):
-            coro = asyncio.coroutine(coro)
-
-        return self.event(coro)
-
     async def change_presence(self, *, activity=None, status=None, afk=False):
         """|coro|
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -25,7 +25,6 @@ DEALINGS IN THE SOFTWARE.
 """
 
 import copy
-import asyncio
 
 from collections import namedtuple, defaultdict
 
@@ -794,8 +793,7 @@ class Guild(Hashable):
 
         await http.edit_guild(self.id, reason=reason, **fields)
 
-    @asyncio.coroutine
-    def get_ban(self, user):
+    async def get_ban(self, user):
         """|coro|
 
         Retrieves the :class:`BanEntry` for a user, which is a namedtuple
@@ -824,7 +822,7 @@ class Guild(Hashable):
         BanEntry
             The BanEntry object for the specified user.
         """
-        data = yield from self._state.http.get_ban(user.id, self.id)
+        data = await self._state.http.get_ban(user.id, self.id)
         return BanEntry(
             user=User(state=self._state, data=data['user']),
             reason=data['reason']


### PR DESCRIPTION
One straggling @asyncio.coroutine was left behind from f25091efe1281aebe70189c61f9cac405b21a72f.

Also, @Client.async_event is no longer necessary, but I put its removal in a separate commit since it is a breaking change.