### PR TITLE
[tasks] Return coro from before and after decorators

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -271,7 +271,7 @@ class Loop:
             raise TypeError('Expected coroutine function, received {0.__name__!r}.'.format(type(coro)))
 
         self._before_loop = coro
-
+        return coro
 
     def after_loop(self, coro):
         """A decorator that register a coroutine to be called after the loop finished running.
@@ -299,6 +299,7 @@ class Loop:
             raise TypeError('Expected coroutine function, received {0.__name__!r}.'.format(type(coro)))
 
         self._after_loop = coro
+        return coro
 
 def loop(*, seconds=0, minutes=0, hours=0, count=None, reconnect=True, loop=None):
     """A decorator that schedules a task in the background for you with


### PR DESCRIPTION
### Summary

This PR allows registering the before or after coroutine to multiple tasks, or calling it outside of task context. Previously this was not possible as the decorators did not return the registered coroutine.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
