### PR TITLE
Fix broken links in client and bot docs.

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -71,7 +71,7 @@ class Client:
 
     A number of options can be passed to the :class:`Client`.
 
-    .. _event loop: https://docs.python.org/3/library/asyncio-eventloops.html
+    .. _event loop: https://docs.python.org/3/library/asyncio-eventloop.html
     .. _connector: http://aiohttp.readthedocs.org/en/stable/client_reference.html#connectors
     .. _ProxyConnector: http://aiohttp.readthedocs.org/en/stable/client_reference.html#proxyconnector
 

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -905,7 +905,7 @@ class Bot(BotBase, discord.Client):
     this bot.
 
     .. _deque: https://docs.python.org/3.4/library/collections.html#collections.deque
-    .. _event loop: https://docs.python.org/3/library/asyncio-eventloops.html
+    .. _event loop: https://docs.python.org/3/library/asyncio-eventloop.html
 
     This class also subclasses :class:`.GroupMixin` to provide the functionality
     to manage commands.


### PR DESCRIPTION
### Summary
This PR fixes two broken links pointing the Python documentation for event loops.
<!-- What is this pull request for? Does it fix any issues? -->

### Checklist

<!-- Put an x inside [ ] to check it -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
