### PR TITLE
Delete  requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp>=1.0.0,<1.1.0
-websockets>=3.1,<4.0
+aiohttp>=1.0.0
+websockets>=3.1


### PR DESCRIPTION
In after upgrading to python 3.7 and istalling with `pip install https://github.com/Rapptz/discord.py/archive/async.zip`, discord.py wouldn't play nicely with EITHER lib at these versions. When I told pip to ignore dependencies, discord.py started working again. 

I'd be happy to fix up this commit with the actual required dependencies if you need them. But no matter what. these values are invalid for the async branch.