### PR TITLE
Rename `guild.invites()` to `guild.fetch_invites()`

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -637,7 +637,7 @@ class GuildChannel:
         data = await self._state.http.create_invite(self.id, reason=reason, **fields)
         return Invite.from_incomplete(data=data, state=self._state)
 
-    async def invites(self):
+    async def fetch_invites(self):
         """|coro|
 
         Returns a list of all active instant invites from this channel.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1138,7 +1138,7 @@ class Guild(Hashable):
         data = await self._state.http.estimate_pruned_members(self.id, days)
         return data['pruned']
 
-    async def invites(self):
+    async def fetch_invites(self):
         """|coro|
 
         Returns a list of all active instant invites from the guild.

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -156,7 +156,7 @@ A list of these changes is enumerated below.
 +---------------------------------------+------------------------------------------------------------------------------+
 | ``Client.get_user_info``              | :meth:`Client.fetch_user`                                                    |
 +---------------------------------------+------------------------------------------------------------------------------+
-| ``Client.invites_from``               | :meth:`abc.GuildChannel.invites` or :meth:`Guild.invites`                    |
+| ``Client.invites_from``               | :meth:`abc.GuildChannel.fetch_invites` or :meth:`Guild.fetch_invites`                    |
 +---------------------------------------+------------------------------------------------------------------------------+
 | ``Client.join_voice_channel``         | :meth:`VoiceChannel.connect` (see :ref:`migrating_1_0_voice`)                |
 +---------------------------------------+------------------------------------------------------------------------------+


### PR DESCRIPTION
Breaking - rename `guild.invites()` to `guild.fetch_invites()`
Update migrating.rst to reflect this change

### Summary

To keep continuity with the latest breaking change of naming functions that perform an HTTP call,
`guild.invites()` has been renamed to `guild.fetch_invites()`

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
