### PR TITLE
Update __main__.py to use new Cog syntax

### DIFF
--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -95,7 +95,7 @@ cog_template = '''# -*- coding: utf-8 -*-
 from discord.ext import commands
 import discord
 
-class {name}:
+class {name}(commands.Cog):
     """The description for {name} goes here."""
 
     def __init__(self, bot):
@@ -106,31 +106,31 @@ def setup(bot):
 '''
 
 cog_extras = '''
-    def __unload(self):
+    def cog_unload(self):
         # clean up logic goes here
         pass
 
-    async def __local_check(self, ctx):
+    async def cog_check(self, ctx):
         # checks that apply to every command in here
         return True
 
-    async def __global_check(self, ctx):
+    async def bot_check(self, ctx):
         # checks that apply to every command to the bot
         return True
 
-    async def __global_check_once(self, ctx):
+    async def bot_check_once(self, ctx):
         # check that apply to every command but is guaranteed to be called only once
         return True
 
-    async def __error(self, ctx, error):
+    async def cog_command_error(self, ctx, error):
         # error handling to every command in here
         pass
 
-    async def __before_invoke(self, ctx):
+    async def cog_before_invoke(self, ctx):
         # called before a command is called here
         pass
 
-    async def __after_invoke(self, ctx):
+    async def cog_after_invoke(self, ctx):
         # called after a command is called here
         pass
 


### PR DESCRIPTION
Fix for #1927 and an example.
This doesn't demonstrate the new `commands.Cog`-specific functionality, only updating names and conventions that have changed.