### PR TITLE
Add bot.owners and the support for it in is_owner

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -361,7 +361,7 @@ class BotBase(GroupMixin):
             app = await self.application_info()
             self.owner_id = owner_id = app.owner.id
             self.owners.append(owner_id)
-        return user.id == self.owner_id if not self.owners else user.id in self.owners
+        return user.id in self.owners
 
     def before_invoke(self, coro):
         """A decorator that registers a coroutine as a pre-invoke hook.

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -160,6 +160,7 @@ class BotBase(GroupMixin):
         self.description = inspect.cleandoc(description) if description else ''
         self.pm_help = pm_help
         self.owner_id = options.get('owner_id')
+        self.owners = options.get('owners') or ([self.owner_id] if self.owner_id else [])
         self.command_not_found = options.pop('command_not_found', 'No command called "{}" found.')
         self.command_has_no_subcommands = options.pop('command_has_no_subcommands', 'Command {0.name} has no subcommands.')
 
@@ -347,7 +348,7 @@ class BotBase(GroupMixin):
         """Checks if a :class:`.User` or :class:`.Member` is the owner of
         this bot.
 
-        If an :attr:`owner_id` is not set, it is fetched automatically
+        If :attr:`owner_id` or :attr:`owners` are not set, it is fetched automatically
         through the use of :meth:`~.Bot.application_info`.
 
         Parameters
@@ -359,8 +360,8 @@ class BotBase(GroupMixin):
         if self.owner_id is None:
             app = await self.application_info()
             self.owner_id = owner_id = app.owner.id
-            return user.id == owner_id
-        return user.id == self.owner_id
+            self.owners.append(owner_id)
+        return user.id == self.owner_id if not self.owners else user.id in self.owners
 
     def before_invoke(self, coro):
         """A decorator that registers a coroutine as a pre-invoke hook.


### PR DESCRIPTION
This PR introduces a new kwarg / attribute for `commands.Bot`.
It adds `bot.owners`, which, by default, is an empty list or `[bot.owner_id]`.
It adds support for `bot.owners` in `bot.is_owner` by checking for the user ID to be in `bot.owners`.
If `bot.owner_id` is None, it will add the acquired user ID to `bot.owners` for future use.

### Why?
This allows bots to be maintained by multiple user easily without need to rewrite 3rd-party libraries, which use the default `bot.is_owner`, or overwriting `bot.is_owner` by subclassing `commands.Bot`.

An example is the commonly used [jishaku](https://github.com/Gorialis/jishaku).

Tested with this code:

**Allows only one person to use owner commands**
```py
import discord
from discord.ext import commands

bot = commands.Bot(command_prefix="dpytest ", owner_id=356091260429402122)

bot.load_extension("jishaku")
bot.run("token")
```

**Allows the application owner to use owner commands**
```py
import discord
from discord.ext import commands

bot = commands.Bot(command_prefix="dpytest ")

bot.load_extension("jishaku")
bot.run("token")
```

**Allows the application owner and any other people to use owner commands**
```py
import discord
from discord.ext import commands

bot = commands.Bot(command_prefix="dpytest ", owners=[244508568517083136])

bot.load_extension("jishaku")
bot.run("token")
```

Site note:
There is a chance that Discord will add this as well, as it is suggested by many people, such as [here](https://support.discordapp.com/hc/en-us/community/posts/360029330132-Shared-Bot-Ownership)