### PR TITLE
[commands] Update default on_command_error

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -161,10 +161,7 @@ class BotBase(GroupMixin):
 
         cog = context.cog
         if cog:
-            handler = getattr(cog, 'cog_command_error')
-            overridden = Cog._get_overridden_method(handler)
-
-            if overridden:
+            if Cog._get_overridden_method(cog.cog_command_error) is not None:
                 return
 
         print('Ignoring exception in command {}:'.format(context.command), file=sys.stderr)

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -161,8 +161,10 @@ class BotBase(GroupMixin):
 
         cog = context.cog
         if cog:
-            attr = '_{0.__class__.__name__}__error'.format(cog)
-            if hasattr(cog, attr):
+            handler = getattr(cog, 'cog_command_error')
+            overridden = Cog._get_overridden_method(handler)
+
+            if overridden:
                 return
 
         print('Ignoring exception in command {}:'.format(context.command), file=sys.stderr)


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->

Since the cogs update, the default `on_command_error` has never been updated.
This means that the check for a cog error handler is essentially useless.

This pull request makes use of the `_get_overridden_method` method within
the default `on_command_error` to check if `cog_command_error` has been
overridden.

I have ticked `I have updated the documentation to reflect the changes` since
none were needed.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
