### PR TITLE
New Colour

### DIFF
--- a/discord/colour.py
+++ b/discord/colour.py
@@ -227,4 +227,13 @@ class Colour:
         """A factory method that returns a :class:`Colour` with a value of ``0x99aab5``."""
         return cls(0x99aab5)
 
+    @classmethod
+    def dark_theme(cls):
+        """A factory method that returns a :class:'Colour' with a value of ``0x36393F``.
+        Will appear transparent on Discord's dark theme and be the text colour on Discord's light theme.
+        
+        .. versionadded:: 1.5
+        """
+        return cls(0x36393F)
+
 Color = Colour


### PR DESCRIPTION
A new colour to discord.colour named darker_greyple. Its the same colour as the discord dark-theme background. Which makes a pretty cool effect:
![screenshot_20180915_183138](https://user-images.githubusercontent.com/38372706/45588472-992b3e80-b915-11e8-84e0-09c705b2c613.png)
And in discord light-theme it also looks pretty okay:
![screenshot_20180915_183323](https://user-images.githubusercontent.com/38372706/45588491-e0b1ca80-b915-11e8-98a3-fd42c442c8c4.png)


