### PR TITLE
TextChannel edit method now specifies slowmode unit

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -198,8 +198,8 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             The new category for this channel. Can be ``None`` to remove the
             category.
         slowmode_delay: :class:`int`
-            Specifies the slowmode rate limit for user in this channel. A value of
-            `0` disables slowmode. The maximum value possible is `21600`.
+            Specifies the slowmode rate limit for user in this channel, in seconds.
+            A value of `0` disables slowmode. The maximum value possible is `21600`.
         reason: Optional[:class:`str`]
             The reason for editing this channel. Shows up on the audit log.
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -676,8 +676,8 @@ class Guild(Hashable):
         topic: Optional[:class:`str`]
             The new channel's topic.
         slowmode_delay: :class:`int`
-            Specifies the slowmode rate limit for user in this channel.
-            The maximum value possible is `120`.
+            Specifies the slowmode rate limit for user in this channel, in seconds.
+            The maximum value possible is `21600`.
         nsfw: :class:`bool`
             To mark the channel as NSFW or not.
         reason: Optional[:class:`str`]


### PR DESCRIPTION
### Summary

The doc string for the edit method of a TextChannel only specified the maximum amount, but was missing the unit, so could be confusing. A `seconds` unit is now clearly specified, just like in the TextChannel doc string itself.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
