### PR TITLE
Fix volume command in basic voice example

### DIFF
--- a/examples/basic_voice.py
+++ b/examples/basic_voice.py
@@ -101,7 +101,7 @@ class Music(commands.Cog):
         if ctx.voice_client is None:
             return await ctx.send("Not connected to a voice channel.")
 
-        ctx.voice_client.source.volume = volume
+        ctx.voice_client.source.volume = volume / 100
         await ctx.send("Changed volume to {}%".format(volume))
 
     @commands.command()


### PR DESCRIPTION
Fixed so source.volume gets proper floating point percentages, e.g. 1.0 for 100%