### PR TITLE
Made the wait_for_reaction coro doc less confusing

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -758,7 +758,7 @@ class Client:
         then the first reaction emoji that is in the list is returned. If ``None`` is
         passed then the first reaction emoji used is returned.
 
-        This function returns the **first reaction that meets the requirements**.
+        This function returns the **first result that meets the requirements**.
 
         Examples
         ---------


### PR DESCRIPTION
The current "returns the first reaction that meets the requirements" information can be really confusing to someone reading the docs, since it isn't what it actually returns - only later down the line it's mentioned that it returns a "namedtuple with reaction and user attributes". Because of that, I wanted to propose a small change that would make it less confusing for other people using the docs.

This is for the current `discord.py`, not rewrite. I wanted to contribute so that people won't spend 2 hours like me figuring out why I'm getting something else than written in the docs.