### PR TITLE
[RFC] [commands] custom default arguments

### DIFF
--- a/discord/ext/commands/__init__.py
+++ b/discord/ext/commands/__init__.py
@@ -16,3 +16,4 @@ from .help import *
 from .converter import *
 from .cooldowns import *
 from .cog import *
+from .default import CustomDefault

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -633,8 +633,10 @@ class Command(_BaseCommand):
     def _get_converter(self, param):
         converter = param.annotation
         if converter is param.empty:
-            if param.default is param.empty or param.default is None or (inspect.isclass(param.default) and issubclass(param.default, defaults.CustomDefault)) or isinstance(param.default, defaults.CustomDefault):
+            if param.default is param.empty or param.default is None:
                 converter = str
+            elif (inspect.isclass(param.default) and issubclass(param.default, defaults.CustomDefault)) or isinstance(param.default, defaults.CustomDefault):
+                converter = typing.Union[param.default.converters]
             else:
                 converter = type(param.default)
         return converter

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -710,7 +710,7 @@ class Command(_BaseCommand):
                 result.append(value)
 
         if not result and not required:
-            return param.default
+            return await self._resolve_default(ctx, param)
         return result
 
     async def _transform_greedy_var_pos(self, ctx, param, converter):
@@ -723,7 +723,7 @@ class Command(_BaseCommand):
             view.index = previous
             raise RuntimeError() from None # break loop
         else:
-            return value
+            return value or await self._resolve_default(ctx, param)
 
     @property
     def clean_params(self) -> Dict[str, inspect.Parameter]:

--- a/discord/ext/commands/default.py
+++ b/discord/ext/commands/default.py
@@ -34,7 +34,19 @@ __all__ = (
     'Call',
 )
 
-class CustomDefault:
+class CustomDefaultMeta(type):
+    def __new__(cls, *args, **kwargs):
+        name, bases, attrs = args
+        attrs['display'] = kwargs.pop('display', name)
+        return super().__new__(cls, name, bases, attrs, **kwargs)
+
+    def __repr__(cls):
+        return str(cls)
+
+    def __str__(cls):
+        return cls.display
+
+class CustomDefault(metaclass=CustomDefaultMeta):
     """The base class of custom defaults that require the :class:`.Context`.
 
     Classes that derive from this should override the :meth:`~.CustomDefault.default`

--- a/discord/ext/commands/default.py
+++ b/discord/ext/commands/default.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-2019 Rapptz
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from .errors import MissingRequiredArgument
+
+__all__ = (
+    'CustomDefault',
+    'Author',
+    'CurrentChannel',
+    'CurrentGuild',
+    'Call',
+)
+
+class CustomDefault:
+    """The base class of custom defaults that require the :class:`.Context`.
+
+    Classes that derive from this should override the :meth:`~.CustomDefault.default`
+    method to do its conversion logic. This method must be a coroutine.
+    """
+
+    async def default(self, ctx, param):
+        """|coro|
+
+        The method to override to do conversion logic.
+
+        If an error is found while converting, it is recommended to
+        raise a :exc:`.CommandError` derived exception as it will
+        properly propagate to the error handlers.
+
+        Parameters
+        -----------
+        ctx: :class:`.Context`
+            The invocation context that the argument is being used in.
+        """
+        raise NotImplementedError('Derived classes need to implement this.')
+
+
+class Author(CustomDefault):
+    """Default parameter which returns the author for this context."""
+
+    async def default(self, ctx, param):
+        return ctx.author
+
+class CurrentChannel(CustomDefault):
+    """Default parameter which returns the channel for this context."""
+
+    async def default(self, ctx, param):
+        return ctx.channel
+
+class CurrentGuild(CustomDefault):
+    """Default parameter which returns the guild for this context."""
+
+    async def default(self, ctx, param):
+        if ctx.guild:
+            return ctx.guild
+        raise MissingRequiredArgument(param)
+
+class Call(CustomDefault):
+    """Easy wrapper for lambdas/inline defaults."""
+
+    def __init__(self, callback):
+        self._callback = callback
+
+    async def default(self, ctx, param):
+        return self._callback(ctx, param)

--- a/discord/ext/commands/default.py
+++ b/discord/ext/commands/default.py
@@ -24,6 +24,8 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
+import discord
+
 from .errors import MissingRequiredArgument
 
 __all__ = (
@@ -49,9 +51,11 @@ class CustomDefaultMeta(type):
 class CustomDefault(metaclass=CustomDefaultMeta):
     """The base class of custom defaults that require the :class:`.Context`.
 
-    Classes that derive from this should override the :meth:`~.CustomDefault.default`
-    method to do its conversion logic. This method must be a coroutine.
+    Classes that derive from this should override the :attr:`~.CustomDefault.converters` attribute to specify
+    converters to use and the :meth:`~.CustomDefault.default` method to do its conversion logic.
+    This method must be a coroutine.
     """
+    converters = (str,)
 
     async def default(self, ctx, param):
         """|coro|
@@ -72,12 +76,14 @@ class CustomDefault(metaclass=CustomDefaultMeta):
 
 class Author(CustomDefault):
     """Default parameter which returns the author for this context."""
+    converters = (discord.Member, discord.User)
 
     async def default(self, ctx, param):
         return ctx.author
 
 class CurrentChannel(CustomDefault):
     """Default parameter which returns the channel for this context."""
+    converters = (discord.TextChannel,)
 
     async def default(self, ctx, param):
         return ctx.channel

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -329,6 +329,22 @@ Converters
 
 .. autoclass:: discord.ext.commands.Greedy()
 
+.. _ext_commands_api_custom_default:
+
+Default Parameters
+-------------------
+
+.. autoclass:: discord.ext.commands.CustomDefault
+    :members:
+
+.. autoclass:: discord.ext.commands.default.Author
+
+.. autoclass:: discord.ext.commands.default.CurrentChannel
+
+.. autoclass:: discord.ext.commands.default.CurrentGuild
+
+.. autoclass:: discord.ext.commands.default.Call
+
 .. _ext_commands_api_errors:
 
 Exceptions

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -656,6 +656,7 @@ A DefaultParam returning ``None`` is valid - if this should be an error, raise :
 
     class LastImage(CustomDefault):
         """Default param which finds the last image in chat."""
+        converters = (AnyImage,)
 
         async def default(self, ctx, param):
             for attachment in message.attachments:
@@ -672,7 +673,7 @@ A DefaultParam returning ``None`` is valid - if this should be an error, raise :
             raise errors.MissingRequiredArgument(param)
 
     @bot.command()
-    async def echo_image(ctx, *, image: Image = LastImage):
+    async def echo_image(ctx, *, image=LastImage):
         async with aiohttp.ClientSession() as sess:
             async with sess.get(image) as resp:
                 resp.raise_for_status()

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -679,6 +679,10 @@ A DefaultParam returning ``None`` is valid - if this should be an error, raise :
                 my_bytes = io.BytesIO(await resp.content.read())
         await ctx.send(file=discord.File(filename="your_image", fp=my_bytes))
 
+.. tip:: You can change the name of a Custom Default that is displayed in help command by passing ``display`` meta option. Using previous example: ``class LastImage(CustomDefault, display='last image from chat')``
+
+
+
 
 Checks
 -------


### PR DESCRIPTION
Modeled slightly after Converters, allow specifying Converter-like class
for context-based default parameters. e.g.

```
class Author(ParamDefault):
  async def default(self, ctx):
    return ctx.author

async def my_command(ctx, user: discord.Member=Author):
  ...
```
