### PR TITLE
Add coodlown_bypass decorators and cog local.

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -369,7 +369,7 @@ class BotBase(GroupMixin):
 
         A cooldown bypass is a check that determines whether command cooldowns should
         be bypassed or not. If the check returns True, cooldowns will be bypassed.
-        Elsewise if False, cooldowns will run as normal and ratelimits will apply.
+        Otherwise if False, cooldowns will run as normal and ratelimits will apply.
 
         This applies to all commands and their cooldowns.
         The cooldown_bypass takes a sole parameter, a :class:`.Context`.

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -357,6 +357,21 @@ class Cog(metaclass=CogMeta):
         """
         pass
 
+    @_cog_special_method
+    async def cog_cooldown_bypass(self, ctx):
+        """A special method that acts as a cog local cooldown bypass check.
+        
+        This is similar to :meth:`.Command.cooldown_bypass`.
+        
+        This **must** be a coroutine.
+        
+        Parameters
+        -----------
+        ctx: :class:`.Context`
+            The invocation context.
+        """
+        pass
+
     def _inject(self, bot):
         cls = self.__class__
 

--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -24,7 +24,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-import asyncio
 import enum
 import time
 
@@ -39,13 +38,12 @@ class BucketType(enum.Enum):
     category = 5
 
 class Cooldown:
-    __slots__ = ('rate', 'per', 'type', 'predicate', '_window', '_tokens', '_last')
+    __slots__ = ('rate', 'per', 'type', '_window', '_tokens', '_last')
 
-    def __init__(self, rate, per, type, predicate):
+    def __init__(self, rate, per, type):
         self.rate = int(rate)
         self.per = float(per)
         self.type = type
-        self.predicate = predicate
         self._window = 0.0
         self._tokens = self.rate
         self._last = 0.0
@@ -90,7 +88,7 @@ class Cooldown:
         self._last = 0.0
 
     def copy(self):
-        return Cooldown(self.rate, self.per, self.type, self.predicate)
+        return Cooldown(self.rate, self.per, self.type)
 
     def __repr__(self):
         return '<Cooldown rate: {0.rate} per: {0.per} window: {0._window} tokens: {0._tokens}>'.format(self)
@@ -136,15 +134,6 @@ class CooldownMapping:
             del self._cache[k]
 
     async def get_bucket(self, message):
-        predicate = self._cooldown.predicate
-
-        if asyncio.iscoroutinefunction(predicate):
-            if await predicate(message):
-                return None
-        elif predicate:
-            if predicate(message):
-                return None
-
         if self._cooldown.type is BucketType.default:
             return self._cooldown
 

--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -133,7 +133,7 @@ class CooldownMapping:
         for k in dead_keys:
             del self._cache[k]
 
-    async def get_bucket(self, message):
+    def get_bucket(self, message):
         if self._cooldown.type is BucketType.default:
             return self._cooldown
 


### PR DESCRIPTION
### Summary

Allow for cooldowns to be bypassed by several methods:

`@bot.cooldown_bypass` (Applies to all commands)
`@command.cooldown_bypass` (Applies to a single command)
`cog_cooldown_bypass` (Applies to all cog commands)

These checks allow the user to determine whether or not a cooldown(s) should be bypassed.

If the check returns True, the cooldown will be bypassed and no ratelimits will apply, else the cooldown will run as normal.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
