### PR TITLE
update add_field

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -342,7 +342,7 @@ class Embed:
         """
         return [EmbedProxy(d) for d in getattr(self, '_fields', [])]
 
-    def add_field(self, *, name, value, inline=True):
+    def add_field(self, name, value, *, inline=True):
         """Adds a field to the embed object.
 
         This function returns the class instance to allow for fluent-style


### PR DESCRIPTION
`name` and `value` no longer need to be given as keyword args.

So, where before you may have had
```python
emb.add_field(name="Some name", value="A value")
```
you can now do:
```python
emb.add_field("Some name", "A value")
```
Reasons I think this is acceptable:
- It is still reasonably obvious from the code what it does (presumably the reason it is like this in the first place)
- Making required parameters keyword-only is inconvienient