### PR TITLE
Make Greedy swallow conversion errors and return default if no convertable args (Fix #1791)

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -359,22 +359,20 @@ class Command:
             # for use with a manual undo
             previous = view.index
 
-            # parsing errors get propagated
             view.skip_ws()
             argument = quoted_word(view)
             try:
                 value = await self.do_conversion(ctx, converter, argument, param)
             except CommandError:
-                if not result:
-                    if required:
-                        raise
-                    else:
-                        view.index = previous
-                        return param.default
                 view.index = previous
+                if not result and not required:
+                    return param.default
                 break
             else:
                 result.append(value)
+
+        if not result and not required:
+            return param.default
         return result
 
     async def _transform_greedy_var_pos(self, ctx, param, converter):

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -365,8 +365,6 @@ class Command:
                 value = await self.do_conversion(ctx, converter, argument, param)
             except CommandError:
                 view.index = previous
-                if not result and not required:
-                    return param.default
                 break
             else:
                 result.append(value)


### PR DESCRIPTION
## Description
As the title says, this makes `Greedy` swallow conversion errors if there's no convertable arguments available. (or raise `TooManyArguments` if `ignore_extra=False`)
Also, if `Greedy` did not convert anything and a default was passed, the default will be returned instead of an empty line.

As of now, the intended behavior for `Greedy` is unclear. As stated in #1971, it can sometimes return an empty list or straight up raise an error.

Greedy variable arguments (`*args`) and "greedy" keyword arguments (`*, kwarg`) are untouched.

## Test cases
```py
@bot.command()
async def greedy(ctx, a: commands.Greedy[int]):
    await ctx.send(f"{a}")
```
![greedy](https://user-images.githubusercontent.com/39178127/50370275-c9ead600-05de-11e9-8095-584bbd0f0821.PNG)
```py
@bot.command()
async def greedy(ctx, a: commands.Greedy[int] = None):
    await ctx.send(f"{a}")
```
![greedy](https://user-images.githubusercontent.com/39178127/50370292-1df5ba80-05df-11e9-847a-f768de179c4b.PNG)
```py
@bot.command()
async def greedy(ctx, a: commands.Greedy[int], b: str, *c: str):
    await ctx.send(f"{a} | {b} | {c}")
```
![greedy](https://user-images.githubusercontent.com/39178127/50370327-90ff3100-05df-11e9-9cf4-d2a61be6ffee.PNG)
```py
@bot.command()
async def greedy(ctx, a: str, b: commands.Greedy[int] = None, *c: str):
    await ctx.send(f"{a} | {b} | {c}")
```
![greedy](https://user-images.githubusercontent.com/39178127/50370446-aa08e180-05e1-11e9-8d9b-59c63e838c2d.PNG)
```py
@bot.command()
async def greedy(ctx, a: commands.Greedy[int] = None, b: str, *c: str):
    await ctx.send(f"{a} | {b} | {c}")
```
Nope. Not possible, since `a` is now a keyword argument (-ish) but `b` is positional.

## Test cases with `ignore_extra=False`
```py
@bot.command(ignore_extra=False)
async def greedy(ctx, a: commands.Greedy[int]):
    await ctx.send(f"{a}")
```
![greedy](https://user-images.githubusercontent.com/39178127/50370427-2949e580-05e1-11e9-92e6-fb11f1227f7d.PNG)
```py
@bot.command(ignore_extra=False)
async def greedy(ctx, a: commands.Greedy[int] = None):
    await ctx.send(f"{a}")
```
![greedy](https://user-images.githubusercontent.com/39178127/50370462-09ff8800-05e2-11e9-974e-6b034aa48b24.PNG)

(after taking all the screenshots and writing this up, I forgot about specially handling `ConversionError`, I guess that needs to be propagated?)

(also, I'll be kinda sad if the intended behavior is to never return an empty list)