### PR TITLE
Fixed an issue where there's a whitespace in a beginning of an artist's name

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -512,7 +512,7 @@ class Spotify:
     @property
     def artists(self):
         """List[:class:`str`]: The artists of the song being played."""
-        return self._state.split(';')
+        return self._state.split('; ')
 
     @property
     def artist(self):


### PR DESCRIPTION

Fixed an issue where there's a whitespace in a beginning of an artist name (happens from the 2nd artist up)
Basically Discord retrieves the data like
`artist1; artist2; artist3` and when you split only by `;` the results will be:
`[artist1, " artist2", " artist3"]`
as can be seen [here](https://cdn.discordapp.com/attachments/217764019661045761/506795177315270656/unknown.png)