### PR TITLE
Bot.unload_extension: don't remove commands from no module

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -734,6 +734,8 @@ class BotBase(GroupMixin):
 
         # first remove all the commands from the module
         for cmd in self.all_commands.copy().values():
+            if cmd.module is None:
+                continue
             if _is_submodule(lib_name, cmd.module):
                 if isinstance(cmd, GroupMixin):
                     cmd.recursively_remove_all_commands()


### PR DESCRIPTION
## steps
1. run this code in an eval:
```py
@bot.command()
async def foo(context):
    await context.send('bar')
```
2. `bot.unload_extension('literally any extension doesn't matter')`

## expected behavior
extension unloaded

## actual behavior
extension not unloaded, exception:
```
  File "discord/ext/commands/bot.py", line 737, in unload_extension
    if _is_submodule(lib_name, cmd.module):
  File "discord/ext/commands/bot.py", line 93, in _is_submodule
    return parent == child or child.startswith(parent + ".")
AttributeError: 'NoneType' object has no attribute 'startswith'
```
## reason
problem code:
https://github.com/Rapptz/discord.py/blob/a93c3d931ca6fa069af591ff92886617ec7abe58/discord/ext/commands/bot.py#L735-L740
Command.module is None if callback.\_\_module__ is None, as is the case for commands added by eval.