### PR TITLE
utils.SnowflakeList.__new__: use super() instead of explicit class

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -308,7 +308,7 @@ class SnowflakeList(array.array):
     __slots__ = ()
 
     def __new__(cls, data, *, is_sorted=False):
-        return array.array.__new__(cls, 'Q', data if is_sorted else sorted(data))
+        return super().__new__(cls, 'Q', data if is_sorted else sorted(data))
 
     def add(self, element):
         i = bisect_left(self, element)


### PR DESCRIPTION
Both work, and `array.array` is uglier.