### PR TITLE
Add support for <:name:id> format for adding reactions

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -764,7 +764,9 @@ class Message:
         if isinstance(emoji, PartialEmoji):
             return emoji._as_reaction()
         if isinstance(emoji, str):
-            return emoji # this is okay
+            # Reactions can be in :name:id format, but not <:name:id>.
+            # No existing emojis have <> in them, so this should be okay.
+            return emoji.strip('<>')
 
         raise InvalidArgument('emoji argument must be str, Emoji, or Reaction not {.__class__.__name__}.'.format(emoji))
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -164,7 +164,7 @@ Quick example: ::
 In case you want to use emoji that come from a message, you already get their code points in the content without needing
 to do anything special. You **cannot** send ``':thumbsup:'`` style shorthands.
 
-For custom emoji, you should pass an instance of :class:`Emoji`. You can also pass a ``'name:id'`` string, but if you
+For custom emoji, you should pass an instance of :class:`Emoji`. You can also pass a ``'<:name:id>'`` string, but if you
 can use said emoji, you should be able to use :meth:`Client.get_emoji` to get an emoji via ID or use :func:`utils.find`/
 :func:`utils.get` on :attr:`Client.emojis` or :attr:`Guild.emojis` collections.
 
@@ -184,7 +184,7 @@ Quick example: ::
         await message.add_reaction(emoji)
 
     # if you have the name and ID of a custom emoji:
-    emoji = 'python3:232720527448342530'
+    emoji = '<:python3:232720527448342530>'
     await message.add_reaction(emoji)
 
 How do I pass a coroutine to the player's "after" function?


### PR DESCRIPTION
### Summary

This PR adds support for <:name:id> format in add_reaction.
It naively strips <> chars from the beginning and end, but no existing emojis have this, and custom emojis can't have <> in their name at all, much less at the beginning and end of the <:name:id> string. 

As a note, discord accepts reactions with or without the leading `:`, so `:name:id` and `a:name:id` are perfectly acceptable. 

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
