### PR TITLE
[commands] Add command.parents

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -505,8 +505,7 @@ class Command(_BaseCommand):
 
     @property
     def parents(self):
-        """
-        Retrieves the parents of this command.
+        """Retrieves the parents of this command.
 
         .. versionadded:: 1.1.0
 

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -512,7 +512,7 @@ class Command(_BaseCommand):
         If the command has no parents then it returns an empty :class:`list`.
 
         For example in commands ``?a b c test``,
-        the parents are ``[a, b, c]``.
+        the parents are ``[c, b, a]``.
 
 
         """

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -505,17 +505,20 @@ class Command(_BaseCommand):
 
     @property
     def parents(self):
-        """Retrieves the parents of this command.
+        """
+        Retrieves the parents of this command.
+
+        .. versionadded:: 1.1.0
 
         If the command has no parents then it returns an empty :class:`list`.
 
         For example in commands ``?a b c test``,
         the parents are ``[a, b, c]``.
 
-        .. versionadded:: 1.1.0
+
         """
-        command = self
         entries = []
+        command = self
         while command.parent is not None:
             command = command.parent
             entries.append(command)

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -504,6 +504,25 @@ class Command(_BaseCommand):
         return ' '.join(reversed(entries))
 
     @property
+    def parents(self):
+        """Retrieves the parents of this command.
+
+        If the command has no parents then it returns an empty :class:`list`.
+
+        For example in commands ``?a b c test``,
+        the parents are ``[a, b, c]``.
+
+        .. versionadded:: 1.1.0
+        """
+        command = self
+        entries = []
+        while command.parent is not None:
+            command = command.parent
+            entries.append(command)
+
+        return entries
+
+    @property
     def root_parent(self):
         """Retrieves the root parent of this command.
 
@@ -512,16 +531,9 @@ class Command(_BaseCommand):
         For example in commands ``?a b c test``, the root parent is
         ``a``.
         """
-        entries = []
-        command = self
-        while command.parent is not None:
-            command = command.parent
-            entries.append(command)
-
-        if len(entries) == 0:
+        if not self.parent:
             return None
-
-        return entries[-1]
+        return self.parents[-1]
 
     @property
     def qualified_name(self):


### PR DESCRIPTION
### Summary

This PR adds the command.parents property, which returns list of all the parents a command has.
Also adjusts command.root_parent to use the new property.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
