### PR TITLE
overwrites_for now returns None if no overwrites are set

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -314,17 +314,19 @@ class GuildChannel:
 
     def overwrites_for(self, obj):
         """Returns the channel-specific overwrites for a member or a role.
-
+        
+        If no overwrites are set, returns None.
+        
         Parameters
         -----------
         obj
             The :class:`Role` or :class:`abc.User` denoting
             whose overwrite to get.
-
+            
         Returns
         ---------
         :class:`PermissionOverwrite`
-            The permission overwrites for this object.
+            The permission overwrites for this object, if set. Returns None otherwise.
         """
 
         if isinstance(obj, User):
@@ -340,7 +342,7 @@ class GuildChannel:
                 deny = Permissions(overwrite.deny)
                 return PermissionOverwrite.from_pair(allow, deny)
 
-        return PermissionOverwrite()
+        return None
 
     @property
     def overwrites(self):


### PR DESCRIPTION
### Summary

`overwrites_for()` now returns None if the overwrite for the tested object isn't set. This is to distinguish between a case where an overwrite is set for a member or role but is empty, and a case where no overwrites are set for them at all.
Currently, the only way to distinguish between those is to iterate over all overwrites manually (using the `overwrites()` method), checking if one exists. I feel like this change would make the behavior more logical, because when testing this method, I never expected it to return an actual overwrite if none has been set for the role I was testing.

I updated the documentation to reflect the change, however I'm not that good with doc-strings so I'm not sure if the change is and looks clear enough. It's a subject to change for sure.

This change might be breaking for code that doesn't expect this method to return None.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
