### PR TITLE
Fix PartialEmoji._as_reaction() for emojis the bot can't see

### DIFF
--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -86,7 +86,7 @@ class PartialEmoji(namedtuple('PartialEmoji', 'animated name id')):
     def _as_reaction(self):
         if self.id is None:
             return self.name
-        return ':%s:%s' % (self.name, self.id)
+        return '%s:%s' % (self.name, self.id)
 
     @property
     def url(self):


### PR DESCRIPTION
Sorry about the last PR.

Using `Message.add_reaction(PartialEmoji)` on an already existing reaction fails if the bot does not have access to the emoji. This PR fixes that.