### PR TITLE
Add additional parameters to channel creation

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -508,17 +508,16 @@ class HTTPClient:
         r = Route('PATCH', '/guilds/{guild_id}/channels', guild_id=guild_id)
         return self.request(r, json=data, reason=reason)
 
-    def create_channel(self, guild_id, name, channel_type, parent_id=None, permission_overwrites=None, *, reason=None):
+    def create_channel(self, guild_id, channel_type, *, reason=None, **options):
         payload = {
-            'name': name,
             'type': channel_type
         }
 
-        if permission_overwrites is not None:
-            payload['permission_overwrites'] = permission_overwrites
-
-        if parent_id is not None:
-            payload['parent_id'] = parent_id
+        valid_keys = ('name', 'parent_id', 'topic', 'bitrate', 'nsfw',
+                      'user_limit', 'position', 'permission_overwrites', 'rate_limit_per_user')
+        payload.update({
+            k: v for k, v in options.items() if k in valid_keys
+        })
 
         return self.request(Route('POST', '/guilds/{guild_id}/channels', guild_id=guild_id), json=payload, reason=reason)
 


### PR DESCRIPTION
This PR adds parameters to both channel creation methods, `create_text_channel` and `create_voice_channel`, that were previously missing.

`create_text_channel` gained:
- `topic`: str, the channel's topic
- `slowmode_delay`: int, the channels' slowmode_delay
- `nsfw`: bool, the channel's nsfw status
- `position`: int, the channel's position in the channel list

`create_voice_channel` gained:
- `bitrate`: int, the channel's bitrate in bits per second
- `user_limit`: int, the user limit of the channel
- `position`: int, the channel's position in the channel list

Note:
Functionality surrounding the `position` parameters may not be intuitive to users. [See the following conversation that took place in DAPI/#api](https://canary.discordapp.com/channels/81384788765712384/381887113391505410/524675554176270336). I am looking for feedback on this parameter.