### PR TITLE
Add cached saving

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -91,6 +91,12 @@ class Attachment:
         seek_begin: bool
             Whether to seek to the beginning of the file after saving is
             successfully done.
+        use_cached: bool
+            Whether to use the proxy_url property, rather than the url
+            property, as the attachment source. This will allow attachments
+            to be saved after deletion more often than with the url, which
+            is deleted after the message is deleted. Note that use_cached will
+            still fail after an uncertain amount of time.
 
         Raises
         --------

--- a/discord/message.py
+++ b/discord/message.py
@@ -77,7 +77,7 @@ class Attachment:
         """:class:`bool`: Whether this attachment contains a spoiler."""
         return self.filename.startswith('SPOILER_')
 
-    async def save(self, fp, *, seek_begin=True):
+    async def save(self, fp, *, seek_begin=True, use_cached=False):
         """|coro|
 
         Saves this attachment into a file-like object.
@@ -104,8 +104,8 @@ class Attachment:
         int
             The number of bytes written.
         """
-
-        data = await self._http.get_attachment(self.url)
+        url = self.proxy_url if use_cached else self.url
+        data = await self._http.get_attachment(url)
         if isinstance(fp, str):
             with open(fp, 'wb') as f:
                 return f.write(data)


### PR DESCRIPTION
Currently it's difficult to save an attachment from a deleted message; you'll get a `Forbidden` exception if you try after the server's deleted the attachment. 

In order to save an attachment after it's been deleted, you have to manually save it. Instead, I propose we add an option to use the proxy URL of the attachment in the attachment.save function. 

This solution is not perfect by any means; there is still a chance the proxy_url will fail. However, it is far less likely than the base url failing.