### PR TITLE
(AutoShardedClient) Don't try to close shards if there are none yet.

### DIFF
--- a/discord/shard.py
+++ b/discord/shard.py
@@ -286,7 +286,9 @@ class AutoShardedClient(Client):
                 pass
 
         to_close = [shard.ws.close() for shard in self.shards.values()]
-        await asyncio.wait(to_close, loop=self.loop)
+        if to_close:
+            await asyncio.wait(to_close, loop=self.loop)
+
         await self.http.close()
 
     async def change_presence(self, *, activity=None, status=None, afk=False, shard_id=None):


### PR DESCRIPTION
As of current, the following code emits an exception:
```py
import discord

client = discord.AutoShardedClient()
client.loop.run_until_complete(client.close())
```
As there are no Shard instances created yet (the bot hasn't been run), this emits `ValueError: Set of coroutines/Futures is empty`.

While not a common scenario for production bots, such structures are useful for CI testing requiring Client instances and actually connecting should not be a requirement for closing a client successfully.