### PR TITLE
Update the installing documentation

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -23,16 +23,16 @@ Installing
 
 You can get the library directly from PyPI: ::
 
-    python3 -m pip install -U discord.py
+    python3 -m pip install -U git+https://github.com/Rapptz/discord.py@rewrite
 
 If you are using Windows, then the following should be used instead: ::
 
-    py -3 -m pip install -U discord.py
+    py -3 -m pip install -U git+https://github.com/Rapptz/discord.py@rewrite
 
 
 To get voice support, you should use ``discord.py[voice]`` instead of ``discord.py``, e.g. ::
 
-    python3 -m pip install -U discord.py[voice]
+    python3 -m pip install -U git+https://github.com/Rapptz/discord.py@rewrite#egg=discord.py[voice]
 
 On Linux environments, installing voice requires getting the following dependencies:
 
@@ -83,7 +83,7 @@ However, for the quick and dirty:
 
     .. code-block:: shell
 
-        $ pip install -U discord.py
+        $ python3 -m pip install -U git+https://github.com/Rapptz/discord.py@rewrite
 
 Congratulations. You now have a virtual environment all set up without messing with your system installation.
 


### PR DESCRIPTION
The rewrite documentation has a problem currently, following it will install the old version, not the rewrite. This commit fixes this in part, but a second look would be appreciated