### PR TITLE
Remove Member.unban()

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -432,13 +432,6 @@ class Member(discord.abc.Messageable, _BaseUser):
         """
         await self.guild.ban(self, **kwargs)
 
-    async def unban(self, *, reason=None):
-        """|coro|
-
-        Unbans this member. Equivalent to :meth:`Guild.unban`
-        """
-        await self.guild.unban(self, reason=reason)
-
     async def kick(self, *, reason=None):
         """|coro|
 


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR removes `Member.unban()` since it is useless due to the fact that the `Member` object doesn't exist anymore after it gets banned.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
