### PR TITLE
Make Guild.features a frozenset

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -113,8 +113,8 @@ class Guild(Hashable):
         The guild's explicit content filter.
     default_notifications: :class:`NotificationLevel`
         The guild's notification settings.
-    features: List[:class:`str`]
-        A list of features that the guild has. They are currently as follows:
+    features: FrozenSet[:class:`str`]
+        A unique set of features that the guild has. They are currently as follows:
 
         - ``VIP_REGIONS``: Guild has VIP voice regions
         - ``VANITY_URL``: Guild has a vanity invite URL (e.g. discord.gg/discord-api)
@@ -231,7 +231,7 @@ class Guild(Hashable):
 
         self.mfa_level = guild.get('mfa_level')
         self.emojis = tuple(map(lambda d: state.store_emoji(self, d), guild.get('emojis', [])))
-        self.features = guild.get('features', [])
+        self.features = frozenset(guild.get('features', []))
         self.splash = guild.get('splash')
         self._system_channel_id = utils._get_as_snowflake(guild, 'system_channel_id')
         self.description = guild.get('description')


### PR DESCRIPTION
### Summary

The most frequent use-case for Guild.features is containment checks, which are slow on a list.
The API does not guarantee any order for guild features anyway, so it's unlikely that anyone would use indexing on this list, making it unlikely to be a breaking change.
Additionally, using a set eases use cases such as the following, which checks if a given guild is partnered:

```py
def is_partnered(guild):
	partnered_features = {'VIP_REGIONS', 'VANITY_URL', 'INVITE_SPLASH'}
	return guild.features.issuperset(partnered_features)
```

Finally, a frozenset is used instead of a set because it should not be modified. I am open to feedback on whether this should be a set instead. `GroupMixin.commands` already uses a regular set, however, that set is copied from an existing dict values view, so mutating it would have no lasting effect.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
