### PR TITLE
[commands] Add __str__ magic method to Cog

### DIFF
--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -183,6 +183,9 @@ class Cog(metaclass=CogMeta):
                 parent.add_command(command)
 
         return self
+    
+    def __str__(self):
+        return self.qualified_name
 
     def get_commands(self):
         r"""Returns a :class:`list` of :class:`.Command`\s that are


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
It feels kind of inconsistent to have many objects in the lib, including `Command`s, return their name except for cogs when the `str()` method is used on them, this PR adds the `__str__` magic method to the Cog class, which returns qualified_name.
This also makes easier to avoid errors when using `Cog.qualified_name` in a custom `HelpCommand` class since, even if one's of `mapping` keys is `None`, it will not give out any errors when using the `str()` method unlike when trying to access `qualified_name`.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
