### PR TITLE
Fixed Middle Dot for MinimalHelpCommand

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -1105,8 +1105,8 @@ class MinimalHelpCommand(HelpCommand):
             The heading to add to the line.
         """
         if commands:
-            # U+2002 Middle Dot
-            joined = '\u2002'.join(c.name for c in commands)
+            # U+2022 = Middle Dot
+            joined = ' \u2022 '.join(c.name for c in commands)
             self.paginator.add_line('__**%s**__' % heading)
             self.paginator.add_line(joined)
 


### PR DESCRIPTION
from U+2002 to U+2022 so it works and shows now and added a space before and after it so it looks better.

### Summary

Fixes the dot between commands of the MinimalHelpCommand

### Checklist

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
