### PR TITLE
Added support for guild descriptions

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -759,7 +759,7 @@ class Guild(Hashable):
         name: str
             The new name of the guild.
         description: str
-            The new description of the guild.
+            The new description of the guild. This is only available to guilds that contain `VERIFIED` in :attr:`Guild.features`.
         icon: bytes
             A :term:`py:bytes-like object` representing the icon. Only PNG/JPEG supported.
             Could be ``None`` to denote removal of the icon.
@@ -803,10 +803,6 @@ class Guild(Hashable):
         """
 
         http = self._state.http
-        try:
-            description = fields['description']
-        except KeyError:
-            pass
         try:
             icon_bytes = fields['icon']
         except KeyError:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -119,7 +119,7 @@ class Guild(Hashable):
     """
 
     __slots__ = ('afk_timeout', 'afk_channel', '_members', '_channels', 'icon',
-                 'name', 'id', 'unavailable', 'name', 'region', '_state',
+                 'name', 'description', 'id', 'unavailable', 'name', 'region', '_state',
                  '_default_role', '_roles', '_member_count', '_large',
                  'owner_id', 'mfa_level', 'emojis', 'features',
                  'verification_level', 'explicit_content_filter', 'splash',
@@ -758,6 +758,8 @@ class Guild(Hashable):
         ----------
         name: str
             The new name of the guild.
+        description: str
+            The new description of the guild.
         icon: bytes
             A :term:`py:bytes-like object` representing the icon. Only PNG/JPEG supported.
             Could be ``None`` to denote removal of the icon.
@@ -801,6 +803,10 @@ class Guild(Hashable):
         """
 
         http = self._state.http
+        try:
+            description = fields['description']
+        except KeyError:
+            pass
         try:
             icon_bytes = fields['icon']
         except KeyError:

--- a/discord/http.py
+++ b/discord/http.py
@@ -568,7 +568,7 @@ class HTTPClient:
         valid_keys = ('name', 'region', 'icon', 'afk_timeout', 'owner_id',
                       'afk_channel_id', 'splash', 'verification_level',
                       'system_channel_id', 'default_message_notifications',
-                      'explicit_content_filter')
+                      'description', 'explicit_content_filter')
 
         payload = {
             k: v for k, v in fields.items() if k in valid_keys


### PR DESCRIPTION
As of yesterday/today verified servers can add descriptions (found in server settings -> server overview).

This PR adds support for it for discord.py, it has been tested and works as it should, though this is my first PR, let me know if I missed something. :x