### PR TITLE
Update __main__.py to match cog updates

### DIFF
--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -95,7 +95,7 @@ cog_template = '''# -*- coding: utf-8 -*-
 from discord.ext import commands
 import discord
 
-class {name}:
+class {name}(commands.Cog{attrs}):
     """The description for {name} goes here."""
 
     def __init__(self, bot):
@@ -106,31 +106,31 @@ def setup(bot):
 '''
 
 cog_extras = '''
-    def __unload(self):
+    def cog_unload(self):
         # clean up logic goes here
         pass
 
-    async def __local_check(self, ctx):
+    async def cog_check(self, ctx):
         # checks that apply to every command in here
         return True
 
-    async def __global_check(self, ctx):
+    async def bot_check(self, ctx):
         # checks that apply to every command to the bot
         return True
 
-    async def __global_check_once(self, ctx):
+    async def bot_check_once(self, ctx):
         # check that apply to every command but is guaranteed to be called only once
         return True
 
-    async def __error(self, ctx, error):
+    async def cog_command_error(self, ctx, error):
         # error handling to every command in here
         pass
 
-    async def __before_invoke(self, ctx):
+    async def cog_before_invoke(self, ctx):
         # called before a command is called here
         pass
 
-    async def __after_invoke(self, ctx):
+    async def cog_after_invoke(self, ctx):
         # called after a command is called here
         pass
 
@@ -217,6 +217,7 @@ def newbot(parser, args):
     print('successfully made bot at', new_directory)
 
 def newcog(parser, args):
+    print(args)
     if sys.version_info < (3, 5):
         parser.error('python version is older than 3.5, consider upgrading.')
 
@@ -230,6 +231,7 @@ def newcog(parser, args):
     directory = directory.with_suffix('.py')
     try:
         with open(str(directory), 'w', encoding='utf-8') as fp:
+            attrs = ''
             extra = cog_extras if args.full else ''
             if args.class_name:
                 name = args.class_name
@@ -239,7 +241,12 @@ def newcog(parser, args):
                     name = name.replace('-', ' ').title().replace(' ', '')
                 else:
                     name = name.title()
-            fp.write(cog_template.format(name=name, extra=extra))
+
+            if args.display_name:
+                attrs += ', name="{}"'.format(args.display_name)
+            if args.hide_commands:
+                attrs += ', command_attrs=dict(hidden=True)'
+            fp.write(cog_template.format(name=name, extra=extra, attrs=attrs))
     except OSError as exc:
         parser.error('could not create cog file ({})'.format(exc))
     else:
@@ -262,6 +269,8 @@ def add_newcog_args(subparser):
     parser.add_argument('name', help='the cog name')
     parser.add_argument('directory', help='the directory to place it in (default: cogs)', nargs='?', default=Path('cogs'))
     parser.add_argument('--class-name', help='the class name of the cog (default: <name>)', dest='class_name')
+    parser.add_argument('--display-name', help='the cog name (default: <name>)')
+    parser.add_argument('--hide-commands', help='whether to hide all commands in the cog', action='store_true')
     parser.add_argument('--full', help='add all special methods as well', action='store_true')
 
 def parse_args():

--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -217,7 +217,6 @@ def newbot(parser, args):
     print('successfully made bot at', new_directory)
 
 def newcog(parser, args):
-    print(args)
     if sys.version_info < (3, 5):
         parser.error('python version is older than 3.5, consider upgrading.')
 


### PR DESCRIPTION
Added two new arguments to the parser, and updated defunct cog code. (#1927)
The two arguments are:
- `--display-name`
- `--hide-commands`

These are simple commands which enable basic [Meta Options](https://discordpy.readthedocs.io/en/rewrite/ext/commands/cogs.html#ext-commands-cogs-meta-options).

# Custom Display Name
`python -m discord newcog misc ./test --display-name miscellaneous`

```py
# -*- coding: utf-8 -*-

from discord.ext import commands
import discord

class Misc(commands.Cog, name="miscellaneous"):
    """The description for Misc goes here."""

    def __init__(self, bot):
        self.bot = bot

def setup(bot):
    bot.add_cog(Misc(bot))
```

# Hide commands
`python -m discord newcog owner ./test --hide-commands`

```py
# -*- coding: utf-8 -*-

from discord.ext import commands
import discord

class Owner(commands.Cog, command_attrs=dict(hidden=True)):
    """The description for Owner goes here."""

    def __init__(self, bot):
        self.bot = bot

def setup(bot):
    bot.add_cog(Owner(bot))
```