### PR TITLE
Lint fixes part 1

### DIFF
--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -197,7 +197,7 @@ def newbot(parser, args):
         with open(str(new_directory / 'config.py'), 'w', encoding='utf-8') as fp:
             fp.write('token = "place your token here"\ncogs = []\n')
     except OSError as e:
-       parser.error('could not create config file ({})'.format(e))
+        parser.error('could not create config file ({})'.format(e))
 
     try:
         with open(str(new_directory / 'bot.py'), 'w', encoding='utf-8') as fp:

--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -28,8 +28,6 @@ import discord
 import argparse
 import sys
 from pathlib import Path
-import os
-import re
 
 def core(parser, args):
     pass

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -955,7 +955,7 @@ class Connectable(metaclass=abc.ABCMeta):
         :class:`VoiceClient`
             A voice client that is fully connected to the voice server.
         """
-        key_id, key_name = self._get_voice_client_key()
+        key_id, _ = self._get_voice_client_key()
         state = self._state
 
         if state._get_voice_client(key_id):

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -742,7 +742,7 @@ class Messageable(metaclass=abc.ABCMeta):
 
             try:
                 data = await state.http.send_files(channel.id, files=[(file.open_file(), file.filename)],
-                                                        content=content, tts=tts, embed=embed, nonce=nonce)
+                                                   content=content, tts=tts, embed=embed, nonce=nonce)
             finally:
                 file.close()
 
@@ -753,7 +753,7 @@ class Messageable(metaclass=abc.ABCMeta):
             try:
                 param = [(f.open_file(), f.filename) for f in files]
                 data = await state.http.send_files(channel.id, files=param, content=content, tts=tts,
-                                                        embed=embed, nonce=nonce)
+                                                   embed=embed, nonce=nonce)
             finally:
                 for f in files:
                     f.close()

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -28,7 +28,7 @@ from .enums import ActivityType, try_enum
 from .colour import Colour
 import datetime
 
-__all__ = ('Activity', 'Streaming', 'Game', 'Spotify')
+__all__ = ['Activity', 'Streaming', 'Game', 'Spotify']
 
 """If curious, this is the current schema for an activity.
 

--- a/discord/calls.py
+++ b/discord/calls.py
@@ -153,4 +153,3 @@ class GroupCall:
         """
 
         return self._voice_states.get(user.id)
-

--- a/discord/calls.py
+++ b/discord/calls.py
@@ -110,7 +110,7 @@ class GroupCall:
         lookup = {u.id: u for u in self.call.channel.recipients}
         me = self.call.channel.me
         lookup[me.id] = me
-        self.ringing = list(filter(None, map(lambda i: lookup.get(i), kwargs.get('ringing', []))))
+        self.ringing = list(filter(None, map(lookup.get, kwargs.get('ringing', []))))
 
     def _update_voice_state(self, data):
         user_id = int(data['user_id'])

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -36,7 +36,7 @@ import discord.abc
 import time
 import asyncio
 
-__all__ = ('TextChannel', 'VoiceChannel', 'DMChannel', 'CategoryChannel', 'GroupChannel', '_channel_factory')
+__all__ = ['TextChannel', 'VoiceChannel', 'DMChannel', 'CategoryChannel', 'GroupChannel', '_channel_factory']
 
 async def _single_delete_strategy(messages):
     for m in messages:

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """
 The MIT License (MIT)
 
@@ -79,8 +80,8 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         top channel is position 0.
     """
 
-    __slots__ = ( 'name', 'id', 'guild', 'topic', '_state', 'nsfw',
-                  'category_id', 'position', '_overwrites' )
+    __slots__ = ('name', 'id', 'guild', 'topic', '_state', 'nsfw',
+                 'category_id', 'position', '_overwrites')
 
     def __init__(self, *, state, guild, data):
         self._state = state
@@ -414,8 +415,8 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
         The channel's limit for number of members that can be in a voice channel.
     """
 
-    __slots__ = ('name', 'id', 'guild', 'bitrate',  'user_limit',
-                 '_state', 'position', '_overwrites', 'category_id' )
+    __slots__ = ('name', 'id', 'guild', 'bitrate', 'user_limit',
+                 '_state', 'position', '_overwrites', 'category_id')
 
     def __init__(self, *, state, guild, data):
         self._state = state

--- a/discord/client.py
+++ b/discord/client.py
@@ -368,10 +368,8 @@ class Client:
                 await self.ws.poll_event()
             except ResumeWebSocket:
                 log.info('Got a request to RESUME the websocket.')
-                coro = DiscordWebSocket.from_client(self, shard_id=self.shard_id,
-                                                          session=self.ws.session_id,
-                                                          sequence=self.ws.sequence,
-                                                          resume=True)
+                coro = DiscordWebSocket.from_client(self, shard_id=self.shard_id, session=self.ws.session_id,
+                                                    sequence=self.ws.sequence, resume=True)
                 self.ws = await asyncio.wait_for(coro, timeout=180.0, loop=self.loop)
 
     async def connect(self, *, reconnect=True):

--- a/discord/client.py
+++ b/discord/client.py
@@ -366,7 +366,7 @@ class Client:
         while True:
             try:
                 await self.ws.poll_event()
-            except ResumeWebSocket as e:
+            except ResumeWebSocket:
                 log.info('Got a request to RESUME the websocket.')
                 coro = DiscordWebSocket.from_client(self, shard_id=self.shard_id,
                                                           session=self.ws.session_id,

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -119,7 +119,7 @@ class Embed:
         # fill in the basic fields
 
         self.title = data.get('title', EmptyEmbed)
-        self.type  = data.get('type', EmptyEmbed)
+        self.type = data.get('type', EmptyEmbed)
         self.description = data.get('description', EmptyEmbed)
         self.url = data.get('url', EmptyEmbed)
 

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -24,7 +24,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-import asyncio
 from collections import namedtuple
 
 from . import utils

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -137,7 +137,7 @@ async def _default_help_command(ctx, *commands : str):
         pages = await bot.formatter.format_help_for(ctx, command)
 
     if bot.pm_help is None:
-        characters = sum(map(lambda l: len(l), pages))
+        characters = sum(map(len, pages))
         # modify destination based on length of pages.
         if characters > 1000:
             destination = ctx.message.author

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -33,7 +33,7 @@ import sys
 import traceback
 import re
 
-from .core import GroupMixin, Command, command
+from .core import GroupMixin, Command
 from .view import StringView
 from .context import Context
 from .errors import CommandNotFound, CommandError

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """
 The MIT License (MIT)
 

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -23,7 +23,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-import asyncio
 import discord.abc
 import discord.utils
 

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -25,12 +25,10 @@ DEALINGS IN THE SOFTWARE.
 """
 
 import discord
-import asyncio
 import re
 import inspect
 
 from .errors import BadArgument, NoPrivateMessage
-from .view import StringView
 
 __all__ = [ 'Converter', 'MemberConverter', 'UserConverter',
             'TextChannelConverter', 'InviteConverter', 'RoleConverter',

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -30,11 +30,11 @@ import inspect
 
 from .errors import BadArgument, NoPrivateMessage
 
-__all__ = [ 'Converter', 'MemberConverter', 'UserConverter',
-            'TextChannelConverter', 'InviteConverter', 'RoleConverter',
-            'GameConverter', 'ColourConverter', 'VoiceChannelConverter',
-            'EmojiConverter', 'PartialEmojiConverter', 'CategoryChannelConverter',
-            'IDConverter', 'clean_content' ]
+__all__ = ['Converter', 'MemberConverter', 'UserConverter',
+           'TextChannelConverter', 'InviteConverter', 'RoleConverter',
+           'GameConverter', 'ColourConverter', 'VoiceChannelConverter',
+           'EmojiConverter', 'PartialEmojiConverter', 'CategoryChannelConverter',
+           'IDConverter', 'clean_content']
 
 def _get_from_guilds(bot, getter, argument):
     result = None

--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """
 The MIT License (MIT)
 
@@ -31,7 +32,7 @@ __all__ = ['BucketType', 'Cooldown', 'CooldownMapping']
 class BucketType(enum.Enum):
     default = 0
     user    = 1
-    guild  = 2
+    guild   = 2
     channel = 3
 
 class Cooldown:

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -321,7 +321,7 @@ class Command:
         try:
             # first/second parameter is context
             result.popitem(last=False)
-        except Exception as e:
+        except Exception:
             raise ValueError('Missing context parameter') from None
 
         return result

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -35,10 +35,10 @@ from .cooldowns import Cooldown, BucketType, CooldownMapping
 from .view import quoted_word
 from . import converter as converters
 
-__all__ = [ 'Command', 'Group', 'GroupMixin', 'command', 'group',
-            'has_role', 'has_permissions', 'has_any_role', 'check',
-            'bot_has_role', 'bot_has_permissions', 'bot_has_any_role',
-            'cooldown', 'guild_only', 'is_owner', 'is_nsfw', ]
+__all__ = ['Command', 'Group', 'GroupMixin', 'command', 'group',
+           'has_role', 'has_permissions', 'has_any_role', 'check',
+           'bot_has_role', 'bot_has_permissions', 'bot_has_any_role',
+           'cooldown', 'guild_only', 'is_owner', 'is_nsfw']
 
 def wrap_callback(coro):
     @functools.wraps(coro)

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """
 The MIT License (MIT)
 
@@ -26,7 +27,7 @@ DEALINGS IN THE SOFTWARE.
 from discord.errors import DiscordException
 
 
-__all__ = [ 'CommandError', 'MissingRequiredArgument', 'BadArgument',
+__all__ = ['CommandError', 'MissingRequiredArgument', 'BadArgument',
            'NoPrivateMessage', 'CheckFailure', 'CommandNotFound',
            'DisabledCommand', 'CommandInvokeError', 'TooManyArguments',
            'UserInputError', 'CommandOnCooldown', 'NotOwner',
@@ -171,7 +172,7 @@ class MissingPermissions(CheckFailure):
         missing = [perm.replace('_', ' ').replace('guild', 'server').title() for perm in missing_perms]
 
         if len(missing) > 2:
-            fmt =  '{}, and {}'.format(", ".join(missing[:-1]), missing[-1])
+            fmt = '{}, and {}'.format(", ".join(missing[:-1]), missing[-1])
         else:
             fmt = ' and '.join(missing)
         message = 'You are missing {} permission(s) to run command.'.format(fmt)
@@ -191,7 +192,7 @@ class BotMissingPermissions(CheckFailure):
         missing = [perm.replace('_', ' ').replace('guild', 'server').title() for perm in missing_perms]
 
         if len(missing) > 2:
-            fmt =  '{}, and {}'.format(", ".join(missing[:-1]), missing[-1])
+            fmt = '{}, and {}'.format(", ".join(missing[:-1]), missing[-1])
         else:
             fmt = ' and '.join(missing)
         message = 'Bot requires {} permission(s) to run command.'.format(fmt)

--- a/discord/ext/commands/formatter.py
+++ b/discord/ext/commands/formatter.py
@@ -26,7 +26,6 @@ DEALINGS IN THE SOFTWARE.
 
 import itertools
 import inspect
-import asyncio
 
 from .core import GroupMixin, Command
 from .errors import CommandError

--- a/discord/ext/commands/view.py
+++ b/discord/ext/commands/view.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """
 The MIT License (MIT)
 

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -40,8 +40,8 @@ import struct
 
 log = logging.getLogger(__name__)
 
-__all__ = [ 'DiscordWebSocket', 'KeepAliveHandler', 'VoiceKeepAliveHandler',
-            'DiscordVoiceWebSocket', 'ResumeWebSocket' ]
+__all__ = ['DiscordWebSocket', 'KeepAliveHandler', 'VoiceKeepAliveHandler',
+           'DiscordVoiceWebSocket', 'ResumeWebSocket']
 
 class ResumeWebSocket(Exception):
     """Signals to initialise via RESUME opcode instead of IDENTIFY."""
@@ -381,7 +381,7 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
             self.sequence = msg['s']
             self.session_id = data['session_id']
             log.info('Shard ID %s has connected to Gateway: %s (Session ID: %s).',
-                      self.shard_id, ', '.join(trace), self.session_id)
+                     self.shard_id, ', '.join(trace), self.session_id)
 
         if event == 'RESUMED':
             self._trace = trace = data.get('_trace', [])
@@ -684,5 +684,3 @@ class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
             self._keep_alive.stop()
 
         await super().close_connection(*args, **kwargs)
-
-

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -69,7 +69,7 @@ class KeepAliveHandler(threading.Thread):
     def run(self):
         while not self._stop_ev.wait(self.interval):
             if self._last_ack + self.heartbeat_timeout < time.monotonic():
-                log.warn("Shard ID %s has stopped responding to the gateway. Closing and restarting." % self.shard_id)
+                log.warning("Shard ID %s has stopped responding to the gateway. Closing and restarting." % self.shard_id)
                 coro = self.ws.close(4000)
                 f = asyncio.run_coroutine_threadsafe(coro, loop=self.ws.loop)
 

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -30,7 +30,7 @@ import websockets
 import asyncio
 
 from . import utils
-from .activity import create_activity, _ActivityTag
+from .activity import _ActivityTag
 from .errors import ConnectionClosed, InvalidArgument
 import logging
 import zlib, json

--- a/discord/http.py
+++ b/discord/http.py
@@ -30,7 +30,6 @@ import json
 import sys
 import logging
 import weakref
-import datetime
 from urllib.parse import quote as _uriquote
 
 log = logging.getLogger(__name__)

--- a/discord/http.py
+++ b/discord/http.py
@@ -339,8 +339,7 @@ class HTTPClient:
         return self.request(r, data=form)
 
     async def ack_message(self, channel_id, message_id):
-        r = Route('POST', '/channels/{channel_id}/messages/{message_id}/ack', channel_id=channel_id,
-                                                                          message_id=message_id)
+        r = Route('POST', '/channels/{channel_id}/messages/{message_id}/ack', channel_id=channel_id, message_id=message_id)
         data = await self.request(r, json={'token': self._ack_token})
         self._ack_token = data['token']
 
@@ -348,8 +347,7 @@ class HTTPClient:
         return self.request(Route('POST', '/guilds/{guild_id}/ack', guild_id=guild_id))
 
     def delete_message(self, channel_id, message_id, *, reason=None):
-        r = Route('DELETE', '/channels/{channel_id}/messages/{message_id}', channel_id=channel_id,
-                                                                            message_id=message_id)
+        r = Route('DELETE', '/channels/{channel_id}/messages/{message_id}', channel_id=channel_id, message_id=message_id)
         return self.request(r, reason=reason)
 
     def delete_messages(self, channel_id, message_ids, *, reason=None):
@@ -361,8 +359,7 @@ class HTTPClient:
         return self.request(r, json=payload, reason=reason)
 
     def edit_message(self, message_id, channel_id, **fields):
-        r = Route('PATCH', '/channels/{channel_id}/messages/{message_id}', channel_id=channel_id,
-                                                                           message_id=message_id)
+        r = Route('PATCH', '/channels/{channel_id}/messages/{message_id}', channel_id=channel_id, message_id=message_id)
         return self.request(r, json=fields)
 
     def add_reaction(self, message_id, channel_id, emoji):
@@ -382,7 +379,7 @@ class HTTPClient:
 
     def get_reaction_users(self, message_id, channel_id, emoji, limit, after=None):
         r = Route('GET', '/channels/{channel_id}/messages/{message_id}/reactions/{emoji}',
-                         channel_id=channel_id, message_id=message_id, emoji=emoji)
+                  channel_id=channel_id, message_id=message_id, emoji=emoji)
 
         params = {'limit': limit}
         if after:
@@ -415,11 +412,11 @@ class HTTPClient:
 
     def pin_message(self, channel_id, message_id):
         return self.request(Route('PUT', '/channels/{channel_id}/pins/{message_id}',
-                            channel_id=channel_id, message_id=message_id))
+                                  channel_id=channel_id, message_id=message_id))
 
     def unpin_message(self, channel_id, message_id):
         return self.request(Route('DELETE', '/channels/{channel_id}/pins/{message_id}',
-                            channel_id=channel_id, message_id=message_id))
+                                  channel_id=channel_id, message_id=message_id))
 
     def pins_from(self, channel_id):
         return self.request(Route('GET', '/channels/{channel_id}/pins', channel_id=channel_id))
@@ -584,7 +581,7 @@ class HTTPClient:
         return self.request(Route('GET', '/guilds/{guild_id}/vanity-url', guild_id=guild_id))
 
     def change_vanity_code(self, guild_id, code, *, reason=None):
-        payload = { 'code': code }
+        payload = {'code': code}
         return self.request(Route('PATCH', '/guilds/{guild_id}/vanity-url', guild_id=guild_id), json=payload, reason=reason)
 
     def prune_members(self, guild_id, days, *, reason=None):
@@ -620,7 +617,7 @@ class HTTPClient:
         return self.request(r, json=payload, reason=reason)
 
     def get_audit_logs(self, guild_id, limit=100, before=None, after=None, user_id=None, action_type=None):
-        params = { 'limit': limit }
+        params = {'limit': limit}
         if before:
             params['before'] = before
         if after:

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -78,8 +78,8 @@ class Invite(Hashable):
     """
 
 
-    __slots__ = ( 'max_age', 'code', 'guild', 'revoked', 'created_at', 'uses',
-                  'temporary', 'max_uses', 'inviter', 'channel', '_state' )
+    __slots__ = ('max_age', 'code', 'guild', 'revoked', 'created_at', 'uses',
+                 'temporary', 'max_uses', 'inviter', 'channel', '_state')
 
     def __init__(self, *, state, data):
         self._state = state

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -24,8 +24,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-import asyncio
-
 from .utils import parse_time
 from .mixins import Hashable
 from .object import Object

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -24,7 +24,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-import sys
 import asyncio
 import datetime
 

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -395,7 +395,7 @@ class AuditLogIterator(_AsyncIterator):
     async def _before_strategy(self, retrieve):
         before = self.before.id if self.before else None
         data = await self.request(self.guild.id, limit=retrieve, user_id=self.user_id,
-                                       action_type=self.action_type, before=before)
+                                  action_type=self.action_type, before=before)
 
         entries = data.get('audit_log_entries', [])
         if len(data) and entries:
@@ -407,7 +407,7 @@ class AuditLogIterator(_AsyncIterator):
     async def _after_strategy(self, retrieve):
         after = self.after.id if self.after else None
         data = await self.request(self.guild.id, limit=retrieve, user_id=self.user_id,
-                                       action_type=self.action_type, after=after)
+                                  action_type=self.action_type, after=after)
         entries = data.get('audit_log_entries', [])
         if len(data) and entries:
             if self.limit is not None:

--- a/discord/member.py
+++ b/discord/member.py
@@ -57,8 +57,8 @@ class VoiceState:
         is not currently in a voice channel.
     """
 
-    __slots__ = ( 'session_id', 'deaf', 'mute', 'self_mute',
-                  'self_deaf', 'afk', 'channel' )
+    __slots__ = ('session_id', 'deaf', 'mute', 'self_mute',
+                 'self_deaf', 'afk', 'channel')
 
     def __init__(self, *, data, channel=None):
         self.session_id = data.get('session_id')

--- a/discord/member.py
+++ b/discord/member.py
@@ -24,7 +24,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-import asyncio
 import itertools
 import copy
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -32,7 +32,7 @@ from .reaction import Reaction
 from .emoji import Emoji, PartialEmoji
 from .calls import CallMessage
 from .enums import MessageType, try_enum
-from .errors import InvalidArgument, ClientException, HTTPException, NotFound
+from .errors import InvalidArgument, ClientException
 from .embeds import Embed
 
 class Attachment:

--- a/discord/message.py
+++ b/discord/message.py
@@ -194,13 +194,13 @@ class Message:
         - ``cover_image``: A string representing the embed's image asset ID.
     """
 
-    __slots__ = ( '_edited_timestamp', 'tts', 'content', 'channel', 'webhook_id',
-                  'mention_everyone', 'embeds', 'id', 'mentions', 'author',
-                  '_cs_channel_mentions', '_cs_raw_mentions', 'attachments',
-                  '_cs_clean_content', '_cs_raw_channel_mentions', 'nonce', 'pinned',
-                  'role_mentions', '_cs_raw_role_mentions', 'type', 'call',
-                  '_cs_system_content', '_cs_guild', '_state', 'reactions',
-                  'application', 'activity' )
+    __slots__ = ('_edited_timestamp', 'tts', 'content', 'channel', 'webhook_id',
+                 'mention_everyone', 'embeds', 'id', 'mentions', 'author',
+                 '_cs_channel_mentions', '_cs_raw_mentions', 'attachments',
+                 '_cs_clean_content', '_cs_raw_channel_mentions', 'nonce', 'pinned',
+                 'role_mentions', '_cs_raw_role_mentions', 'type', 'call',
+                 '_cs_system_content', '_cs_guild', '_state', 'reactions',
+                 'application', 'activity')
 
     def __init__(self, *, state, channel, data):
         self._state = state

--- a/discord/message.py
+++ b/discord/message.py
@@ -366,7 +366,7 @@ class Message:
     def channel_mentions(self):
         if self.guild is None:
             return []
-        it = filter(None, map(lambda m: self.guild.get_channel(m), self.raw_channel_mentions))
+        it = filter(None, map(self.guild.get_channel, self.raw_channel_mentions))
         return utils._unique(it)
 
     @utils.cached_slot_property('_cs_clean_content')

--- a/discord/object.py
+++ b/discord/object.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """
 The MIT License (MIT)
 

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -493,7 +493,7 @@ class Permissions:
     # after these 32 bits, there's 21 more unused ones technically
 
 def augment_from_permissions(cls):
-    cls.VALID_NAMES = { name for name in dir(Permissions) if isinstance(getattr(Permissions, name), property) }
+    cls.VALID_NAMES = {name for name in dir(Permissions) if isinstance(getattr(Permissions, name), property)}
 
     # make descriptors for all the valid names
     for name in cls.VALID_NAMES:
@@ -562,7 +562,7 @@ class PermissionOverwrite:
         """
 
         allow = Permissions.none()
-        deny  = Permissions.none()
+        deny = Permissions.none()
 
         for key, value in self._values.items():
             if value is True:

--- a/discord/player.py
+++ b/discord/player.py
@@ -36,7 +36,7 @@ from .opus import Encoder as OpusEncoder
 
 log = logging.getLogger(__name__)
 
-__all__ = [ 'AudioSource', 'PCMAudio', 'FFmpegPCMAudio', 'PCMVolumeTransformer' ]
+__all__ = ['AudioSource', 'PCMAudio', 'FFmpegPCMAudio', 'PCMVolumeTransformer']
 
 class AudioSource:
     """Represents an audio stream.

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -64,7 +64,7 @@ class RawBulkMessageDeleteEvent:
     __slots__ = ('message_ids', 'channel_id', 'guild_id')
 
     def __init__(self, data):
-        self.message_ids = { int(x) for x in data.get('ids', []) }
+        self.message_ids = {int(x) for x in data.get('ids', [])}
         self.channel_id = int(data['channel_id'])
 
         try:

--- a/discord/relationship.py
+++ b/discord/relationship.py
@@ -26,8 +26,6 @@ DEALINGS IN THE SOFTWARE.
 
 from .enums import RelationshipType, try_enum
 
-import asyncio
-
 class Relationship:
     """Represents a relationship in Discord.
 

--- a/discord/role.py
+++ b/discord/role.py
@@ -92,7 +92,7 @@ class Role(Hashable):
     """
 
     __slots__ = ('id', 'name', 'permissions', 'color', 'colour', 'position',
-                 'managed', 'mentionable', 'hoist', 'guild', '_state' )
+                 'managed', 'mentionable', 'hoist', 'guild', '_state')
 
     def __init__(self, *, guild, state, data):
         self.guild = guild

--- a/discord/role.py
+++ b/discord/role.py
@@ -24,8 +24,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-import asyncio
-
 from .permissions import Permissions
 from .errors import InvalidArgument
 from .colour import Colour

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -74,7 +74,7 @@ class Shard:
     async def poll(self):
         try:
             await self.ws.poll_event()
-        except ResumeWebSocket as e:
+        except ResumeWebSocket:
             log.info('Got a request to RESUME the websocket at Shard ID %s.', self.id)
             coro = DiscordWebSocket.from_client(self._client, resume=True,
                                                               shard_id=self.id,
@@ -212,7 +212,7 @@ class AutoShardedClient(Client):
         try:
             coro = websockets.connect(gateway, loop=self.loop, klass=DiscordWebSocket, compression=None)
             ws = await asyncio.wait_for(coro, loop=self.loop, timeout=180.0)
-        except Exception as e:
+        except Exception:
             log.info('Failed to connect for shard_id: %s. Retrying...', shard_id)
             await asyncio.sleep(5.0, loop=self.loop)
             return (await self.launch_shard(gateway, shard_id))
@@ -265,7 +265,7 @@ class AutoShardedClient(Client):
 
         while True:
             pollers = [shard.get_future() for shard in self.shards.values()]
-            done, pending = await asyncio.wait(pollers, loop=self.loop, return_when=asyncio.FIRST_COMPLETED)
+            done, _ = await asyncio.wait(pollers, loop=self.loop, return_when=asyncio.FIRST_COMPLETED)
             for f in done:
                 # we wanna re-raise to the main Client.connect handler if applicable
                 f.result()

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -76,10 +76,8 @@ class Shard:
             await self.ws.poll_event()
         except ResumeWebSocket:
             log.info('Got a request to RESUME the websocket at Shard ID %s.', self.id)
-            coro = DiscordWebSocket.from_client(self._client, resume=True,
-                                                              shard_id=self.id,
-                                                              session=self.ws.session_id,
-                                                              sequence=self.ws.sequence)
+            coro = DiscordWebSocket.from_client(self._client, resume=True, shard_id=self.id,
+                                                session=self.ws.session_id, sequence=self.ws.sequence)
             self.ws = await asyncio.wait_for(coro, timeout=180.0, loop=self.loop)
 
     def get_future(self):

--- a/discord/state.py
+++ b/discord/state.py
@@ -35,7 +35,6 @@ from .raw_models import *
 from .member import Member
 from .role import Role
 from .enums import ChannelType, try_enum, Status
-from .calls import GroupCall
 from . import utils
 from .embeds import Embed
 

--- a/discord/state.py
+++ b/discord/state.py
@@ -240,7 +240,7 @@ class ConnectionState:
         return guild
 
     def chunks_needed(self, guild):
-        for chunk in range(math.ceil(guild._member_count / 1000)):
+        for _ in range(math.ceil(guild._member_count / 1000)):
             yield self.receive_chunk(guild.id)
 
     def _get_guild_channel(self, data):
@@ -423,7 +423,7 @@ class ConnectionState:
             emoji = self._upgrade_partial_emoji(emoji)
             try:
                 reaction = message._remove_reaction(data, emoji, raw.user_id)
-            except (AttributeError, ValueError) as e: # eventual consistency lol
+            except (AttributeError, ValueError): # eventual consistency lol
                 pass
             else:
                 user = self._get_reaction_user(message.channel, raw.user_id)

--- a/discord/state.py
+++ b/discord/state.py
@@ -405,7 +405,7 @@ class ConnectionState:
         raw = RawReactionClearEvent(data)
         self.dispatch('raw_reaction_clear', raw)
 
-        message =  self._get_message(raw.message_id)
+        message = self._get_message(raw.message_id)
         if message is not None:
             old_reactions = message.reactions.copy()
             message.reactions.clear()
@@ -457,7 +457,7 @@ class ConnectionState:
         self.user = ClientUser(state=self, data=data)
 
     def parse_channel_delete(self, data):
-        guild =  self._get_guild(utils._get_as_snowflake(data, 'guild_id'))
+        guild = self._get_guild(utils._get_as_snowflake(data, 'guild_id'))
         channel_id = int(data['id'])
         if guild is not None:
             channel = guild.get_channel(channel_id)

--- a/discord/user.py
+++ b/discord/user.py
@@ -31,7 +31,6 @@ from .errors import ClientException, InvalidArgument
 from collections import namedtuple
 
 import discord.abc
-import asyncio
 
 VALID_STATIC_FORMATS = {"jpeg", "jpg", "webp", "png"}
 VALID_AVATAR_FORMATS = VALID_STATIC_FORMATS | {"gif"}

--- a/discord/user.py
+++ b/discord/user.py
@@ -466,7 +466,7 @@ class User(BaseUser, discord.abc.Messageable):
         Specifies if the user is a bot account.
     """
 
-    __slots__ = ('__weakref__')
+    __slots__ = ('__weakref__',)
 
     def __repr__(self):
         return '<User id={0.id} name={0.name!r} discriminator={0.discriminator!r} bot={0.bot}>'.format(self)

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -281,7 +281,7 @@ async def async_all(gen, *, check=_isawaitable):
     return True
 
 async def sane_wait_for(futures, *, timeout, loop):
-    done, pending = await asyncio.wait(futures, timeout=timeout, loop=loop)
+    _, pending = await asyncio.wait(futures, timeout=timeout, loop=loop)
 
     if len(pending) != 0:
         raise asyncio.TimeoutError()

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -132,7 +132,6 @@ class VoiceClient:
     async def start_handshake(self):
         log.info('Starting voice handshake...')
 
-        key_id, key_name = self.channel._get_voice_client_key()
         guild_id, channel_id = self.channel._get_voice_state_pair()
         state = self._state
         self.main_ws = ws = state._get_websocket(guild_id)

--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -222,7 +222,7 @@ class RequestsWebhookAdapter(WebhookAdapter):
             data = utils.to_json(payload)
 
         if multipart is not None:
-            data = { 'payload_json': multipart.pop('payload_json') }
+            data = {'payload_json': multipart.pop('payload_json')}
 
         for tries in range(5):
             r = self.session.request(verb, url, headers=headers, data=data, files=multipart)

--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -34,7 +34,7 @@ from . import utils
 from .errors import InvalidArgument, HTTPException, Forbidden, NotFound
 from .user import BaseUser, User
 
-__all__ = ('WebhookAdapter', 'AsyncWebhookAdapter', 'RequestsWebhookAdapter', 'Webhook')
+__all__ = ['WebhookAdapter', 'AsyncWebhookAdapter', 'RequestsWebhookAdapter', 'Webhook']
 
 class WebhookAdapter:
     """Base class for all webhook adapters.


### PR DESCRIPTION
This is the first set of fixes related to my linting of the library using Pylint.  These are primarily fixing inconsistent whitespace and removing unused imports and variables.  Additionally 3 unnecessary lambdas, a deprecated function call, and some inconsistent types used for `__all__` and `__slots__` are also fixed.

A brief description of most of the changes is available in the [filtered lint report](http://www.hornwitser.no/x/discord/lint/#ref=origin/lint-1&cmp=f06563c&types=warning,convention&modules=all&diffs=add,chg,sub&hide=filters,reports).