### PR TITLE
Bump aiohttp requirement and update AsyncWebhookAdapter to use non-deprecated property

### DIFF
--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -141,7 +141,7 @@ class AsyncWebhookAdapter(WebhookAdapter):
 
     def __init__(self, session):
         self.session = session
-        self.loop = session.loop
+        self.loop = asyncio.get_event_loop()
 
     async def request(self, verb, url, payload=None, multipart=None):
         headers = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp>=3.3.0,<3.5.0
+aiohttp>=3.3.0,<3.6.0
 websockets>=6.0,<7.0


### PR DESCRIPTION
3.5 brings a bunch of bug fixes and only one small API change that affects this library

Relevant changes: https://github.com/aio-libs/aiohttp/blob/f6f647eb828fa738610d61481f11fa51e42599e9/CHANGES.rst#350-2018-12-22