### PR TITLE
Fix behavior of reaction type-conversion

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -720,7 +720,8 @@ class Message:
     @staticmethod
     def _emoji_reaction(emoji):
         if isinstance(emoji, Reaction):
-            return emoji.emoji
+            emoji = emoji.emoji
+
         if isinstance(emoji, Emoji):
             return '%s:%s' % (emoji.name, emoji.id)
         if isinstance(emoji, PartialEmoji):


### PR DESCRIPTION
This is broken out from #1497 and returns the type-conversion to its behavior prior to 0c446398d18fb63cc4fbc2c634640cc278dc95c4 (while still being de-duplicated).

cc @Hornwitser 