### PR TITLE
guild.py: change wording for create_role error

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1244,7 +1244,7 @@ class Guild(Hashable):
         Forbidden
             You do not have permissions to create the role.
         HTTPException
-            Editing the role failed.
+            Creating the role failed.
         InvalidArgument
             An invalid keyword argument was given.
 


### PR DESCRIPTION
### Summary

Since this function creates a role, I assume this error is meant to say "Creating the role failed" rather than "editing the role failed".

### Checklist

<!-- Put an x inside [ ] to check it -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
