### PR TITLE
Add MessageConverter to the command converters

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -31,7 +31,7 @@ import discord
 
 from .errors import BadArgument, NoPrivateMessage
 
-__all__ = ['Converter', 'MemberConverter', 'UserConverter',
+__all__ = ['Converter', 'MemberConverter', 'UserConverter', 'MessageConverter'
            'TextChannelConverter', 'InviteConverter', 'RoleConverter',
            'GameConverter', 'ColourConverter', 'VoiceChannelConverter',
            'EmojiConverter', 'PartialEmojiConverter', 'CategoryChannelConverter',

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -169,7 +169,7 @@ class MessageConverter(IDConverter):
     3. Lookup by message ID (the message **must** be in the context channel)
     """
 
-    async def convert(self, ctx, argument: str) -> discord.Message:
+    async def convert(self, ctx, argument):
         """|coro|
 
         The method to override to do conversion logic.

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -159,7 +159,7 @@ class UserConverter(IDConverter):
 
         return result
 
-class MessageConverter(discord.ext.commands.converter.IDConverter):
+class MessageConverter(IDConverter):
     """Converts to a :class:`discord.Message`.
 
     The lookup strategu is as follows (in order):

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -162,29 +162,14 @@ class UserConverter(IDConverter):
 class MessageConverter(IDConverter):
     """Converts to a :class:`discord.Message`.
 
-    The lookup strategu is as follows (in order):
+    The lookup strategy is as follows (in order):
 
     1. Lookup by "{channel ID}-{message ID}" (got by shift-clicking on "Copy ID")
-    2. Lookup by message URI
-    3. Lookup by message ID (the message **must** be in the context channel)
+    2. Lookup by message ID (the message **must** be in the context channel)
+    3. Lookup by message URL
     """
 
     async def convert(self, ctx, argument):
-        """|coro|
-
-        The method to override to do conversion logic.
-
-        If an error is found while converting, it is recommended to
-        raise a :exc:`.CommandError` derived exception as it will
-        properly propagate to the error handlers.
-
-        Parameters
-        -----------
-        ctx: :class:`.Context`
-            The invocation context that the argument is being used in.
-        argument: :class:`str`
-            The argument that is being converted.
-        """
         if len(argument.split()) > 1:
             raise BadArgument("The message must be an ID or an URI.")
         exception = BadArgument('Message "{msg}" not found.'.format(msg=argument))

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -164,59 +164,35 @@ class MessageConverter(IDConverter):
 
     The lookup strategy is as follows (in order):
 
-    1. Lookup by "{channel ID}-{message ID}" (got by shift-clicking on "Copy ID")
+    1. Lookup by "{channel ID}-{message ID}" (retrieved by shift-clicking on "Copy ID")
     2. Lookup by message ID (the message **must** be in the context channel)
     3. Lookup by message URL
     """
 
     async def convert(self, ctx, argument):
-        prog = re.compile(r'^(?:(?P<channel_id>[0-9]{15,21})-)?(?P<message_id>[0-9]{15,21})$')
-        match = prog.match(argument)
-        if match:
-            message_id = int(match.group("message_id"))
-            message = ctx.bot._connection._get_message(message_id)
-            if message:
-                return message
-            channel_id = match.group("channel_id")
-            if channel_id:
-                channel = ctx.bot.get_channel(int(channel_id))
-                if not channel:
-                    raise BadArgument('Channel "{channel}" not found.'.format(channel=channel_id))
-                try:
-                    message = await channel.fetch_message(message_id)
-                except discord.errors.NotFound:
-                    raise BadArgument('Message "{msg}" not found.'.format(msg=argument))
-                except discord.errors.Forbidden:
-                    raise BadArgument("Can't read messages in {channel}".format(channel=channel.mention))
-            else:
-                channel = ctx.channel
-                try:
-                    message = await channel.fetch_message(message_id)
-                except discord.errors.NotFound:
-                    raise BadArgument('Message "{msg}" not found.'.format(msg=argument))
-        else:
-            prog = re.compile(
-                r'^https?://(?:(ptb|canary)\.)?discordapp\.com/channels/'
-                r'(?P<guild_id>[0-9]{15,21})/(?P<channel_id>[0-9]{15,21})/(?P<message_id>[0-9]{15,21})$'
-            )
-            match = prog.match(argument)
-            if not match:
-                raise BadArgument('Message "{msg}" not found'.format(msg=argument))
-            channel_id = int(match.group("channel_id"))
-            message_id = int(match.group("message_id"))
-            message = ctx.bot._connection._get_message(message_id)
-            if message:
-                return message
-            channel = ctx.bot.get_channel(int(match.group("channel_id")))
-            if not channel:
-                BadArgument('Message "{msg}" not found'.format(msg=argument))
-            try:
-                message = await channel.fetch_message(message_id)
-            except discord.errors.NotFound:
-                BadArgument('Message "{msg}" not found'.format(msg=argument))
-            except discord.errors.Forbidden:
-                raise BadArgument("Can't read messages in {channel}".format(channel=channel.mention))
-        return message
+        id_regex = re.compile(r'^(?:(?P<channel_id>[0-9]{15,21})-)?(?P<message_id>[0-9]{15,21})$')
+        link_regex = re.compile(
+            r'^https?://(?:(ptb|canary)\.)?discordapp\.com/channels/'
+            r'(?:([0-9]{15,21})|(@me))'
+            r'/(?P<channel_id>[0-9]{15,21})/(?P<message_id>[0-9]{15,21})$'
+        )
+        match = id_regex.match(argument) or link_regex.match(argument)
+        if not match:
+            raise BadArgument('Message "{msg}" not found.'.format(msg=argument))
+        message_id = int(match.group("message_id"))
+        channel_id = match.group("channel_id")
+        message = ctx.bot._connection._get_message(message_id)
+        if message:
+            return message
+        channel = ctx.bot.get_channel(int(channel_id)) if channel_id else ctx.channel
+        if not channel:
+            raise BadArgument('Channel "{channel}" not found.'.format(channel=channel_id))
+        try:
+            return await channel.fetch_message(message_id)
+        except discord.errors.NotFound:
+            raise BadArgument('Message "{msg}" not found.'.format(msg=argument))
+        except discord.errors.Forbidden:
+            raise BadArgument("Can't read messages in {channel}".format(channel=channel.mention))
 
 class TextChannelConverter(IDConverter):
     """Converts to a :class:`TextChannel`.

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -31,7 +31,7 @@ import discord
 
 from .errors import BadArgument, NoPrivateMessage
 
-__all__ = ['Converter', 'MemberConverter', 'UserConverter', 'MessageConverter'
+__all__ = ['Converter', 'MemberConverter', 'UserConverter', 'MessageConverter',
            'TextChannelConverter', 'InviteConverter', 'RoleConverter',
            'GameConverter', 'ColourConverter', 'VoiceChannelConverter',
            'EmojiConverter', 'PartialEmojiConverter', 'CategoryChannelConverter',
@@ -170,6 +170,21 @@ class MessageConverter(IDConverter):
     """
 
     async def convert(self, ctx, argument: str) -> discord.Message:
+        """|coro|
+
+        The method to override to do conversion logic.
+
+        If an error is found while converting, it is recommended to
+        raise a :exc:`.CommandError` derived exception as it will
+        properly propagate to the error handlers.
+
+        Parameters
+        -----------
+        ctx: :class:`.Context`
+            The invocation context that the argument is being used in.
+        argument: :class:`str`
+            The argument that is being converted.
+        """
         if len(argument.split()) > 1:
             raise BadArgument("The message must be an ID or an URI.")
         exception = BadArgument('Message "{msg}" not found.'.format(msg=argument))

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -183,7 +183,7 @@ class MessageConverter(IDConverter):
             if not channel:
                 raise exception
             try:
-                message = await channel.get_message(message_id)
+                message = await channel.fetch_message(message_id)
             except discord.errors.NotFound:
                 raise exception
             except discord.errors.Forbidden:
@@ -203,7 +203,7 @@ class MessageConverter(IDConverter):
             if not channel:
                 raise exception
             try:
-                message = await channel.get_message(int(message_id.group(1)))
+                message = await channel.fetch_message(int(message_id.group(1)))
             except discord.errors.NotFound:
                 raise exception
             except discord.errors.Forbidden:
@@ -211,7 +211,7 @@ class MessageConverter(IDConverter):
         else:
             channel = ctx.channel
             try:
-                message = await channel.get_message(int(argument))
+                message = await channel.fetch_message(int(argument))
             except KeyError:
                 raise exception
             except discord.errors.NotFound:

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -168,6 +168,9 @@ Converters
 .. autoclass:: discord.ext.commands.UserConverter
     :members:
 
+.. autoclass:: discord.ext.commands.MessageConverter
+    :members:
+
 .. autoclass:: discord.ext.commands.TextChannelConverter
     :members:
 


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR adds a message converter to easily get a message object from 3 possible ways:
- Use the combo {channel ID}-{message ID} (you can get this by shift-clicking on "Copy ID" on a message)
- Use the message link
- Use the single message ID (in this case, the context channel will be used)

If one of these matches, a `discord.Message` object is returned.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
