### PR TITLE
Bump aiohttp contraint to <3.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp>=3.3.0,<3.4.0
+aiohttp>=3.3.0,<3.5.0
 websockets>=6.0,<7.0


### PR DESCRIPTION
New version contains many bugfixes, a couple new features and seemingly no breaking changes (for this lib's purposes at least).

Relevant changes: https://github.com/aio-libs/aiohttp/blob/master/CHANGES.rst#340-2018-08-25