### PR TITLE
Add notes to say what fetch_guild/s give back

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -835,7 +835,12 @@ class Client:
     def fetch_guilds(self, *, limit=100, before=None, after=None):
         """|coro|
 
-        Retreives an :class:`AsyncIterator` that enables receiving your guilds.
+        Retrieves an :class:`AsyncIterator` that enables receiving your guilds.
+
+        .. note::
+
+            Using this, you will only receive :attr:`Guild.owner`, :attr:`Guild.icon`,
+            :attr:`Guild.id`, and :attr:`Guild.name` per :class:`Guild`.
 
         All parameters are optional.
 
@@ -881,7 +886,12 @@ class Client:
     async def fetch_guild(self, guild_id):
         """|coro|
 
-        Retreives a :class:`Guild` from an ID.
+        Retrieves a :class:`Guild` from an ID.
+
+        .. note::
+
+            Using this, you will not receive :attr:`Guild.channels`, :class:`Guild.members`,
+            :attr:`Member.activity` and :attr:`Member.voice` per :class:`Member`.
 
         Parameters
         -----------


### PR DESCRIPTION
### Summary

This has been requested twice now, so I wanted to create the PR now.

It essentially adds notes to `Client.fetch_guild/s` to say what is given back, since some people in the help channels are led to believe that it provides the complete cached Guild object, which it does not.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
