### PR TITLE
Fix typo in on_raw_reaction_add documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -290,7 +290,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
 .. function:: on_raw_reaction_add(payload)
 
-    Called when a reaction has a reaction added. Unlike :func:`on_reaction_add`, this is
+    Called when a message has a reaction added. Unlike :func:`on_reaction_add`, this is
     called regardless of the state of the internal message cache.
 
     :param payload: The raw event payload data.


### PR DESCRIPTION
Changes "reaction" to "message"