### PR TITLE
Parse message links

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -29,7 +29,6 @@ from collections import namedtuple
 import logging
 import signal
 import sys
-import re
 import traceback
 
 import aiohttp

--- a/discord/client.py
+++ b/discord/client.py
@@ -982,7 +982,7 @@ class Client:
     async def fetch_url_message(self, url: str):
         """|coro|
 
-        Retrieves a :class:`Message` from a URL.
+        Retrieves a :class:`.Message` from a jump URL.
         If channel or message is not found, returns ``None``.
 
         Parameters

--- a/discord/client.py
+++ b/discord/client.py
@@ -983,7 +983,7 @@ class Client:
         """|coro|
 
         Retrieves a :class:`Message` from a URL.
-        If channel is not found, returns None.
+        If channel or message is not found, returns None.
 
         Parameters
         -----------

--- a/discord/client.py
+++ b/discord/client.py
@@ -994,8 +994,6 @@ class Client:
         -------
         ValueError
             The URL does not match any recognized format.
-        :exc:`.NotFound`
-            The specified message was not found.
         :exc:`.Forbidden`
             You do not have the permissions required to get a message.
         :exc:`.HTTPException`
@@ -1010,7 +1008,10 @@ class Client:
         message_channel = self.get_channel(int(channel_id))
         if message_channel is None:
             return None
-        return await message_channel.fetch_message(int(message_id))
+        try:
+            return await message_channel.fetch_message(int(message_id))
+        except NotFound:
+            return None
 
     # Invite management
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -979,7 +979,7 @@ class Client:
         data = await self.http.create_guild(name, region, icon)
         return Guild(data=data, state=self._connection)
 
-    async def fetch_url_message(self, url: str):
+    async def fetch_message_from_url(self, url: str):
         """|coro|
 
         Retrieves a :class:`.Message` from a jump URL.

--- a/discord/client.py
+++ b/discord/client.py
@@ -979,6 +979,39 @@ class Client:
         data = await self.http.create_guild(name, region, icon)
         return Guild(data=data, state=self._connection)
 
+    async def fetch_url_message(self, url: str):
+        """|coro|
+
+        Retrieves a :class:`Message` from a URL.
+        If channel is not found, returns None.
+
+        Parameters
+        -----------
+        url: :class:`str`
+            The message URL (message link).
+
+        Raises
+        -------
+        ValueError
+            The URL does not match any recognized format.
+        :exc:`.NotFound`
+            The specified message was not found.
+        :exc:`.Forbidden`
+            You do not have the permissions required to get a message.
+        :exc:`.HTTPException`
+            Retrieving the message failed.
+
+        Returns
+        -------
+        :class:`.Message`
+            The message referenced by the URL.
+        """
+        channel_id, message_id = url.split(r"/")[-2:]
+        message_channel = self.get_channel(int(channel_id))
+        if message_channel is None:
+            return None
+        return await message_channel.fetch_message(int(message_id))
+
     # Invite management
 
     async def fetch_invite(self, url, *, with_counts=True):

--- a/discord/client.py
+++ b/discord/client.py
@@ -1002,7 +1002,7 @@ class Client:
         Returns
         -------
         :class:`.Message`
-            The message referenced by the URL.
+            The message referenced by the jump URL.
         """
         channel_id, message_id = url.split(r"/")[-2:]
         message_channel = self.get_channel(int(channel_id))

--- a/discord/client.py
+++ b/discord/client.py
@@ -983,7 +983,7 @@ class Client:
         """|coro|
 
         Retrieves a :class:`Message` from a URL.
-        If channel or message is not found, returns None.
+        If channel or message is not found, returns ``None``.
 
         Parameters
         -----------

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -30,6 +30,7 @@ import inspect
 import discord
 
 from .errors import BadArgument, NoPrivateMessage
+from discord.errors import Forbidden, HTTPException
 
 __all__ = ['Converter', 'MemberConverter', 'UserConverter',
            'TextChannelConverter', 'InviteConverter', 'RoleConverter',
@@ -405,6 +406,22 @@ class PartialEmojiConverter(Converter):
                                                    id=emoji_id)
 
         raise BadArgument('Couldn\'t convert "{}" to PartialEmoji.'.format(argument))
+
+class MessageConverter(Converter):
+    """Converts a jump URL to a :class:`Message`
+
+    This is done by extracting the guild_id, channel_id, and message_id from
+    a jump URL, taking into account any jump URL special cases.
+    """
+    async def convert(self, ctx, argument):
+        try:
+            return await ctx.bot.fetch_message_from_url(argument)
+        except ValueError:
+            raise BadArgument("Jump URL does not match any known format")
+        except HTTPException:
+            raise BadArgument("Retrieving the message failed")
+        except Forbidden:
+            raise BadArgument("Lack permissions to retrieve message")
 
 class clean_content(Converter):
     """Converts the argument to mention scrubbed version of


### PR DESCRIPTION
### Summary

This is a rewrite of https://github.com/Rapptz/discord.py/pull/2064. It aims to fix the issues presented there.

"Jump URL" refers to a message link (https://discordapp.com/channels/336642139381301249/381974649019432981/381976391303823360).

PR additions:
parse_jump_url method: Parses a jump URL and returns a tuple of (guild_id, channel_id, message_id)
fetch_message_from_url method: Returns a message object from a jump URL
MessageConverter: Converter for messages, which returns a message from a jump URL argument.

Updates:

As pointed out by @Vexs, there is a special case where replacing message_id with 0 will be treated as the first message in a channel. Discord does not have any public documentation on special cases with message links, but more special cases may come up in the future. For the special case with 0, as well as in order to support future special cases, the client method to retrieve the Message object will be included in addition to the parser, since it will take care of special cases.

Sometimes the guildID will match the channelID in a jump URL. However, in cases like this, get_guild will still accept the channel ID, so no additional steps must be taken.

Retrieving the first message (using the special 0 case) will take quite a long time if the channel has many messages. It may be desired to ignore this special case to avoid long requests; thoughts?

As requested by some reviewers, the netloc of the URL must match discordapp.com else a ValueError will be raised. I am personally of the opinion that this should not be checked, as it is unlikely to be confused if the rest of the format matches, and will invalidate future alias URLs. 

Casing for "channel" (/channel/...) is ignored, since incorrect casing will work on the client. Incorrect casing WILL fail off-client (on browsers) most of the time, but I believe "Channel" is a typo that should be allowed to pass.

As requested by @Gorialis, the method will return None regardless of what ID it failed to retrieve (guild, channel, message)

As requested by @NCPlayz, the method has been renamed to fetch_message_from_url for clarity, and the URL is referred to as both "message link" and "jump URL" to make it easy to find.

discord.com is not included as a valid network location for a jump link. This is because it will redirect to discordapp.com, but will not do so in-client. If anyone disagrees with this, it can certainly be changed.

Please let me know if you have any issues with it! 

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
