### PR TITLE
Remove "needs python 3.5+" from async iter section

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1390,8 +1390,7 @@ Certain utilities make working with async iterators easier, detailed below.
 
         .. describe:: async for x in y
 
-            Iterates over the contents of the async iterator. Note
-            that this is only available in Python 3.5 or higher.
+            Iterates over the contents of the async iterator.
 
 
     .. comethod:: next()


### PR DESCRIPTION
### Summary
Removes `Note that this is only available in Python 3.5 or higher.` from Async Iterator section. This library itself needs Python 3.5.3+, so there's no need to write it.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
