### PR TITLE
Added User.mutual_friends()

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -775,3 +775,6 @@ class HTTPClient:
 
     def leave_hypesquad_house(self):
         return self.request(Route('DELETE', '/hypesquad/online'))
+
+    def get_mutual_friends(self, user_id):
+        return self.request(Route('GET', '/users/{user_id}/relationships', user_id=user_id))

--- a/discord/http.py
+++ b/discord/http.py
@@ -769,12 +769,12 @@ class HTTPClient:
     def get_user_profile(self, user_id):
         return self.request(Route('GET', '/users/{user_id}/profile', user_id=user_id))
 
+    def get_mutual_friends(self, user_id):
+        return self.request(Route('GET', '/users/{user_id}/relationships', user_id=user_id))
+        
     def change_hypesquad_house(self, house_id):
         payload = {'house_id': house_id}
         return self.request(Route('POST', '/hypesquad/online'), json=payload)
 
     def leave_hypesquad_house(self):
         return self.request(Route('DELETE', '/hypesquad/online'))
-
-    def get_mutual_friends(self, user_id):
-        return self.request(Route('GET', '/users/{user_id}/relationships', user_id=user_id))

--- a/discord/user.py
+++ b/discord/user.py
@@ -554,7 +554,28 @@ class User(BaseUser, discord.abc.Messageable):
     def relationship(self):
         """Returns the :class:`Relationship` with this user if applicable, ``None`` otherwise."""
         return self._state.user.get_relationship(self.id)
+    
+    async def mutual_friends(self):
+        """|coro|
 
+        Get all mutual friends of this user.
+
+        Returns 
+        -------
+        list
+            :class:User objects
+
+        Raises
+        -------
+        HTTPException
+            Getting mutual friends failed.
+        """
+        mutuals = await self._state.http.get_mutual_friends(self.id)
+        users = list()
+        for friend in mutuals:
+            users.append(self._state.get_user(int(friend["id"])))
+        return users
+        
     def is_friend(self):
         """:class:`bool`: Checks if the user is your friend."""
         r = self.relationship

--- a/discord/user.py
+++ b/discord/user.py
@@ -558,24 +558,22 @@ class User(BaseUser, discord.abc.Messageable):
     async def mutual_friends(self):
         """|coro|
 
-        Get all mutual friends of this user.
+        Gets all mutual friends of this user. This can only be used by non-bot accounts
 
         Returns 
         -------
-        list
-            :class:User objects
+            List[:class:`User`] - The users that are mutual friends.
 
         Raises
         -------
+        Forbidden
+            Not allowed to get mutual friends of this user.
         HTTPException
             Getting mutual friends failed.
         """
         mutuals = await self._state.http.get_mutual_friends(self.id)
-        users = list()
-        for friend in mutuals:
-            users.append(self._state.get_user(int(friend["id"])))
-        return users
-        
+        return [self._state.get_user(int(friend["id"])) for friend in mutuals]
+
     def is_friend(self):
         """:class:`bool`: Checks if the user is your friend."""
         r = self.relationship


### PR DESCRIPTION
#1766 
**What it Does**:
I added support for selfbots to get all mutual friends with a user using `await User.mutual_friends()`
This will return a list of User objects that are mutual friends between the bot and the user.

**Use Cases**:
1. Ordering users by the amount of mutual friends
2. Comparing mutual friends between different users

**Weaknesses**:
1. If a mutual friend is not in the bots cache, they will show up as None in the list. I don't know how much of a problem this will be seeing as how selfbots can only be in up to 100 guilds.
2. I have never written docs like this before and I do not know how good these are, so if anyone has any changes or suggestions to make to the docs, I am happy to change them.

**Testing**:
I have quickly tested this with me and a few users and it worked throughout all of the tests.
