### PR TITLE
Correct ClientException message raised when registering invocation hooks that are not coroutines

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -387,7 +387,7 @@ class BotBase(GroupMixin):
             The coroutine is not actually a coroutine.
         """
         if not asyncio.iscoroutinefunction(coro):
-            raise discord.ClientException('The error handler must be a coroutine.')
+            raise discord.ClientException('The pre-invoke hook must be a coroutine.')
 
         self._before_invoke = coro
         return coro
@@ -420,7 +420,7 @@ class BotBase(GroupMixin):
             The coroutine is not actually a coroutine.
         """
         if not asyncio.iscoroutinefunction(coro):
-            raise discord.ClientException('The error handler must be a coroutine.')
+            raise discord.ClientException('The post-invoke hook must be a coroutine.')
 
         self._after_invoke = coro
         return coro

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -612,7 +612,7 @@ class Command:
             The coroutine is not actually a coroutine.
         """
         if not asyncio.iscoroutinefunction(coro):
-            raise discord.ClientException('The error handler must be a coroutine.')
+            raise discord.ClientException('The pre-invoke hook must be a coroutine.')
 
         self._before_invoke = coro
         return coro
@@ -639,7 +639,7 @@ class Command:
             The coroutine is not actually a coroutine.
         """
         if not asyncio.iscoroutinefunction(coro):
-            raise discord.ClientException('The error handler must be a coroutine.')
+            raise discord.ClientException('The post-invoke hook must be a coroutine.')
 
         self._after_invoke = coro
         return coro


### PR DESCRIPTION
Pretty sure `before_invoke` and `after_invoke` aren't error handlers. (at least the former)
The terms 'pre-invoke hook' and 'post-invoke hook' were used to stay consistent with the documentation.