### PR TITLE
Documentation change: "any" to "all" permissions

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1337,7 +1337,7 @@ def has_any_role(*items):
     return check(predicate)
 
 def has_permissions(**perms):
-    """A :func:`.check` that is added that checks if the member has any of
+    """A :func:`.check` that is added that checks if the member has all of
     the permissions necessary.
 
     The permissions passed in must be exactly like the properties shown under


### PR DESCRIPTION
has_permissions doesn't check if any of the permission:bool combinations is satisfied, it checks all of them.

Edit: :)