### PR TITLE
Add integrations API support

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -39,6 +39,7 @@ from .permissions import Permissions, PermissionOverwrite
 from .role import Role
 from .file import File
 from .colour import Color, Colour
+from .integrations import Integration, IntegrationAccount
 from .invite import Invite, PartialInviteChannel, PartialInviteGuild
 from .widget import Widget, WidgetMember, WidgetChannel
 from .object import Object

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -50,6 +50,8 @@ __all__ = (
     'TeamMembershipState',
     'Theme',
     'WebhookType',
+    'ExpireBehaviour',
+    'ExpireBehavior'
 )
 
 def _create_value_cls(name):
@@ -433,17 +435,7 @@ class ExpireBehaviour(Enum):
     remove_role = 0
     kick = 1
 
-class ExpireGracePeriod(Enum):
-    one_day = 1
-    day = 1
-    three_days = 3
-    three = 3
-    seven_days = 7
-    week = 7
-    fourteen_days = 14
-    fortnight = 14
-    thirty_days = 30
-    month = 30
+ExpireBehavior = ExpireBehaviour
 
 def try_enum(cls, val):
     """A function that tries to turn the value into enum ``cls``.

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -429,6 +429,22 @@ class WebhookType(Enum):
     incoming = 1
     channel_follower = 2
 
+class ExpireBehaviour(Enum):
+    remove_role = 0
+    kick = 1
+
+class ExpireGracePeriod(Enum):
+    one_day = 1
+    day = 1
+    three_days = 3
+    three = 3
+    seven_days = 7
+    week = 7
+    fourteen_days = 14
+    fortnight = 14
+    thirty_days = 30
+    month = 30
+
 def try_enum(cls, val):
     """A function that tries to turn the value into enum ``cls``.
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1525,6 +1525,49 @@ class Guild(Hashable):
         data = await self._state.http.get_all_integrations(self.id)
         return [Integration(self, d) for d in data]
 
+    async def fetch_emojis(self):
+        """|coro|
+
+        Retrieves all custom :class:`Emoji`s from the guild.
+
+        Raises
+        ---------
+        HTTPException
+            An error occurred fetching the emojis.
+
+        Returns
+        --------
+        List[:class:`Emoji`]
+            The retrieved emojis.
+        """
+        data = await self._state.http.get_all_custom_emojis(self.id)
+        return [Emoji(guild=self, state=self._state, data=d) for d in data]
+
+    async def fetch_emoji(self, emoji_id):
+        """|coro|
+
+        Retrieves a custom :class:`Emoji` from the guild.
+
+        Parameters
+        -------------
+        emoji_id: :class:`int`
+            The emoji's ID.
+
+        Raises
+        ---------
+        NotFound
+            The emoji requested could not be found.
+        HTTPException
+            An error occurred fetching the emoji.
+
+        Returns
+        --------
+        :class:`Emoji`
+            The retrieved emoji.
+        """
+        data = await self._state.http.get_custom_emoji(self.id, emoji_id)
+        return Emoji(guild=self, state=self._state, data=data)
+
     async def create_custom_emoji(self, *, name, image, roles=None, reason=None):
         r"""|coro|
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1486,6 +1486,8 @@ class Guild(Hashable):
         You must have the :attr:`~Permissions.manage_guild` permission to
         do this.
 
+        .. versionadded:: 1.4
+
         Parameters
         -----------
         type: :class:`str`
@@ -1509,6 +1511,8 @@ class Guild(Hashable):
 
         You must have the :attr:`~Permissions.manage_guild` permission to
         do this.
+
+        .. versionadded:: 1.4
 
         Raises
         -------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -46,6 +46,8 @@ from .webhook import Webhook
 from .widget import Widget
 from .asset import Asset
 from .flags import SystemChannelFlags
+from .integrations import Integration
+
 
 BanEntry = namedtuple('BanEntry', 'reason user')
 _GuildLimit = namedtuple('_GuildLimit', 'emoji bitrate filesize')
@@ -1475,6 +1477,53 @@ class Guild(Hashable):
         """
         data = await self._state.http.get_custom_emoji(self.id, emoji_id)
         return Emoji(guild=self, state=self._state, data=data)
+
+    async def create_integration(self, integration_type, integration_id):
+        """|coro|
+
+        Attaches an integration to the guild.
+
+        You must have the :attr:`~Permissions.manage_guild` permission to
+        do this.
+
+        Parameters
+        -----------
+        integration_type: :class:`string`
+            The integration type (i.e. Twitch).
+        integration_id: :class:`id`
+            The integration ID.
+
+        Raises
+        -------
+        Forbidden
+            You do not have permission to create the integration.
+        HTTPException
+            The account could not be found.
+        """
+        await self._state.http.create_integration(self.id, integration_type, integration_id)
+
+    async def integrations(self):
+        """|coro|
+
+        Returns a list of all integrations attached to the guild.
+
+        You must have the :attr:`~Permissions.manage_guild` permission to
+        do this.
+
+        Raises
+        -------
+        Forbidden
+            You do not have permission to create the integration.
+        HTTPException
+            Fetching the integrations failed.
+
+        Returns
+        --------
+        List[:class:`Integration`]
+            The list of integrations that are attached to the guild.
+        """
+        data = await self._state.http.get_all_integrations(self.id)
+        return [Integration(self, d) for d in data]
 
     async def create_custom_emoji(self, *, name, image, roles=None, reason=None):
         r"""|coro|

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1478,7 +1478,7 @@ class Guild(Hashable):
         data = await self._state.http.get_custom_emoji(self.id, emoji_id)
         return Emoji(guild=self, state=self._state, data=data)
 
-    async def create_integration(self, integration_type, integration_id):
+    async def create_integration(self, *, type, id):
         """|coro|
 
         Attaches an integration to the guild.
@@ -1488,9 +1488,9 @@ class Guild(Hashable):
 
         Parameters
         -----------
-        integration_type: :class:`string`
-            The integration type (i.e. Twitch).
-        integration_id: :class:`id`
+        type: :class:`str`
+            The integration type (e.g. Twitch).
+        id: :class:`int`
             The integration ID.
 
         Raises
@@ -1500,7 +1500,7 @@ class Guild(Hashable):
         HTTPException
             The account could not be found.
         """
-        await self._state.http.create_integration(self.id, integration_type, integration_id)
+        await self._state.http.create_integration(self.id, type, id)
 
     async def integrations(self):
         """|coro|
@@ -1523,7 +1523,7 @@ class Guild(Hashable):
             The list of integrations that are attached to the guild.
         """
         data = await self._state.http.get_all_integrations(self.id)
-        return [Integration(self, d) for d in data]
+        return [Integration(guild=self, data=d) for d in data]
 
     async def fetch_emojis(self):
         """|coro|

--- a/discord/http.py
+++ b/discord/http.py
@@ -699,6 +699,38 @@ class HTTPClient:
         r = Route('PATCH', '/guilds/{guild_id}/emojis/{emoji_id}', guild_id=guild_id, emoji_id=emoji_id)
         return self.request(r, json=payload, reason=reason)
 
+    def get_all_integrations(self, guild_id):
+        r = Route('GET', '/guilds/{guild_id}/integrations', guild_id=guild_id)
+
+        return self.request(r)
+
+    def create_integration(self, guild_id, type, id):
+        payload = {
+            'type': type,
+            'id': id
+        }
+
+        r = Route('POST', '/guilds/{guild_id}/integrations', guild_id=guild_id)
+        return self.request(r, json=payload)
+
+    def edit_integration(self, guild_id, integration_id, **payload):
+        r = Route('PATCH', '/guilds/{guild_id}/integrations/{integration_id}', guild_id=guild_id,
+                  integration_id=integration_id)
+
+        return self.request(r, json=payload)
+
+    def sync_integration(self, guild_id, integration_id):
+        r = Route('POST', '/guilds/{guild_id}/integrations/{integration_id}/sync', guild_id=guild_id,
+                  integration_id=integration_id)
+
+        return self.request(r)
+
+    def delete_integration(self, guild_id, integration_id):
+        r = Route('DELETE', '/guilds/{guild_id}/integrations/{integration_id}', guild_id=guild_id,
+                  integration_id=integration_id)
+
+        return self.request(r)
+
     def get_audit_logs(self, guild_id, limit=100, before=None, after=None, user_id=None, action_type=None):
         params = {'limit': limit}
         if before:

--- a/discord/integrations.py
+++ b/discord/integrations.py
@@ -140,18 +140,18 @@ class Integration:
             ``expire_behaviour`` did not receive a :class:`ExpireBehaviour`.
         """
         try:
-            expire_behavior = fields['expire_behaviour']
+            expire_behaviour = fields['expire_behaviour']
         except KeyError:
-            expire_behavior = fields.get('expire_behavior', self.expire_behaviour)
+            expire_behaviour = fields.get('expire_behavior', self.expire_behaviour)
 
-        if not isinstance(expire_behavior, ExpireBehaviour):
+        if not isinstance(expire_behaviour, ExpireBehaviour):
             raise InvalidArgument('expire_behaviour field must be of type ExpireBehaviour')
 
         expire_grace_period = fields.get('expire_grace_period', self.expire_grace_period)
 
         payload = {
-            'expire_behavior': expire_behavior.value,
-            'expire_grace_period': expire_grace_period.value,
+            'expire_behavior': expire_behaviour.value,
+            'expire_grace_period': expire_grace_period,
         }
 
         enable_emoticons = fields.get('enable_emoticons')
@@ -182,7 +182,6 @@ class Integration:
             Syncing the integration failed.
         """
         await self._state.http.sync_integration(self.guild.id, self.id)
-
         self.synced_at = datetime.datetime.utcnow()
 
     async def delete(self):

--- a/discord/integrations.py
+++ b/discord/integrations.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-2019 Rapptz
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+import datetime
+from collections import namedtuple
+from .utils import _get_as_snowflake, get, parse_time
+from .user import User
+from .errors import InvalidArgument
+from .enums import try_enum, ExpireGracePeriod, ExpireBehaviour
+
+class IntegrationAccount(namedtuple('IntegrationAccount', 'id name')):
+    """Represents an integration account.
+
+    Attributes
+    -----------
+    id: :class:`int`
+        The account ID.
+    name: :class:`str`
+        The account name.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self):
+        return '<IntegrationAccount id={0.id} name={0.name!r}>'.format(self)
+
+class Integration:
+    """Represents a guild integration.
+
+    Attributes
+    -----------
+    id: :class:`int`
+        The integration ID.
+    name: :class:`str`
+        The integration name.
+    guild: :class:`Guild`
+        The guild of the integration.
+    type: :class:`str`
+        The integration type (i.e. Twitch).
+    enabled: :class:`bool`
+        Whether the integration is currently enabled.
+    syncing: :class:`bool`
+        Where the integration is currently syncing.
+    role: :class:`Role`
+        The role which the integration uses for subscribers.
+    expire_behaviour: :class:`ExpireBehaviour`
+        The behaviour of expiring subscribers.
+    expire_grace_period: :class:`ExpireGracePeriod`
+        The grace period for expiring subscribers.
+    user: :class:`User`
+        The user for the integration.
+    account: :class:`IntegrationAccount`
+        The integration account information.
+    synced_at: :class:`datetime.datetime`
+        When the integration was last synced.
+    """
+
+    __slots__ = ('id', '_state', 'guild', 'name', 'enabled', 'type',
+                 'syncing', 'role', 'expire_behaviour', 'expire_behavior',
+                 'expire_grace_period', 'synced_at', 'user', 'account')
+
+    def __init__(self, guild, data):
+        self.guild = guild
+        self._state = guild._state
+        self._from_data(data)
+
+    def __repr__(self):
+        return '<Integration id={0.id} name={0.name!r} type={0.type!r}>'.format(self)
+
+    def _from_data(self, integ):
+        self.id = _get_as_snowflake(integ, 'id')
+        self.name = integ['name']
+        self.type = integ['type']
+        self.enabled = integ['enabled']
+        self.syncing = integ['syncing']
+        self.role = get(self.guild.roles, id=int(integ['role_id']))
+        self.expire_behaviour = try_enum(ExpireBehaviour, integ['expire_behavior'])
+        self.expire_behavior = self.expire_behaviour
+        self.expire_grace_period = try_enum(ExpireGracePeriod, integ['expire_grace_period'])
+        self.synced_at = parse_time(integ['synced_at'])
+
+        self.user = User(state=self._state, data=integ['user'])
+        self.account = IntegrationAccount(**integ['account'])
+
+    async def edit(self, **fields):
+        """|coro|
+
+        Edits the integration.
+
+        You must have the :attr:`~Permissions.manage_guild` permission to
+        do this.
+
+        Parameters
+        -----------
+        expire_behaviour: :class:`ExpireBehaviour`
+            The behaviour when an integration subscription lapses.
+        expire_grace_period: :class:`ExpireGracePeriod`
+            The period where the integration will ignore lapsed subscriptions.
+        enable_emoticons: :class:`bool`
+            Where emoticons should be synced for this integration (currently only
+            works for twitch).
+
+        Raises
+        -------
+        Forbidden
+            You do not have permission to edit the integration.
+        HTTPException
+            Editing the guild failed.
+        InvalidArgument
+            ``expire_grace_period`` or ``expire_behaviour`` did not receive their
+            respective enum.
+        """
+        try:
+            expire_behavior = fields['expire_behaviour']
+        except KeyError:
+            expire_behavior = fields.get('expire_behavior', self.expire_behaviour)
+
+        if not isinstance(expire_behavior, ExpireBehaviour):
+            raise InvalidArgument('expire_behaviour field must be of type ExpireBehaviour')
+
+        expire_grace_period = fields.get('expire_grace_period', self.expire_grace_period)
+
+        if not isinstance(expire_grace_period, ExpireGracePeriod):
+            raise InvalidArgument('expire_grace_period field must be of type ExpireGracePeriod')
+
+        payload = {
+            'expire_behavior': expire_behavior.value,
+            'expire_grace_period': expire_grace_period.value,
+        }
+
+        enable_emoticons = fields.get('enable_emoticons')
+
+        if enable_emoticons is not None:
+            payload['enable_emoticons'] = enable_emoticons
+
+        await self._state.http.edit_integration(self.guild.id, self.id, **payload)
+
+        self.expire_behaviour = expire_behavior
+        self.expire_behavior = self.expire_behaviour
+        self.expire_grace_period = expire_grace_period
+
+    async def sync(self):
+        """|coro|
+
+        Syncs the integration.
+
+        You must have the :attr:`~Permissions.manage_guild` permission to
+        do this.
+
+        Raises
+        -------
+        Forbidden
+            You do not have permission to sync the integration.
+        HTTPException
+            Syncing the integration failed.
+        """
+        await self._state.http.sync_integration(self.guild.id, self.id)
+
+        self.synced_at = datetime.datetime.utcnow()
+
+    async def delete(self):
+        """|coro|
+
+        Deletes the integration.
+
+        You must have the :attr:`~Permissions.manage_guild` permission to
+        do this.
+
+        Raises
+        -------
+        Forbidden
+            You do not have permission to delete the integration.
+        HTTPException
+            Deleting the integration failed.
+        """
+        await self._state.http.delete_integration(self.guild.id, self.id)

--- a/discord/integrations.py
+++ b/discord/integrations.py
@@ -34,6 +34,8 @@ from .enums import try_enum, ExpireBehaviour
 class IntegrationAccount(namedtuple('IntegrationAccount', 'id name')):
     """Represents an integration account.
 
+    .. versionadded:: 1.4
+
     Attributes
     -----------
     id: :class:`int`
@@ -49,6 +51,8 @@ class IntegrationAccount(namedtuple('IntegrationAccount', 'id name')):
 
 class Integration:
     """Represents a guild integration.
+
+    .. versionadded:: 1.4
 
     Attributes
     -----------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1645,22 +1645,6 @@ of :class:`enum.Enum`.
 
         The action is the update of something.
 
-.. class:: ExpireBehaviour
-
-    Represents the behaviour the :class:`Integration` should perform
-    when a user's subscription has finished.
-
-    There is an alias for this called ExpireBehavior.
-
-    .. attribute:: remove_role
-
-        This will remove the :attr:`Integration.role` from the user
-        when their subscription is finished.
-
-    .. attribute:: kick
-
-        This will kick the user when their subscription is finished.
-
 .. class:: RelationshipType
 
     Specifies the type of :class:`Relationship`.
@@ -1805,6 +1789,10 @@ of :class:`enum.Enum`.
     Represents the behaviour the :class:`Integration` should perform
     when a user's subscription has finished.
 
+    There is an alias for this called ``ExpireBehavior``.
+
+    .. versionadded:: 1.4
+
     .. attribute:: remove_role
 
         This will remove the :attr:`Integration.role` from the user
@@ -1813,52 +1801,6 @@ of :class:`enum.Enum`.
     .. attribute:: kick
 
         This will kick the user when their subscription is finished.
-
-
-.. class:: ExpireGracePeriod
-
-    Represents the grace period before the :attr:`Integration.expire_behaviour`
-    will take in effect.
-
-    .. attribute:: one_day
-
-        Represents a day for the grace period.
-
-    .. attribute:: day
-
-        An alias for :attr:`one_day`.
-
-    .. attribute:: three_days
-
-        Represents three days for the grace period.
-
-    .. attribute:: three
-
-        An alias for :attr:`three`.
-
-    .. attribute:: seven_days
-
-        Represents seven days for the grace period.
-
-    .. attribute:: week
-
-        An alias for :attr:`week`.
-
-    .. attribute:: fourteen_days
-
-        Represents fourteen days for the grace period.
-
-    .. attribute:: fortnight
-
-        An alias for :attr:`fourteen_days`.
-
-    .. attribute:: thirty_days
-
-        Represents thirty days for the grace period.
-
-    .. attribute:: month
-
-        An alias for :attr:`thirty_days`.
 
 Async Iterator
 ----------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1643,7 +1643,6 @@ of :class:`enum.Enum`.
 
         The action is the update of something.
 
-
 .. class:: RelationshipType
 
     Specifies the type of :class:`Relationship`.
@@ -1782,6 +1781,66 @@ of :class:`enum.Enum`.
     .. attribute:: channel_follower
 
         Represents a webhook that is internally managed by Discord, used for following channels.
+
+.. class:: ExpireBehaviour
+
+    Represents the behaviour the :class:`Integration` should perform
+    when a user's subscription has finished.
+
+    .. attribute:: remove_role
+
+        This will remove the :attr:`Integration.role` from the user
+        when their subscription is finished.
+
+    .. attribute:: kick
+
+        This will kick the user when their subscription is finished.
+
+
+.. class:: ExpireGracePeriod
+
+    Represents the grace period before the :attr:`Integration.expire_behaviour`
+    will take in effect.
+
+    .. attribute:: one_day
+
+        Represents a day for the grace period.
+
+    .. attribute:: day
+
+        An alias for :attr:`one_day`.
+
+    .. attribute:: three_days
+
+        Represents three days for the grace period.
+
+    .. attribute:: three
+
+        An alias for :attr:`three`.
+
+    .. attribute:: seven_days
+
+        Represents seven days for the grace period.
+
+    .. attribute:: week
+
+        An alias for :attr:`week`.
+
+    .. attribute:: fourteen_days
+
+        Represents fourteen days for the grace period.
+
+    .. attribute:: fortnight
+
+        An alias for :attr:`fourteen_days`.
+
+    .. attribute:: thirty_days
+
+        Represents thirty days for the grace period.
+
+    .. attribute:: month
+
+        An alias for :attr:`thirty_days`.
 
 Async Iterator
 ----------------
@@ -2371,6 +2430,15 @@ Guild
 
     .. automethod:: audit_logs
         :async-for:
+
+Integration
+~~~~~~~~~~~~
+
+.. autoclass:: Integration()
+    :members:
+
+.. autoclass:: IntegrationAccount()
+    :members:
 
 Member
 ~~~~~~

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1643,6 +1643,22 @@ of :class:`enum.Enum`.
 
         The action is the update of something.
 
+.. class:: ExpireBehaviour
+
+    Represents the behaviour the :class:`Integration` should perform
+    when a user's subscription has finished.
+
+    There is an alias for this called ExpireBehavior.
+
+    .. attribute:: remove_role
+
+        This will remove the :attr:`Integration.role` from the user
+        when their subscription is finished.
+
+    .. attribute:: kick
+
+        This will kick the user when their subscription is finished.
+
 .. class:: RelationshipType
 
     Specifies the type of :class:`Relationship`.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -480,6 +480,8 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
 .. function:: on_guild_integrations_update(guild)
 
+    .. versionadded:: 1.4
+
     Called whenever an integration is created, modified, or removed from a guild.
 
     :param guild: The guild that had its integrations updated.


### PR DESCRIPTION
### Summary

This resolves #1083, a feature request for integrations, in terms of the API, not event.

This allows for:

- [`GET/guilds/{guild.id}/integrations`](https://discordapp.com/developers/docs/resources/guild#get-guild-integrations): `await Guild.integrations()`
- [`POST/guilds/{guild.id}/integrations`](https://discordapp.com/developers/docs/resources/guild#create-guild-integration): `await Guild.create_integration(id, type)`
- [`PATCH/guilds/{guild.id}/integrations/{integration.id}`](https://discordapp.com/developers/docs/resources/guild#modify-guild-integration): `await Integration.edit(**fields)`
- [`DELETE/guilds/{guild.id}/integrations/{integration.id}`](https://discordapp.com/developers/docs/resources/guild#delete-guild-integration): `await Integration.delete()`
- [`POST/guilds/{guild.id}/integrations/{integration.id}/sync`](https://discordapp.com/developers/docs/resources/guild#sync-guild-integration): `await Integration.sync()`

It also completes both the [Integration](https://discordapp.com/developers/docs/resources/guild#integration-object) and [Account](https://discordapp.com/developers/docs/resources/guild#integration-account-object) models.

All code has been tested with a valid integrations server.

### Why is this better than #1085?

- You can enable/disable emoticons using `Integrations.edit`.
- `expire_behaviour` / `expire_behavior` and `expire_grace_period` follow an enum rather than arbitrary numbers.
    - `ExpireBehaviour` and `ExpireGracePeriod`
- `Integration` and `IntegrationAccount` have their attributes documented properly.
- You can create integrations via `Guild.create_integration`
- The merge conflict resolve for `guild.py` doesn't slice `Guild.widget` out of `Guild`

*At the time of me making this (last week), I did not see their PR, I only saw the issue.*

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
