### PR TITLE
Fix pagination of huge command help messages (> ~2,000 chars)

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -889,7 +889,12 @@ class DefaultHelpCommand(HelpCommand):
         self.paginator.add_line(signature, empty=True)
 
         if command.help:
-            self.paginator.add_line(command.help, empty=True)
+            try:
+                self.paginator.add_line(command.help, empty=True)
+            except RuntimeError:
+                for line in command.help.splitlines():
+                    self.paginator.add_line(line)
+                self.paginator.add_line()
 
     def get_destination(self):
         ctx = self.context
@@ -1115,7 +1120,12 @@ class MinimalHelpCommand(HelpCommand):
             self.paginator.add_line(signature, empty=True)
 
         if command.help:
-            self.paginator.add_line(command.help, empty=True)
+            try:
+                self.paginator.add_line(command.help, empty=True)
+            except RuntimeError:
+                for line in command.help.splitlines():
+                    self.paginator.add_line(line)
+                self.paginator.add_line()
 
     def get_destination(self):
         ctx = self.context


### PR DESCRIPTION
### Summary

When `command.help` is bigger than ~2,000 characters, default help commands silently fail to send a help message for it. This is because the entirety of `command.help` is added as a singular line, which raises if it's too big.

This PR adds behavior that catches the `RuntimeError` raised by `add_line`, and adds all lines individually if so:

```py
try:
    self.paginator.add_line(command.help, empty=True)
except RuntimeError:
    for line in command.help.splitlines():
        self.paginator.add_line(line)
    self.paginator.add_line()
```

Because lines are only added individually if `command.help` is too big, this shouldn't incur any performance penalties for short enough `command.help`s (which, I assume, is most of them).

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
