### PR TITLE
Fix typo in Loop.restart documentation

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -137,7 +137,7 @@ class Loop:
             self._task.cancel()
 
     def restart(self, *args, **kwargs):
-        r"""A convenience method to restart the internal start.
+        r"""A convenience method to restart the internal task.
 
         .. note::
 


### PR DESCRIPTION
Fixes Freudian slip.
