### PR TITLE
Fix user/user_id documentation for reaction remove events (Fix #1803)

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -99,7 +99,7 @@ class RawReactionActionEvent:
     message_id: :class:`int`
         The message ID that got or lost a reaction.
     user_id: :class:`int`
-        The user ID who added or removed the reaction.
+        The user ID who added the reaction or whose reaction was removed.
     channel_id: :class:`int`
         The channel ID where the reaction got added or removed.
     guild_id: Optional[:class:`int`]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -307,7 +307,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
         To get the message being reacted, access it via :attr:`Reaction.message`.
 
     :param reaction: A :class:`Reaction` showing the current state of the reaction.
-    :param user: A :class:`User` or :class:`Member` of the user who removed the reaction.
+    :param user: A :class:`User` or :class:`Member` of the user whose reaction was removed.
 
 .. function:: on_raw_reaction_remove(payload)
 


### PR DESCRIPTION
Tested with both `on_reaction_remove` and `on_raw_reaction_remove`. Here's `on_reaction_remove`:

![reaction](https://user-images.githubusercontent.com/39178127/50504638-ee94f100-0aa9-11e9-97ac-acc5c3f64f65.PNG)
![reaction](https://user-images.githubusercontent.com/39178127/50504616-c1484300-0aa9-11e9-9a8d-bb5b9fdd36d1.PNG)
