### PR TITLE
Removed inaccurate note in emoji.py

### DIFF
--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -235,8 +235,6 @@ class Emoji(Hashable):
         You must have :attr:`~Permissions.manage_emojis` permission to
         do this.
 
-        Note that bot accounts can only edit custom emojis they own.
-
         Parameters
         -----------
         name: str


### PR DESCRIPTION
In the docs, it says ``Note that bot accounts can only edit custom emojis they own.``

But after testing a bit. My bot was able to edit emojis in any guild that had the permissions `manage_emojis`. Even if the bot didn't own the guild. Or was the original emoji uploader.

And I don't see any mentions of this in the API server or in the documentation. So I'm unsure how this ended up in here. It's possible I am misunderstanding the whole note. My bad if that's the case.