### PR TITLE
Added option to hide all commands from a cog

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -538,8 +538,9 @@ class BotBase(GroupMixin):
             The cog to register to the bot.
         hidden: bool
             Whether or not all commands in this cog should be hidden
-            from the help command. Defaults to ``False``. Commands with 
-            force_visible set to True will still appear in the help.
+            from the help command. Defaults to ``False``. Commands
+            which manually specifiy hidden as ``False`` will still 
+            be shown in the help.
             
         """
 
@@ -566,7 +567,7 @@ class BotBase(GroupMixin):
             # register commands the cog has
             if isinstance(member, Command):
                 if member.parent is None:
-                    if hidden and not member.force_visible:
+                    if hidden and not member.force_visibility:
                         member.hidden = True
                     self.add_command(member)
                 continue

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -517,7 +517,7 @@ class BotBase(GroupMixin):
 
     # cogs
 
-    def add_cog(self, cog):
+    def add_cog(self, cog, **kwargs):
         """Adds a "cog" to the bot.
 
         A cog is a class that has its own event listeners and commands.
@@ -536,6 +536,11 @@ class BotBase(GroupMixin):
         -----------
         cog
             The cog to register to the bot.
+        hidden: bool
+            Whether or not all commands in this cog should be hidden
+            from the help command. Defaults to ``False``. Commands with 
+            force_visible set to True will still appear in the help.
+            
         """
 
         self.cogs[type(cog).__name__] = cog
@@ -554,11 +559,15 @@ class BotBase(GroupMixin):
         else:
             self.add_check(check, call_once=True)
 
+        hidden = kwargs.get('hidden', False)
+
         members = inspect.getmembers(cog)
         for name, member in members:
             # register commands the cog has
             if isinstance(member, Command):
                 if member.parent is None:
+                    if hidden and not member.force_visible:
+                        member.hidden = True
                     self.add_command(member)
                 continue
 

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -142,6 +142,11 @@ class Command:
     hidden: :class:`bool`
         If ``True``\, the default help command does not show this in the
         help output.
+    force_visible: :class:`bool`
+        If ``True``\, the default help commaand will show this in the help
+        output even if the cog is set to be hidden. Setting this to true 
+        will not make the command visible if it is directly specified as hidden.
+        Defaults to ``False``. 
     rest_is_raw: :class:`bool`
         If ``False`` and a keyword-only argument is provided then the keyword
         only argument is stripped and handled as if it was a regular argument
@@ -173,6 +178,7 @@ class Command:
 
         self.description = inspect.cleandoc(kwargs.get('description', ''))
         self.hidden = kwargs.get('hidden', False)
+        self.force_visible = kwargs.get('force_visible', False)
         signature = inspect.signature(callback)
         self.params = signature.parameters.copy()
         self.checks = kwargs.get('checks', [])

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -141,12 +141,8 @@ class Command:
         The message prefixed into the default help command.
     hidden: :class:`bool`
         If ``True``\, the default help command does not show this in the
-        help output.
-    force_visible: :class:`bool`
-        If ``True``\, the default help commaand will show this in the help
-        output even if the cog is set to be hidden. Setting this to true 
-        will not make the command visible if it is directly specified as hidden.
-        Defaults to ``False``. 
+        help output. Manually specifying this has ``False`` will cause
+        the command to be shown in help even if the cog is hidden.
     rest_is_raw: :class:`bool`
         If ``False`` and a keyword-only argument is provided then the keyword
         only argument is stripped and handled as if it was a regular argument
@@ -177,8 +173,13 @@ class Command:
             raise TypeError("Aliases of a command must be a list of strings.")
 
         self.description = inspect.cleandoc(kwargs.get('description', ''))
-        self.hidden = kwargs.get('hidden', False)
-        self.force_visible = kwargs.get('force_visible', False)
+        hidden = kwargs.get('hidden', None)
+        if hidden is None:
+            self.hidden = False # Default to false
+            self.force_visibility = False
+        else:
+            self.hidden = hidden
+            self.force_visibility = True
         signature = inspect.signature(callback)
         self.params = signature.parameters.copy()
         self.checks = kwargs.get('checks', [])


### PR DESCRIPTION
Added a keyword argument to `bot.add_cog` that allows all commands from a cog to be hidden. Additionally added a keyword argument to the command class which forces the command to be shown in help, even if the entire cog is hidden.

Both arguments default to False, keeping all behavior the same unless the arguments are supplied.