### PR TITLE
Read guild description

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -97,6 +97,8 @@ class Guild(Hashable):
         Check the :func:`on_guild_unavailable` and :func:`on_guild_available` events.
     banner: Optional[:class:`str`]
         The guild's banner.
+    description: Optional[:class:`str`]
+        The guild's description.
     mfa_level: :class:`int`
         Indicates the guild's two factor authorisation level. If this value is 0 then
         the guild does not require 2FA for their administrative members. If the value is
@@ -125,7 +127,8 @@ class Guild(Hashable):
                  '_default_role', '_roles', '_member_count', '_large',
                  'owner_id', 'mfa_level', 'emojis', 'features',
                  'verification_level', 'explicit_content_filter', 'splash',
-                 '_voice_states', '_system_channel_id', 'default_notifications')
+                 '_voice_states', '_system_channel_id', 'default_notifications',
+                 'description')
 
     def __init__(self, *, data, state):
         self._channels = {}
@@ -227,6 +230,7 @@ class Guild(Hashable):
         self.features = guild.get('features', [])
         self.splash = guild.get('splash')
         self._system_channel_id = utils._get_as_snowflake(guild, 'system_channel_id')
+        self.description = guild.get('description')
 
         for mdata in guild.get('members', []):
             member = Member(data=mdata, guild=self, state=state)

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -81,7 +81,7 @@ class PartialInviteChannel(namedtuple('PartialInviteChannel', 'id name type')):
         """Returns the channel's creation time in UTC."""
         return utils.snowflake_time(self.id)
 
-class PartialInviteGuild(namedtuple('PartialInviteGuild', 'features icon banner id name splash verification_level')):
+class PartialInviteGuild(namedtuple('PartialInviteGuild', 'features icon banner id name splash verification_level description')):
     """Represents a "partial" invite guild.
 
     This model will be given when the user is not part of the
@@ -121,6 +121,8 @@ class PartialInviteGuild(namedtuple('PartialInviteGuild', 'features icon banner 
         The partial guild's banner.
     splash: Optional[:class:`str`]
         The partial guild's invite splash.
+    description: Optional[:class:`str`]
+        The partial guild's description.
     """
 
     __slots__ = ()
@@ -278,7 +280,8 @@ class Invite(Hashable):
                                        icon=guild_data.get('icon'),
                                        banner=guild_data.get('banner'),
                                        splash=guild_data.get('splash'),
-                                       verification_level=try_enum(VerificationLevel, guild_data.get('verification_level')))
+                                       verification_level=try_enum(VerificationLevel, guild_data.get('verification_level')),
+                                       description=guild_data.get('description'))
         data['guild'] = guild
         data['channel'] = channel
         return cls(state=state, data=data)


### PR DESCRIPTION
### Summary

Added `Guild.description` and `PartialInviteGuild.description`. #1964 only lets you edit the description, whereas this PR lets you read it. 

![Representation of how this works](https://im-in.the-cute-person.club/a8EwS7i.png)

thanks @SnowyLuma.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
