### PR TITLE
Add cls kwarg to commands.group decorator

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1210,13 +1210,17 @@ def command(name=None, cls=None, **attrs):
 
     return decorator
 
-def group(name=None, **attrs):
+def group(name=None, cls=None, **attrs):
     """A decorator that transforms a function into a :class:`.Group`.
 
     This is similar to the :func:`.command` decorator but creates a
-    :class:`.Group` instead of a :class:`.Command`.
+    :class:`.Group` instead of a :class:`.Command` by default.
     """
-    return command(name=name, cls=Group, **attrs)
+
+    if cls is None:
+        cls = Group
+
+    return command(name=name, cls=cls, **attrs)
 
 def check(predicate):
     r"""A decorator that adds a check to the :class:`.Command` or its

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1216,13 +1216,11 @@ def group(name=None, **attrs):
     This is similar to the :func:`.command` decorator but the ``cls``
     parameter is set to :class:`Group` by default.
 
-    .. versionchanged 1.1.0
-
-        Allow passing of ``cls`` parameter
+    .. versionchanged:: 1.1.0
+        The ``cls`` parameter can now be passed.
     """
 
     attrs.setdefault('cls', Group)
-
     return command(name=name, **attrs)
 
 def check(predicate):

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1215,6 +1215,10 @@ def group(name=None, **attrs):
 
     This is similar to the :func:`.command` decorator but the ``cls``
     parameter is set to :class:`Group` by default.
+
+    .. versionchanged 1.1.0
+
+        Allow passing of ``cls`` parameter
     """
 
     attrs.setdefault('cls', Group)

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1210,17 +1210,16 @@ def command(name=None, cls=None, **attrs):
 
     return decorator
 
-def group(name=None, cls=None, **attrs):
+def group(name=None, **attrs):
     """A decorator that transforms a function into a :class:`.Group`.
 
-    This is similar to the :func:`.command` decorator but creates a
-    :class:`.Group` instead of a :class:`.Command` by default.
+    This is similar to the :func:`.command` decorator but the ``cls``
+    parameter is set to :class:`Group` by default.
     """
 
-    if cls is None:
-        cls = Group
+    attrs.setdefault('cls', Group)
 
-    return command(name=name, cls=cls, **attrs)
+    return command(name=name, **attrs)
 
 def check(predicate):
     r"""A decorator that adds a check to the :class:`.Command` or its


### PR DESCRIPTION
### Summary
This is a purely aesthetic modification to the behavior of `commands.Group` decorator enabling slightly tidier usage of subclasses of command group.

Prior to this change, if you had subclassed command group, you would use the existing commands.Command decorator:
`@commands.command(cls=group_subclass)`
This is a slight readability discontinuity, compared to:
`@commands.group(cls=group_subclass)`

This also makes group slightly more consistent with command.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
