### PR TITLE
Correct the documentation for methods and properties that return Assets

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1030,7 +1030,7 @@ class GroupChannel(discord.abc.Messageable, Hashable):
 
     @property
     def icon_url(self):
-        """:class:`Asset`: Returns the channel's icon asset if available."""
+        """:class:`Asset`: Returns the channel's icon asset."""
         return Asset._from_icon(self._state, self, 'channel')
 
     @property

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -418,7 +418,7 @@ class Guild(Hashable):
 
     @property
     def icon_url(self):
-        """:class:`Asset`: Returns the guilds's icon asset."""
+        """:class:`Asset`: Returns the guild's icon asset."""
         return self.icon_url_as()
 
     def icon_url_as(self, *, format='webp', size=1024):

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -418,11 +418,11 @@ class Guild(Hashable):
 
     @property
     def icon_url(self):
-        """Returns the URL version of the guild's icon. Returns an empty string if it has no icon."""
+        """:class:`Asset`: Returns the guilds's icon asset."""
         return self.icon_url_as()
 
     def icon_url_as(self, *, format='webp', size=1024):
-        """Returns a friendly URL version of the guild's icon. Returns an empty string if it has no icon.
+        """Returns a :class:`Asset`: for the guild's icon.
 
         The format must be one of 'webp', 'jpeg', 'jpg', or 'png'. The
         size must be a power of 2 between 16 and 4096.
@@ -448,11 +448,11 @@ class Guild(Hashable):
 
     @property
     def banner_url(self):
-        """Returns the URL version of the guild's banner. Returns an empty string if it has no banner."""
+        """:class:`Asset`: Returns the guild's banner asset."""
         return self.banner_url_as()
 
     def banner_url_as(self, *, format='webp', size=2048):
-        """Returns a friendly URL version of the guild's banner. Returns an empty string if it has no banner.
+        """Returns a :class:`Asset`: for the guild's banner.
 
         The format must be one of 'webp', 'jpeg', or 'png'. The
         size must be a power of 2 between 16 and 4096.
@@ -478,11 +478,11 @@ class Guild(Hashable):
 
     @property
     def splash_url(self):
-        """Returns the URL version of the guild's invite splash. Returns an empty string if it has no splash."""
+        """:class:`Asset`: Returns the guild's invite splash asset."""
         return self.splash_url_as()
 
     def splash_url_as(self, *, format='webp', size=2048):
-        """Returns a friendly URL version of the guild's invite splash. Returns an empty string if it has no splash.
+        """Returns a :class:`Asset`: for the guild's invite splash.
 
         The format must be one of 'webp', 'jpeg', 'jpg', or 'png'. The
         size must be a power of 2 between 16 and 4096.

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -151,7 +151,7 @@ class PartialInviteGuild:
 
     @property
     def icon_url(self):
-        """Returns the URL version of the guild's icon. Returns an empty string if it has no icon."""
+        """:class:`Asset`: Returns the Guilds's icon asset."""
         return self.icon_url_as()
 
     def icon_url_as(self, *, format='webp', size=1024):
@@ -160,7 +160,7 @@ class PartialInviteGuild:
 
     @property
     def banner_url(self):
-        """Returns the URL version of the guild's banner. Returns an empty string if it has no banner."""
+        """:class:`Asset`: Returns the Guild's banner asset."""
         return self.banner_url_as()
 
     def banner_url_as(self, *, format='webp', size=2048):
@@ -169,7 +169,7 @@ class PartialInviteGuild:
 
     @property
     def splash_url(self):
-        """Returns the URL version of the guild's invite splash. Returns an empty string if it has no splash."""
+        """:class:`Asset`: Returns the Guild's invite splash asset."""
         return self.splash_url_as()
 
     def splash_url_as(self, *, format='webp', size=2048):

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -151,7 +151,7 @@ class PartialInviteGuild:
 
     @property
     def icon_url(self):
-        """:class:`Asset`: Returns the Guilds's icon asset."""
+        """:class:`Asset`: Returns the guild's icon asset."""
         return self.icon_url_as()
 
     def icon_url_as(self, *, format='webp', size=1024):
@@ -160,7 +160,7 @@ class PartialInviteGuild:
 
     @property
     def banner_url(self):
-        """:class:`Asset`: Returns the Guild's banner asset."""
+        """:class:`Asset`: Returns the guild's banner asset."""
         return self.banner_url_as()
 
     def banner_url_as(self, *, format='webp', size=2048):
@@ -169,7 +169,7 @@ class PartialInviteGuild:
 
     @property
     def splash_url(self):
-        """:class:`Asset`: Returns the Guild's invite splash asset."""
+        """:class:`Asset`: Returns the guild's invite splash asset."""
         return self.splash_url_as()
 
     def splash_url_as(self, *, format='webp', size=2048):

--- a/discord/user.py
+++ b/discord/user.py
@@ -114,10 +114,10 @@ class BaseUser(_BaseUser):
 
     @property
     def avatar_url(self):
-        """Returns a friendly URL version of the avatar the user has.
+        """Returns a :class:`Asset`: for the avatar the user has.
 
-        If the user does not have a traditional avatar, their default
-        avatar URL is returned instead.
+        If the user does not have a traditional avatar, an asset for
+        the default avatar is returned instead.
 
         This is equivalent to calling :meth:`avatar_url_as` with
         the default parameters (i.e. webp/gif detection and a size of 1024).
@@ -129,10 +129,10 @@ class BaseUser(_BaseUser):
         return bool(self.avatar and self.avatar.startswith('a_'))
 
     def avatar_url_as(self, *, format=None, static_format='webp', size=1024):
-        """Returns a friendly URL version of the avatar the user has.
+        """Returns a :class:`Asset`: for the avatar the user has.
 
-        If the user does not have a traditional avatar, their default
-        avatar URL is returned instead.
+        If the user does not have a traditional avatar, an asset for
+        the default avatar is returned instead.
 
         The format must be one of 'webp', 'jpeg', 'jpg', 'png' or 'gif', and
         'gif' is only valid for animated avatars. The size must be a power of 2

--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -523,10 +523,10 @@ class Webhook:
 
     @property
     def avatar_url(self):
-        """Returns a friendly URL version of the avatar the webhook has.
+        """Returns a :class:`Asset`: for the avatar the webhook has.
 
-        If the webhook does not have a traditional avatar, their default
-        avatar URL is returned instead.
+        If the webhook does not have a traditional avatar, an asset for
+        the default avatar is returned instead.
 
         This is equivalent to calling :meth:`avatar_url_as` with the
         default parameters.
@@ -534,10 +534,10 @@ class Webhook:
         return self.avatar_url_as()
 
     def avatar_url_as(self, *, format=None, size=1024):
-        """Returns a friendly URL version of the avatar the webhook has.
+        """Returns a :class:`Asset`: for the avatar the webhook has.
 
-        If the webhook does not have a traditional avatar, their default
-        avatar URL is returned instead.
+        If the webhook does not have a traditional avatar, an asset for
+        the default avatar is returned instead.
 
         The format must be one of 'jpeg', 'jpg', or 'png'.
         The size must be a power of 2 between 16 and 1024.


### PR DESCRIPTION
### Summary

Corrects the various `x_url` and `x_url_as` methods/properties to correctly note they return assets instead of the ambiguous "url".

During this I noticed a couple discontinuities I didn't want to address- 
User and webhook both note that `This is equivalent to calling :meth:`avatar_url_as` with the default parameters` and none of the other similar properties do. Decided to left untouched. 

Also, `groupchannel` does not implement `icon_url_as`. Dunno if intentional. 

### Checklist

<!-- Put an x inside [ ] to check it -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
