### PR TITLE
Improve Client.latency

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -62,14 +62,14 @@ class KeepAliveHandler(threading.Thread):
         self.shard_id = shard_id
         self.msg = 'Keeping websocket alive with sequence %s.'
         self._stop_ev = threading.Event()
-        self._last_ack = time.monotonic()
-        self._last_send = time.monotonic()
+        self._last_ack = time.perf_counter()
+        self._last_send = time.perf_counter()
         self.latency = float('inf')
         self.heartbeat_timeout = ws._max_heartbeat_timeout
 
     def run(self):
         while not self._stop_ev.wait(self.interval):
-            if self._last_ack + self.heartbeat_timeout < time.monotonic():
+            if self._last_ack + self.heartbeat_timeout < time.perf_counter():
                 log.warning("Shard ID %s has stopped responding to the gateway. Closing and restarting." % self.shard_id)
                 coro = self.ws.close(4000)
                 f = asyncio.run_coroutine_threadsafe(coro, loop=self.ws.loop)
@@ -92,7 +92,7 @@ class KeepAliveHandler(threading.Thread):
             except Exception:
                 self.stop()
             else:
-                self._last_send = time.monotonic()
+                self._last_send = time.perf_counter()
 
     def get_payload(self):
         return {
@@ -104,7 +104,7 @@ class KeepAliveHandler(threading.Thread):
         self._stop_ev.set()
 
     def ack(self):
-        ack_time = time.monotonic()
+        ack_time = time.perf_counter()
         self._last_ack = ack_time
         self.latency = ack_time - self._last_send
 


### PR DESCRIPTION
This PR consists of two parts:

1. If you request the latency between the client sending a heartbeat request and discord acknowledging it, it returns a negative number. The reason for that is that it naively measures the time between the latest request and the latest response without checking if the two are corrolated. I've fixed it by instead measuring the time between the latest response and its corresponding request.

2. Currently latency times are measured via time.monotonic(). I've changed the measurements to use time.perf_counter() as semantically monotonic is for measuring long intervals because of its stability while perf_counter is for measuring shorter intervals because of its precision. In reality the change only affects Windows where it uses QueryPerformanceCounter instead of GetTickCount64. The differences between these two are that GetTickCount64 is less susceptible to drift while sacrificing precision with a resolution of 10-16ms compared to QueryPerformanceCounter's ~300ns which makes it very imprecise for sub-second measurements.

   One concern for this change would be the possibility of the time drifting while checking if the gateway 
   stopped responding however with the default timeout of 60 seconds it wouldn't be an issue as the 
   increased resolution would greatly minimize the inaccuracies cause by any potential drifts.