### PR TITLE
Adding ClientUser.premium_type and PremiumType enumeration.

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -29,7 +29,7 @@ from enum import Enum, IntEnum
 __all__ = ['ChannelType', 'MessageType', 'VoiceRegion', 'VerificationLevel',
            'ContentFilter', 'Status', 'DefaultAvatar', 'RelationshipType',
            'AuditLogAction', 'AuditLogActionCategory', 'UserFlags',
-           'ActivityType', 'HypeSquadHouse', 'NotificationLevel']
+           'ActivityType', 'HypeSquadHouse', 'NotificationLevel', 'PremiumType']
 
 class ChannelType(Enum):
     text     = 0
@@ -235,6 +235,10 @@ class HypeSquadHouse(Enum):
     bravery = 1
     brilliance = 2
     balance = 3
+
+class PremiumType(Enum):
+    nitro_classic = 1
+    nitro = 2
 
 def try_enum(cls, val):
     """A function that tries to turn the value into enum ``cls``.

--- a/discord/user.py
+++ b/discord/user.py
@@ -299,6 +299,8 @@ class ClientUser(BaseUser):
         Specifies if the user has MFA turned on and working.
     premium: :class:`bool`
         Specifies if the user is a premium user (e.g. has Discord Nitro).
+    premium_type: :class:`NitroType`
+        Specifies the type of premium a user has (e.g. Nitro or Nitro Classic). Could be None if the user is not premium.
     """
     __slots__ = ('email', 'verified', 'mfa_enabled', 'premium', 'premium_type', '_relationships')
 

--- a/discord/user.py
+++ b/discord/user.py
@@ -300,7 +300,7 @@ class ClientUser(BaseUser):
     premium: :class:`bool`
         Specifies if the user is a premium user (e.g. has Discord Nitro).
     """
-    __slots__ = ('email', 'verified', 'mfa_enabled', 'premium', '_relationships')
+    __slots__ = ('email', 'verified', 'mfa_enabled', 'premium', 'premium_type', '_relationships')
 
     def __init__(self, *, state, data):
         super().__init__(state=state, data=data)
@@ -308,6 +308,11 @@ class ClientUser(BaseUser):
         self.email = data.get('email')
         self.mfa_enabled = data.get('mfa_enabled', False)
         self.premium = data.get('premium', False)
+        premium_type = self.data.get('premium_type', None)
+        if premium_type is None:
+            self.premium_type = premium_type
+        else:
+            self.premium_type = PremiumType(premium_type)
         self._relationships = {}
 
     def __repr__(self):
@@ -344,15 +349,6 @@ class ClientUser(BaseUser):
     def blocked(self):
         r"""Returns a :class:`list` of :class:`User`\s that the user has blocked."""
         return [r.user for r in self._relationships.values() if r.type is RelationshipType.blocked]
-    
-    @property
-    def premium_type(self):
-        """Returns a :class:`NitroType` or None if the user isnt premium."""
-        premium_type = self.data.get('premium_type', None)
-        if premium_type is None:
-            return premium_type
-        else:
-            return PremiumType(premium_type)
 
     async def edit(self, **fields):
         """|coro|

--- a/discord/user.py
+++ b/discord/user.py
@@ -28,7 +28,7 @@ from collections import namedtuple
 
 import discord.abc
 from .utils import snowflake_time, _bytes_to_base64_data, parse_time, valid_icon_size
-from .enums import DefaultAvatar, RelationshipType, UserFlags, HypeSquadHouse
+from .enums import DefaultAvatar, RelationshipType, UserFlags, HypeSquadHouse, PremiumType
 from .errors import ClientException, InvalidArgument
 from .colour import Colour
 
@@ -344,6 +344,15 @@ class ClientUser(BaseUser):
     def blocked(self):
         r"""Returns a :class:`list` of :class:`User`\s that the user has blocked."""
         return [r.user for r in self._relationships.values() if r.type is RelationshipType.blocked]
+    
+    @property
+    def premium_type(self):
+        """Returns a :class:`NitroType` or None if the user isnt premium."""
+        premium_type = self.data.get('premium_type', None)
+        if premium_type is None:
+            return premium_type
+        else:
+            return PremiumType(premium_type)
 
     async def edit(self, **fields):
         """|coro|

--- a/discord/user.py
+++ b/discord/user.py
@@ -299,7 +299,7 @@ class ClientUser(BaseUser):
         Specifies if the user has MFA turned on and working.
     premium: :class:`bool`
         Specifies if the user is a premium user (e.g. has Discord Nitro).
-    premium_type: :class:`NitroType`
+    premium_type: :class:`PremiumType`
         Specifies the type of premium a user has (e.g. Nitro or Nitro Classic). Could be None if the user is not premium.
     """
     __slots__ = ('email', 'verified', 'mfa_enabled', 'premium', 'premium_type', '_relationships')

--- a/discord/user.py
+++ b/discord/user.py
@@ -308,7 +308,7 @@ class ClientUser(BaseUser):
         self.email = data.get('email')
         self.mfa_enabled = data.get('mfa_enabled', False)
         self.premium = data.get('premium', False)
-        premium_type = self.data.get('premium_type', None)
+        premium_type = data.get('premium_type', None)
         if premium_type is None:
             self.premium_type = premium_type
         else:

--- a/discord/user.py
+++ b/discord/user.py
@@ -28,7 +28,7 @@ from collections import namedtuple
 
 import discord.abc
 from .utils import snowflake_time, _bytes_to_base64_data, parse_time, valid_icon_size
-from .enums import DefaultAvatar, RelationshipType, UserFlags, HypeSquadHouse, PremiumType
+from .enums import DefaultAvatar, RelationshipType, UserFlags, HypeSquadHouse, PremiumType, try_enum
 from .errors import ClientException, InvalidArgument
 from .colour import Colour
 
@@ -310,11 +310,7 @@ class ClientUser(BaseUser):
         self.email = data.get('email')
         self.mfa_enabled = data.get('mfa_enabled', False)
         self.premium = data.get('premium', False)
-        premium_type = data.get('premium_type', None)
-        if premium_type is None:
-            self.premium_type = premium_type
-        else:
-            self.premium_type = PremiumType(premium_type)
+        self.premium_type = try_enum(PremiumType, data.get('premium_type', None))
         self._relationships = {}
 
     def __repr__(self):


### PR DESCRIPTION
This Pull Request adds ClientUser.premium_type and a PremiumType enumeration.

There are currently only two types that can be found [here](https://discordapp.com/developers/docs/resources/user#user-object-premium-types).

I am not sure if I added to the docstring correctly so let me know and I will be glad to change it.