### PR TITLE
[commands] Add missing backtick for is_nsfw docs

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1573,7 +1573,7 @@ def is_nsfw():
 
     .. versionchanged:: 1.1.0
 
-        Raise :exc:`.NSFWChannelRequired instead of generic :exc:`.CheckFailure`.
+        Raise :exc:`.NSFWChannelRequired` instead of generic :exc:`.CheckFailure`.
         DM channels will also now pass this check.
     """
     def pred(ctx):


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
I was scrolling the docs and found that the docs for `is_nsfw` look like this: https://i.notequity.com/tvuyWyvK.png
I noticed a missing backtick, hence the creation of this PR.
### Checklist

<!-- Put an x inside [ ] to check it -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
