### PR TITLE
Implement "Partial Messages"

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -29,7 +29,7 @@ from .channel import *
 from .guild import Guild
 from .relationship import Relationship
 from .member import Member, VoiceState
-from .message import Message, Attachment
+from .message import Message, Attachment, PartialMessage
 from .asset import Asset
 from .errors import *
 from .calls import CallMessage, GroupCall

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -854,7 +854,7 @@ class Messageable(metaclass=abc.ABCMeta):
         data = await self._state.http.get_message(channel.id, id)
         return self._state.create_message(channel=channel, data=data)
 
-    async def create_partial_message(self, id):
+    def create_partial_message(self, id):
         """|coro|
         Creates a single :class:`PartialMessage` from the destination.
 
@@ -870,8 +870,7 @@ class Messageable(metaclass=abc.ABCMeta):
         """
         # Avoid circular import
         from .message import PartialMessage
-        channel = await self._get_channel()
-        return PartialMessage(state=self._state, channel_id=channel.id, message_id=id)
+        return PartialMessage(messageable=self, message_id=id)
 
     async def pins(self):
         """|coro|

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -32,6 +32,7 @@ from collections import namedtuple
 from .iterators import HistoryIterator
 from .context_managers import Typing
 from .errors import InvalidArgument, ClientException, HTTPException
+from .message import PartialMessage
 from .permissions import PermissionOverwrite, Permissions
 from .role import Role
 from .invite import Invite
@@ -853,6 +854,24 @@ class Messageable(metaclass=abc.ABCMeta):
         channel = await self._get_channel()
         data = await self._state.http.get_message(channel.id, id)
         return self._state.create_message(channel=channel, data=data)
+
+    async def create_partial_message(self, id):
+        """|coro|
+        Creates a single :class:`PartialMessage` from the destination.
+
+        Parameters
+        ------------
+        id: :class:`int`
+            The message ID to create a partial message for.
+
+        Returns
+        --------
+        :class:`PartialMessage`
+            The PartialMessage created.
+        """
+
+        channel = await self._get_channel()
+        return PartialMessage(state=self._state, channel_id=channel.id, message_id=id)
 
     async def pins(self):
         """|coro|

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -32,7 +32,6 @@ from collections import namedtuple
 from .iterators import HistoryIterator
 from .context_managers import Typing
 from .errors import InvalidArgument, ClientException, HTTPException
-from .message import PartialMessage
 from .permissions import PermissionOverwrite, Permissions
 from .role import Role
 from .invite import Invite
@@ -869,7 +868,8 @@ class Messageable(metaclass=abc.ABCMeta):
         :class:`PartialMessage`
             The PartialMessage created.
         """
-
+        # Avoid circular import
+        from .message import PartialMessage
         channel = await self._get_channel()
         return PartialMessage(state=self._state, channel_id=channel.id, message_id=id)
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -128,7 +128,7 @@ def resolve_destination(coro):
     @wraps(coro)
     async def wrapped(self, *args, **kwargs):
         if self.channel is None:
-            self.channel = await self._messageable._get_channel()
+            self.channel = await self.messageable._get_channel()
         return await coro(self, *args, **kwargs)
     return wrapped
 
@@ -138,12 +138,19 @@ class PartialMessage:
     :class:`Message` object.
 
     These can be created with :meth:`abc.Messageable.create_partial_message`
+
+    Attributes
+    -----------
+    messageable: :class:`abc.Messageable`
+        The Messageable containing the message to be represented.
+    message_id: :class:`int`
+        The ID of the message represented.
     """
 
     def __init__(self, *, messageable, message_id):
         self._state = messageable._state
         self.channel = None
-        self._messageable = messageable
+        self.messageable = messageable
         self.id = message_id
 
     @resolve_destination

--- a/discord/message.py
+++ b/discord/message.py
@@ -37,7 +37,6 @@ from .calls import CallMessage
 from .enums import MessageType, try_enum
 from .errors import InvalidArgument, ClientException, HTTPException
 from .embeds import Embed
-from .object import Object
 from .member import Member
 
 class Attachment:

--- a/discord/message.py
+++ b/discord/message.py
@@ -137,7 +137,7 @@ class PartialMessage:
     For use when you have a message and channel ID, but do not have a readily available
     :class:`Message` object.
 
-    These should be created with :meth:`abc.Messageable.create_partial_message`
+    These can be created with :meth:`abc.Messageable.create_partial_message`
     """
 
     def __init__(self, *, messageable, message_id):

--- a/discord/user.py
+++ b/discord/user.py
@@ -301,6 +301,10 @@ class ClientUser(BaseUser):
     def get_relationship(self, user_id):
         """Retrieves the :class:`Relationship` if applicable.
 
+        .. note::
+
+            This only applies to non-bot accounts.
+
         Parameters
         -----------
         user_id: :class:`int`
@@ -315,17 +319,32 @@ class ClientUser(BaseUser):
 
     @property
     def relationships(self):
-        """Returns a :class:`list` of :class:`Relationship` that the user has."""
+        """Returns a :class:`list` of :class:`Relationship` that the user has.
+
+        .. note::
+
+            This only applies to non-bot accounts.
+        """
         return list(self._relationships.values())
 
     @property
     def friends(self):
-        r"""Returns a :class:`list` of :class:`User`\s that the user is friends with."""
+        r"""Returns a :class:`list` of :class:`User`\s that the user is friends with.
+
+        .. note::
+
+            This only applies to non-bot accounts.
+        """
         return [r.user for r in self._relationships.values() if r.type is RelationshipType.friend]
 
     @property
     def blocked(self):
-        r"""Returns a :class:`list` of :class:`User`\s that the user has blocked."""
+        r"""Returns a :class:`list` of :class:`User`\s that the user has blocked.
+
+        .. note::
+
+            This only applies to non-bot accounts.
+        """
         return [r.user for r in self._relationships.values() if r.type is RelationshipType.blocked]
 
     async def edit(self, **fields):
@@ -435,7 +454,9 @@ class ClientUser(BaseUser):
         provided. These recipients must be have a relationship
         of type :attr:`RelationshipType.friend`.
 
-        Bot accounts cannot create a group.
+        .. note::
+
+            This only applies to non-bot accounts.
 
         Parameters
         -----------
@@ -469,7 +490,11 @@ class ClientUser(BaseUser):
     async def edit_settings(self, **kwargs):
         """|coro|
 
-        Edits the client user's settings. Only applicable to user accounts.
+        Edits the client user's settings.
+
+        .. note::
+
+            This only applies to non-bot accounts.
 
         Parameters
         -------
@@ -642,13 +667,22 @@ class User(BaseUser, discord.abc.Messageable):
 
     @property
     def relationship(self):
-        """Returns the :class:`Relationship` with this user if applicable, ``None`` otherwise."""
+        """Returns the :class:`Relationship` with this user if applicable, ``None`` otherwise.
+
+        .. note::
+
+            This only applies to non-bot accounts.
+        """
         return self._state.user.get_relationship(self.id)
 
     async def mutual_friends(self):
         """|coro|
 
-        Gets all mutual friends of this user. This can only be used by non-bot accounts
+        Gets all mutual friends of this user.
+
+        .. note::
+
+            This only applies to non-bot accounts.
 
         Raises
         -------
@@ -667,14 +701,24 @@ class User(BaseUser, discord.abc.Messageable):
         return [User(state=state, data=friend) for friend in mutuals]
 
     def is_friend(self):
-        """:class:`bool`: Checks if the user is your friend."""
+        """:class:`bool`: Checks if the user is your friend.
+
+        .. note::
+
+            This only applies to non-bot accounts.
+        """
         r = self.relationship
         if r is None:
             return False
         return r.type is RelationshipType.friend
 
     def is_blocked(self):
-        """:class:`bool`: Checks if the user is blocked."""
+        """:class:`bool`: Checks if the user is blocked.
+
+        .. note::
+
+            This only applies to non-bot accounts.
+        """
         r = self.relationship
         if r is None:
             return False
@@ -684,6 +728,10 @@ class User(BaseUser, discord.abc.Messageable):
         """|coro|
 
         Blocks the user.
+
+        .. note::
+
+            This only applies to non-bot accounts.
 
         Raises
         -------
@@ -700,6 +748,10 @@ class User(BaseUser, discord.abc.Messageable):
 
         Unblocks the user.
 
+        .. note::
+
+            This only applies to non-bot accounts.
+
         Raises
         -------
         Forbidden
@@ -713,6 +765,10 @@ class User(BaseUser, discord.abc.Messageable):
         """|coro|
 
         Removes the user as a friend.
+
+        .. note::
+
+            This only applies to non-bot accounts.
 
         Raises
         -------
@@ -728,6 +784,10 @@ class User(BaseUser, discord.abc.Messageable):
 
         Sends the user a friend request.
 
+        .. note::
+
+            This only applies to non-bot accounts.
+
         Raises
         -------
         Forbidden
@@ -740,7 +800,11 @@ class User(BaseUser, discord.abc.Messageable):
     async def profile(self):
         """|coro|
 
-        Gets the user's profile. This can only be used by non-bot accounts.
+        Gets the user's profile.
+
+        .. note::
+
+            This only applies to non-bot accounts.
 
         Raises
         -------


### PR DESCRIPTION
### Summary

This PR implements a "Partial message". A partial message is a message object with no meaningful content attributes, but are instead designed to be user-created and have all available message-related API calls. 
It also refactors `Message` to be a subclass of the new `PartialMessage` class.

With the current design, message objects are not to be user created, but instead generated by the library- either from API calls returning messages, (`.send`, `.history`, .`fetch_message`). However, this creates a non-ideal situation when attempting to do anything to message objects outside of cache, without having to do needless, and in the case of `fetch_message`, heavily ratelimited API calls. 

The `PartialMessage` class has a number of benefits over the other method for the same concept, `channel.raw_do_thing`. It avoids cluttering the existing channel objects with more methods, and maintains the stateful concepts already present in the library. Further, in the event the user wants to do multiple API calls for some "raw" message, it is, to my mind, far cleaner to use a partial- IE
```py
partial = channel.create_partial_message(12345)
await partial.edit(content='hello')
await partial.pin()
```
Versus 
```py
channel.raw_edit_message(message_id=12345, content='hello')
channel.raw_pin_message(message_id=12345)
```
I also believe that `PartialMessage`s will be far less likely to result in the following antipattern:
`channel.raw_edit_message(message.id, content='hello')` Where `message` is a fully-established message object. 

I'm slightly unsure of the implementation- I believe the exposed API to be everything required and more or less clean, but due to DM channels, `_get_channel()` has to be a coro. To avoid making creating the class a coro, (the original reason for `channel.create_partial_message` existing) destinations are now resolved when an API call is attempted to be made by the `@resolve_destination` decorator.
Without this change, single-liners are `await (await channel.create_partial_message(id))` which is more than a little odd. It might be a good idea to split this class entirely from `Message`, instead of making it a parent class. 

The documentation also needs work. 
~~also the commit history for this is a mess yikes~~
### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
