### PR TITLE
Document on_error "special" behavior

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -152,6 +152,14 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     ``raise`` statement.  Exceptions raised by ``on_error`` will not be
     handled in any way by :class:`Client`.
 
+    .. note::
+
+        ``on_error`` will only be dispatched to :meth:`Client.event`.
+
+        It will not be received by :meth:`Client.wait_for`, or, if used,
+        :class:`~ext.commands.Bot` listeners such as
+        :meth:`~ext.commands.Bot.listen` or :meth:`~ext.commands.Cog.listener`.
+
     :param event: The name of the event that raised the exception.
     :param args: The positional arguments for the event that raised the
         exception.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -157,7 +157,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
         ``on_error`` will only be dispatched to :meth:`Client.event`.
 
         It will not be received by :meth:`Client.wait_for`, or, if used,
-        :class:`~ext.commands.Bot` listeners such as
+        :ref:`ext_commands_api_bot` listeners such as
         :meth:`~ext.commands.Bot.listen` or :meth:`~ext.commands.Cog.listener`.
 
     :param event: The name of the event that raised the exception.


### PR DESCRIPTION
### Summary

This documents the unique not-really-an-event behavior of `on_error`.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
