### PR TITLE
Fixed webhook local file send

### DIFF
--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -123,7 +123,10 @@ class WebhookAdapter:
             multipart = None
         url = '%s?wait=%d' % (self._request_url, wait)
         maybe_coro = self.request('POST', url, multipart=multipart, payload=data)
-        return self.handle_execution_response(maybe_coro, wait=wait, f=f)
+        if isinstance(self.webhook._adapter, RequestsWebhookAdapter):
+            return self.handle_execution_response(maybe_coro, wait=wait)
+        else:
+            return self.handle_execution_response(maybe_coro, wait=wait, f=f)
 
 class AsyncWebhookAdapter(WebhookAdapter):
     """A webhook adapter suited for use with aiohttp.

--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -104,7 +104,7 @@ class WebhookAdapter:
         # mocks a ConnectionState for appropriate use for Message
         return BaseUser(state=self.webhook._state, data=data)
 
-    async def execute_webhook(self, *, payload, wait=False, file=None, files=None):
+    def execute_webhook(self, *, payload, wait=False, file=None, files=None, f=None):
         if file is not None:
             multipart = {
                 'file': file,
@@ -123,12 +123,7 @@ class WebhookAdapter:
             multipart = None
         url = '%s?wait=%d' % (self._request_url, wait)
         maybe_coro = self.request('POST', url, multipart=multipart, payload=data)
-        data = await maybe_coro
-        if not wait:
-            return data
-        # transform into Message object
-        from .message import Message
-        return Message(data=data, state=self.webhook._state, channel=self.webhook.channel)
+        return self.handle_execution_response(maybe_coro, wait=wait, f=f)
 
 class AsyncWebhookAdapter(WebhookAdapter):
     """A webhook adapter suited for use with aiohttp.
@@ -194,7 +189,19 @@ class AsyncWebhookAdapter(WebhookAdapter):
                 else:
                     raise HTTPException(r, data)
 
-
+    async def handle_execution_response(self, response, *, wait, f=None):
+        data = await response
+        if f:
+            if isinstance(f, list):
+                for file in f:
+                    file.close()
+            else:
+                f.close()
+        if not wait:
+            return data
+        # transform into Message object
+        from .message import Message
+        return Message(data=data, state=self.webhook._state, channel=self.webhook.channel)
 
 class RequestsWebhookAdapter(WebhookAdapter):
     """A webhook adapter suited for use with ``requests``.
@@ -655,11 +662,11 @@ class Webhook:
 
         if file is not None:
             to_pass = (file.filename, file.open_file(), 'application/octet-stream')
-            return self._adapter.execute_webhook(wait=wait, file=to_pass, payload=payload)
+            return self._adapter.execute_webhook(wait=wait, file=to_pass, payload=payload, f=file)
         elif files is not None:
             to_pass = [(file.filename, file.open_file(), 'application/octet-stream')
                            for file in files]
-            return self._adapter.execute_webhook(wait=wait, files=to_pass, payload=payload)
+            return self._adapter.execute_webhook(wait=wait, files=to_pass, payload=payload, f=files)
 
         else:
             return self._adapter.execute_webhook(wait=wait, payload=payload)

--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -104,7 +104,7 @@ class WebhookAdapter:
         # mocks a ConnectionState for appropriate use for Message
         return BaseUser(state=self.webhook._state, data=data)
 
-    def execute_webhook(self, *, payload, wait=False, file=None, files=None, f=None):
+    async def execute_webhook(self, *, payload, wait=False, file=None, files=None):
         if file is not None:
             multipart = {
                 'file': file,
@@ -123,7 +123,12 @@ class WebhookAdapter:
             multipart = None
         url = '%s?wait=%d' % (self._request_url, wait)
         maybe_coro = self.request('POST', url, multipart=multipart, payload=data)
-        return self.handle_execution_response(maybe_coro, wait=wait, f=f)
+        data = await maybe_coro
+        if not wait:
+            return data
+        # transform into Message object
+        from .message import Message
+        return Message(data=data, state=self.webhook._state, channel=self.webhook.channel)
 
 class AsyncWebhookAdapter(WebhookAdapter):
     """A webhook adapter suited for use with aiohttp.
@@ -189,19 +194,7 @@ class AsyncWebhookAdapter(WebhookAdapter):
                 else:
                     raise HTTPException(r, data)
 
-    async def handle_execution_response(self, response, *, wait, f=None):
-        data = await response
-        if f:
-            if isinstance(f, list):
-                for file in f:
-                    file.close()
-            else:
-                f.close()
-        if not wait:
-            return data
-        # transform into Message object
-        from .message import Message
-        return Message(data=data, state=self.webhook._state, channel=self.webhook.channel)
+
 
 class RequestsWebhookAdapter(WebhookAdapter):
     """A webhook adapter suited for use with ``requests``.
@@ -662,11 +655,11 @@ class Webhook:
 
         if file is not None:
             to_pass = (file.filename, file.open_file(), 'application/octet-stream')
-            return self._adapter.execute_webhook(wait=wait, file=to_pass, payload=payload, f=file)
+            return self._adapter.execute_webhook(wait=wait, file=to_pass, payload=payload)
         elif files is not None:
             to_pass = [(file.filename, file.open_file(), 'application/octet-stream')
                            for file in files]
-            return self._adapter.execute_webhook(wait=wait, files=to_pass, payload=payload, f=files)
+            return self._adapter.execute_webhook(wait=wait, files=to_pass, payload=payload)
 
         else:
             return self._adapter.execute_webhook(wait=wait, payload=payload)

--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -123,10 +123,7 @@ class WebhookAdapter:
             multipart = None
         url = '%s?wait=%d' % (self._request_url, wait)
         maybe_coro = self.request('POST', url, multipart=multipart, payload=data)
-        if isinstance(self.webhook._adapter, RequestsWebhookAdapter):
-            return self.handle_execution_response(maybe_coro, wait=wait)
-        else:
-            return self.handle_execution_response(maybe_coro, wait=wait, f=f)
+        return self.handle_execution_response(maybe_coro, wait=wait, f=f)
 
 class AsyncWebhookAdapter(WebhookAdapter):
     """A webhook adapter suited for use with aiohttp.
@@ -279,7 +276,13 @@ class RequestsWebhookAdapter(WebhookAdapter):
             else:
                 raise HTTPException(r, data)
 
-    def handle_execution_response(self, response, *, wait):
+    def handle_execution_response(self, response, *, wait, f=None):
+        if f:
+            if isinstance(f, list):
+                for file in f:
+                    file.close()
+            else:
+                f.close()
         if not wait:
             return response
 


### PR DESCRIPTION
This fixes the problem from #1770. All I did was change the way files are closed and instead of closing them in a finally (which runs before the return and therefore before the file is actually used), I close them right after the file is used. I have tested this a few times and it works with both the file and files kwargs.

It isn't the cleanest because I had to add another kwarg to get the file/files to handle_execution_response() so I could close them right after the files are used. If anyone has any style suggestions, or any suggestions in general, I am open to criticism.