### PR TITLE
[commands] Add dm_only()

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1435,7 +1435,7 @@ def bot_has_permissions(**perms):
 
 def dm_only():
     """A :func:`.check` that indicates this command must only be used in a
-    DM context only. Basically, private messages ONLY are allowed when
+    DM context only. Only private messages are allowed when
     using the command.
 
     This check raises a special exception, :exc:`.PrivateMessageOnly`

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1433,6 +1433,22 @@ def bot_has_permissions(**perms):
 
     return check(predicate)
 
+def dm_only():
+    """A :func:`.check` that indicates this command must only be used in a
+    DM context only. Basically, private messages ONLY are allowed when
+    using the command.
+
+    This check raises a special exception, :exc:`.PrivateMessageOnly`
+    that is inherited from :exc:`.CheckFailure`.
+    """
+
+    def predicate(ctx):
+        if ctx.guild is not None:
+            raise PrivateMessageOnly('This command cannot be used in private messages.')
+        return True
+
+    return check(predicate)
+
 def guild_only():
     """A :func:`.check` that indicates this command must only be used in a
     guild context only. Basically, no private messages are allowed when

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -40,7 +40,7 @@ from .cog import Cog
 __all__ = ['Command', 'Group', 'GroupMixin', 'command', 'group',
            'has_role', 'has_permissions', 'has_any_role', 'check',
            'bot_has_role', 'bot_has_permissions', 'bot_has_any_role',
-           'cooldown', 'guild_only', 'is_owner', 'is_nsfw']
+           'cooldown', 'dm_only', 'guild_only', 'is_owner', 'is_nsfw']
 
 def wrap_callback(coro):
     @functools.wraps(coro)

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -28,15 +28,15 @@ from discord.errors import DiscordException
 
 
 __all__ = ['CommandError', 'MissingRequiredArgument', 'BadArgument',
-           'NoPrivateMessage', 'CheckFailure', 'CommandNotFound',
-           'DisabledCommand', 'CommandInvokeError', 'TooManyArguments',
-           'UserInputError', 'CommandOnCooldown', 'NotOwner',
-           'MissingPermissions', 'BotMissingPermissions', 'ConversionError',
-           'BadUnionArgument', 'ArgumentParsingError',
+           'PrivateMessageOnly', 'NoPrivateMessage', 'CheckFailure',
+           'CommandNotFound' ,'DisabledCommand', 'CommandInvokeError',
+           'TooManyArguments', 'UserInputError', 'CommandOnCooldown',
+           'NotOwner', 'MissingPermissions', 'BotMissingPermissions',
+           'ConversionError', 'BadUnionArgument', 'ArgumentParsingError',
            'UnexpectedQuoteError', 'InvalidEndOfQuotedStringError',
            'ExpectedClosingQuoteError', 'ExtensionError', 'ExtensionAlreadyLoaded',
            'ExtensionNotLoaded', 'NoEntryPointError', 'ExtensionFailed',
-           'ExtensionNotFound' ]
+           'ExtensionNotFound']
 
 class CommandError(DiscordException):
     r"""The base exception type for all command related errors.

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -118,6 +118,12 @@ class CheckFailure(CommandError):
     """Exception raised when the predicates in :attr:`.Command.checks` have failed."""
     pass
 
+class PrivateMessageOnly(CheckFailure):
+    """Exception raised when an operation does not work outside of private
+    message contexts.
+    """
+    pass
+
 class NoPrivateMessage(CheckFailure):
     """Exception raised when an operation does not work in private message
     contexts.


### PR DESCRIPTION
### Summary
Add a new check, `dm_only`, that restricts commands to a DM context.
Complements #2059.
<!-- What is this pull request for? Does it fix any issues? -->

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

Enjoy.