### PR TITLE
Remove loop calls

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -768,12 +768,12 @@ class Messageable(metaclass=abc.ABCMeta):
         ret = state.create_message(channel=channel, data=data)
         if delete_after is not None:
             async def delete():
-                await asyncio.sleep(delete_after, loop=state.loop)
+                await asyncio.sleep(delete_after)
                 try:
                     await ret.delete()
                 except:
                     pass
-            asyncio.ensure_future(delete(), loop=state.loop)
+            asyncio.ensure_future(delete())
         return ret
 
     async def trigger_typing(self):

--- a/discord/context_managers.py
+++ b/discord/context_managers.py
@@ -35,7 +35,6 @@ def _typing_done_callback(fut):
 
 class Typing:
     def __init__(self, messageable):
-        self.loop = messageable._state.loop
         self.messageable = messageable
 
     async def do_typing(self):
@@ -51,7 +50,7 @@ class Typing:
             await asyncio.sleep(5)
 
     def __enter__(self):
-        self.task = asyncio.ensure_future(self.do_typing(), loop=self.loop)
+        self.task = asyncio.ensure_future(self.do_typing())
         self.task.add_done_callback(_typing_done_callback)
         return self
 

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -189,7 +189,7 @@ class BotBase(GroupMixin):
         ev = 'on_' + event_name
         for event in self.extra_events.get(ev, []):
             coro = self._run_event(event, event_name, *args, **kwargs)
-            asyncio.ensure_future(coro, loop=self.loop)
+            asyncio.ensure_future(coro)
 
     async def close(self):
         for extension in tuple(self.extensions):

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -72,7 +72,7 @@ class KeepAliveHandler(threading.Thread):
             if self._last_ack + self.heartbeat_timeout < time.perf_counter():
                 log.warning("Shard ID %s has stopped responding to the gateway. Closing and restarting." % self.shard_id)
                 coro = self.ws.close(4000)
-                f = asyncio.run_coroutine_threadsafe(coro, loop=self.ws.loop)
+                f = asyncio.run_coroutine_threadsafe(coro)
 
                 try:
                     f.result()
@@ -85,7 +85,7 @@ class KeepAliveHandler(threading.Thread):
             data = self.get_payload()
             log.debug(self.msg, data['d'])
             coro = self.ws.send_as_json(data)
-            f = asyncio.run_coroutine_threadsafe(coro, loop=self.ws.loop)
+            f = asyncio.run_coroutine_threadsafe(coro)
             try:
                 # block until sending is complete
                 f.result()
@@ -363,7 +363,7 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
 
         if op == self.INVALIDATE_SESSION:
             if data == True:
-                await asyncio.sleep(5.0, loop=self.loop)
+                await asyncio.sleep(5.0)
                 await self.close()
                 raise ResumeWebSocket(self.shard_id)
 
@@ -677,7 +677,7 @@ class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
 
     async def poll_event(self):
         try:
-            msg = await asyncio.wait_for(self.recv(), timeout=30.0, loop=self.loop)
+            msg = await asyncio.wait_for(self.recv(), timeout=30.0)
             await self.received_message(json.loads(msg))
         except websockets.exceptions.ConnectionClosed as e:
             raise ConnectionClosed(e, shard_id=None) from e

--- a/discord/http.py
+++ b/discord/http.py
@@ -90,7 +90,7 @@ class HTTPClient:
         self.connector = connector
         self._session = aiohttp.ClientSession(connector=connector, loop=self.loop)
         self._locks = weakref.WeakValueDictionary()
-        self._global_over = asyncio.Event(loop=self.loop)
+        self._global_over = asyncio.Event()
         self._global_over.set()
         self.token = None
         self.bot_token = False
@@ -111,7 +111,7 @@ class HTTPClient:
 
         lock = self._locks.get(bucket)
         if lock is None:
-            lock = asyncio.Lock(loop=self.loop)
+            lock = asyncio.Lock()
             if bucket is not None:
                 self._locks[bucket] = lock
 
@@ -188,7 +188,7 @@ class HTTPClient:
                             log.info('Global rate limit has been hit. Retrying in %.2f seconds.', retry_after)
                             self._global_over.clear()
 
-                        await asyncio.sleep(retry_after, loop=self.loop)
+                        await asyncio.sleep(retry_after)
                         log.debug('Done sleeping for the rate limit. Retrying...')
 
                         # release the global lock now that the
@@ -201,7 +201,7 @@ class HTTPClient:
 
                     # we've received a 500 or 502, unconditional retry
                     if r.status in {500, 502}:
-                        await asyncio.sleep(1 + tries * 2, loop=self.loop)
+                        await asyncio.sleep(1 + tries * 2)
                         continue
 
                     # the usual error cases

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -130,7 +130,7 @@ class ReactionIterator(_AsyncIterator):
         self.emoji = emoji
         self.guild = message.guild
         self.channel_id = message.channel.id
-        self.users = asyncio.Queue(loop=state.loop)
+        self.users = asyncio.Queue()
 
     async def next(self):
         if self.users.empty():
@@ -227,7 +227,7 @@ class HistoryIterator(_AsyncIterator):
 
         self.state = self.messageable._state
         self.logs_from = self.state.http.logs_from
-        self.messages = asyncio.Queue(loop=self.state.loop)
+        self.messages = asyncio.Queue()
 
         if self.around:
             if self.limit is None:
@@ -361,7 +361,6 @@ class AuditLogIterator(_AsyncIterator):
 
 
         self.guild = guild
-        self.loop = guild._state.loop
         self.request = guild._state.http.get_audit_logs
         self.limit = limit
         self.before = before
@@ -378,7 +377,7 @@ class AuditLogIterator(_AsyncIterator):
 
         self._filter = None  # entry dict -> bool
 
-        self.entries = asyncio.Queue(loop=self.loop)
+        self.entries = asyncio.Queue()
 
         if self.before and self.after:
             if self.reverse:

--- a/discord/message.py
+++ b/discord/message.py
@@ -596,13 +596,13 @@ class Message:
         else:
             if delete_after is not None:
                 async def delete():
-                    await asyncio.sleep(delete_after, loop=self._state.loop)
+                    await asyncio.sleep(delete_after)
                     try:
                         await self._state.http.delete_message(self.channel.id, self.id)
                     except:
                         pass
 
-                asyncio.ensure_future(delete(), loop=self._state.loop)
+                asyncio.ensure_future(delete())
 
     async def pin(self):
         """|coro|

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -45,7 +45,7 @@ class Shard:
         self.loop = self._client.loop
         self._current = self.loop.create_future()
         self._current.set_result(None) # we just need an already done future
-        self._pending = asyncio.Event(loop=self.loop)
+        self._pending = asyncio.Event()
         self._pending_task = None
 
     @property
@@ -66,7 +66,7 @@ class Shard:
             pass
 
     def launch_pending_reads(self):
-        self._pending_task = asyncio.ensure_future(self._pending_reads(), loop=self.loop)
+        self._pending_task = asyncio.ensure_future(self._pending_reads())
 
     def wait(self):
         return self._pending_task
@@ -78,11 +78,11 @@ class Shard:
             log.info('Got a request to RESUME the websocket at Shard ID %s.', self.id)
             coro = DiscordWebSocket.from_client(self._client, resume=True, shard_id=self.id,
                                                 session=self.ws.session_id, sequence=self.ws.sequence)
-            self.ws = await asyncio.wait_for(coro, timeout=180.0, loop=self.loop)
+            self.ws = await asyncio.wait_for(coro, timeout=180.0)
 
     def get_future(self):
         if self._current.done():
-            self._current = asyncio.ensure_future(self.poll(), loop=self.loop)
+            self._current = asyncio.ensure_future(self.poll())
 
         return self._current
 
@@ -209,10 +209,10 @@ class AutoShardedClient(Client):
     async def launch_shard(self, gateway, shard_id):
         try:
             coro = websockets.connect(gateway, loop=self.loop, klass=DiscordWebSocket, compression=None)
-            ws = await asyncio.wait_for(coro, loop=self.loop, timeout=180.0)
+            ws = await asyncio.wait_for(coro, timeout=180.0)
         except Exception:
             log.info('Failed to connect for shard_id: %s. Retrying...', shard_id)
-            await asyncio.sleep(5.0, loop=self.loop)
+            await asyncio.sleep(5.0)
             return (await self.launch_shard(gateway, shard_id))
 
         ws.token = self.http.token
@@ -225,17 +225,17 @@ class AutoShardedClient(Client):
 
         try:
             # OP HELLO
-            await asyncio.wait_for(ws.poll_event(), loop=self.loop, timeout=180.0)
-            await asyncio.wait_for(ws.identify(), loop=self.loop, timeout=180.0)
+            await asyncio.wait_for(ws.poll_event(), timeout=180.0)
+            await asyncio.wait_for(ws.identify(), timeout=180.0)
         except asyncio.TimeoutError:
             log.info('Timed out when connecting for shard_id: %s. Retrying...', shard_id)
-            await asyncio.sleep(5.0, loop=self.loop)
-            return (await self.launch_shard(gateway, shard_id))
+            await asyncio.sleep(5.0)
+            return await self.launch_shard(gateway, shard_id)
 
         # keep reading the shard while others connect
         self.shards[shard_id] = ret = Shard(ws, self)
         ret.launch_pending_reads()
-        await asyncio.sleep(5.0, loop=self.loop)
+        await asyncio.sleep(5.0)
 
     async def launch_shards(self):
         if self.shard_count is None:
@@ -263,7 +263,7 @@ class AutoShardedClient(Client):
 
         while True:
             pollers = [shard.get_future() for shard in self.shards.values()]
-            done, _ = await asyncio.wait(pollers, loop=self.loop, return_when=asyncio.FIRST_COMPLETED)
+            done, _ = await asyncio.wait(pollers, return_when=asyncio.FIRST_COMPLETED)
             for f in done:
                 # we wanna re-raise to the main Client.connect handler if applicable
                 f.result()
@@ -285,7 +285,7 @@ class AutoShardedClient(Client):
                 pass
 
         to_close = [shard.ws.close() for shard in self.shards.values()]
-        await asyncio.wait(to_close, loop=self.loop)
+        await asyncio.wait(to_close)
         await self.http.close()
 
     async def change_presence(self, *, activity=None, status=None, afk=False, shard_id=None):

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -256,7 +256,7 @@ class AutoShardedClient(Client):
             shards_to_wait_for.append(shard.wait())
 
         # wait for all pending tasks to finish
-        await utils.sane_wait_for(shards_to_wait_for, timeout=300.0, loop=self.loop)
+        await utils.sane_wait_for(shards_to_wait_for, timeout=300.0)
 
     async def _connect(self):
         await self.launch_shards()

--- a/discord/state.py
+++ b/discord/state.py
@@ -282,7 +282,7 @@ class ConnectionState:
                     # this snippet of code is basically waiting 2 seconds
                     # until the last GUILD_CREATE was sent
                     launch.set()
-                    await asyncio.sleep(2, loop=self.loop)
+                    await asyncio.sleep(2)
 
             guilds = next(zip(*self._ready_state.guilds), [])
             if self._fetch_offline:
@@ -339,7 +339,7 @@ class ConnectionState:
             self._add_private_channel(factory(me=self.user, data=pm, state=self))
 
         self.dispatch('connect')
-        self._ready_task = asyncio.ensure_future(self._delay_ready(), loop=self.loop)
+        self._ready_task = asyncio.ensure_future(self._delay_ready())
 
     def parse_resumed(self, data):
         self.dispatch('resumed')
@@ -664,7 +664,7 @@ class ConnectionState:
             # since we're not waiting for 'useful' READY we'll just
             # do the chunk request here if wanted
             if self._fetch_offline:
-                asyncio.ensure_future(self._chunk_and_dispatch(guild, unavailable), loop=self.loop)
+                asyncio.ensure_future(self._chunk_and_dispatch(guild, unavailable))
                 return
 
         # Dispatch available if newly available
@@ -927,7 +927,7 @@ class AutoShardedConnectionState(ConnectionState):
             # this snippet of code is basically waiting 2 seconds
             # until the last GUILD_CREATE was sent
             launch.set()
-            await asyncio.sleep(2.0 * self.shard_count, loop=self.loop)
+            await asyncio.sleep(2.0 * self.shard_count)
 
         if self._fetch_offline:
             guilds = sorted(self._ready_state.guilds, key=lambda g: g[0].shard_id)
@@ -981,4 +981,4 @@ class AutoShardedConnectionState(ConnectionState):
 
         self.dispatch('connect')
         if self._ready_task is None:
-            self._ready_task = asyncio.ensure_future(self._delay_ready(), loop=self.loop)
+            self._ready_task = asyncio.ensure_future(self._delay_ready())

--- a/discord/state.py
+++ b/discord/state.py
@@ -268,7 +268,7 @@ class ConnectionState:
         # wait for the chunks
         if chunks:
             try:
-                await utils.sane_wait_for(chunks, timeout=len(chunks) * 30.0, loop=self.loop)
+                await utils.sane_wait_for(chunks, timeout=len(chunks) * 30.0)
             except asyncio.TimeoutError:
                 log.info('Somehow timed out waiting for chunks.')
 
@@ -625,7 +625,7 @@ class ConnectionState:
         await self.chunker(guild)
         if chunks:
             try:
-                await utils.sane_wait_for(chunks, timeout=len(chunks), loop=self.loop)
+                await utils.sane_wait_for(chunks, timeout=len(chunks))
             except asyncio.TimeoutError:
                 log.info('Somehow timed out waiting for chunks.')
 
@@ -917,7 +917,7 @@ class AutoShardedConnectionState(ConnectionState):
         # wait for the chunks
         if chunks:
             try:
-                await utils.sane_wait_for(chunks, timeout=len(chunks) * 30.0, loop=self.loop)
+                await utils.sane_wait_for(chunks, timeout=len(chunks) * 30.0)
             except asyncio.TimeoutError:
                 log.info('Somehow timed out waiting for chunks.')
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -280,8 +280,8 @@ async def async_all(gen, *, check=_isawaitable):
             return False
     return True
 
-async def sane_wait_for(futures, *, timeout, loop):
-    _, pending = await asyncio.wait(futures, timeout=timeout, loop=loop)
+async def sane_wait_for(futures, *, timeout):
+    _, pending = await asyncio.wait(futures, timeout=timeout)
 
     if len(pending) != 0:
         raise asyncio.TimeoutError()

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -99,7 +99,7 @@ class VoiceClient:
         self._state = state
         # this will be used in the AudioPlayer thread
         self._connected = threading.Event()
-        self._handshake_complete = asyncio.Event(loop=self.loop)
+        self._handshake_complete = asyncio.Event()
 
         self._connections = 0
         self.sequence = 0
@@ -141,7 +141,7 @@ class VoiceClient:
         await ws.voice_state(guild_id, channel_id)
 
         try:
-            await asyncio.wait_for(self._handshake_complete.wait(), timeout=self.timeout, loop=self.loop)
+            await asyncio.wait_for(self._handshake_complete.wait(), timeout=self.timeout)
         except asyncio.TimeoutError as e:
             await self.terminate_handshake(remove=True)
             raise e
@@ -210,7 +210,7 @@ class VoiceClient:
         except (ConnectionClosed, asyncio.TimeoutError):
             if reconnect and _tries < 5:
                 log.exception('Failed to connect to voice... Retrying...')
-                await asyncio.sleep(1 + _tries * 2.0, loop=self.loop)
+                await asyncio.sleep(1 + _tries * 2.0)
                 await self.terminate_handshake()
                 await self.connect(reconnect=reconnect, _tries=_tries + 1)
             else:
@@ -237,7 +237,7 @@ class VoiceClient:
                 retry = backoff.delay()
                 log.exception('Disconnected from voice... Reconnecting in %.2fs.', retry)
                 self._connected.clear()
-                await asyncio.sleep(retry, loop=self.loop)
+                await asyncio.sleep(retry)
                 await self.terminate_handshake()
                 try:
                     await self.connect(reconnect=True)

--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -133,7 +133,6 @@ class AsyncWebhookAdapter(WebhookAdapter):
 
     def __init__(self, session):
         self.session = session
-        self.loop = session.loop
 
     async def request(self, verb, url, payload=None, multipart=None):
         headers = {}
@@ -160,7 +159,7 @@ class AsyncWebhookAdapter(WebhookAdapter):
                 remaining = r.headers.get('X-Ratelimit-Remaining')
                 if remaining == '0' and r.status != 429:
                     delta = utils._parse_ratelimit_header(r)
-                    await asyncio.sleep(delta, loop=self.loop)
+                    await asyncio.sleep(delta)
 
                 if 300 > r.status >= 200:
                     return data
@@ -168,11 +167,11 @@ class AsyncWebhookAdapter(WebhookAdapter):
                 # we are being rate limited
                 if r.status == 429:
                     retry_after = data['retry_after'] / 1000.0
-                    await asyncio.sleep(retry_after, loop=self.loop)
+                    await asyncio.sleep(retry_after)
                     continue
 
                 if r.status in (500, 502):
-                    await asyncio.sleep(1 + tries * 2, loop=self.loop)
+                    await asyncio.sleep(1 + tries * 2)
                     continue
 
                 if r.status == 403:


### PR DESCRIPTION
Removes loop from the following places:
1. discord.utils.sane_wait_for (commit 1, safest to merge)
2. Every call to a built in asyncio callable. This includes Lock, Event, wait_for, wait, sleep, and ensure_future.

This is possible because these functions just call asyncio.get_event_loop(), which, post 3.5.3, always return the current running event loop in the current thread, as discussed in #general.

Loop arguments to websockets, aiohttp, and discord.py classes such as ConnectionState have been kept. Some of these may be removable, except for aiohttp.ClientSession (warns about creation outside of a coroutine otherwise).

Note: this code is **untested**. I wanted to file a pull request now, so I can gather feedback. I will post the results of my tests later.