### PR TITLE
Fix behavior of everyone role mention

### DIFF
--- a/discord/role.py
+++ b/discord/role.py
@@ -160,7 +160,7 @@ class Role(Hashable):
     @property
     def mention(self):
         """Returns a string that allows you to mention a role."""
-        return '<@&%s>' % self.id
+        return '<@&%s>' % self.id if self.guild.id != self.id else '@everyone'
 
     @property
     def members(self):


### PR DESCRIPTION
Prior to this change, attempting to do `everyone_role.mention` would result in the mention being formatted strangely when viewed in discord, appearing as `@@everyone`. 

This fixes this behavior, which appears as a kind of "gotya" to anyone trying to make a message filter ala #1429, or trying, for some reason, to list off all a member's or server's roles including everyone.