### PR TITLE
Remove inconsistent ordering possibility from HistoryIterator and friends

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -863,7 +863,7 @@ class Messageable(metaclass=abc.ABCMeta):
         data = await state.http.pins_from(channel.id)
         return [state.create_message(channel=channel, data=m) for m in data]
 
-    def history(self, *, limit=100, before=None, after=None, around=None, reverse=None):
+    def history(self, *, limit=100, before=None, after=None, around=None, oldest_first=None):
         """Return an :class:`.AsyncIterator` that enables receiving the destination's message history.
 
         You must have :attr:`~.Permissions.read_message_history` permissions to use this.
@@ -902,11 +902,9 @@ class Messageable(metaclass=abc.ABCMeta):
             If a date is provided it must be a timezone-naive datetime representing UTC time.
             When using this argument, the maximum limit is 101. Note that if the limit is an
             even number then this will return at most limit + 1 messages.
-        reverse: Optional[:class:`bool`]
-            If set to true, return messages in oldest->newest order. If unspecified,
-            this defaults to ``False`` for most cases. However if passing in a
-            ``after`` parameter then this is set to ``True``. This avoids getting messages
-            out of order in the ``after`` case.
+        oldest_first: Optional[:class:`bool`]
+            If set to true, return messages in oldest->newest order. Defaults to True if
+            ``after`` is specified, otherwise False.
 
         Raises
         ------
@@ -920,7 +918,7 @@ class Messageable(metaclass=abc.ABCMeta):
         :class:`.Message`
             The message with the message data parsed.
         """
-        return HistoryIterator(self, limit=limit, before=before, after=after, around=around, reverse=reverse)
+        return HistoryIterator(self, limit=limit, before=before, after=after, around=around, oldest_first=oldest_first)
 
 
 class Connectable(metaclass=abc.ABCMeta):

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -265,7 +265,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         message_ids = [m.id for m in messages]
         await self._state.http.delete_messages(self.id, message_ids)
 
-    async def purge(self, *, limit=100, check=None, before=None, after=None, around=None, reverse=False, bulk=True):
+    async def purge(self, *, limit=100, check=None, before=None, after=None, around=None, oldest_first=False, bulk=True):
         """|coro|
 
         Purges a list of messages that meet the criteria given by the predicate
@@ -306,8 +306,8 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             Same as ``after`` in :meth:`history`.
         around
             Same as ``around`` in :meth:`history`.
-        reverse
-            Same as ``reverse`` in :meth:`history`.
+        oldest_first
+            Same as ``oldest_first`` in :meth:`history`.
         bulk: class:`bool`
             If True, use bulk delete. bulk=False is useful for mass-deleting
             a bot's own messages without manage_messages. When True, will fall
@@ -330,7 +330,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         if check is None:
             check = lambda m: True
 
-        iterator = self.history(limit=limit, before=before, after=after, reverse=reverse, around=around)
+        iterator = self.history(limit=limit, before=before, after=after, oldest_first=oldest_first, around=around)
         ret = []
         count = 0
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1437,7 +1437,7 @@ class Guild(Hashable):
             raise ClientException('Must not be a bot account to ack messages.')
         return state.http.ack_guild(self.id)
 
-    def audit_logs(self, *, limit=100, before=None, after=None, reverse=None, user=None, action=None):
+    def audit_logs(self, *, limit=100, before=None, after=None, oldest_first=None, user=None, action=None):
         """Return an :class:`AsyncIterator` that enables receiving the guild's audit logs.
 
         You must have the :attr:`~Permissions.view_audit_log` permission to use this.
@@ -1470,11 +1470,9 @@ class Guild(Hashable):
         after: Union[:class:`abc.Snowflake`, datetime]
             Retrieve entries after this date or entry.
             If a date is provided it must be a timezone-naive datetime representing UTC time.
-        reverse: :class:`bool`
-            If set to true, return entries in oldest->newest order. If unspecified,
-            this defaults to ``False`` for most cases. However if passing in a
-            ``after`` parameter then this is set to ``True``. This avoids getting entries
-            out of order in the ``after`` case.
+        oldest_first: :class:`bool`
+            If set to true, return entries in oldest->newest order. Defaults to True if
+            ``after`` is specified, otherwise False.
         user: :class:`abc.Snowflake`
             The moderator to filter entries from.
         action: :class:`AuditLogAction`
@@ -1499,7 +1497,7 @@ class Guild(Hashable):
             action = action.value
 
         return AuditLogIterator(self, before=before, after=after, limit=limit,
-                                reverse=reverse, user_id=user, action_type=action)
+                                oldest_first=oldest_first, user_id=user, action_type=action)
     
     async def widget(self):
         """|coro|

--- a/discord/http.py
+++ b/discord/http.py
@@ -413,11 +413,11 @@ class HTTPClient:
             'limit': limit
         }
 
-        if before:
+        if before is not None:
             params['before'] = before
-        if after:
+        if after is not None:
             params['after'] = after
-        if around:
+        if around is not None:
             params['around'] = around
 
         return self.request(Route('GET', '/channels/{channel_id}/messages', channel_id=channel_id), params=params)

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -306,7 +306,7 @@ class HistoryIterator(_AsyncIterator):
 
         if self._get_retrieve():
             data = await self._retrieve_messages(self.retrieve)
-            if self.limit is None and len(data) < 100:
+            if len(data) < 100:
                 self.limit = 0 # terminate the infinite loop
 
             if self.reverse:
@@ -439,7 +439,7 @@ class AuditLogIterator(_AsyncIterator):
 
         if self._get_retrieve():
             users, data = await self._strategy(self.retrieve)
-            if self.limit is None and len(data) < 100:
+            if len(data) < 100:
                 self.limit = 0 # terminate the infinite loop
 
             if self.reverse:

--- a/docs/locale/ja/LC_MESSAGES/api.po
+++ b/docs/locale/ja/LC_MESSAGES/api.po
@@ -7361,8 +7361,8 @@ msgid "Same as ``around`` in :meth:`history`."
 msgstr ":meth:`history` での ``around`` と同じです。"
 
 #: discord.TextChannel.purge:25 of
-msgid "Same as ``reverse`` in :meth:`history`."
-msgstr ":meth:`history` での ``reverse`` と同じです。"
+msgid "Same as ``oldest_first`` in :meth:`history`."
+msgstr ":meth:`history` での ``oldest_first`` と同じです。"
 
 #: discord.TextChannel.purge:26 of
 msgid "If True, use bulk delete. bulk=False is useful for mass-deleting a bot's own messages without manage_messages. When True, will fall back to single delete if current account is a user bot, or if messages are older than two weeks."


### PR DESCRIPTION
### Summary

rename reverse->oldest_first, change `after` not specified to imply `after=0`.

Pull the auditlogiterator change if you want, I can't test since after= doesn't work lmao
<!-- What is this pull request for? Does it fix any issues? -->

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
