### PR TITLE
Add notes warning that fetch_ methods are api calls

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -861,6 +861,10 @@ class Client:
             Using this, you will only receive :attr:`Guild.owner`, :attr:`Guild.icon`,
             :attr:`Guild.id`, and :attr:`Guild.name` per :class:`Guild`.
 
+        .. note::
+
+            This method is an API call. For general usage, consider :attr:`guilds` instead.
+
         All parameters are optional.
 
         Parameters
@@ -911,6 +915,10 @@ class Client:
 
             Using this, you will not receive :attr:`Guild.channels`, :class:`Guild.members`,
             :attr:`Member.activity` and :attr:`Member.voice` per :class:`Member`.
+
+        .. note::
+
+            This method is an API call. For general usage, consider :meth:`get_guild` instead.
 
         Parameters
         -----------
@@ -1098,6 +1106,10 @@ class Client:
         be used by bot accounts. You do not have to share any guilds
         with the user to get this information, however many operations
         do require that you do.
+
+        .. note::
+
+            This method is an API call. For general usage, consider :meth:`get_user` instead.
 
         Parameters
         -----------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -931,6 +931,10 @@ class Guild(Hashable):
 
         Retreives a :class:`Member` from a guild ID, and a member ID.
 
+        .. note::
+
+            This method is an API call. For general usage, consider :meth:`get_member` instead.
+
         Parameters
         -----------
         member_id: :class:`int`
@@ -1149,6 +1153,10 @@ class Guild(Hashable):
 
         Retrieves all custom :class:`Emoji`\s from the guild.
 
+        .. note::
+
+            This method is an API call. For general usage, consider :attr:`emojis` instead.
+
         Raises
         ---------
         HTTPException
@@ -1166,6 +1174,11 @@ class Guild(Hashable):
         """|coro|
 
         Retrieves a custom :class:`Emoji` from the guild.
+
+        .. note::
+
+            This method is an API call.
+            For general usage, consider iterating over :attr:`emojis` instead.
 
         Parameters
         -------------


### PR DESCRIPTION
### Summary

This adds a note on `fetch_x` methods that have an equivilant-ish `get_x` method advising the user that they most likely want to use the `get_x` method instead. 

This is done because although useful, the `fetch_x` methods are a common trap for new users to fall into, not realizing they are making an API call, or that there is a similar method that relies on cache. 


### Checklist

<!-- Put an x inside [ ] to check it -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
