### PR TITLE
Allow cog name override

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -517,7 +517,7 @@ class BotBase(GroupMixin):
 
     # cogs
 
-    def add_cog(self, cog):
+    def add_cog(self, cog, name=None):
         """Adds a "cog" to the bot.
 
         A cog is a class that has its own event listeners and commands.
@@ -536,9 +536,16 @@ class BotBase(GroupMixin):
         -----------
         cog
             The cog to register to the bot.
+        name
+            The name under which to register the cog. If not present, defaults to the name of the cog class.
         """
-
-        self.cogs[type(cog).__name__] = cog
+        
+        if name is not None:
+            cog_name = str(name)
+        else:
+            cog_name = type(cog).__name__
+        
+        self.cogs[cog_name] = cog
 
         try:
             check = getattr(cog, '_{.__class__.__name__}__global_check'.format(cog))


### PR DESCRIPTION
I have added an additional parameter to bot.add_cog, allowing the name of the cog to be set to something other than the name of the cog class.

I think this will be useful in circumstances, for instance, where a developer wants to give all their cog classes names ending in `Cog`, but wants the "categories" in the help system to not have that suffix, without having to change any of the help functionality themselves.

Additionally, this adds extra configurability, which is generally useful in a library such as this.