### PR TITLE
Validate kwargs in Client.start

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -503,10 +503,19 @@ class Client:
         """|coro|
 
         A shorthand coroutine for :meth:`login` + :meth:`connect`.
+
+        Raises
+        -------
+        TypeError
+            An unexpected keyword argument was received.
         """
 
         bot = kwargs.pop('bot', True)
         reconnect = kwargs.pop('reconnect', True)
+
+        if kwargs:
+            raise TypeError("unexpected keyword argument(s) %s" % list(kwargs.keys()))
+
         await self.login(*args, bot=bot)
         await self.connect(reconnect=reconnect)
 


### PR DESCRIPTION
### Summary

This resolves #953, a feature request suggesting the validation of keyword arguments for `Client.run` (passed to `Client.start`). I am aware that a Pull Request for this was already given, but it was closed as the rewrite branch got deleted (#1896), as well as not being updated. Likewise, I take in mind what Danny has said.

I also thought that `ConnectionState` keyword arguments should be validated, in case a user error is made when instantiating `Client`. However, this seemed to have taken more time to start up the bot, hence why it is not included.

```py
>>> bot.run(TOKEN, user=False, say_hello_on_boot=True)
Traceback (most recent call last):
  File "python\discord\client.py", line 556, in runner
    await self.start(*args, **kwargs)
  File "python\discord\client.py", line 517, in start
    raise TypeError("unexpected keyword argument(s) %s" % list(kwargs.keys()))
TypeError: unexpected keyword argument(s) ['user', 'say_hello_on_boot']
```
### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
