### PR TITLE
Rewrite readme: change URL to download rewrite edition

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ To install the development version, do the following:
 
 .. code:: sh
 
-    python3 -m pip install -U https://github.com/Rapptz/discord.py/archive/master.zip#egg=discord.py[voice]
+    python3 -m pip install -U https://github.com/Rapptz/discord.py/archive/rewrite.zip#egg=discord.py[voice]
 
 or the more long winded from cloned source:
 


### PR DESCRIPTION
Downloading `master.zip` gives you the old 0.16 version of discord.py, not the rewrite version. This change tells users how to actually install the rewrite "development" version rather than the old one.