### PR TITLE
Update Message.mention_everyone docs to include @here

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -142,8 +142,8 @@ class Message:
 
         .. note::
 
-            This does not check if the ``@everyone`` text is in the message itself.
-            Rather this boolean indicates if the ``@everyone`` text is in the message
+            This does not check if the ``@everyone`` or the ``@here`` text is in the message itself.
+            Rather this boolean indicates if either the ``@everyone`` or the ``@here`` text is in the message
             **and** it did end up mentioning everyone.
 
     mentions: :class:`list`

--- a/discord/message.py
+++ b/discord/message.py
@@ -144,7 +144,7 @@ class Message:
 
             This does not check if the ``@everyone`` or the ``@here`` text is in the message itself.
             Rather this boolean indicates if either the ``@everyone`` or the ``@here`` text is in the message
-            **and** it did end up mentioning everyone.
+            **and** it did end up mentioning.
 
     mentions: :class:`list`
         A list of :class:`Member` that were mentioned. If the message is in a private message

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -368,7 +368,7 @@ class Permissions:
 
     @property
     def mention_everyone(self):
-        """Returns True if a user's @everyone will mention everyone in the text channel."""
+        """Returns True if a user's @everyone or @here will mention everyone in the text channel."""
         return self._bit(17)
 
     @mention_everyone.setter


### PR DESCRIPTION
The documentation for Message.mention_everyone does not include @here, even though it is True if @here is mentioned.
The disocord UI also mentions both @here and @everyone.
![14a9cd2b0b33cfe0d49bdb07ea433970](https://user-images.githubusercontent.com/10470023/49935579-aedae080-fed1-11e8-8efb-6508270b5575.png)
