### PR TITLE
Only escape characters as necessary in clean_content

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -472,16 +472,11 @@ class clean_content(Converter):
         result = pattern.sub(repl, argument)
 
         if self.escape_markdown:
-            transformations = {
-                re.escape(c): '\\' + c
-                for c in ('*', '`', '_', '~', '\\', '||')
-            }
-
-            def replace(obj):
-                return transformations.get(re.escape(obj.group(0)), '')
-
-            pattern = re.compile('|'.join(transformations.keys()))
-            result = pattern.sub(replace, result)
+            result = re.sub(r'\\', r'\\\\', result)
+            for c in ('*', '`', '_', '~', '|'):
+                regex = r'\{0}(?=([\s\S]*((?<!\{0})\{0})))'.format(c)
+                replace = '\{0}'.format(c)
+                result = re.sub(regex, replace, result)
 
         # Completely ensure no mentions escape:
         return re.sub(r'@(everyone|here|[!&]?[0-9]{17,21})', '@\u200b\\1', result)


### PR DESCRIPTION
### Summary

This PR makes it so the commands.clean_content() converter only escapes markdown characters as necessary. No doc changes were needed because it doesn't change what it does or how the user interacts with it.  Resolves #1885 

### Checklist

<!-- Put an x inside [ ] to check it -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
