### PR TITLE
[tasks] Add Loop.restart()

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -133,6 +133,21 @@ class Loop:
         if self._task:
             self._task.cancel()
 
+    def restart(self, *args, **kwargs):
+        """A convenience method to cancel, and then start another internal task.
+
+        This is also technically an alias to :meth:`.Loop.start`.
+
+        This is equivalent to:
+
+        .. code-block:: python3
+
+            Loop.cancel()
+            Loop.start(*args, **kwargs)
+        """
+        self.cancel()
+        self.start(*args, **kwargs)
+
     def add_exception_type(self, exc):
         r"""Adds an exception type to be handled during the reconnect logic.
 

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -146,7 +146,7 @@ class Loop:
             Loop.start(*args, **kwargs)
         """
         self.cancel()
-        self.start(*args, **kwargs)
+        return self.start(*args, **kwargs)
 
     def add_exception_type(self, exc):
         r"""Adds an exception type to be handled during the reconnect logic.


### PR DESCRIPTION
### Summary

It's a convenience method to cancel and then restart a Loop. Doubles as a `Loop.start()` alias.

Heavily relies on #2074 being merged. 😜 

Documentation phrasing criticism is welcome. _I may not have gotten the Sphinx linking correct._

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
