### PR TITLE
Specify a tuple for startswith

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -249,7 +249,7 @@ def _get_mime_type_for_image(data):
         return 'image/png'
     elif data.startswith(b'\xFF\xD8') and data.rstrip(b'\0').endswith(b'\xFF\xD9'):
         return 'image/jpeg'
-    elif data.startswith(b'\x47\x49\x46\x38\x37\x61') or data.startswith(b'\x47\x49\x46\x38\x39\x61'):
+    elif data.startswith((b'\x47\x49\x46\x38\x37\x61', b'\x47\x49\x46\x38\x39\x61')):
         return 'image/gif'
     else:
         raise InvalidArgument('Unsupported image type given')


### PR DESCRIPTION
Making advantage of `startswith` accepting tuples.