### PR TITLE
Added example for template checkboxes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ about: Report broken or incorrect behaviour
 
 ### Checklist
 
-<!-- Put an x inside [ ] to check it -->
+<!-- Put an x inside [ ] to check it, like so: [x] -->
 
 - [ ] I have searched the open issues for duplicates.
 - [ ] I have shown the entire traceback, if possible.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ### Checklist
 
-<!-- Put an x inside [ ] to check it -->
+<!-- Put an x inside [ ] to check it, like so: [x] -->
 
 - [ ] If code changes were made then they have been tested.
     - [ ] I have updated the documentation to reflect the changes.


### PR DESCRIPTION
### Summary
Judging by the initial content of some PRs, some people (like me initially) don't seem to understand that a Markdown check mark is `[x]` and not `[ x]` or otherwise. I have changed the template to address this confusion.
<!-- What is this pull request for? Does it fix any issues? -->

### Checklist

<!-- Put an x inside [ ] to check it -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
