### PR TITLE
Do None checks instead of falsy checks on Command text attributes

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -722,9 +722,9 @@ class Command:
         If that lookup leads to an empty string then the first line of the
         :attr:`help` attribute is used instead.
         """
-        if self.brief:
+        if self.brief is not None:
             return self.brief
-        if self.help:
+        if self.help is not None:
             return self.help.split('\n', 1)[0]
         return ''
 
@@ -743,7 +743,7 @@ class Command:
             name = self.name if not parent else parent + ' ' + self.name
             result.append(name)
 
-        if self.usage:
+        if self.usage is not None:
             result.append(self.usage)
             return ' '.join(result)
 


### PR DESCRIPTION
This allows empty strings to be used for `help`, `brief`, and `usage`, where they would previously be ignored.

The previous behavior made it not possible to overwrite the brief or usage of a command to be blank without using invisible characters. This change allows e.g. `@commands.command(usage='')` to be done if the user does not want the automatic, parameter-based usage guide to be displayed.