### PR TITLE
Added note to Emoji.user

### DIFF
--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -167,7 +167,7 @@ class Emoji:
         The guild ID the emoji belongs to.
     user: Optional[:class:`User`]
         The user that created the emoji. This can only be retrieved using :meth:`Guild.fetch_emoji` and
-        :attr:`~Permissions.manage_emojis` permission.
+        having the :attr:`~Permissions.manage_emojis` permission.
     """
     __slots__ = ('require_colons', 'animated', 'managed', 'id', 'name', '_roles', 'guild_id',
                  '_state', 'user')

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -166,7 +166,8 @@ class Emoji:
     guild_id: :class:`int`
         The guild ID the emoji belongs to.
     user: Optional[:class:`User`]
-        The user that created the emoji. This can only be retrieved using :meth:`Guild.fetch_emoji`.
+        The user that created the emoji. This can only be retrieved using :meth:`Guild.fetch_emoji` and
+        :attr:`~Permissions.manage_emojis` permission..
     """
     __slots__ = ('require_colons', 'animated', 'managed', 'id', 'name', '_roles', 'guild_id',
                  '_state', 'user')

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -167,7 +167,7 @@ class Emoji:
         The guild ID the emoji belongs to.
     user: Optional[:class:`User`]
         The user that created the emoji. This can only be retrieved using :meth:`Guild.fetch_emoji` and
-        :attr:`~Permissions.manage_emojis` permission..
+        :attr:`~Permissions.manage_emojis` permission.
     """
     __slots__ = ('require_colons', 'animated', 'managed', 'id', 'name', '_roles', 'guild_id',
                  '_state', 'user')


### PR DESCRIPTION
### Summary
This simply adds a note indicating that `Emoji.user` requires `manage_emojis` permissions in order to obtain it using `Guild.fetch_emoji`.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
