### PR TITLE
add read-only cached_messages property to Client

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -228,6 +228,14 @@ class Client:
         return self._connection.emojis
 
     @property
+    def cached_messages(self):
+        """Sequence[:class:`~discord.Message`]: Read-only list of messages the connected client has cached.
+
+        .. versionadded:: 1.1.0
+        """
+        return utils.SequenceProxy(self._connection._messages)
+
+    @property
     def private_channels(self):
         """List[:class:`abc.PrivateChannel`]: The private channels that the connected client is participating on.
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -26,6 +26,7 @@ DEALINGS IN THE SOFTWARE.
 
 import array
 import asyncio
+import collections.abc
 import unicodedata
 from base64 import b64encode
 from bisect import bisect_left
@@ -77,6 +78,32 @@ def cached_slot_property(name):
     def decorator(func):
         return CachedSlotProperty(name, func)
     return decorator
+
+class SequenceProxy(collections.abc.Sequence):
+    """Read-only proxy of a Sequence."""
+    def __init__(self, proxied):
+        self.__proxied = proxied
+
+    def __getitem__(self, idx):
+        return self.__proxied[idx]
+
+    def __len__(self):
+        return len(self.__proxied)
+
+    def __contains__(self, item):
+        return item in self.__proxied
+
+    def __iter__(self):
+        return iter(self.__proxied)
+
+    def __reversed__(self):
+        return reversed(self.__proxied)
+
+    def index(self, value, *args, **kwargs):
+        return self.__proxied.index(value, *args, **kwargs)
+
+    def count(self, value):
+        return self.__proxied.count(value)
 
 def parse_time(timestamp):
     if timestamp:

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -206,8 +206,6 @@ A list of these changes is enumerated below.
 +---------------------------------------+------------------------------------------------------------------------------+
 | ``Client.wait_until_login``           | Removed                                                                      |
 +---------------------------------------+------------------------------------------------------------------------------+
-| ``Client.messages``                   | Removed                                                                      |
-+---------------------------------------+------------------------------------------------------------------------------+
 | ``Client.wait_until_ready``           | No change                                                                    |
 +---------------------------------------+------------------------------------------------------------------------------+
 
@@ -329,6 +327,10 @@ They will be enumerated here.
 - ``Client.get_all_emojis``
 
     - Use :attr:`Client.emojis` instead.
+
+` ``Client.messages``
+
+    - Use read-only :attr:`Client.cached_messages` instead.
 
 - ``Client.wait_for_message`` and ``Client.wait_for_reaction`` are gone.
 


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
For those of us who want access to this sweet trove of zero hop messages

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
