### PR TITLE
Add colour attribute for BaseUser

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -27,6 +27,7 @@ DEALINGS IN THE SOFTWARE.
 from .utils import snowflake_time, _bytes_to_base64_data, parse_time, valid_icon_size
 from .enums import DefaultAvatar, RelationshipType, UserFlags, HypeSquadHouse
 from .errors import ClientException, InvalidArgument
+from .colour import Colour
 
 from collections import namedtuple
 
@@ -169,6 +170,17 @@ class BaseUser(_BaseUser):
     def default_avatar_url(self):
         """Returns a URL for a user's default avatar."""
         return 'https://cdn.discordapp.com/embed/avatars/{}.png'.format(self.default_avatar.value)
+
+    @property
+    def colour(self):
+        """A property that returns a :class:`Colour` denoting the rendered colour
+        for the user. This always returns :meth:`Colour.default`.
+
+        There is an alias for this under ``color``.
+        """
+        return Colour.default()
+
+    color = colour
 
     @property
     def mention(self):


### PR DESCRIPTION
This PR makes `ctx.me.colour` or `ctx.author.colour` possible in `DMChannel`. For instance, using them for an embed colour (without try/except). Also adds a bit of consistency between `User` and `Member` (for lack of a better word). It always returns `Colour.default()` because there's no role colours.

Also, color alias.