### PR TITLE
Fix for #1462 (Implement Emoji.user attr)

### DIFF
--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -141,8 +141,10 @@ class Emoji(Hashable):
         If this emoji is managed by a Twitch integration.
     guild_id: :class:`int`
         The guild ID the emoji belongs to.
+    user Optional[:class:`User`]
+        The user that created the emoji, None if not avaliable.
     """
-    __slots__ = ('require_colons', 'animated', 'managed', 'id', 'name', '_roles', 'guild_id', '_state')
+    __slots__ = ('require_colons', 'animated', 'managed', 'id', 'name', '_roles', 'guild_id', '_state', 'user')
 
     def __init__(self, *, guild, state, data):
         self.guild_id = guild.id
@@ -156,6 +158,9 @@ class Emoji(Hashable):
         self.name = emoji['name']
         self.animated = emoji.get('animated', False)
         self._roles = set(emoji.get('roles', []))
+        self.user = user = emoji.get('user', None)
+        if user is not None:
+            self.user = self._state.store_user(user)
 
     def _iterator(self):
         for attr in self.__slots__:


### PR DESCRIPTION
Please review prior to merging.

This change implements a user attribute on the discord.Emoji object of a discord.User type.
(should it be a Member instance instead?)