### PR TITLE
Add self_video attribute to VoiceState

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -49,6 +49,8 @@ class VoiceState:
         Indicates if the user is currently muted by their own accord.
     self_deaf: :class:`bool`
         Indicates if the user is currently deafened by their own accord.
+    self_video: :class:`bool`
+        Indicates if the user is currently broadcasting video.
     afk: :class:`bool`
         Indicates if the user is currently in the AFK channel in the guild.
     channel: :class:`VoiceChannel`
@@ -57,7 +59,7 @@ class VoiceState:
     """
 
     __slots__ = ('session_id', 'deaf', 'mute', 'self_mute',
-                 'self_deaf', 'afk', 'channel', 'self_video')
+                 'self_video', 'self_deaf', 'afk', 'channel')
 
     def __init__(self, *, data, channel=None):
         self.session_id = data.get('session_id')

--- a/discord/member.py
+++ b/discord/member.py
@@ -57,7 +57,7 @@ class VoiceState:
     """
 
     __slots__ = ('session_id', 'deaf', 'mute', 'self_mute',
-                 'self_deaf', 'afk', 'channel')
+                 'self_deaf', 'afk', 'channel', 'self_video')
 
     def __init__(self, *, data, channel=None):
         self.session_id = data.get('session_id')
@@ -66,13 +66,14 @@ class VoiceState:
     def _update(self, data, channel):
         self.self_mute = data.get('self_mute', False)
         self.self_deaf = data.get('self_deaf', False)
+        self.self_video = data.get('self_video', False)
         self.afk = data.get('suppress', False)
         self.mute = data.get('mute', False)
         self.deaf = data.get('deaf', False)
         self.channel = channel
 
     def __repr__(self):
-        return '<VoiceState self_mute={0.self_mute} self_deaf={0.self_deaf} channel={0.channel!r}>'.format(self)
+        return '<VoiceState self_mute={0.self_mute} self_deaf={0.self_deaf} self_video={0.self_video} channel={0.channel!r}>'.format(self)
 
 def flatten_user(cls):
     for attr, value in itertools.chain(BaseUser.__dict__.items(), User.__dict__.items()):


### PR DESCRIPTION
The `self_video` attribute denotes if a user is transmitting video in a voice channel. This can be useful for logging purposes or to restrict specific users from being able to screenshare in a guild via the API (currently there is no way for server owners to disable video in voice channels).