### PR TITLE
Revert "Ensure gif avatar urls end in `.gif`"

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -155,10 +155,7 @@ class BaseUser(_BaseUser):
             else:
                 format = static_format
 
-        # Discord has trouble animating gifs if the url does not end in `.gif`
-        gif_fix = '&_=.gif' if format == 'gif' else ''
-
-        return 'https://cdn.discordapp.com/avatars/{0.id}/{0.avatar}.{1}?size={2}{3}'.format(self, format, size, gif_fix)
+        return 'https://cdn.discordapp.com/avatars/{0.id}/{0.avatar}.{1}?size={2}'.format(self, format, size)
 
     @property
     def default_avatar(self):


### PR DESCRIPTION
This reverts commit 456390f417e63126b08ac52fa8ee49ca68cefed8.

This commit isn't needed anymore - the image proxy now properly
handles gifs that do not end in .gif