### PR TITLE
Fix wording in documentation for ClientUser.locale

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -279,7 +279,7 @@ class ClientUser(BaseUser):
     email: Optional[:class:`str`]
         The email the user used when registering.
     locale: Optional[:class:`str`]
-        The IETF language tag used to identify the user is using.
+        The IETF language tag used to identify the language the user is using.
     mfa_enabled: :class:`bool`
         Specifies if the user has MFA turned on and working.
     premium: :class:`bool`


### PR DESCRIPTION
### Summary

Add missing words in [the documentation for `ClientUser.locale`](https://discordpy.readthedocs.io/en/latest/api.html#discord.ClientUser.locale).

### Checklist

<!-- Put an x inside [ ] to check it -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
