### PR TITLE
Document remaining public enums.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -940,23 +940,6 @@ All enumerations are subclasses of `enum`_.
         a presence a la :meth:`Client.change_presence`. When you receive a
         user's presence this will be :attr:`offline` instead.
 
-.. class:: RelationshipType
-
-    Specifies the type of :class:`Relationship`
-
-    .. attribute:: friend
-
-        You are friends with this user.
-    .. attribute:: blocked
-
-        You have blocked this user.
-    .. attribute:: incoming_request
-
-        The user has sent you a friend request.
-    .. attribute:: outgoing_request
-
-        You have sent a friend request to this user.
-
 
 .. class:: AuditLogAction
 
@@ -1366,10 +1349,39 @@ All enumerations are subclasses of `enum`_.
         The action is the update of something.
 
 
+.. class:: RelationshipType
+
+    Specifies the type of :class:`Relationship`.
+
+    .. note::
+
+        This only applies to users, *not* bots.
+
+    .. attribute:: friend
+
+        You are friends with this user.
+
+    .. attribute:: blocked
+
+        You have blocked this user.
+
+    .. attribute:: incoming_request
+
+        The user has sent you a friend request.
+
+    .. attribute:: outgoing_request
+
+        You have sent a friend request to this user.
+
+
 .. class:: UserContentFilter
 
     Represents the options found in ``Settings > Privacy & Safety > Safe Direct Messaging``
     in the Discord client.
+
+    .. note::
+
+        This only applies to users, *not* bots.
 
     .. attribute:: all_messages
 
@@ -1388,6 +1400,10 @@ All enumerations are subclasses of `enum`_.
 
     Represents the options found in ``Settings > Privacy & Safety > Who Can Add You As A Friend``
     in the Discord client.
+
+    .. note::
+
+        This only applies to users, *not* bots.
 
     .. attribute:: noone
 
@@ -1414,6 +1430,10 @@ All enumerations are subclasses of `enum`_.
 
     Represents the user's Discord Nitro subscription type.
 
+    .. note::
+
+        This only applies to users, *not* bots.
+
     .. attribute:: nitro
 
         Represents the Discord Nitro with Nitro-exclusive games.
@@ -1426,6 +1446,10 @@ All enumerations are subclasses of `enum`_.
 .. class:: Theme
 
     Represents the theme synced across all Discord clients.
+
+    .. note::
+
+        This only applies to users, *not* bots.
 
     .. attribute:: light
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1366,6 +1366,75 @@ All enumerations are subclasses of `enum`_.
         The action is the update of something.
 
 
+.. class:: UserContentFilter
+
+    Represents the options found in ``Settings > Privacy & Safety > Safe Direct Messaging``
+    in the Discord client.
+
+    .. attribute:: all_messages
+
+        Scan all direct messages from everyone.
+
+    .. attribute:: friends
+
+        Scan all direct messages that aren't from friends.
+
+    .. attribute:: disabled
+
+        Don't scan any direct messages.
+
+
+.. class:: FriendFlags
+
+    Represents the options found in ``Settings > Privacy & Safety > Who Can Add You As A Friend``
+    in the Discord client.
+
+    .. attribute:: noone
+
+        This allows no-one to add you as a friend.
+
+    .. attribute:: mutual_guilds
+
+        This allows guild members to add you as a friend.
+
+    .. attribute:: mutual_friends
+
+        This allows friends of friends to add you as a friend.
+
+    .. attribute:: guild_and_friends
+
+        This is a superset of :attr:`mutual_guilds` and :attr:`mutual_friends`.
+
+    .. attribute:: everyone
+
+        This allows everyone to add you as a friend.
+
+
+.. class:: PremiumType
+
+    Represents the user's Discord Nitro subscription type.
+
+    .. attribute:: nitro
+
+        Represents the Discord Nitro with Nitro-exclusive games.
+
+    .. attribute:: nitro_classic
+
+        Represents the Discord Nitro with no Nitro-exclusive games.
+
+
+.. class:: Theme
+
+    Represents the theme synced across all Discord clients.
+
+    .. attribute:: light
+
+        Represents the Light theme on Discord.
+
+    .. attribute:: dark
+
+        Represents the Dark theme on Discord.
+
 
 Async Iterator
 ----------------


### PR DESCRIPTION
### Summary

I have documented the remaining public enums, which are:

- UserContentFilter
- FriendFlags
- PremiumType
- Theme

UserFlags is not documented as though it is only used internally.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
