### PR TITLE
Fix overlooked asyncio import removal

### DIFF
--- a/examples/background_task.py
+++ b/examples/background_task.py
@@ -1,4 +1,5 @@
 import discord
+import asyncio
 
 class MyClient(discord.Client):
     def __init__(self, *args, **kwargs):

--- a/examples/edits.py
+++ b/examples/edits.py
@@ -1,4 +1,5 @@
 import discord
+import asyncio
 
 class MyClient(discord.Client):
     async def on_ready(self):

--- a/examples/guessing_game.py
+++ b/examples/guessing_game.py
@@ -1,5 +1,6 @@
 import discord
 import random
+import asyncio
 
 class MyClient(discord.Client):
     async def on_ready(self):


### PR DESCRIPTION
Not sure how this got overlooked, but this just re-adds the required asyncio imports that were removed.