### PR TITLE
Added fetch_url_message

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -982,7 +982,7 @@ class Client:
     async def fetch_url_message(self, url: str):
         """|coro|
 
-        Retrieves a :class:`Message` from a URL.
+        Retrieves a :class:`.Message` from a jump URL.
         If channel or message is not found, returns ``None``.
 
         Parameters

--- a/discord/client.py
+++ b/discord/client.py
@@ -983,7 +983,7 @@ class Client:
         """|coro|
 
         Retrieves a :class:`Message` from a URL.
-        If channel is not found, returns None.
+        If channel or message is not found, returns None.
 
         Parameters
         -----------

--- a/discord/client.py
+++ b/discord/client.py
@@ -994,8 +994,6 @@ class Client:
         -------
         ValueError
             The URL does not match any recognized format.
-        :exc:`.NotFound`
-            The specified message was not found.
         :exc:`.Forbidden`
             You do not have the permissions required to get a message.
         :exc:`.HTTPException`
@@ -1010,7 +1008,10 @@ class Client:
         message_channel = self.get_channel(int(channel_id))
         if message_channel is None:
             return None
-        return await message_channel.fetch_message(int(message_id))
+        try:
+            return await message_channel.fetch_message(int(message_id))
+        except NotFound:
+            return None
 
     # Invite management
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -979,7 +979,7 @@ class Client:
         data = await self.http.create_guild(name, region, icon)
         return Guild(data=data, state=self._connection)
 
-    async def fetch_url_message(self, url: str):
+    async def fetch_message_from_url(self, url: str):
         """|coro|
 
         Retrieves a :class:`.Message` from a jump URL.

--- a/discord/client.py
+++ b/discord/client.py
@@ -979,6 +979,39 @@ class Client:
         data = await self.http.create_guild(name, region, icon)
         return Guild(data=data, state=self._connection)
 
+    async def fetch_url_message(self, url: str):
+        """|coro|
+
+        Retrieves a :class:`Message` from a URL.
+        If channel is not found, returns None.
+
+        Parameters
+        -----------
+        url: :class:`str`
+            The message URL (message link).
+
+        Raises
+        -------
+        ValueError
+            The URL does not match any recognized format.
+        :exc:`.NotFound`
+            The specified message was not found.
+        :exc:`.Forbidden`
+            You do not have the permissions required to get a message.
+        :exc:`.HTTPException`
+            Retrieving the message failed.
+
+        Returns
+        -------
+        :class:`.Message`
+            The message referenced by the URL.
+        """
+        channel_id, message_id = url.split(r"/")[-2:]
+        message_channel = self.get_channel(int(channel_id))
+        if message_channel is None:
+            return None
+        return await message_channel.fetch_message(int(message_id))
+
     # Invite management
 
     async def fetch_invite(self, url, *, with_counts=True):

--- a/discord/client.py
+++ b/discord/client.py
@@ -1002,7 +1002,7 @@ class Client:
         Returns
         -------
         :class:`.Message`
-            The message referenced by the URL.
+            The message referenced by the jump URL.
         """
         channel_id, message_id = url.split(r"/")[-2:]
         message_channel = self.get_channel(int(channel_id))

--- a/discord/client.py
+++ b/discord/client.py
@@ -983,7 +983,7 @@ class Client:
         """|coro|
 
         Retrieves a :class:`Message` from a URL.
-        If channel or message is not found, returns None.
+        If channel or message is not found, returns ``None``.
 
         Parameters
         -----------


### PR DESCRIPTION
### Summary

This pull request adds a fetch_url_message function, which allows a message link (https://discordapp.com/channels/336642139381301249/381974649019432981/381976391303823360) to be used to fetch a message.

Returns None on non-found channel to reflect get_channel's behavior.
Raises NotFound on non-found message to reflect fetch_message's behavior.
This difference will also allow the user to differentiate issues.

The benefit of this function, in my opinion, is to allow users to specify a certain message when using a bot command without having to enable Discord developer mode. It also allows a single argument for channel and message IDs.

Possible usage of this addition:
```
@commands.command()
async def reject_message(self, ctx, message_url):
    try:
        target_message = await ctx.bot.fetch_url_message(message_url)
    except NotFound:
        await ctx.send("That message does not appear to exist anymore! :o")
    else:
        if target_message is None:
            await ctx.send("I don't have access to that channel!")
        else:
            target_message.add_reaction(❌)
```

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
