### PR TITLE
Added Hidden Cogs

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -519,7 +519,7 @@ class BotBase(GroupMixin):
 
     # cogs
 
-    def add_cog(self, cog):
+    def add_cog(self, cog, **kwargs):
         """Adds a "cog" to the bot.
 
         A cog is a class that has its own event listeners and commands.
@@ -538,6 +538,8 @@ class BotBase(GroupMixin):
         -----------
         cog
             The cog to register to the bot.
+        hidden : Optional[:class:`bool`]
+            Whether or not to make all commands in this cog hidden. Defaults to ``False``.
         """
 
         self.cogs[type(cog).__name__] = cog
@@ -556,10 +558,13 @@ class BotBase(GroupMixin):
         else:
             self.add_check(check, call_once=True)
 
+        hidden = kwargs.get("hidden", False)
         members = inspect.getmembers(cog)
         for name, member in members:
             # register commands the cog has
             if isinstance(member, Command):
+                if hidden:
+                    member.hidden = hidden
                 if member.parent is None:
                     self.add_command(member)
                 continue


### PR DESCRIPTION
I added an option to have a hidden kwarg in bot.add_cog() which, if set to True, would make all commands in that cog hidden. This is useful for admin/owner cogs where all commands inside need to be hidden. 

**Example**:
```
def setup(bot):
    bot.add_cog(Cog(bot), hidden = True)
```
This would make all commands inside Cog hidden. 

**Testing**:
This has been tested a few times and it worked throughout all of the tests.

**Weaknesses**:
This will overrule anything inside of specific decorators if set to True. 

_Any and all recommendations are welcome._