### PR TITLE
Removed fixed string from HelpFormatter

### DIFF
--- a/discord/ext/commands/formatter.py
+++ b/discord/ext/commands/formatter.py
@@ -145,13 +145,17 @@ class HelpFormatter:
     commands_heading: :class:`str`
         The command list's heading string used when the help command is invoked with a categoly name.
         Useful for i18n. Defaults to ``"Commands:"``
+    no_categoly: :class:`str`
+        The string used when there is a command which does not belong to any categoly(cog).
+        Useful for i18n. Defaults to ``"No Categoly"``
     """
     def __init__(self, show_hidden=False, show_check_failure=False, width=80,
-                 commands_heading="Commands:"):
+                 commands_heading="Commands:", no_categoly="No Categoly"):
         self.width = width
         self.show_hidden = show_hidden
         self.show_check_failure = show_check_failure
         self.commands_heading = commands_heading
+        self.no_categoly = no_categoly
 
     def has_subcommands(self):
         """:class:`bool`: Specifies if the command has subcommands."""
@@ -322,7 +326,7 @@ class HelpFormatter:
             cog = tup[1].cog_name
             # we insert the zero width space there to give it approximate
             # last place sorting position.
-            return cog + ':' if cog is not None else '\u200bNo Category:'
+            return cog + ':' if cog is not None else '\u200b' + self.no_categoly + ':'
 
         filtered = await self.filter_command_list()
         if self.is_bot():

--- a/discord/ext/commands/formatter.py
+++ b/discord/ext/commands/formatter.py
@@ -143,19 +143,19 @@ class HelpFormatter:
         The maximum number of characters that fit in a line.
         Defaults to 80.
     commands_heading: :class:`str`
-        The command list's heading string used when the help command is invoked with a categoly name.
+        The command list's heading string used when the help command is invoked with a category name.
         Useful for i18n. Defaults to ``"Commands:"``
-    no_categoly: :class:`str`
-        The string used when there is a command which does not belong to any categoly(cog).
-        Useful for i18n. Defaults to ``"No Categoly"``
+    no_category: :class:`str`
+        The string used when there is a command which does not belong to any category(cog).
+        Useful for i18n. Defaults to ``"No Category"``
     """
     def __init__(self, show_hidden=False, show_check_failure=False, width=80,
-                 commands_heading="Commands:", no_categoly="No Categoly"):
+                 commands_heading="Commands:", no_category="No Category"):
         self.width = width
         self.show_hidden = show_hidden
         self.show_check_failure = show_check_failure
         self.commands_heading = commands_heading
-        self.no_categoly = no_categoly
+        self.no_category = no_category
 
     def has_subcommands(self):
         """:class:`bool`: Specifies if the command has subcommands."""
@@ -326,7 +326,7 @@ class HelpFormatter:
             cog = tup[1].cog_name
             # we insert the zero width space there to give it approximate
             # last place sorting position.
-            return cog + ':' if cog is not None else '\u200b' + self.no_categoly + ':'
+            return cog + ':' if cog is not None else '\u200b' + self.no_category + ':'
 
         filtered = await self.filter_command_list()
         if self.is_bot():

--- a/discord/ext/commands/formatter.py
+++ b/discord/ext/commands/formatter.py
@@ -142,30 +142,15 @@ class HelpFormatter:
     width: :class:`int`
         The maximum number of characters that fit in a line.
         Defaults to 80.
-    ending_note 
-        The ending note modify strings that is at end of help page. Useful for i18n.
-        This property could either be a plain string or a callable that takes
-        :class:`.HelpFormatter` as its parameter and returns :class:`str`.
-        Defaults to a callable like
-
-        .. code-block:: python
-
-            async def _ending_note_default(formatter):
-                command_name = formatter.context.invoked_with
-                return "Type {0}{1} command for more info on a command.\\n" \\
-                    "You can also type {0}{1} category for more info on a category." \\
-                    .format(formatter.clean_prefix, command_name)
-
     commands_heading: :class:`str`
         The command list's heading string used when the help command is invoked with a categoly name.
         Useful for i18n. Defaults to ``"Commands:"``
     """
     def __init__(self, show_hidden=False, show_check_failure=False, width=80,
-                 ending_note=None, commands_heading="Commands:"):
+                 commands_heading="Commands:"):
         self.width = width
         self.show_hidden = show_hidden
         self.show_check_failure = show_check_failure
-        self.ending_note = ending_note
         self.commands_heading = commands_heading
 
     def has_subcommands(self):
@@ -214,26 +199,10 @@ class HelpFormatter:
         cmd = self.command
         return prefix + cmd.signature
 
-    async def get_ending_note(self):
-        async def _ending_note_default(formatter):
-            command_name = formatter.context.invoked_with
-            return "Type {0}{1} command for more info on a command.\n" \
-                "You can also type {0}{1} category for more info on a category." \
-                .format(formatter.clean_prefix, command_name)
-
-        ending_note = self.ending_note
-        if ending_note is None:
-            ending_note = _ending_note_default
-
-        if isinstance(ending_note, str):
-            return ending_note
-        if callable(ending_note):
-            ending_note_callable = await discord.utils.maybe_coroutine(ending_note, self)
-            return ending_note_callable
-
-        # ending_note is neither a str nor a callable
-        raise TypeError("ending_note must be plain string or a callable "
-                        "returning string, not {}".format(ending_note.__class__.__name__))
+    def get_ending_note(self):
+        command_name = self.context.invoked_with
+        return "Type {0}{1} command for more info on a command.\n" \
+               "You can also type {0}{1} category for more info on a category.".format(self.clean_prefix, command_name)
 
     async def filter_command_list(self):
         """Returns a filtered list of commands based on the two attributes
@@ -373,6 +342,6 @@ class HelpFormatter:
 
         # add the ending note
         self._paginator.add_line()
-        ending_note = await self.get_ending_note()
+        ending_note = self.get_ending_note()
         self._paginator.add_line(ending_note)
         return self._paginator.pages


### PR DESCRIPTION
Removed fixed strings `"Commands:"` and help page ending note(`"Type ?help command for more info on a command ..."`)
and added properties modify these strings.
default behavior is not changed. fix #1886

I wrote these codes referencing code about `Bot.command_prefix` .

I added comment about added properties too.(for document)
I apologize if there are any mistakes in my English and document writing.