### PR TITLE
Implementing GET '/channels/:id' & '/guilds/:id/channels'

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -39,6 +39,8 @@ from .asset import Asset
 from .invite import Invite
 from .widget import Widget
 from .guild import Guild
+from .channel import _channel_factory
+from .enums import ChannelType
 from .member import Member
 from .errors import *
 from .enums import Status, VoiceRegion
@@ -48,6 +50,7 @@ from .voice_client import VoiceClient
 from .http import HTTPClient
 from .state import ConnectionState
 from . import utils
+from .object import Object
 from .backoff import ExponentialBackoff
 from .webhook import Webhook
 from .iterators import GuildIterator
@@ -1154,6 +1157,49 @@ class Client:
                        mutual_guilds=mutual_guilds,
                        user=User(data=user, state=state),
                        connected_accounts=data['connected_accounts'])
+
+    async def fetch_channel(self, channel_id):
+        """|coro|
+
+        Retrieves a :class:`.abc.GuildChannel` or :class:`.abc.PrivateChannel` with the specified ID.
+
+        .. note::
+
+            This method is an API call. For general usage, consider :meth:`get_channel` instead.
+
+        .. versionadded:: 1.2.0
+
+        Raises
+        -------
+        TypeError
+            An unknown channel type was received from Discord.
+        :exc:`.HTTPException`
+            Retrieving the channel failed.
+        :exc:`.NotFound`
+            Invalid Channel ID.
+        :exc:`.Forbidden`
+            You do not have permission to fetch this channel.
+
+        Returns
+        --------
+        Union[:class:`.abc.GuildChannel`, :class:`.abc.PrivateChannel`]
+            The channel from the ID.
+        """
+        data = await self.http.get_channel(channel_id)
+
+        factory, ch_type = _channel_factory(data['type'])
+        if factory is None:
+            raise TypeError('Unknown channel type %s.' % data['type'])
+
+        if ch_type in (ChannelType.group, ChannelType.private):
+            channel = factory(me=self.user, data=data, state=self._connection)
+        else:
+            guild_id = int(data['guild_id'])
+            guild = self.get_guild(guild_id) or Object(id=guild_id)
+
+            channel = factory(guild=guild, state=self._connection, data=data)
+
+        return channel
 
     async def fetch_webhook(self, webhook_id):
         """|coro|

--- a/discord/client.py
+++ b/discord/client.py
@@ -1189,14 +1189,13 @@ class Client:
 
         factory, ch_type = _channel_factory(data['type'])
         if factory is None:
-            raise TypeError('Unknown channel type %s.' % data['type'])
+            raise InvalidData('Unknown channel type {type} for channel ID {id}.'.format_map(data))
 
         if ch_type in (ChannelType.group, ChannelType.private):
             channel = factory(me=self.user, data=data, state=self._connection)
         else:
             guild_id = int(data['guild_id'])
             guild = self.get_guild(guild_id) or Object(id=guild_id)
-
             channel = factory(guild=guild, state=self._connection, data=data)
 
         return channel

--- a/discord/errors.py
+++ b/discord/errors.py
@@ -125,6 +125,12 @@ class NotFound(HTTPException):
     pass
 
 
+class InvalidData(ClientException):
+    """Exception that's raised when the library encounters unknown
+    or invalid data from Discord.
+    """
+    pass
+
 class InvalidArgument(ClientException):
     """Exception that's thrown when an argument to a function
     is invalid some way (e.g. wrong value or wrong type).

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -32,6 +32,7 @@ from .role import Role
 from .member import Member, VoiceState
 from .activity import create_activity
 from .emoji import Emoji
+from .errors import InvalidData
 from .permissions import PermissionOverwrite
 from .colour import Colour
 from .errors import InvalidArgument, ClientException
@@ -955,7 +956,7 @@ class Guild(Hashable):
         def convert(d):
             factory, ch_type = _channel_factory(d['type'])
             if factory is None:
-                raise TypeError('Unknown channel type %s.' % d['type'])
+                raise InvalidData('Unknown channel type {type} for channel ID {id}.'.format_map(data))
 
             channel = factory(guild=self, state=self._state, data=d)
             return channel

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -927,6 +927,41 @@ class Guild(Hashable):
         fields['explicit_content_filter'] = explicit_content_filter.value
         await http.edit_guild(self.id, reason=reason, **fields)
 
+    async def fetch_channels(self):
+        """|coro|
+
+        Retrieves all :class:`abc.GuildChannel` that the guild has.
+
+        .. note::
+
+            This method is an API call. For general usage, consider :attr:`channels` instead.
+
+        .. versionadded:: 1.2.0
+
+        Raises
+        -------
+        TypeError
+            An unknown channel type was received from Discord.
+        HTTPException
+            Retrieving the channels failed.
+
+        Returns
+        -------
+        List[:class:`abc.GuildChannel`]
+            All channels in the guild.
+        """
+        data = await self._state.http.get_all_guild_channels(self.id)
+
+        def convert(d):
+            factory, ch_type = _channel_factory(d['type'])
+            if factory is None:
+                raise TypeError('Unknown channel type %s.' % d['type'])
+
+            channel = factory(guild=self, state=self._state, data=d)
+            return channel
+
+        return [convert(d) for d in data]
+
     async def fetch_member(self, member_id):
         """|coro|
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -408,6 +408,10 @@ class HTTPClient:
         r = Route('GET', '/channels/{channel_id}/messages/{message_id}', channel_id=channel_id, message_id=message_id)
         return self.request(r)
 
+    def get_channel(self, channel_id):
+        r = Route('GET', '/channels/{channel_id}', channel_id=channel_id)
+        return self.request(r)
+
     def logs_from(self, channel_id, limit, before=None, after=None, around=None):
         params = {
             'limit': limit
@@ -612,6 +616,9 @@ class HTTPClient:
     def change_vanity_code(self, guild_id, code, *, reason=None):
         payload = {'code': code}
         return self.request(Route('PATCH', '/guilds/{guild_id}/vanity-url', guild_id=guild_id), json=payload, reason=reason)
+
+    def get_all_guild_channels(self, guild_id):
+        return self.request(Route('GET', '/guilds/{guild_id}/channels', guild_id=guild_id))
 
     def get_member(self, guild_id, member_id):
         return self.request(Route('GET', '/guilds/{guild_id}/members/{member_id}', guild_id=guild_id, member_id=member_id))


### PR DESCRIPTION
### Summary

This adds the two known channel metadata endpoints, listed on #133.

- `GET /channels/:id` -> `Client.fetch_channel`
- `GET /guilds/:id/channels` -> `Guild.fetch_channels`

Both of these give full objects of channels, not partial objects.
You can also do `Client.login` -> `Client.fetch_channel`, or `Client.login` -> `Client.fetch_guild` -> `Guild.fetch_channels`.

Just a side note: weirdly enough, doing `Client.fetch_channel(cannot_read_channel_id)` gives `Forbidden`, but `Guild.fetch_channels() -> utils.get id=cannot_read_channel_id` doesn't.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
