### PR TITLE
Recognise inherited special methods of cogs

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -542,7 +542,8 @@ class BotBase(GroupMixin):
 
         self.cogs[type(cog).__name__] = cog
 
-        for cls in inspect.getmro(cog.__class__)[:-1]:
+        mro = inspect.getmro(cog.__class__)[:-1]
+        for cls in mro:
             try:
                 check = getattr(cog, '_{.__name__}__global_check'.format(cls))
             except AttributeError:
@@ -551,6 +552,7 @@ class BotBase(GroupMixin):
                 self.add_check(check)
                 break
 
+        for cls in mro:
             try:
                 check = getattr(cog, '_{.__name__}__global_check_once'.format(cls))
             except AttributeError:


### PR DESCRIPTION
I know I'm not the first person to have cog classes inherit from other classes. One drawback of this, however, is that special methods of superclasses, which would otherwise be utilised by the commands package, are ignored (`__unload`, `__global_check` etc.), unless the cog dev creates these methods in the cog class only to delegate the call to a super class through `super()` or otherwise.

With this change, the MRO is inspected to get the first of these special methods encountered in the cog's super-classes. In each case, I decided to have the loop break after finding the first matching method, since the function can still continue up the MRO with calls through `super()` if they so desire, and this behaviour is more consistent with how inherited methods are usually discovered.

This is mostly just a convenience change so people don't have to use the solution I mentioned above. I'm guessing that avoiding calls to inherited methods is not the reason these special methods start with double underscore, but rather a side-effect.

Note: In each inspection of the MRO I've sliced off the last element since (to my knowledge) it should always be just `object`, unless some maniac modifies that behaviour.
