### PR TITLE
[docs] sort the VoiceRegions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -714,63 +714,63 @@ All enumerations are subclasses of `enum`_.
 
     Specifies the region a voice server belongs to.
 
-    .. attribute:: us_west
+    .. attribute:: amsterdam
 
-        The US West region.
+        The Amsterdam region.
+    .. attribute:: brazil
+
+        The Brazil region.
+    .. attribute:: eu_central
+
+        The EU Central region.
+    .. attribute:: eu_west
+
+        The EU West region.
+    .. attribute:: frankfurt
+
+        The Frankfurt region.
+    .. attribute:: hongkong
+
+        The Hong Kong region.
+    .. attribute:: japan
+
+        The Japan region.
+    .. attribute:: london
+
+        The London region.
+    .. attribute:: russia
+
+        The Russia region.
+    .. attribute:: singapore
+
+        The Singapore region.
+    .. attribute:: southafrica
+
+        The South Africa region.
+    .. attribute:: sydney
+
+        The Sydney region.
+    .. attribute:: us_central
+
+        The US Central region.
     .. attribute:: us_east
 
         The US East region.
     .. attribute:: us_south
 
         The US South region.
-    .. attribute:: us_central
+    .. attribute:: us_west
 
-        The US Central region.
-    .. attribute:: eu_west
+        The US West region.
+    .. attribute:: vip_amsterdam
 
-        The EU West region.
-    .. attribute:: eu_central
-
-        The EU Central region.
-    .. attribute:: singapore
-
-        The Singapore region.
-    .. attribute:: london
-
-        The London region.
-    .. attribute:: sydney
-
-        The Sydney region.
-    .. attribute:: amsterdam
-
-        The Amsterdam region.
-    .. attribute:: frankfurt
-
-        The Frankfurt region.
-    .. attribute:: brazil
-
-        The Brazil region.
-    .. attribute:: hongkong
-
-        The Hong Kong region.
-    .. attribute:: russia
-
-        The Russia region.
-    .. attribute:: japan
-
-        The Japan region.
-    .. attribute:: southafrica
-    
-        The South Africa region.
+        The Amsterdam region for VIP guilds.
     .. attribute:: vip_us_east
-    
+
         The US East region for VIP guilds.
     .. attribute:: vip_us_west
 
         The US West region for VIP guilds.
-    .. attribute:: vip_amsterdam
-
-        The Amsterdam region for VIP guilds.
 
 .. class:: VerificationLevel
 


### PR DESCRIPTION
having them appear in the docs ordered by their internal number
is not useful to the user. Sorting them by name
allows one to more quickly locate a voice region in the docs.