### PR TITLE
Fixed a typo in GuildChannel.overwrites docstring

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -347,7 +347,7 @@ class GuildChannel:
         """Returns all of the channel's overwrites.
 
         This is returned as a dictionary where the key contains the target which
-        can be either a :class:`Role` or a :class:`Member` and the key is the
+        can be either a :class:`Role` or a :class:`Member` and the value is the
         overwrite as a :class:`PermissionOverwrite`.
 
         Returns


### PR DESCRIPTION
### Summary

This is just a simple fix for a description error.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
