### PR TITLE
Fix Reaction.users documentation

### DIFF
--- a/discord/reaction.py
+++ b/discord/reaction.py
@@ -94,10 +94,7 @@ class Reaction:
         return '<Reaction emoji={0.emoji!r} me={0.me} count={0.count}>'.format(self)
 
     def users(self, limit=None, after=None):
-        """|coro|
-
-        Returns an :class:`AsyncIterator` representing the
-        users that have reacted to the message.
+        """Returns an :class:`AsyncIterator` representing the users that have reacted to the message.
 
         The ``after`` parameter must represent a member
         and meet the :class:`abc.Snowflake` abc.


### PR DESCRIPTION
Reaction.users is not a coroutine as of https://github.com/Rapptz/discord.py/commit/ae6fb54b1b926463166cb248d6b399dd38ea1e6e. (wow, that's more than a year ago)

First PR, sorry I don't know what to do :/