### PR TITLE
add Client.is_ready

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -593,6 +593,11 @@ class Client:
     # helpers/getters
 
     @property
+    def is_ready(self):
+        """Return whether the the client's internal cache is all ready."""
+        return self._ready.is_set()
+
+    @property
     def users(self):
         """Returns a :obj:`list` of all the :class:`User` the bot can see."""
         return list(self._connection._users.values())


### PR DESCRIPTION
I have some code where instead of waiting until the bot is ready, I want to do something differently if the bot is not ready yet. Since this code runs in on_message, using wait_until_ready might "block" for several seconds when the user runs a command before the bot is ready. This property allows one to check whether the bot is ready yet, without necessarily waiting for it to become ready.