### PR TITLE
discord.Activity application_id should be INT

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -94,7 +94,7 @@ class Activity(_ActivityTag):
 
     Attributes
     ------------
-    application_id: :class:`str`
+    application_id: :class:`int`
         The application ID of the game.
     name: :class:`str`
         The name of the activity.

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -138,7 +138,7 @@ class Activity(_ActivityTag):
         self.timestamps = kwargs.pop('timestamps', {})
         self.assets = kwargs.pop('assets', {})
         self.party = kwargs.pop('party', {})
-        self.application_id = kwargs.pop('application_id', None)
+        self.application_id = int(kwargs.pop('application_id', None))
         self.name = kwargs.pop('name', None)
         self.url = kwargs.pop('url', None)
         self.flags = kwargs.pop('flags', 0)

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -3,7 +3,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2015-2017 Rapptz
+Copyright (c) 2015-2019 Rapptz
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -28,6 +28,7 @@ import datetime
 
 from .enums import ActivityType, try_enum
 from .colour import Colour
+from .utils import _get_as_snowflake
 
 __all__ = ['Activity', 'Streaming', 'Game', 'Spotify']
 
@@ -56,7 +57,7 @@ secrets: dict
     join: str (max: 128)
     spectate: str (max: 128)
 instance: bool
-application_id: int
+application_id: str
 name: str (max: 128)
 url: str
 type: int
@@ -93,7 +94,7 @@ class Activity(_ActivityTag):
 
     Attributes
     ------------
-    application_id: :class:`int`
+    application_id: :class:`str`
         The application ID of the game.
     name: :class:`str`
         The name of the activity.
@@ -138,7 +139,7 @@ class Activity(_ActivityTag):
         self.timestamps = kwargs.pop('timestamps', {})
         self.assets = kwargs.pop('assets', {})
         self.party = kwargs.pop('party', {})
-        self.application_id = int(kwargs.pop('application_id', None))
+        self.application_id = _get_as_snowflake(kwargs, 'application_id')
         self.name = kwargs.pop('name', None)
         self.url = kwargs.pop('url', None)
         self.flags = kwargs.pop('flags', 0)

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -56,7 +56,7 @@ secrets: dict
     join: str (max: 128)
     spectate: str (max: 128)
 instance: bool
-application_id: str
+application_id: int
 name: str (max: 128)
 url: str
 type: int
@@ -93,7 +93,7 @@ class Activity(_ActivityTag):
 
     Attributes
     ------------
-    application_id: :class:`str`
+    application_id: :class:`int`
         The application ID of the game.
     name: :class:`str`
         The name of the activity.


### PR DESCRIPTION
For some reason application_id is documented to being string. But in rewrite all other IDs are integers meaning that application_id should follow that too. I didn't even see any reason why it was string and not integer. So here we are with a pull request.