### PR TITLE
Allow custom cog names and multiple cog instances

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -517,7 +517,7 @@ class BotBase(GroupMixin):
 
     # cogs
 
-    def add_cog(self, cog):
+    def add_cog(self, cog, name=None):
         """Adds a "cog" to the bot.
 
         A cog is a class that has its own event listeners and commands.
@@ -536,9 +536,16 @@ class BotBase(GroupMixin):
         -----------
         cog
             The cog to register to the bot.
+        name
+            The name under which to register the cog. If not present, defaults to the name of the cog class.
         """
 
-        self.cogs[type(cog).__name__] = cog
+        cog_name = str(name) if name else type(cog).__name__
+        type(cog).cog_name = cog_name
+
+        assert cog_name not in self.cogs
+
+        self.cogs[cog_name] = cog
 
         try:
             check = getattr(cog, '_{.__class__.__name__}__global_check'.format(cog))

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -711,7 +711,7 @@ class Command:
     @property
     def cog_name(self):
         """The name of the cog this command belongs to. None otherwise."""
-        return type(self.instance).__name__ if self.instance is not None else None
+        return type(self.instance).cog_name if self.instance is not None else None
 
     @property
     def short_doc(self):


### PR DESCRIPTION
Cogs can now specify a custom cog name when added
Additionally, this allows cog instances of the same type to be added with different names