### PR TITLE
Moved http.close to before _closed.set

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -440,6 +440,7 @@ class Client:
         if self.is_closed():
             return
 
+        await self.http.close()
         self._closed.set()
 
         for voice in self.voice_clients:
@@ -452,8 +453,6 @@ class Client:
         if self.ws is not None and self.ws.open:
             await self.ws.close()
 
-
-        await self.http.close()
         self._ready.clear()
 
     def clear(self):


### PR DESCRIPTION
### Summary

Fixes #1862. 

### Explanation

By moving the closing of the http client before the websocket, I was able to achieve no errors.

```py
from discord.ext import commands
import logging

logging.basicConfig(level=logging.INFO)
bot = commands.Bot(command_prefix='>')

@commands.is_owner()
@bot.command()
async def die(ctx):
    await bot.close()

bot.run('')
```
->
```
2019-03-09 14:09:11,584:INFO:discord.client: Cleaning up event loop.
2019-03-09 14:09:11,690:INFO:discord.gateway: Websocket closed with 1000 (), cannot reconnect.
2019-03-09 14:09:11,690:INFO:discord.client: Cleaning up after 5 tasks

Process finished with exit code 0
```

If I were to raise `KeyboardInterrupt`, I would receive:
```
2019-03-09 14:24:26,840:INFO:discord.client: Received signal to terminate bot and event loop.
2019-03-09 14:24:26,840:INFO:discord.client: Cleaning up event loop.
2019-03-09 14:24:26,946:INFO:discord.gateway: Websocket closed with 1000 (), cannot reconnect.
2019-03-09 14:24:26,947:INFO:discord.client: Cleaning up after 5 tasks

Process finished with exit code 0
```
Which seems to work as intended.

### Checklist

- [x] This PR fixes the `Unclosed client session / connector` bug.
- [x] `Ctrl C / ^C` no longer errors like [this](https://github.com/Rapptz/discord.py/pull/1863#issuecomment-459148936).

I have tested this in a few cases, but if there are any other issues with this implementation, please let me know.