### PR TITLE
Bulk delete change

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -35,14 +35,16 @@ class RawMessageDeleteEvent:
         The guild ID where the deletion took place, if applicable.
     message_id: :class:`int`
         The message ID that got deleted.
+    cached_message: Optional[:class:`Message`]
+        The cached message, if found in the internal message cache.
     """
 
-    __slots__ = ('message_id', 'channel_id', 'guild_id')
+    __slots__ = ('message_id', 'channel_id', 'guild_id', 'cached_message')
 
     def __init__(self, data):
         self.message_id = int(data['id'])
         self.channel_id = int(data['channel_id'])
-
+        self.cached_message = None
         try:
             self.guild_id = int(data['guild_id'])
         except KeyError:
@@ -59,13 +61,16 @@ class RawBulkMessageDeleteEvent:
         The channel ID where the message got deleted.
     guild_id: Optional[:class:`int`]
         The guild ID where the message got deleted, if applicable.
+    cached_messages: :class:`list`
+        The cached messages, if found in the internal message cache.
     """
 
-    __slots__ = ('message_ids', 'channel_id', 'guild_id')
+    __slots__ = ('message_ids', 'channel_id', 'guild_id', 'cached_messages')
 
     def __init__(self, data):
         self.message_ids = {int(x) for x in data.get('ids', [])}
         self.channel_id = int(data['channel_id'])
+        self.cached_messages = []
 
         try:
             self.guild_id = int(data['guild_id'])

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -61,7 +61,7 @@ class RawBulkMessageDeleteEvent:
         The channel ID where the message got deleted.
     guild_id: Optional[:class:`int`]
         The guild ID where the message got deleted, if applicable.
-    cached_messages: :class:`list`
+    cached_messages: List[:class:`Message`]
         The cached messages, if found in the internal message cache.
     """
 

--- a/discord/state.py
+++ b/discord/state.py
@@ -366,21 +366,22 @@ class ConnectionState:
 
     def parse_message_delete(self, data):
         raw = RawMessageDeleteEvent(data)
-        self.dispatch('raw_message_delete', raw)
-
         found = self._get_message(raw.message_id)
+        raw.cached_message = found
+        self.dispatch('raw_message_delete', raw)
         if found is not None:
             self.dispatch('message_delete', found)
             self._messages.remove(found)
 
     def parse_message_delete_bulk(self, data):
         raw = RawBulkMessageDeleteEvent(data)
+        found_messages = [message for message in self._messages if message.id in raw.message_ids]
+        raw.cached_messages = found_messages
         self.dispatch('raw_bulk_message_delete', raw)
-
-        to_be_deleted = [message for message in self._messages if message.id in raw.message_ids]
-        for msg in to_be_deleted:
-            self.dispatch('message_delete', msg)
-            self._messages.remove(msg)
+        if found_messages:
+            self.dispatch('bulk_message_delete', found_messages)
+            for msg in found_messages:
+                self._messages.remove(msg)
 
     def parse_message_update(self, data):
         raw = RawMessageUpdateEvent(data)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -235,13 +235,13 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
     Called when messages are bulk deleted. If none of the messages deleted
     are found in the internal message cache, then this event will not be called.
-    If some individual messages are not found in the internal message cache,
-    the event will still be called, but the messages will not be included in
-    the messages list. Messages will not be in cache if the message is too old
+    If individual messages were not found in the internal message cache,
+    this event will still be called, but the messages not found will not be included in
+    the messages list. Messages might not be in cache if the message is too old
     or the client is participating in high traffic guilds.
     To fix this, increase the ``max_messages`` option of :class:`Client`.
 
-    :param messages: A List[:class:`Message`] of the deleted messages.
+    :param messages: A :class:`list` of :class:`Message` that have been deleted.
 
 .. function:: on_raw_message_delete(payload)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -224,12 +224,24 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 .. function:: on_message_delete(message)
 
     Called when a message is deleted. If the message is not found in the
-    internal message cache, then these events will not be called. This
+    internal message cache, then this event will not be called. This
     happens if the message is too old or the client is participating in high
     traffic guilds. To fix this, increase the ``max_messages`` option of
     :class:`Client`.
 
     :param message: A :class:`Message` of the deleted message.
+
+.. function:: on_bulk_message_delete(messages)
+
+    Called when messages are bulk deleted. If none of the messages deleted
+    are found in the internal message cache, then this event will not be called.
+    If some individual messages are not found in the internal message cache,
+    the event will still be called, but the messages will not be included in
+    the messages list. Messages will not be in cache if the message is too old
+    or the client is participating in high traffic guilds.
+    To fix this, increase the ``max_messages`` option of :class:`Client`.
+
+    :param messages: A List[:class:`Message`] of the deleted messages.
 
 .. function:: on_raw_message_delete(payload)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -224,10 +224,11 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 .. function:: on_message_delete(message)
 
     Called when a message is deleted. If the message is not found in the
-    internal message cache, then this event will not be called. This
-    happens if the message is too old or the client is participating in high
-    traffic guilds. To fix this, increase the ``max_messages`` option of
-    :class:`Client`.
+    internal message cache, then this event will not be called.
+    Messages might not be in cache if the message is too old
+    or the client is participating in high traffic guilds.
+
+    If this occurs increase the :attr:`Client.max_messages` attribute.
 
     :param message: A :class:`Message` of the deleted message.
 
@@ -239,7 +240,8 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     this event will still be called, but the messages not found will not be included in
     the messages list. Messages might not be in cache if the message is too old
     or the client is participating in high traffic guilds.
-    To fix this, increase the ``max_messages`` option of :class:`Client`.
+
+    If this occurs increase the :attr:`Client.max_messages` attribute.
 
     :param messages: A :class:`list` of :class:`Message` that have been deleted.
 
@@ -248,13 +250,19 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     Called when a message is deleted. Unlike :func:`on_message_delete`, this is
     called regardless of the message being in the internal message cache or not.
 
+    If the message is found in the message cache,
+    it can be accessed via:attr:`RawMessageDeleteEvent.cached_message`
+
     :param payload: The raw event payload data.
     :type payload: :class:`RawMessageDeleteEvent`
 
 .. function:: on_raw_bulk_message_delete(payload)
 
-    Called when a bulk delete is triggered. This event is called regardless
-    of the message IDs being in the internal message cache or not.
+    Called when a bulk delete is triggered. Unlike :func:`on_bulk_message_delete`, this is
+    called regardless of the messages being in the internal message cache or not.
+
+    If the messages are found in the message cache,
+    they can be accessed via :attr:`RawBulkMessageDeleteEvent.cached_messages`
 
     :param payload: The raw event payload data.
     :type payload: :class:`RawBulkMessageDeleteEvent`
@@ -263,8 +271,10 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
     Called when a :class:`Message` receives an update event. If the message is not found
     in the internal message cache, then these events will not be called.
-    This happens if the message is too old or the client is participating in high
-    traffic guilds. To fix this, increase the ``max_messages`` option of :class:`Client`.
+    Messages might not be in cache if the message is too old
+    or the client is participating in high traffic guilds.
+
+    If this occurs increase the :attr:`Client.max_messages` attribute.
 
     The following non-exhaustive cases trigger this event:
 
@@ -297,7 +307,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
 .. function:: on_reaction_add(reaction, user)
 
-    Called when a message has a reaction added to it. Similar to on_message_edit,
+    Called when a message has a reaction added to it. Similar to :func:`on_message_edit`,
     if the message is not found in the internal message cache, then this
     event will not be called.
 


### PR DESCRIPTION
### Summary

This PR changes the behavior of the `message_delete`, event, adds the `message_bulk_delete` event and adds an attribute to `raw_message_delete`, `raw_bulk_message_delete`. It also fixes a typo in the on_message_delete documentation.

`message_delete` will no longer receive individual messages bulk deleted. Instead, those will be dispatched to `message_bulk_delete`. This is technically(?) a breaking change.

`raw_message_delete` and `raw_bulk_message_delete`'s payload objects now have a `cached_message(s)` attribute, containing the relevant cached message. This is explicitly done as there is no way to "manually" fetch a message object in raw_(bulk_)message_delete events, as the message is purged from cache immediately when the event is called. This enables people to do different logging events depending on if it is cached.

With the changes to include cached messages in the raw_ events, it's questionable if the non-raw methods are required at all. I also feel like adding the cached objects to the raw payloads is questionable in and of itself, however, I find it necessary as there is no other way to work around it, short of users managing a second cache. The cached messages were added as an attribute of the raw payload objects instead of passing through the event to avoid a larger breaking change.

Resolves #1807

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
