### PR TITLE
Added missing get_role method to the faq.

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -230,6 +230,7 @@ one of the following functions:
 - :meth:`Client.get_emoji`
 - :meth:`Guild.get_member`
 - :meth:`Guild.get_channel`
+- :meth:`Guild.get_role`
 
 The following use an HTTP request:
 


### PR DESCRIPTION
### Summary

The method to get a role object via ``Guild.get_role`` was not documented on the faq. So, there you go.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
