### PR TITLE
Updating the alias descriptions for discord.Member.color

### DIFF
--- a/docs/locale/ja/LC_MESSAGES/api.po
+++ b/docs/locale/ja/LC_MESSAGES/api.po
@@ -7350,8 +7350,12 @@ msgid ""
 "instance of :meth:`Colour.default` is returned."
 msgstr ""
 
-#: discord.Member.color:5 discord.Member.colour:5 of
+#: discord.Member.colour:5 of
 msgid "There is an alias for this under ``color``."
+msgstr ""
+
+#: discord.Member.color:5 of
+msgid "There is an alias for this under ``colour``."
 msgstr ""
 
 #: discord.Member.mention:1 of


### PR DESCRIPTION
Like the title says, the docs for `discord.Member.colour` denote that there is an alias for this under `color`. So far so good, but `discord.Member.color` is denoting the exact same thing. So I changed that for discord.Member.colour to denote that there is the alias `color` and for discord.Member.color to denote that there is the alias `colour`.