### PR TITLE
Update voice code to vws V4

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -26,10 +26,10 @@ DEALINGS IN THE SOFTWARE.
 
 from enum import Enum, IntEnum
 
-__all__ = ['ChannelType', 'MessageType', 'VoiceRegion', 'VerificationLevel',
-           'ContentFilter', 'Status', 'DefaultAvatar', 'RelationshipType',
-           'AuditLogAction', 'AuditLogActionCategory', 'UserFlags',
-           'ActivityType', 'HypeSquadHouse', 'NotificationLevel']
+__all__ = ['ChannelType', 'MessageType', 'VoiceRegion', 'SpeakingState',
+           'VerificationLevel', 'ContentFilter', 'Status', 'DefaultAvatar',
+           'RelationshipType', 'AuditLogAction', 'AuditLogActionCategory',
+           'UserFlags', 'ActivityType', 'HypeSquadHouse', 'NotificationLevel']
 
 class ChannelType(Enum):
     text     = 0
@@ -74,6 +74,15 @@ class VoiceRegion(Enum):
 
     def __str__(self):
         return self.value
+
+class SpeakingState(IntEnum):
+    none       = 0
+    voice      = 1
+    soundshare = 2
+    priority   = 4
+
+    def __str__(self):
+        return self.name
 
 class VerificationLevel(IntEnum):
     none              = 0

--- a/discord/player.py
+++ b/discord/player.py
@@ -27,6 +27,7 @@ DEALINGS IN THE SOFTWARE.
 import threading
 import subprocess
 import audioop
+import asyncio
 import logging
 import shlex
 import time
@@ -261,6 +262,7 @@ class AudioPlayer(threading.Thread):
 
         # getattr lookup speed ups
         play_audio = self.client.send_audio_packet
+        self._speak(True)
 
         while not self._end.is_set():
             # are we paused?
@@ -309,14 +311,19 @@ class AudioPlayer(threading.Thread):
     def stop(self):
         self._end.set()
         self._resumed.set()
+        self._speak(False)
 
-    def pause(self):
+    def pause(self, *, update_speaking=True):
         self._resumed.clear()
+        if update_speaking:
+            self._speak(False)
 
-    def resume(self):
+    def resume(self, *, update_speaking=True):
         self.loops = 0
         self._start = time.time()
         self._resumed.set()
+        if update_speaking:
+            self._speak(True)
 
     def is_playing(self):
         return self._resumed.is_set() and not self._end.is_set()
@@ -326,6 +333,12 @@ class AudioPlayer(threading.Thread):
 
     def _set_source(self, source):
         with self._lock:
-            self.pause()
+            self.pause(update_speaking=False)
             self.source = source
-            self.resume()
+            self.resume(update_speaking=False)
+
+    def _speak(self, speaking):
+        try:
+            asyncio.run_coroutine_threadsafe(self.client.ws.speak(speaking), self.client.loop)
+        except Exception as e:
+            log.info("Speaking call in player failed: %s", e)

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -102,6 +102,7 @@ class VoiceClient:
         self._connected = threading.Event()
         self._handshake_complete = asyncio.Event(loop=self.loop)
 
+        self.mode = None
         self._connections = 0
         self.sequence = 0
         self.timestamp = 0
@@ -110,6 +111,10 @@ class VoiceClient:
         self.encoder = opus.Encoder()
 
     warn_nacl = not has_nacl
+    supported_modes = (
+        'xsalsa20_poly1305_suffix',
+        'xsalsa20_poly1305',
+    )
 
     @property
     def guild(self):
@@ -288,21 +293,29 @@ class VoiceClient:
 
     def _get_voice_packet(self, data):
         header = bytearray(12)
-        nonce = bytearray(24)
-        box = nacl.secret.SecretBox(bytes(self.secret_key))
 
-        # Formulate header
+        # Formulate rtp header
         header[0] = 0x80
         header[1] = 0x78
         struct.pack_into('>H', header, 2, self.sequence)
         struct.pack_into('>I', header, 4, self.timestamp)
         struct.pack_into('>I', header, 8, self.ssrc)
 
-        # Copy header to nonce's first 12 bytes
+        encrypt_packet = getattr(self, '_encrypt_' + self.mode)
+        return encrypt_packet(header, data)
+
+    def _encrypt_xsalsa20_poly1305(self, header, data):
+        box = nacl.secret.SecretBox(bytes(self.secret_key))
+        nonce = bytearray(24)
         nonce[:12] = header
 
-        # Encrypt and return the data
         return header + box.encrypt(bytes(data), bytes(nonce)).ciphertext
+
+    def _encrypt_xsalsa20_poly1305_suffix(self, header, data):
+        box = nacl.secret.SecretBox(bytes(self.secret_key))
+        nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
+
+        return header + box.encrypt(bytes(data), nonce).ciphertext + nonce
 
     def play(self, source, *, after=None):
         """Plays an :class:`AudioSource`.


### PR DESCRIPTION
- Update internals to be compatible with v4
- Adds multiple encryption mode support.  Previously only `xsalsa20_poly1305` was supported.  Now `xsalsa20_poly1305_suffix` is also supported.
  **Note**: There is no (nice) way to manually select a mode.  The user needn't worry about this however.
- Fixed speaking state bug.  When you disconnected from a voice channel while a bot was playing, upon reconnect you would be unable to hear the bot.  This was caused by bots not setting their speaking state while transmitting.  Bots will now set their speaking state properly during transmission.  
  **Note**: This does not account for sending actual silence, the speaking indicator will still be active.