### PR TITLE
Space Insensitivity

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -161,6 +161,7 @@ class BotBase(GroupMixin):
         self.owner_id = options.get('owner_id')
         self.command_not_found = options.pop('command_not_found', 'No command called "{}" found.')
         self.command_has_no_subcommands = options.pop('command_has_no_subcommands', 'Command {0.name} has no subcommands.')
+        self.space_insensitive = options.get('space_insensitive', False)
 
         if options.pop('self_bot', False):
             self._skip_check = lambda x, y: x != y
@@ -872,7 +873,7 @@ class BotBase(GroupMixin):
                 # Getting here shouldn't happen
                 raise
 
-        invoker = view.get_word()
+        invoker = view.get_word(self.space_insensitive)
         ctx.invoked_with = invoker
         ctx.prefix = invoked_prefix
         ctx.command = self.all_commands.get(invoker)
@@ -975,6 +976,9 @@ class Bot(BotBase, discord.Client):
         Whether the commands should be case insensitive. Defaults to ``False``. This
         attribute does not carry over to groups. You must set it to every group if
         you require group commands to be case insensitive as well.
+    space_insensitive: :class:`bool`
+        Whether commands should be space insensitive. Defaults to ``False``. This
+        would mean that ``!    ping`` and ``!ping`` would be equivelant.
     description : :class:`str`
         The content prefixed into the default help message.
     self_bot : :class:`bool`

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -978,7 +978,7 @@ class Bot(BotBase, discord.Client):
         you require group commands to be case insensitive as well.
     space_insensitive: :class:`bool`
         Whether commands should be space insensitive. Defaults to ``False``. This
-        would mean that ``!    ping`` and ``!ping`` would be equivelant.
+        would mean that ``!    ping`` and ``!ping`` would be equivalent.
     description : :class:`str`
         The content prefixed into the default help message.
     self_bot : :class:`bool`

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -167,7 +167,7 @@ class Context(discord.abc.Messageable):
             to_call = cmd.root_parent or cmd
             view.index = len(self.prefix)
             view.previous = 0
-            view.get_word() # advance to get the root command
+            view.get_word(self.bot.space_insensitive) # advance to get the root command
         else:
             to_call = cmd
 

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -928,7 +928,7 @@ class Group(GroupMixin, Command):
         view = ctx.view
         previous = view.index
         view.skip_ws()
-        trigger = view.get_word()
+        trigger = view.get_word(ctx.bot.space_insensitive)
 
         if trigger:
             ctx.subcommand_passed = trigger
@@ -959,7 +959,7 @@ class Group(GroupMixin, Command):
         view = ctx.view
         previous = view.index
         view.skip_ws()
-        trigger = view.get_word()
+        trigger = view.get_word(ctx.bot.space_insensitive)
 
         if trigger:
             ctx.subcommand_passed = trigger

--- a/discord/ext/commands/view.py
+++ b/discord/ext/commands/view.py
@@ -88,20 +88,24 @@ class StringView:
         self.index += 1
         return result
 
-    def get_word(self):
+    def get_word(self, space_insensitive):
         pos = 0
+        non_space = False
         while not self.eof:
             try:
                 current = self.buffer[self.index + pos]
                 if current.isspace():
-                    break
+                    if non_space or not space_insensitive:
+                        break
+                else:
+                    non_space = True
                 pos += 1
             except IndexError:
                 break
         self.previous = self.index
         result = self.buffer[self.index:self.index + pos]
         self.index += pos
-        return result
+        return result.strip()
 
     def __repr__(self):
         return '<StringView pos: {0.index} prev: {0.previous} end: {0.end} eof: {0.eof}>'.format(self)


### PR DESCRIPTION
Allows for commands to be called with space insensitivity

**Examples**
`!ping` works
`!          ping` works too

This PR adds a kwarg for `commands.Bot`, `space_insensitive`. It is set to `False` on default.