### PR TITLE
Add cached_message to on_raw_message_edit event

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -86,14 +86,17 @@ class RawMessageUpdateEvent:
         The message ID that got updated.
     data: :class:`dict`
         The raw data given by the
-        `gateway <https://discordapp.com/developers/docs/topics/gateway#message-update>`_
+        `gateway <https://discordapp.com/developers/docs/topics/gateway#message-update>`
+    cached_message: Optional[:class:`Message`]
+        The cached message, if found in the internal message cache.
     """
 
-    __slots__ = ('message_id', 'data')
+    __slots__ = ('message_id', 'data', 'cached_message')
 
     def __init__(self, data):
         self.message_id = int(data['id'])
         self.data = data
+        self.cached_message = None
 
 class RawReactionActionEvent:
     """Represents the payload for a :func:`on_raw_reaction_add` or

--- a/discord/state.py
+++ b/discord/state.py
@@ -385,10 +385,11 @@ class ConnectionState:
 
     def parse_message_update(self, data):
         raw = RawMessageUpdateEvent(data)
-        self.dispatch('raw_message_edit', raw)
         message = self._get_message(raw.message_id)
         if message is not None:
             older_message = copy.copy(message)
+            raw.cached_message = older_message
+            self.dispatch('raw_message_edit', raw)
             if 'call' in data:
                 # call state message edit
                 message._handle_call(data['call'])
@@ -399,6 +400,8 @@ class ConnectionState:
                 message._update(channel=message.channel, data=data)
 
             self.dispatch('message_edit', older_message, message)
+        else:
+            self.dispatch('raw_message_edit', raw)
 
     def parse_message_reaction_add(self, data):
         emoji_data = data['emoji']

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -296,6 +296,9 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     Called when a message is edited. Unlike :func:`on_message_edit`, this is called
     regardless of the state of the internal message cache.
 
+    If the message is found in the message cache,
+    it can be accessed via :attr:`RawMessageUpdateEvent.cached_message`
+
     Due to the inherently raw nature of this event, the data parameter coincides with
     the raw data given by the `gateway <https://discordapp.com/developers/docs/topics/gateway#message-update>`_
 


### PR DESCRIPTION
### Summary

This PR adds a cached_message attribute to the `RawMessageUpdateEvent` payload
for usage in the `raw_message_edit` event in the same vein as #2020. 

This is done because the message in cache is edited prior to the event listener running, leading to
the same potential difficulties as in #2020.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
