### PR TITLE
Move conditional RTD dependencies to 'docs' extra

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,8 +16,6 @@ import sys
 import os
 import re
 
-on_rtd = os.getenv('READTHEDOCS') == 'True'
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -36,14 +34,10 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.extlinks',
     'sphinx.ext.intersphinx',
+    'sphinx.ext.napoleon',
     'sphinxcontrib.asyncio',
     'details'
 ]
-
-if on_rtd:
-  extensions.append('sphinxcontrib.napoleon')
-else:
-  extensions.append('sphinx.ext.napoleon')
 
 autodoc_member_order = 'bysource'
 

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,9 @@
 from setuptools import setup, find_packages
-import re, os
-
-on_rtd = os.getenv('READTHEDOCS') == 'True'
+import re
 
 requirements = []
 with open('requirements.txt') as f:
   requirements = f.read().splitlines()
-
-if on_rtd:
-  requirements.append('sphinx==1.7.4')
-  requirements.append('sphinxcontrib-napoleon')
-  requirements.append('sphinxcontrib-asyncio')
-  requirements.append('sphinxcontrib-websupport')
 
 version = ''
 with open('discord/__init__.py') as f:
@@ -43,7 +35,11 @@ with open('README.rst') as f:
 
 extras_require = {
     'voice': ['PyNaCl==1.1.2'],
-    'docs': ['sphinxcontrib-asyncio']
+    'docs': [
+        'sphinx==1.7.4',
+        'sphinxcontrib-asyncio',
+        'sphinxcontrib-websupport',
+    ]
 }
 
 setup(name='discord.py',


### PR DESCRIPTION
I can see conditional RTD dependencies were added way back in this commit c6b31c9663c60d72b64a0e3eab984d48681004a0. This is no longer necessary, and in fact the dependencies listed in setup.py under the `on_rtd` condition are actually being installed on everyone's RTD builds which list discord.py as a dependency. The `docs` extra is there already and RTD is including it during the build anyway, so that's where they've been moved, which avoids the issue.

Also I've removed `sphinxcontrib-napoleon` as a dependency since there should never be any situation where we have sphinx<1.3 installed :grin:
