### PR TITLE
Change slowmode max value in docs

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -200,7 +200,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             category.
         slowmode_delay: :class:`int`
             Specifies the slowmode rate limit for user in this channel. A value of
-            `0` disables slowmode. The maximum value possible is `120`.
+            `0` disables slowmode. The maximum value possible is `21600`.
         reason: Optional[:class:`str`]
             The reason for editing this channel. Shows up on the audit log.
 


### PR DESCRIPTION
### Summary
The documentation for `TextChannel.edit()` says 120 is the maximum value for slowmode_delay. However, according to discordapp/discord-api-docs#918 ( and my PTB ) 21600 is the new maximum value.

This PR changes that documentation.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
