### PR TITLE
Change activity images to Asset

### DIFF
--- a/discord/asset.py
+++ b/discord/asset.py
@@ -95,6 +95,20 @@ class Asset:
         return cls(state, url)
 
     @classmethod
+    def _from_activity(cls, state, application_id, size, available_assets):
+        if application_id is None:
+            return cls(state)
+
+        url = 'https://cdn.discordapp.com/app-assets/{0}/{1}.png'
+
+        try:
+            image = available_assets['{0}_image'.format(size)]
+        except KeyError:
+            return cls(state)
+
+        return cls(state, url.format(application_id, image))
+
+    @classmethod
     def _from_guild_image(cls, state, id, hash, key, *, format='webp', size=1024):
         if not utils.valid_icon_size(size):
             raise InvalidArgument("size must be a power of 2 between 16 and 4096")

--- a/discord/client.py
+++ b/discord/client.py
@@ -582,7 +582,7 @@ class Client:
     @property
     def activity(self):
         """Optional[Union[:class:`.Activity`, :class:`.Game`, :class:`.Streaming`]]: The activity being used upon logging in."""
-        return create_activity(self._connection._activity)
+        return create_activity(self._connection._activity, self._connection)
 
     @activity.setter
     def activity(self, value):

--- a/discord/member.py
+++ b/discord/member.py
@@ -160,7 +160,7 @@ class Member(discord.abc.Messageable, _BaseUser):
         self._client_status = {
             None: 'offline'
         }
-        self.activities = tuple(map(create_activity, data.get('activities', [])))
+        self.activities = tuple(map(lambda a: create_activity(a, self._state), data.get('activities', [])))
         self.nick = data.get('nick', None)
 
     def __str__(self):
@@ -235,7 +235,7 @@ class Member(discord.abc.Messageable, _BaseUser):
         self._update_roles(data)
 
     def _presence_update(self, data, user):
-        self.activities = tuple(map(create_activity, data.get('activities', [])))
+        self.activities = tuple(map(lambda a: create_activity(a, self._state), data.get('activities', [])))
         self._client_status = {
             key: value
             for key, value in data.get('client_status', {}).items()


### PR DESCRIPTION
### Summary

This changes the behaviour of:

- `Activity.large_image_url` (moved to classmethod: `Asset._from_activity`)
- `Activity.small_image_url` (moved to classmethod: `Asset._from_activity`)
- `Spotify.album_cover_url`

to follow the consistent returns type of `Asset`.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
