### PR TITLE
Change superclass to subclass in some documentation

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -53,13 +53,13 @@ class Context(discord.abc.Messageable):
     prefix: :class:`str`
         The prefix that was used to invoke the command.
     command
-        The command (i.e. :class:`.Command` or its superclasses) that is being
+        The command (i.e. :class:`.Command` or its subclasses) that is being
         invoked currently.
     invoked_with: :class:`str`
         The command name that triggered this invocation. Useful for finding out
         which alias called the command.
     invoked_subcommand
-        The subcommand (i.e. :class:`.Command` or its superclasses) that was
+        The subcommand (i.e. :class:`.Command` or its subclasses) that was
         invoked. If no valid subcommand was invoked then this is equal to
         `None`.
     subcommand_passed: Optional[:class:`str`]
@@ -105,7 +105,7 @@ class Context(discord.abc.Messageable):
         Parameters
         -----------
         command: :class:`.Command`
-            A command or superclass of a command that is going to be called.
+            A command or subclass of a command that is going to be called.
         \*args
             The arguments to to use.
         \*\*kwargs

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -909,7 +909,7 @@ class GroupMixin:
     Attributes
     -----------
     all_commands: :class:`dict`
-        A mapping of command name to :class:`.Command` or superclass
+        A mapping of command name to :class:`.Command` or subclass
         objects.
     case_insensitive: :class:`bool`
         Whether the commands should be case insensitive. Defaults to ``False``.
@@ -932,7 +932,7 @@ class GroupMixin:
             self.remove_command(command.name)
 
     def add_command(self, command):
-        """Adds a :class:`.Command` or its superclasses into the internal list
+        """Adds a :class:`.Command` or its subclasses into the internal list
         of commands.
 
         This is usually not called, instead the :meth:`~.GroupMixin.command` or

--- a/docs/locale/ja/LC_MESSAGES/ext/commands/api.po
+++ b/docs/locale/ja/LC_MESSAGES/ext/commands/api.po
@@ -307,7 +307,7 @@ msgstr ""
 #: discord.ext.commands.Group.add_command:1
 #: discord.ext.commands.GroupMixin.add_command:1 of
 msgid ""
-"Adds a :class:`.Command` or its superclasses into the internal list of "
+"Adds a :class:`.Command` or its subclasses into the internal list of "
 "commands."
 msgstr ""
 
@@ -1934,7 +1934,7 @@ msgstr ""
 #: discord.ext.commands.GroupMixin:6 of
 msgid ""
 ":class:`dict` -- A mapping of command name to :class:`.Command` or "
-"superclass objects."
+"subclass objects."
 msgstr ""
 
 #: discord.ext.commands.GroupMixin:11 of
@@ -2585,7 +2585,7 @@ msgstr ""
 
 #: discord.ext.commands.Context:35 of
 msgid ""
-"The command (i.e. :class:`.Command` or its superclasses) that is being "
+"The command (i.e. :class:`.Command` or its subclasses) that is being "
 "invoked currently."
 msgstr ""
 
@@ -2597,7 +2597,7 @@ msgstr ""
 
 #: discord.ext.commands.Context:45 of
 msgid ""
-"The subcommand (i.e. :class:`.Command` or its superclasses) that was "
+"The subcommand (i.e. :class:`.Command` or its subclasses) that was "
 "invoked. If no valid subcommand was invoked then this is equal to `None`."
 msgstr ""
 
@@ -2775,7 +2775,7 @@ msgid "The first parameter passed **must** be the command being invoked."
 msgstr ""
 
 #: discord.ext.commands.Context.invoke:12 of
-msgid "A command or superclass of a command that is going to be called."
+msgid "A command or subclass of a command that is going to be called."
 msgstr ""
 
 #: discord.ext.commands.Context.invoke:14 of


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
It makes no sense that methods accept "Command or superclass objects", because this for example includes a plain `object()`.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
