### PR TITLE
Use is_connected() instead of _connected in checks

### DIFF
--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -261,7 +261,7 @@ class VoiceClient:
 
         Disconnects this voice client from voice.
         """
-        if not force and not self._connected.is_set():
+        if not force and not self.is_connected():
             return
 
         self.stop()
@@ -348,7 +348,7 @@ class VoiceClient:
             source is not a :class:`AudioSource` or after is not a callable.
         """
 
-        if not self._connected:
+        if not self.is_connected():
             raise ClientException('Not connected to voice.')
 
         if self.is_playing():


### PR DESCRIPTION
### Summary

Fix bad checks in voice_client.py.  Was doing a falsy check on an Event object instead of using the (unused) is_connected() function.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
