### PR TITLE
Implement `Webhook.move_to`.

### DIFF
--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -653,16 +653,12 @@ class Webhook:
         return self._adapter.edit_webhook(**payload)
 
     async def _async_move(self, channel_id, token, payload):
-        try:
-            await self._adapter.move_webhook(token, **payload)
-        finally:
-            self.channel_id = channel_id
+        await self._adapter.move_webhook(token, **payload)
+        self.channel_id = channel_id
 
     def _sync_move(self, channel_id, token, payload):
-        try:
-            self._adapter.move_webhook(token, **payload)
-        finally:
-            self.channel_id = channel_id
+        self._adapter.move_webhook(token, **payload)
+        self.channel_id = channel_id
 
     def move_to(self, channel):
         """|maybecoro|
@@ -680,7 +676,7 @@ class Webhook:
 
         Parameters
         -----------
-        channel: Union[:class:`TextChannel`]
+        channel: :class:`TextChannel`
             Where to move the webhook. Must be a text channel.
 
         Raises

--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -663,21 +663,21 @@ class Webhook:
     def move_to(self, channel):
         """|maybecoro|
 
-        Moves this Webhook.
+        Moves this Webhook to another channel.
 
         If the webhook is constructed with a :class:`RequestsWebhookAdapter` then this is
         not a coroutine.
 
         .. warning::
 
-            This will only work if you fetch the webhook from a client, as there is a state attached.
+            This will only work if you fetch the channel from a client, as there is a state attached.
 
         .. versionadded:: 1.2.0
 
         Parameters
         -----------
         channel: :class:`TextChannel`
-            Where to move the webhook. Must be a text channel.
+            Where to move the webhook.
 
         Raises
         -------
@@ -700,7 +700,7 @@ class Webhook:
 
         token = channel._state.http.token
 
-        if self._state.is_bot:
+        if channel._state.is_bot:
             token = 'Bot ' + token
 
         if isinstance(self._adapter, AsyncWebhookAdapter):


### PR DESCRIPTION
### Summary

This allows you to move a webhook to another channel, which could resolve #1761. Unlike the previous Pull Requests, this seperates it from `Webhook.edit`. 
Two reasons: 

- This technically uses a different endpoint.
- This also requires ConnectionState. 
    - Since ConnectionState relies on being fetched from `Client`, `Guild`, or `TextChannel` (in this case), this would mean it could raise an exception, interrupting the rest of `Webhook.edit`. 
    - By seperating it, it would only raise an exception when you specifically want to move the webhook. 

However, **I am willing to incorporate it as part of `Webhook.edit`** if preferred.

Another benefit of my PR, I set `Webhook.channel_id`. :)

### Sample code

```py
import discord

client = discord.Client()

@client.event
async def on_ready():
    global client # dont do this :P

    channel = client.get_channel(id)  # another channel
    webhook = await client.fetch_webhook(id)
    await webhook.move_to(channel=channel)

client.run("token")
```

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)