### PR TITLE
Consider news channel type as a TextChannel

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -261,7 +261,7 @@ class Guild(Hashable):
         if 'channels' in data:
             channels = data['channels']
             for c in channels:
-                if c['type'] == ChannelType.text.value:
+                if c['type'] == ChannelType.text.value or c['type'] == ChannelType.news.value:
                     self._add_channel(TextChannel(guild=self, data=c, state=self._state))
                 elif c['type'] == ChannelType.voice.value:
                     self._add_channel(VoiceChannel(guild=self, data=c, state=self._state))


### PR DESCRIPTION
### Summary

News Channel currently cannot be found in guild.channels. Since news channels features are a part of text channels (Such as `channel.is_news()` method), proposed changes should make d.py count news channel as a text channel.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
