### PR TITLE
Use non-deprecated method of acquiring lock

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -148,7 +148,7 @@ class HTTPClient:
             # wait until the global lock is complete
             await self._global_over.wait()
 
-        await lock
+        await lock.acquire()
         with MaybeUnlock(lock) as maybe_lock:
             for tries in range(5):
                 async with self._session.request(method, url, **kwargs) as r:


### PR DESCRIPTION
Sometimes the current use of `await lock` here prints this deprecation warning in the console on python 3.7:
```
discord/http.py:155: DeprecationWarning: 'with await lock' is deprecated use 'async with lock' instead
```
What `await lock` does is simply call `await lock.acquire()` and return a context manager. In this case the return value of `await lock` is being discarded anyway, so I see no reason not to make this change.