### PR TITLE
Bool fix in TextChannel.purge documentation

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -308,7 +308,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             Same as ``around`` in :meth:`history`.
         oldest_first
             Same as ``oldest_first`` in :meth:`history`.
-        bulk: class:`bool`
+        bulk: :class:`bool`
             If True, use bulk delete. bulk=False is useful for mass-deleting
             a bot's own messages without manage_messages. When True, will fall
             back to single delete if current account is a user bot, or if


### PR DESCRIPTION
### Summary

This PR fixes a missed ``:`` in TextChannel.purge documentation when trying to "hyperlink" ``bool``.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
