### PR TITLE
Add delay kwarg to message.delete()

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -784,13 +784,7 @@ class Messageable(metaclass=abc.ABCMeta):
 
         ret = state.create_message(channel=channel, data=data)
         if delete_after is not None:
-            async def delete():
-                await asyncio.sleep(delete_after, loop=state.loop)
-                try:
-                    await ret.delete()
-                except HTTPException:
-                    pass
-            asyncio.ensure_future(delete(), loop=state.loop)
+            await ret.delete(delay=delete_after)
         return ret
 
     async def trigger_typing(self):

--- a/discord/message.py
+++ b/discord/message.py
@@ -563,7 +563,7 @@ class Message:
             else:
                 return '{0.author.name} started a call \N{EM DASH} Join the call.'.format(self)
 
-    async def delete(self, delay=None):
+    async def delete(self, *, delay=None):
         """|coro|
 
         Deletes the message.

--- a/discord/message.py
+++ b/discord/message.py
@@ -563,7 +563,7 @@ class Message:
             else:
                 return '{0.author.name} started a call \N{EM DASH} Join the call.'.format(self)
 
-    async def delete(self):
+    async def delete(self, delay=None):
         """|coro|
 
         Deletes the message.
@@ -572,6 +572,12 @@ class Message:
         delete other people's messages, you need the :attr:`~Permissions.manage_messages`
         permission.
 
+        Parameters
+        -----------
+        delay: Optional[:class:`float`]
+            If provided, the number of seconds to wait in the background
+            before deleting the message.
+
         Raises
         ------
         Forbidden
@@ -579,7 +585,17 @@ class Message:
         HTTPException
             Deleting the message failed.
         """
-        await self._state.http.delete_message(self.channel.id, self.id)
+        if delay is not None:
+            async def delete():
+                await asyncio.sleep(delay, loop=self._state.loop)
+                try:
+                    await self._state.http.delete_message(self.channel.id, self.id)
+                except HTTPException:
+                    pass
+
+            asyncio.ensure_future(delete(), loop=self._state.loop)
+        else:
+            await self._state.http.delete_message(self.channel.id, self.id)
 
     async def edit(self, **fields):
         """|coro|
@@ -632,14 +648,7 @@ class Message:
             pass
         else:
             if delete_after is not None:
-                async def delete():
-                    await asyncio.sleep(delete_after, loop=self._state.loop)
-                    try:
-                        await self._state.http.delete_message(self.channel.id, self.id)
-                    except HTTPException:
-                        pass
-
-                asyncio.ensure_future(delete(), loop=self._state.loop)
+                await self.delete(delay=delete_after)
 
     async def pin(self):
         """|coro|


### PR DESCRIPTION
### Summary

This PR adds a `delay` kwarg to message.delete that delays the deletion of a message while yielding back to the event loop. This is the same behavior used in `delete_after` kwargs, but for more generic usage. It also refactors existing `delete_after` behaviors to use the new kwarg. 

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
