### PR TITLE
Cause ext.commands.ColourConverter to fail if colour value out of range

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -294,6 +294,8 @@ class ColourConverter(Converter):
             arg = arg[1:]
         try:
             value = int(arg, base=16)
+            if not 0 <= value <= 16777215:
+                raise ValueError()
             return discord.Colour(value=value)
         except ValueError:
             method = getattr(discord.Colour, arg.replace(' ', '_'), None)

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -294,7 +294,7 @@ class ColourConverter(Converter):
             arg = arg[1:]
         try:
             value = int(arg, base=16)
-            if not 0 <= value <= 16777215:
+            if not (0 <= value <= 0xFFFFFF):
                 raise ValueError()
             return discord.Colour(value=value)
         except ValueError:

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -295,7 +295,7 @@ class ColourConverter(Converter):
         try:
             value = int(arg, base=16)
             if not (0 <= value <= 0xFFFFFF):
-                raise ValueError()
+                raise BadArgument('Colour "{}" is invalid.'.format(arg))
             return discord.Colour(value=value)
         except ValueError:
             method = getattr(discord.Colour, arg.replace(' ', '_'), None)


### PR DESCRIPTION
### Summary

changes make the `ext.commands.ColourConverter` Converter fail when user input is outside the acceptable value range 0x000000 - 0xFFFFFF

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
