### PR TITLE
Add read method to attachment objects

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -123,6 +123,42 @@ class Attachment:
             with open(fp, 'wb') as f:
                 return f.write(data)
 
+    async def read(self, *, use_cached=False):
+        """|coro|
+
+        Retrieves the content of this attachment as a :class:`bytes` object.
+
+        Parameters
+        -----------
+        use_cached: :class:`bool`
+            Whether to use :attr:`proxy_url` rather than :attr:`url` when downloading
+            the attachment. This will allow attachments to be saved after deletion
+            more often, compared to the regular URL which is generally deleted right
+            after the message is deleted. Note that this can still fail to download
+            deleted attachments if too much time has passed and it does not work
+            on some type of attachments.
+
+        .. versionadded:: 1.1.0
+
+        Raises
+        ------
+        HTTPException
+            Downloading the attachment failed.
+        Forbidden
+            You do not have permissions to access this attachment
+        NotFound
+            The attachment was deleted.
+
+        Returns
+        -------
+        :class:`bytes`
+            The contents of the attachment.
+        """
+        url = self.proxy_url if use_cached else self.url
+        data = await self._http.get_from_cdn(url)
+        return data
+
+
 class Message:
     r"""Represents a message from Discord.
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -112,8 +112,7 @@ class Attachment:
         :class:`int`
             The number of bytes written.
         """
-        url = self.proxy_url if use_cached else self.url
-        data = await self._http.get_from_cdn(url)
+        data = await self.read(use_cached=use_cached)
         if isinstance(fp, io.IOBase) and fp.writable():
             written = fp.write(data)
             if seek_begin:


### PR DESCRIPTION
### Summary

This adds a `read` method to `Attachment` objects. 
Useful for when you want to read the attachment object and not save it to some file-like object.

Also noticed that the exceptions `http.get_from_cdn` raise are all hardcoded to say `asset`, despite usage in areas besides assets. Seems out of scope for this PR though. 

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
