### PR TITLE
Added change/leave hypesquad house for non bot clients

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -29,7 +29,7 @@ from .invite import Invite
 from .object import Object
 from .guild import Guild
 from .errors import *
-from .enums import Status, VoiceRegion
+from .enums import Status, VoiceRegion, HypesquadHouse
 from .gateway import *
 from .activity import _ActivityTag, create_activity
 from .voice_client import VoiceClient
@@ -1053,3 +1053,48 @@ class Client:
         """
         data = await self.http.get_webhook(webhook_id)
         return Webhook.from_state(data, state=self._connection)
+
+    async def change_hypesquad_house(self, house, first_name, last_name):
+        """|coro|
+
+        Change the users hypesquad house. This can only be used by non-bot accounts.
+
+        Parameters
+        ------------
+        house: Union[int, :class:`HypesquadHouse`]
+            The ID of the user to fetch their profile for.
+
+        Raises
+        -------
+        Forbidden
+            Not allowed to change house.
+        HTTPException
+            Changing house failed.
+
+        Returns
+        --------
+        :class:`HypesquadHouse`
+            The house changed into..
+        """
+
+        if isinstance(house, HypesquadHouse):
+            house_id = house.value
+        else:
+            house_id = int(house)
+
+        await self.http.change_hypesquad_house(house_id, first_name, last_name)
+        return house
+
+    async def leave_hypesquad_house(self):
+        """|coro|
+
+        Leave the users hypesquad house. This can only be used by non-bot accounts.
+
+        Raises
+        -------
+        Forbidden
+            Not allowed to leave the house.
+        HTTPException
+            leaving house failed.
+        """
+        return await self.http.leave_hypesquad_house()

--- a/discord/client.py
+++ b/discord/client.py
@@ -29,7 +29,7 @@ from .invite import Invite
 from .object import Object
 from .guild import Guild
 from .errors import *
-from .enums import Status, VoiceRegion, HypesquadHouse
+from .enums import Status, VoiceRegion
 from .gateway import *
 from .activity import _ActivityTag, create_activity
 from .voice_client import VoiceClient
@@ -1053,48 +1053,3 @@ class Client:
         """
         data = await self.http.get_webhook(webhook_id)
         return Webhook.from_state(data, state=self._connection)
-
-    async def change_hypesquad_house(self, house, first_name, last_name):
-        """|coro|
-
-        Change the users hypesquad house. This can only be used by non-bot accounts.
-
-        Parameters
-        ------------
-        house: Union[int, :class:`HypesquadHouse`]
-            The ID of the user to fetch their profile for.
-
-        Raises
-        -------
-        Forbidden
-            Not allowed to change house.
-        HTTPException
-            Changing house failed.
-
-        Returns
-        --------
-        :class:`HypesquadHouse`
-            The house changed into..
-        """
-
-        if isinstance(house, HypesquadHouse):
-            house_id = house.value
-        else:
-            house_id = int(house)
-
-        await self.http.change_hypesquad_house(house_id, first_name, last_name)
-        return house
-
-    async def leave_hypesquad_house(self):
-        """|coro|
-
-        Leave the users hypesquad house. This can only be used by non-bot accounts.
-
-        Raises
-        -------
-        Forbidden
-            Not allowed to leave the house.
-        HTTPException
-            leaving house failed.
-        """
-        return await self.http.leave_hypesquad_house()

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -220,12 +220,10 @@ class ActivityType(IntEnum):
     listening = 2
     watching = 3
 
-
 class HypesquadHouse(Enum):
     bravery = 1
     brilliance = 2
     balance = 3
-
 
 def try_enum(cls, val):
     """A function that tries to turn the value into enum ``cls``.

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -212,6 +212,9 @@ class UserFlags(Enum):
     staff = 1
     partner = 2
     hypesquad = 4
+    hypesquad_bravery = 64
+    hypesquad_brilliance = 128
+    hypesquad_balance = 256
 
 class ActivityType(IntEnum):
     unknown = -1

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -29,7 +29,7 @@ from enum import Enum, IntEnum
 __all__ = ['ChannelType', 'MessageType', 'VoiceRegion', 'VerificationLevel',
            'ContentFilter', 'Status', 'DefaultAvatar', 'RelationshipType',
            'AuditLogAction', 'AuditLogActionCategory', 'UserFlags',
-           'ActivityType', ]
+           'ActivityType', 'HypesquadHouse']
 
 class ChannelType(Enum):
     text     = 0
@@ -219,6 +219,12 @@ class ActivityType(IntEnum):
     streaming = 1
     listening = 2
     watching = 3
+
+
+class HypesquadHouse(Enum):
+    bravery = 1
+    brilliance = 2
+    balance = 3
 
 
 def try_enum(cls, val):

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -29,7 +29,7 @@ from enum import Enum, IntEnum
 __all__ = ['ChannelType', 'MessageType', 'VoiceRegion', 'VerificationLevel',
            'ContentFilter', 'Status', 'DefaultAvatar', 'RelationshipType',
            'AuditLogAction', 'AuditLogActionCategory', 'UserFlags',
-           'ActivityType', 'HypesquadHouse']
+           'ActivityType', 'HypeSquadHouse']
 
 class ChannelType(Enum):
     text     = 0
@@ -223,7 +223,7 @@ class ActivityType(IntEnum):
     listening = 2
     watching = 3
 
-class HypesquadHouse(Enum):
+class HypeSquadHouse(Enum):
     bravery = 1
     brilliance = 2
     balance = 3

--- a/discord/http.py
+++ b/discord/http.py
@@ -769,13 +769,8 @@ class HTTPClient:
     def get_user_profile(self, user_id):
         return self.request(Route('GET', '/users/{user_id}/profile', user_id=user_id))
 
-    def change_hypesquad_house(self, house_id, first_name, last_name):
-        payload = {
-            'house_id': house_id,
-            'first_name': first_name,
-            'last_name': last_name
-        }
-
+    def change_hypesquad_house(self, house_id):
+        payload = {'house_id': house_id}
         return self.request(Route('POST', '/hypesquad/online'), json=payload)
 
     def leave_hypesquad_house(self):

--- a/discord/http.py
+++ b/discord/http.py
@@ -768,3 +768,15 @@ class HTTPClient:
 
     def get_user_profile(self, user_id):
         return self.request(Route('GET', '/users/{user_id}/profile', user_id=user_id))
+
+    def change_hypesquad_house(self, house_id, first_name, last_name):
+        payload = {
+            'house_id': house_id,
+            'first_name': first_name,
+            'last_name': last_name
+        }
+
+        return self.request(Route('POST', '/hypesquad/online'), json=payload)
+
+    def leave_hypesquad_house(self):
+        return self.route(Route('DELETE', '/hypesquad/online'))

--- a/discord/http.py
+++ b/discord/http.py
@@ -779,4 +779,4 @@ class HTTPClient:
         return self.request(Route('POST', '/hypesquad/online'), json=payload)
 
     def leave_hypesquad_house(self):
-        return self.request(self.route(Route('DELETE', '/hypesquad/online')))
+        return self.request(Route('DELETE', '/hypesquad/online'))

--- a/discord/http.py
+++ b/discord/http.py
@@ -779,4 +779,4 @@ class HTTPClient:
         return self.request(Route('POST', '/hypesquad/online'), json=payload)
 
     def leave_hypesquad_house(self):
-        return self.route(Route('DELETE', '/hypesquad/online'))
+        return self.request(self.route(Route('DELETE', '/hypesquad/online')))

--- a/discord/user.py
+++ b/discord/user.py
@@ -343,7 +343,6 @@ class ClientUser(BaseUser):
             The new email you wish to change to.
             Only applicable to user accounts.
         Optional[:class:`HypeSquadHouse`]
-            If this is supplied also supply ``first_name`` and ``last_name`` fields of str type.
             The hypesquad house you wish to change to.
             Could be ``None`` to leave the current house.
             Only applicable to user accounts.
@@ -361,7 +360,7 @@ class ClientUser(BaseUser):
             Wrong image format passed for ``avatar``.
         ClientException
             Password is required for non-bot accounts.
-            house keyword argument supplied but ``first_name`` and ``last_name`` fields were not.
+            House field was not a HypeSquadHouse.
         """
 
         try:
@@ -393,20 +392,16 @@ class ClientUser(BaseUser):
 
         http = self._state.http
 
-        try:
+        if 'house' in fields:
             house = fields['house']
             if house is None:
                 await http.leave_hypesquad_house()
-            elif 'first_name' not in fields or 'last_name' not in fields:
-                raise ClientException('When changing hypesquad houses first_name and last_name fields are required.')
-            elif isinstance(house, HypeSquadHouse):
-                value = house.value
+            elif not isinstance(house, HypeSquadHouse):
+                raise ClientException('`house` parameter was not a HypeSquadHouse')
             else:
-                value = int(house)
+                value = house.value
 
-            await http.change_hypesquad_house(value, fields['first_name'], fields['last_name'])
-        except KeyError:
-            pass
+            await http.change_hypesquad_house(value)
 
         data = await http.edit_profile(**args)
         if not_bot_account:

--- a/discord/user.py
+++ b/discord/user.py
@@ -61,6 +61,9 @@ class Profile(namedtuple('Profile', 'flags user mutual_guilds connected_accounts
     def partner(self):
         return self._has_flag(UserFlags.partner)
 
+    @property
+    def hypesquad_houses(self):
+        return [house for house, flag in zip(HypesquadHouse, (64, 128, 256)) if (self.flags & flag) == flag]
 
 _BaseUser = discord.abc.User
 

--- a/discord/user.py
+++ b/discord/user.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 """
 
 from .utils import snowflake_time, _bytes_to_base64_data, parse_time, valid_icon_size
-from .enums import DefaultAvatar, RelationshipType, UserFlags, HypesquadHouse
+from .enums import DefaultAvatar, RelationshipType, UserFlags, HypeSquadHouse
 from .errors import ClientException, InvalidArgument
 
 from collections import namedtuple
@@ -63,7 +63,8 @@ class Profile(namedtuple('Profile', 'flags user mutual_guilds connected_accounts
 
     @property
     def hypesquad_houses(self):
-        return [house for house, flag in zip(HypesquadHouse, (64, 128, 256)) if (self.flags & flag) == flag]
+        flags = (UserFlags.hypesquad_bravery, UserFlags.hypesquad_brilliance, UserFlags.hypesquad_balance)
+        return [house for house, flag in zip(HypeSquadHouse, flags) if self._has_flag(flag)]
 
 _BaseUser = discord.abc.User
 
@@ -341,7 +342,7 @@ class ClientUser(BaseUser):
         email: str
             The new email you wish to change to.
             Only applicable to user accounts.
-        house: Union[int, :class:HypesquadHouse]
+        Optional[:class:`HypeSquadHouse`]
             If this is supplied also supply ``first_name`` and ``last_name`` fields of str type.
             The hypesquad house you wish to change to.
             Could be ``None`` to leave the current house.
@@ -360,6 +361,7 @@ class ClientUser(BaseUser):
             Wrong image format passed for ``avatar``.
         ClientException
             Password is required for non-bot accounts.
+            house keyword argument supplied but ``first_name`` and ``last_name`` fields were not.
         """
 
         try:
@@ -395,17 +397,14 @@ class ClientUser(BaseUser):
             house = fields['house']
             if house is None:
                 await http.leave_hypesquad_house()
-
             elif 'first_name' not in fields or 'last_name' not in fields:
                 raise ClientException('When changing hypesquad houses first_name and last_name fields are required.')
-
+            elif isinstance(house, HypeSquadHouse):
+                value = house.value
             else:
-                if isinstance(house, HypesquadHouse):
-                    value = house.value
-                else:
-                    value = int(house)
+                value = int(house)
 
-                await http.change_hypesquad_house(value, fields['first_name'], fields['last_name'])
+            await http.change_hypesquad_house(value, fields['first_name'], fields['last_name'])
         except KeyError:
             pass
 


### PR DESCRIPTION
Please review.

This PR is due to the new Hypesquad 2.0, where it's open to everybody and delegated into hypesquad houses (bravery, brilliance, balance).

What this PR does is add two methods to both the HTTPClient and the Client allowing the action of changing a hypesquad house and leaving a hypesquad house. Also adding an Enum for hypesquad houses (see enums.py)

Hopefully with further review and scrutiny this PR can allow differentiating between the type of current hypesquad house and joining one remotely and or decide if this functionality is even needed in the library.