### PR TITLE
Add fetch custom emoji, all custom emojis; Add user property to Emoji

### DIFF
--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -150,8 +150,8 @@ class Emoji:
         If this emoji is managed by a Twitch integration.
     guild_id: :class:`int`
         The guild ID the emoji belongs to.
-    user: :class:`User`
-        The user that created the emoji.
+    user: Optional[:class:`User`]
+        The user that created the emoji. This can only be retrieved using :meth:`Guild.fetch_emoji`.
     """
     __slots__ = ('require_colons', 'animated', 'managed', 'id', 'name', '_roles', 'guild_id',
                  '_state', 'user')

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -27,6 +27,7 @@ DEALINGS IN THE SOFTWARE.
 from collections import namedtuple
 
 from . import utils
+from .user import User
 
 class PartialEmoji(namedtuple('PartialEmoji', 'animated name id')):
     """Represents a "partial" emoji.
@@ -149,8 +150,11 @@ class Emoji:
         If this emoji is managed by a Twitch integration.
     guild_id: :class:`int`
         The guild ID the emoji belongs to.
+    created_by: :class:`User`
+        The user that created the emoji.
     """
-    __slots__ = ('require_colons', 'animated', 'managed', 'id', 'name', '_roles', 'guild_id', '_state')
+    __slots__ = ('require_colons', 'animated', 'managed', 'id', 'name', '_roles', 'guild_id',
+                 '_state', 'created_by')
 
     def __init__(self, *, guild, state, data):
         self.guild_id = guild.id
@@ -164,6 +168,9 @@ class Emoji:
         self.name = emoji['name']
         self.animated = emoji.get('animated', False)
         self._roles = utils.SnowflakeList(map(int, emoji.get('roles', [])))
+        user = emoji.get('user')
+        if user:
+            self.created_by = User(state=self._state, data=user)
 
     def _iterator(self):
         for attr in self.__slots__:

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -150,11 +150,11 @@ class Emoji:
         If this emoji is managed by a Twitch integration.
     guild_id: :class:`int`
         The guild ID the emoji belongs to.
-    created_by: :class:`User`
+    user: :class:`User`
         The user that created the emoji.
     """
     __slots__ = ('require_colons', 'animated', 'managed', 'id', 'name', '_roles', 'guild_id',
-                 '_state', 'created_by')
+                 '_state', 'user')
 
     def __init__(self, *, guild, state, data):
         self.guild_id = guild.id
@@ -169,8 +169,7 @@ class Emoji:
         self.animated = emoji.get('animated', False)
         self._roles = utils.SnowflakeList(map(int, emoji.get('roles', [])))
         user = emoji.get('user')
-        if user:
-            self.created_by = User(state=self._state, data=user)
+        self.user = User(state=self._state, data=user) if user else None
 
     def _iterator(self):
         for attr in self.__slots__:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1186,7 +1186,6 @@ class Guild(Hashable):
             The retrieved emojis.
         """
         data = await self._state.http.get_all_custom_emojis(self.id)
-
         return [Emoji(guild=self, state=self._state, data=d) for d in data]
 
     async def fetch_emoji(self, emoji_id):
@@ -1212,7 +1211,6 @@ class Guild(Hashable):
             The retrieved emoji.
         """
         data = await self._state.http.get_custom_emoji(self.id, emoji_id)
-
         return Emoji(guild=self, state=self._state, data=data)
 
     async def create_custom_emoji(self, *, name, image, roles=None, reason=None):

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -31,6 +31,7 @@ from . import utils
 from .role import Role
 from .member import Member, VoiceState
 from .activity import create_activity
+from .emoji import Emoji
 from .permissions import PermissionOverwrite
 from .colour import Colour
 from .errors import InvalidArgument, ClientException
@@ -1168,6 +1169,51 @@ class Guild(Hashable):
             result.append(Invite(state=self._state, data=invite))
 
         return result
+
+    async def fetch_all_custom_emojis(self):
+        """|coro|
+
+        Retrieves all custom :class:`Emoji`s from the guild.
+
+        Raises
+        ---------
+        HTTPException
+            An error occurred fetching the emojis.
+
+        Returns
+        --------
+        List[:class:`Emoji`]
+            The retrieved emojis.
+        """
+        data = await self._state.http.get_all_custom_emojis(self.id)
+
+        emojis = [Emoji(guild=self, state=self._state, data=d) for d in data]
+
+        return emojis
+
+    async def fetch_custom_emoji(self, emoji_id):
+        """|coro|
+
+        Retrieves a custom :class:`Emoji` from the guild.
+
+        Parameters
+        -------------
+        emoji_id: :class:`int`
+            The emoji's ID.
+
+        Raises
+        ---------
+        HTTPException
+            An error occurred fetching the emoji.
+
+        Returns
+        --------
+        :class:`Emoji`
+            The retrieved emoji.
+        """
+        data = await self._state.http.get_custom_emoji(self.id, emoji_id)
+
+        return Emoji(guild=self, state=self._state, data=data)
 
     async def create_custom_emoji(self, *, name, image, roles=None, reason=None):
         r"""|coro|

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1170,7 +1170,7 @@ class Guild(Hashable):
 
         return result
 
-    async def fetch_all_custom_emojis(self):
+    async def fetch_emojis(self):
         """|coro|
 
         Retrieves all custom :class:`Emoji`s from the guild.
@@ -1187,11 +1187,9 @@ class Guild(Hashable):
         """
         data = await self._state.http.get_all_custom_emojis(self.id)
 
-        emojis = [Emoji(guild=self, state=self._state, data=d) for d in data]
+        return [Emoji(guild=self, state=self._state, data=d) for d in data]
 
-        return emojis
-
-    async def fetch_custom_emoji(self, emoji_id):
+    async def fetch_emoji(self, emoji_id):
         """|coro|
 
         Retrieves a custom :class:`Emoji` from the guild.
@@ -1203,6 +1201,8 @@ class Guild(Hashable):
 
         Raises
         ---------
+        NotFound
+            The emoji requested could not be found.
         HTTPException
             An error occurred fetching the emoji.
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -623,6 +623,12 @@ class HTTPClient:
         }
         return self.request(Route('GET', '/guilds/{guild_id}/prune', guild_id=guild_id), params=params)
 
+    def get_all_custom_emojis(self, guild_id):
+        return self.request(Route('GET', '/guilds/{guild_id}/emojis', guild_id=guild_id))
+
+    def get_custom_emoji(self, guild_id, emoji_id):
+        return self.request(Route('GET', '/guilds/{guild_id}/emojis/{emoji_id}', guild_id=guild_id, emoji_id=emoji_id))
+
     def create_custom_emoji(self, guild_id, name, image, *, roles=None, reason=None):
         payload = {
             'name': name,


### PR DESCRIPTION
### Summary

This resolves #1462 

This adds two new metadata endpoints for guilds:

- `/guilds/{guild.id}/emojis` - `Guild.fetch_all_custom_emojis`
- `/guilds/{guild.id/emojis/{emoji.id}` - `Guild.fetch_custom_emoji`

Requesting a specific emoji gives you the user property (who created the emoji), conveniently named `Emoji.created_by`. 

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
