### PR TITLE
Remove superfluous Member._copy implementation

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -25,7 +25,6 @@ DEALINGS IN THE SOFTWARE.
 """
 
 import itertools
-import copy
 
 import discord.abc
 
@@ -224,11 +223,6 @@ class Member(discord.abc.Messageable, _BaseUser):
             u.name = user.get('username', u.name)
             u.avatar = user.get('avatar', u.avatar)
             u.discriminator = user.get('discriminator', u.discriminator)
-
-    def _copy(self):
-        c = copy.copy(self)
-        c._user = copy.copy(self._user)
-        return c
 
     @property
     def colour(self):


### PR DESCRIPTION
The old Member._copy implementation was left over in 095f0ec.  Being defined later it replaced the new one and despite the changed interface it just happens to be that `member._copy()` is the same as `Member._copy(member)`, thus masking the mistake.

Perhaps more interesting is that pylint doesn't catch this.  I'll have to investigate that.