### PR TITLE
Adding docs about Member.activity returning None with long song names

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -320,6 +320,10 @@ class Member(discord.abc.Messageable, _BaseUser):
         .. note::
 
             A user may have multiple activities, these can be accessed under :attr:`activities`.
+            
+        .. note::
+            If a User is listening to Spotify and the song's name is longer than 128 characters, this will return None.
+            This is a discord API limitation.
         """
         if self.activities:
             return self.activities[0]

--- a/discord/member.py
+++ b/discord/member.py
@@ -322,8 +322,8 @@ class Member(discord.abc.Messageable, _BaseUser):
             A user may have multiple activities, these can be accessed under :attr:`activities`.
             
         .. note::
-            If a User is listening to Spotify and the song's name is longer than 128 characters, this will return None.
-            This is a discord API limitation.
+            If a user is listening to Spotify and the song's name is longer than 128 characters, this will return None.
+            This is a Discord API limitation.
         """
         if self.activities:
             return self.activities[0]


### PR DESCRIPTION
These docs address #1738 about Member.activity returning None if a Spotify song name is longer than 128 characters. As always, suggestions and criticisms are welcome.