### PR TITLE
Add `File.from_response` constructor

### DIFF
--- a/discord/file.py
+++ b/discord/file.py
@@ -87,6 +87,26 @@ class File:
         if spoiler and self.filename is not None and not self.filename.startswith('SPOILER_'):
             self.filename = 'SPOILER_' + self.filename
 
+    @classmethod
+    async def from_response(cls, resp, *args, **kwargs):
+        """|coro|
+
+        Alternate constructor for a :class:`discord.File` object.
+
+        Basically equivalent to:
+
+        .. code-block:: python3
+
+            discord.File(io.BytesIO(await resp.content.read()), filename, spoiler=spoiler)
+
+        Parameters
+        -----------
+        resp: :class:`aiohttp.ClientResponse`
+            The response to read the content from.
+
+        """
+        return cls(io.BytesIO(await resp.content.read()), *args, **kwargs)
+
     def reset(self, *, seek=True):
         # The `seek` parameter is needed because
         # the retry-loop is iterated over multiple times


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR addresses #2069 directly by adding a constructor to `discord.File` that takes an `aiohttp.ClientResponse` response object and any subsequent arguments and reads the response into an `io.BytesIO` object.

Additionally I could not confirm that the code blocks presented in #2069 would work pre-https://github.com/Rapptz/discord.py/commit/5e65ec978cf278fefcc5586e2df732bc7a8bed4e
as I kept encountering an ClientConnectionError exception being thrown with a traceback similar to [this](https://hastebin.com/qepebeneva.sql) (HEAD: https://github.com/Rapptz/discord.py/commit/8ba48c14a7c59c2fc3062f3e8aea09cbbc910c16 code: [here](https://hastebin.com/nokahinuye.py)) while trying to design a more elegant implementation without the need for a new method.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
