### PR TITLE
Implement Widget

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -36,6 +36,7 @@ from .role import Role
 from .file import File
 from .colour import Color, Colour
 from .invite import Invite, PartialInviteChannel, PartialInviteGuild
+from .widget import Widget, WidgetMember, WidgetChannel
 from .object import Object
 from .reaction import Reaction
 from . import utils, opus, abc

--- a/discord/client.py
+++ b/discord/client.py
@@ -974,7 +974,6 @@ class Client:
             The widget.
         """
         data = await self.http.get_widget(guild_id)
-        print(data)
         invite = None
         if data['instant_invite']:
             invite = await self.get_invite(data['instant_invite'])

--- a/discord/client.py
+++ b/discord/client.py
@@ -37,6 +37,7 @@ import websockets
 
 from .user import User, Profile
 from .invite import Invite
+from .widget import Widget
 from .object import Object
 from .guild import Guild
 from .errors import *
@@ -945,6 +946,40 @@ class Client:
         await self.http.delete_invite(invite_id)
 
     # Miscellaneous stuff
+
+    async def get_widget(self, guild_id):
+        """|coro|
+
+        Gets a :class:`Widget` from a guild ID.
+
+        .. note::
+
+            The guild must have the widget enabled to get this information.
+
+        Parameters
+        -----------
+        guild_id: :class:`int`
+            The ID of the guild.
+
+        Raises
+        -------
+        Forbidden
+            The widget for this guild is disabled.
+        HTTPException
+            Retrieving the widget failed.
+
+        Returns
+        --------
+        :class:`Widget`
+            The widget.
+        """
+        data = await self.http.get_widget(guild_id)
+        print(data)
+        invite = None
+        if data['instant_invite']:
+            invite = await self.get_invite(data['instant_invite'])
+
+        return Widget(data=data, invite=invite)
 
     async def application_info(self):
         """|coro|

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1455,12 +1455,9 @@ class Guild(Hashable):
 
         Returns the widget of the guild.
 
-        The guild must have the widget enabled to get this information.
+        .. note::
 
-        Returns
-        --------
-        :class:`Widget`
-            The widget.
+            The guild must have the widget enabled to get this information.
 
         Raises
         -------
@@ -1468,6 +1465,11 @@ class Guild(Hashable):
             The widget for this guild is disabled.
         HTTPException
             Retrieving the widget failed.
+
+        Returns
+        --------
+        :class:`Widget`
+            The widget.
         """
         data = await self._state.http.get_widget(self.id)
 
@@ -1479,4 +1481,4 @@ class Guild(Hashable):
             inv_data = await self._state.http.get_invite(inv)
             invite = Invite.from_incomplete(state=self._state, data=inv_data)
 
-        return Widget(state=self._state, data=data, invite=invite)
+        return Widget(data=data, invite=invite)

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1469,16 +1469,8 @@ class Guild(Hashable):
         Returns
         --------
         :class:`Widget`
-            The widget.
+            The guild's widget.
         """
         data = await self._state.http.get_widget(self.id)
 
-        invite = None
-        if data['instant_invite']:
-            inv = data['instant_invite']
-            inv = inv[inv.index('invite/')+7:]
-
-            inv_data = await self._state.http.get_invite(inv)
-            invite = Invite.from_incomplete(state=self._state, data=inv_data)
-
-        return Widget(data=data, invite=invite)
+        return Widget(state=self._state, data=data)

--- a/discord/http.py
+++ b/discord/http.py
@@ -637,6 +637,9 @@ class HTTPClient:
         r = Route('GET', '/guilds/{guild_id}/audit-logs', guild_id=guild_id)
         return self.request(r, params=params)
 
+    def get_widget(self, guild_id):
+        return self.request(Route('GET', '/guilds/{guild_id}/widget.json', guild_id=guild_id))
+
     # Invite management
 
     def create_invite(self, channel_id, *, reason=None, **options):

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -38,6 +38,7 @@ import re
 import warnings
 
 from .errors import InvalidArgument
+from .object import Object
 
 DISCORD_EPOCH = 1420070400000
 
@@ -340,3 +341,28 @@ def _string_width(string, *, _IS_ASCII=_IS_ASCII):
     for char in string:
         width += 2 if func(char) in UNICODE_WIDE_CHAR_TYPE else 1
     return width
+
+def resolve_invite(invite):
+    """
+    Resolves an invite from a :class:`Invite`, URL or ID
+
+    Parameters
+    -----------
+    invite: Union[:class:`Invite`, :class:`Object`, :class:`str`]
+        The invite.
+
+    Returns
+    --------
+    :class:`str`
+        The invite code.
+    """
+    from .invite import Invite  # circular import
+    if isinstance(invite, Invite) or isinstance(invite, Object):
+        return invite.id
+    else:
+        rx = r'(?:https?\:\/\/)?discord(?:\.gg|app\.com\/invite)\/(.+)'
+        m = re.match(rx, invite)
+        if m:
+            return m.group(1)
+    return invite
+

--- a/discord/widget.py
+++ b/discord/widget.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-2019 Rapptz
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from .utils import valid_icon_size, snowflake_time, get
+from .errors import InvalidArgument
+from .activity import Game
+from .enums import Status, DefaultAvatar, try_enum
+from collections import namedtuple
+
+VALID_ICON_FORMATS = {"jpeg", "jpg", "webp", "png"}
+
+class WidgetChannel(namedtuple('WidgetChannel', 'id name position')):
+    """Represents a "partial" widget channel.
+
+    Attributes
+    -----------
+    id: :class:`id`
+        The channel's ID.
+    name: :class:`str`
+        The channel's name.
+    position: :class:`int`
+        The channel's position
+    """
+    __slots__ = ()
+
+    def __str__(self):
+        return self.name
+
+    @property
+    def mention(self):
+        """:class:`str` : The string that allows you to mention the channel."""
+        return '<#%s>' % self.id
+
+    @property
+    def created_at(self):
+        """Returns the channel's creation time in UTC."""
+        return snowflake_time(self.id)
+
+class WidgetMember(namedtuple('WidgetMember', 'username status nick avatar discriminator id bot game deafened suppress '
+                                              'muted connected_channel')):
+    """Represents a "partial" member of the widget's guild.
+
+    This model will always be given, as long as it is enabled.
+
+    Attributes
+    -----------
+    id: :class:`int`
+        The member's ID.
+    username: :class:`str`
+        The member's username.
+    discriminator: :class:`str`
+        The member's discriminator.
+    bot: :class:`bool`
+        Whether the member is a bot.
+    status: :class:`Status`
+        The member's status.
+    nick: Optional[:class:`str`]
+        The member's nickname.
+    avatar: Optional[:class:`str`]
+        The member's avatar hash.
+    game: Optional[:class:`Game`]
+        The member's activity.
+    deafened: Optional[:class:`bool`]
+        Whether the member is currently deafened.
+    muted: Optional[:class:`bool`]
+        Whether the member is currently muted.
+    suppress: Optional[:class:`bool`]
+        Whether the member is currently being suppressed.
+    connected_channel: Optional[:class:`VoiceChannel`]
+        Which channel the member is connected to.
+    """
+    __slots__ = ()
+
+    def __str__(self):
+        return '{}#{}'.format(self.username, self.discriminator)
+
+    @property
+    def mention(self):
+        """:class:`str` : The string that allows you to mention the member."""
+        return '<@%s>' % self.id
+
+    @property
+    def created_at(self):
+        """Returns the member's creation time in UTC."""
+        return snowflake_time(self.id)
+
+    @property
+    def display_name(self):
+        """Returns the member's display name."""
+        return self.nick if self.nick else self.username
+
+    @property
+    def avatar_url(self):
+        """Returns the URL version of the member's avatar. Returns an empty string if it has no avatar."""
+        return self.avatar_url_as()
+
+    def avatar_url_as(self, *, format='webp', size=1024):
+        """:class:`str`: The same operation as :meth:`User.avatar_url_as`."""
+        if not valid_icon_size(size):
+            raise InvalidArgument("size must be a power of 2 between 16 and 4096")
+        if format not in VALID_ICON_FORMATS:
+            raise InvalidArgument("format must be one of {}".format(VALID_ICON_FORMATS))
+
+        if self.avatar is None:
+            return self.default_avatar_url
+
+        return 'https://cdn.discordapp.com/avatars/{0.id}/{0.avatar}.{1}?size={2}'.format(self, format, size)
+
+    @property
+    def default_avatar(self):
+        """:class:`DefaultAvatar`: The same operation as :meth:`User.default_avatar`."""
+        return DefaultAvatar(int(self.discriminator) % len(DefaultAvatar))
+
+    @property
+    def default_avatar_url(self):
+        """Returns a URL for a user's default avatar."""
+        return 'https://cdn.discordapp.com/embed/avatars/{}.png'.format(self.default_avatar.value)
+
+class Widget:
+    """Represents a :class:`Guild` widget.
+
+    This model is always given, as long as it is enabled.
+
+    Attributes
+    -----------
+    id: :class:`int`
+        The guild's ID.
+    name: :class:`str`
+        The guild's name.
+    channels: List[:class:`VoiceChannel`]
+        The accessible voice channels in the guild.
+    members: List[:class:`Member`]
+        The online members in the server. Note: offline
+        members do not appear in the widget.
+    invite: Optional[:class:`Invite`]
+        The invite set for the widget.
+    """
+    __slots__ = ('_state', 'channels', 'invite', 'id', 'members', 'name')
+
+    def __init__(self, *, state, data, invite):
+        self._state = state
+        self.invite = invite
+        self.name = data.get('name')
+        self.id = int(data.get('id'))
+
+        self.channels = []
+        for channel in data.get('channels'):
+            _id = int(channel['id'])
+            self.channels.append(WidgetChannel(id=_id, name=channel['name'], position=channel['position']))
+
+        self.members = []
+        for member in data.get('members'):
+            _id = int(member.get('id'))
+            bot = bool(member.get('bot'))
+            status = try_enum(Status, member.get('status'))
+            deafened = bool(member.get('deaf')) or bool(member.get('self_deaf'))
+            muted = bool(member.get('mute')) or bool(member.get('self_mute'))
+            suppress = bool(member.get('mute'))
+
+            game = None
+            if member.get('game'):
+                game = Game(**member.get('game'))
+
+            connected_channel = None
+            if member.get('channel_id'):
+                connected_channel = get(self.channels, id=int(member.get('channel_id')))
+
+            self.members.append(WidgetMember(id=_id,
+                                             bot=bot,
+                                             username=member.get('username'),
+                                             discriminator=member.get('discriminator'),
+                                             status=status,
+                                             avatar=member.get('avatar'),
+                                             nick=member.get('nick'),
+                                             game=game,
+                                             deafened=deafened,
+                                             muted=muted,
+                                             suppress=suppress,
+                                             connected_channel=connected_channel))
+
+    def __str__(self):
+        return self.json_url
+
+    def __repr__(self):
+        return '<Widget id={0.id} name={0.name!r} invite={0.invite!r}>'.format(self)
+
+    @property
+    def created_at(self):
+        """Returns the member's creation time in UTC."""
+        return snowflake_time(self.id)
+
+    @property
+    def json_url(self):
+        """The JSON URL of the widget."""
+        return "https://discordapp.com/api/guilds/{0.id}/widget.json".format(self)

--- a/discord/widget.py
+++ b/discord/widget.py
@@ -160,8 +160,7 @@ class Widget:
     """
     __slots__ = ('_state', 'channels', 'invite', 'id', 'members', 'name')
 
-    def __init__(self, *, state, data, invite):
-        self._state = state
+    def __init__(self, *, data, invite):
         self.invite = invite
         self.name = data.get('name')
         self.id = int(data.get('id'))

--- a/discord/widget.py
+++ b/discord/widget.py
@@ -219,7 +219,7 @@ class Widget:
         """The JSON URL of the widget."""
         return "https://discordapp.com/api/guilds/{0.id}/widget.json".format(self)
 
-    async def get_invite(self, *, with_counts=True):
+    async def fetch_invite(self, *, with_counts=True):
         """|coro|
 
         Retrieves an :class:`Invite` from a invite URL or ID.

--- a/discord/widget.py
+++ b/discord/widget.py
@@ -37,7 +37,7 @@ class WidgetChannel(namedtuple('WidgetChannel', 'id name position')):
 
     Attributes
     -----------
-    id: :class:`id`
+    id: :class:`int`
         The channel's ID.
     name: :class:`str`
         The channel's name.


### PR DESCRIPTION
### Summary

This implements the widget API via `/guilds/{guild_id}/widget.json`

```py
>>> g = bot.get_guild(81384788765712384) 
... w = await g.widget() # you can also do Client.get_widget()
... print(w.invite)
http://discord.gg/discord-api
```

This also implements simple members and channels that are provided by the Widget API.

```py
>>> for i in w.members:
...     print(i.name)
Danny
Voltana
Sinister Rectus
[...]
>>> discord.utils.get(w.channels, name="API Gaming")
WidgetChannel(id=183361433059328000, name='API Gaming', position=6)
```

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)