### PR TITLE
Add back __repr__ that were deleted in the Asset redesign

### DIFF
--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -68,6 +68,10 @@ class AppInfo:
         self.bot_require_code_grant = data['bot_require_code_grant']
         self.owner = User(state=self._state, data=data['owner'])
 
+    def __repr__(self):
+        return '<{0.__class__.__name__} id={0.id} name={0.name!r} description={0.description!r} public={0.bot_public} ' \
+               'owner={0.owner!r}>'.format(self)
+
     @property
     def icon_url(self):
         """:class:`.Asset`: Retrieves the application's icon asset."""

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -86,6 +86,9 @@ class PartialEmoji:
             return '<a:%s:%s>' % (self.name, self.id)
         return '<:%s:%s>' % (self.name, self.id)
 
+    def __repr__(self):
+        return '<{0.__class__.__name__} animated={0.animated} name={0.name!r} id={0.id}>'.format(self)
+
     def __eq__(self, other):
         if self.is_unicode_emoji():
             return isinstance(other, PartialEmoji) and self.name == other.name

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -140,6 +140,10 @@ class PartialInviteGuild:
     def __str__(self):
         return self.name
 
+    def __repr__(self):
+        return '<{0.__class__.__name__} id={0.id} name={0.name!r} features={0.features} ' \
+               'description={0.description!r}>'.format(self)
+
     @property
     def created_at(self):
         """Returns the guild's creation time in UTC."""


### PR DESCRIPTION

### Summary

The Asset PR (be227ebcf0c8bad6b56798339b5414b8da414dc0) changed some namedtuple-deriving
classes to object-deriving classes, which meant that the free `__repr__` provided by namedtuple
was removed.

### Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
