### PR TITLE
Allow embeds from default help

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -473,3 +473,19 @@ class Embed:
             result['title'] = self.title
 
         return result
+
+    def __len__(self):
+        """Returns total length of strings from the Embed's author.name,
+        footer.text, description, title, all field names and all field
+        values.        
+        """
+        values = [f.name for f in self.fields]
+        values.extend([f.value for f in self.fields]) 
+        values.extend([self.title, self.description, self.author.name, self.footer.text])
+        
+        count = 0
+        for v in values:
+            if isinstance(v, str):
+                count = count + len(v)
+        
+        return count

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -37,7 +37,7 @@ from .view import StringView
 from .context import Context
 from .errors import CommandNotFound, CommandError
 from .formatter import HelpFormatter
-from discord import Embed
+from discord.embeds import Embed
 
 def _get_variable(name):
     stack = inspect.stack()

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -37,6 +37,7 @@ from .view import StringView
 from .context import Context
 from .errors import CommandNotFound, CommandError
 from .formatter import HelpFormatter
+from discord import Embed
 
 def _get_variable(name):
     stack = inspect.stack()
@@ -140,7 +141,10 @@ def _default_help_command(ctx, *commands : str):
             destination = ctx.message.author
 
     for page in pages:
-        yield from bot.send_message(destination, page)
+        if isinstance(page, Embed):
+            yield from bot.send_message(destination, embed=page)
+        else:
+            yield from bot.send_message(destination, page)
 
 
 class Bot(GroupMixin, discord.Client):


### PR DESCRIPTION
When trying to override the format() function by extending the HelpFormatter, I found out that it wasn't possible to send Embed messages due to the inner functionality of the `_default_help_command()` function in `discord/ext/commands/bot.py`.

In this PR I tried to solve that by checking if the returned value from `<HelpFormatter>.format_help_for()` was an instance of discord.Embed.
I also implemented the `len()` function for the discord.Embed class, since it was also being used on the returned values from `<HelpFormatter>.format_help_for()`. This `len()` function returns the total length of strings from the author.name, footer.text, title, description, and all field names + field values of the Embed.

I also think it might be worth mentioning in the docstring that if a user decides to override `<HelpFormatter>.format()`, they should make sure that they return a list.