### PR TITLE
Fix socket_raw_send not getting dispatched

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -456,7 +456,7 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
 
     async def send_as_json(self, data):
         try:
-            await super().send(utils.to_json(data))
+            await self.send(utils.to_json(data))
         except websockets.exceptions.ConnectionClosed as e:
             if not self._can_handle_close(e.code):
                 raise ConnectionClosed(e, shard_id=self.shard_id) from e


### PR DESCRIPTION
Currently all but presence changes don't dispatch socket_raw_send. The cause is from send_as_json ignoring the class's own send method where the event gets dispatched. This PR simply fixes that by not delegating the send method get via super() and instead looking it up normally.