### PR TITLE
Added support for saving an attachment using a pathlib.Path object

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -28,6 +28,7 @@ import asyncio
 import datetime
 import re
 import io
+from pathlib import Path
 
 from . import utils
 from .reaction import Reaction
@@ -118,6 +119,8 @@ class Attachment:
             if seek_begin:
                 fp.seek(0)
             return written
+        elif isinstance(fp, Path):
+            fp.write_bytes(data)
         else:
             with open(fp, 'wb') as f:
                 return f.write(data)

--- a/discord/message.py
+++ b/discord/message.py
@@ -86,10 +86,10 @@ class Attachment:
 
         Parameters
         -----------
-        fp: Union[BinaryIO, :class:`os.PathLike`]
+        fp: Union[BinaryIO, :class:`os.PathLike` :class:`pathlib.Path`]
             The file-like object to save this attachment to or the filename
-            to use. If a filename is passed then a file is created with that
-            filename and used instead.
+            to use. If a filename or a pathlib.Path object is passed then a
+            file is created with that filename and used instead.
         seek_begin: :class:`bool`
             Whether to seek to the beginning of the file after saving is
             successfully done.


### PR DESCRIPTION
### Summary

This pull request adds support for saving attachments using a pathlib.Path object. This was suggested in an issue comment here: https://github.com/Rapptz/discord.py/issues/1955#issuecomment-470264668

### Checklist

<!-- Put an x inside [ ] to check it -->

- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
