### PR TITLE
Make implicit raw backslashes explicit

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -533,7 +533,7 @@ class GuildChannel:
             The :class:`Member` or :class:`Role` to overwrite permissions for.
         overwrite: :class:`PermissionOverwrite`
             The permissions to allow and deny to the target.
-        \*\*permissions
+        \\*\\*permissions
             A keyword argument list of permissions to set for ease of use.
             Cannot be mixed with ``overwrite``.
         reason: Optional[str]

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -187,7 +187,7 @@ class AuditLogEntry:
     action: :class:`AuditLogAction`
         The action that was done.
     user: :class:`abc.User`
-        The user who initiated this action. Usually a :class:`Member`\, unless gone
+        The user who initiated this action. Usually a :class:`Member`\\, unless gone
         then it's a :class:`User`.
     id: :class:`int`
         The entry ID.

--- a/discord/calls.py
+++ b/discord/calls.py
@@ -58,7 +58,7 @@ class CallMessage:
 
     @property
     def channel(self):
-        """:class:`GroupChannel`\: The private channel associated with this message."""
+        """:class:`GroupChannel`\\: The private channel associated with this message."""
         return self.message.channel
 
     @property
@@ -132,7 +132,7 @@ class GroupCall:
 
     @property
     def channel(self):
-        """:class:`GroupChannel`\: Returns the channel the group call is in."""
+        """:class:`GroupChannel`\\: Returns the channel the group call is in."""
         return self.call.channel
 
     def voice_state_for(self, user):

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -819,7 +819,7 @@ class GroupChannel(discord.abc.Messageable, Hashable):
 
         Parameters
         -----------
-        \*recipients: :class:`User`
+        \\*recipients: :class:`User`
             An argument list of users to add to this group.
 
         Raises
@@ -841,7 +841,7 @@ class GroupChannel(discord.abc.Messageable, Hashable):
 
         Parameters
         -----------
-        \*recipients: :class:`User`
+        \\*recipients: :class:`User`
             An argument list of users to remove from this group.
 
         Raises

--- a/discord/client.py
+++ b/discord/client.py
@@ -93,7 +93,7 @@ class Client:
         The total number of shards.
     fetch_offline_members: :class:`bool`
         Indicates if :func:`on_ready` should be delayed to fetch all offline
-        members from the guilds the bot belongs to. If this is ``False``\, then
+        members from the guilds the bot belongs to. If this is ``False``\\, then
         no offline members are received and :meth:`request_offline_members`
         must be used to fetch the offline members of the guild.
     status: Optional[:class:`Status`]
@@ -166,7 +166,7 @@ class Client:
         if isinstance(invite, Invite) or isinstance(invite, Object):
             return invite.id
         else:
-            rx = r'(?:https?\:\/\/)?discord\.gg\/(.+)'
+            rx = r'(?:https?\\:\/\/)?discord\.gg\/(.+)'
             m = re.match(rx, invite)
             if m:
                 return m.group(1)
@@ -302,7 +302,7 @@ class Client:
 
         Parameters
         -----------
-        \*guilds
+        \\*guilds
             An argument list of guilds to request offline members for.
 
         Raises

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -244,7 +244,7 @@ class BotBase(GroupMixin):
 
             This function can either be a regular function or a coroutine.
 
-        Similar to a command :func:`.check`\, this takes a single parameter
+        Similar to a command :func:`.check`\\, this takes a single parameter
         of type :class:`.Context` and can only raise exceptions derived from
         :exc:`.CommandError`.
 
@@ -316,7 +316,7 @@ class BotBase(GroupMixin):
 
             This function can either be a regular function or a coroutine.
 
-        Similar to a command :func:`.check`\, this takes a single parameter
+        Similar to a command :func:`.check`\\, this takes a single parameter
         of type :class:`.Context` and can only raise exceptions derived from
         :exc:`.CommandError`.
 
@@ -403,7 +403,7 @@ class BotBase(GroupMixin):
 
         .. note::
 
-            Similar to :meth:`~.Bot.before_invoke`\, this is not called unless
+            Similar to :meth:`~.Bot.before_invoke`\\, this is not called unless
             checks and argument parsing procedures succeed. This hook is,
             however, **always** called regardless of the internal command
             callback raising an error (i.e. :exc:`.CommandInvokeError`\).

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -48,7 +48,7 @@ class Context(discord.abc.Messageable):
         then this list could be incomplete.
     kwargs: :class:`dict`
         A dictionary of transformed arguments that were passed into the command.
-        Similar to :attr:`args`\, if this is accessed in the
+        Similar to :attr:`args`\\, if this is accessed in the
         :func:`on_command_error` event then this dict could be incomplete.
     prefix: :class:`str`
         The prefix that was used to invoke the command.
@@ -106,9 +106,9 @@ class Context(discord.abc.Messageable):
         -----------
         command: :class:`.Command`
             A command or superclass of a command that is going to be called.
-        \*args
+        \\*args
             The arguments to to use.
-        \*\*kwargs
+        \\*\\*kwargs
             The keyword arguments to use.
         """
 
@@ -219,6 +219,6 @@ class Context(discord.abc.Messageable):
 
     @property
     def voice_client(self):
-        """Optional[:class:`VoiceClient`]: A shortcut to :attr:`Guild.voice_client`\, if applicable."""
+        """Optional[:class:`VoiceClient`]: A shortcut to :attr:`Guild.voice_client`\\, if applicable."""
         g = self.guild
         return g.voice_client if g else None

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -140,7 +140,7 @@ class Command:
     description: :class:`str`
         The message prefixed into the default help command.
     hidden: :class:`bool`
-        If ``True``\, the default help command does not show this in the
+        If ``True``\\, the default help command does not show this in the
         help output.
     rest_is_raw: :class:`bool`
         If ``False`` and a keyword-only argument is provided then the keyword
@@ -150,7 +150,7 @@ class Command:
         then the keyword-only argument will pass in the rest of the arguments
         in a completely raw matter. Defaults to ``False``.
     ignore_extra: :class:`bool`
-        If ``True``\, ignores extraneous strings passed to a command if all its
+        If ``True``\\, ignores extraneous strings passed to a command if all its
         requirements are met (e.g. ``?foo a b c`` when only expecting ``a``
         and ``b``). Otherwise :func:`.on_command_error` and local error handlers
         are called with :exc:`.TooManyArguments`. Defaults to ``True``.
@@ -1173,7 +1173,7 @@ def has_any_role(*names):
     command has **any** of the roles specified. This means that if they have
     one out of the three roles specified, then this check will return `True`.
 
-    Similar to :func:`.has_role`\, the names passed in must be exact.
+    Similar to :func:`.has_role`\\, the names passed in must be exact.
 
     Parameters
     -----------

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -41,7 +41,7 @@ class CommandError(DiscordException):
 
     This exception and exceptions derived from it are handled
     in a special way as they are caught and passed into a special event
-    from :class:`.Bot`\, :func:`on_command_error`.
+    from :class:`.Bot`\\, :func:`on_command_error`.
     """
     def __init__(self, message=None, *args):
         if message is not None:

--- a/discord/member.py
+++ b/discord/member.py
@@ -476,7 +476,7 @@ class Member(discord.abc.Messageable, _BaseUser):
 
         Parameters
         -----------
-        \*roles
+        \\*roles
             An argument list of :class:`abc.Snowflake` representing a :class:`Role`
             to give to the member.
         reason: Optional[str]
@@ -514,7 +514,7 @@ class Member(discord.abc.Messageable, _BaseUser):
 
         Parameters
         -----------
-        \*roles
+        \\*roles
             An argument list of :class:`abc.Snowflake` representing a :class:`Role`
             to remove from the member.
         reason: Optional[str]

--- a/discord/message.py
+++ b/discord/message.py
@@ -149,7 +149,7 @@ class Message:
     mentions: :class:`list`
         A list of :class:`Member` that were mentioned. If the message is in a private message
         then the list will be of :class:`User` instead. For messages that are not of type
-        :attr:`MessageType.default`\, this array can be used to aid in system messages.
+        :attr:`MessageType.default`\\, this array can be used to aid in system messages.
         For more information, see :attr:`system_content`.
 
         .. warning::
@@ -444,7 +444,7 @@ class Message:
         """A property that returns the content that is rendered
         regardless of the :attr:`Message.type`.
 
-        In the case of :attr:`MessageType.default`\, this just returns the
+        In the case of :attr:`MessageType.default`\\, this just returns the
         regular :attr:`Message.content`. Otherwise this returns an English
         message denoting the contents of the system message.
         """

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -177,7 +177,7 @@ class Permissions:
 
         Parameters
         ------------
-        \*\*kwargs
+        \\*\\*kwargs
             A list of key/value pairs to bulk update permissions with.
         """
         for key, value in kwargs.items():
@@ -512,7 +512,7 @@ def augment_from_permissions(cls):
 class PermissionOverwrite:
     """A type that is used to represent a channel specific permission.
 
-    Unlike a regular :class:`Permissions`\, the default value of a
+    Unlike a regular :class:`Permissions`\\, the default value of a
     permission is equivalent to ``None`` and not ``False``. Setting
     a value to ``False`` is **explicitly** denying that permission,
     while setting a value to ``True`` is **explicitly** allowing
@@ -534,7 +534,7 @@ class PermissionOverwrite:
 
     Parameters
     -----------
-    \*\*kwargs
+    \\*\\*kwargs
         Set the value of permissions by their name.
     """
 
@@ -603,7 +603,7 @@ class PermissionOverwrite:
 
         Parameters
         ------------
-        \*\*kwargs
+        \\*\\*kwargs
             A list of key/value pairs to bulk update with.
         """
         for key, value in kwargs.items():

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -190,7 +190,7 @@ class AutoShardedClient(Client):
 
         Parameters
         -----------
-        \*guilds
+        \\*guilds
             An argument list of guilds to request offline members for.
 
         Raises

--- a/discord/user.py
+++ b/discord/user.py
@@ -424,7 +424,7 @@ class ClientUser(BaseUser):
 
         Parameters
         -----------
-        \*recipients
+        \\*recipients
             An argument :class:`list` of :class:`User` to have in
             your group.
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -210,7 +210,7 @@ def get(iterable, **attrs):
     -----------
     iterable
         An iterable to search through.
-    \*\*attrs
+    \\*\\*attrs
         Keyword arguments that denote attributes to search with.
     """
 


### PR DESCRIPTION
In Python 3.8 implicit raw backslashes in strings will be deprecated. So, this.