### PR TITLE
[tasks] set internal task to None after canceling

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -132,6 +132,7 @@ class Loop:
         """Cancels the internal task, if any are running."""
         if self._task:
             self._task.cancel()
+            self._task = None
 
     def add_exception_type(self, exc):
         r"""Adds an exception type to be handled during the reconnect logic.


### PR DESCRIPTION
### Summary

This allows for 

```python
Loop.cancel()
Loop.start()
```

Previously it would raise the RuntimeError from `.start()`.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
