### PR TITLE
[commands] raise ConversionError on Converter error

### DIFF
--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -30,7 +30,7 @@ __all__ = [ 'CommandError', 'MissingRequiredArgument', 'BadArgument',
            'NoPrivateMessage', 'CheckFailure', 'CommandNotFound',
            'DisabledCommand', 'CommandInvokeError', 'TooManyArguments',
            'UserInputError', 'CommandOnCooldown', 'NotOwner',
-           'MissingPermissions', 'BotMissingPermissions']
+           'MissingPermissions', 'BotMissingPermissions', 'ConversionError']
 
 class CommandError(DiscordException):
     """The base exception type for all command related errors.
@@ -48,6 +48,19 @@ class CommandError(DiscordException):
             super().__init__(m, *args)
         else:
             super().__init__(*args)
+
+class ConversionError(CommandError):
+    """Exception raised when a Converter class raises non-CommandError.
+
+    Attributes
+    ----------
+    converter: :class:`discord.ext.commands.Converter`
+        The converter that failed.
+
+    This inherits from :exc:`.CommandError`.
+    """
+    def __init__(self, converter):
+        self.converter = converter
 
 class UserInputError(CommandError):
     """The base exception type for errors that involve errors

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -187,6 +187,9 @@ Errors
 .. autoexception:: discord.ext.commands.CommandError
     :members:
 
+.. autoexception:: discord.ext.commands.ConversionError
+    :members:
+
 .. autoexception:: discord.ext.commands.MissingRequiredArgument
     :members:
 


### PR DESCRIPTION
This assumes that a Converter class raising non-CommandError
is a programmer error. Makes this type of error easier to
disambiguate from a generic BadArgument.

This is mostly motivated from experience developing converters, it's difficult currently to tell the difference between a converter succeeding but finding no results (e.g. calling converter.convert(), raises BadArgument etc.), and converter outright failing due to buggy implementation, since both end up raising BadArgument in the end. One downside is if anyone was just raising any old error in convert() instead of a CommandError, this would change the exception from a UserInputError/BadArgument to the more generic CommandError/ConversionError.

function and type style converters (e.g. int), should be unaffected by this change.