### PR TITLE
Grammar fixes for notes on EmbedProxy

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -64,9 +64,9 @@ class Embed:
             Returns the total size of the embed.
             Useful for checking if it's within the 6000 character limit.
 
-    Certain properties return an ``EmbedProxy``. Which is a type
-    that acts similar to a regular :class:`dict` except access the attributes
-    via dotted access, e.g. ``embed.author.icon_url``. If the attribute
+    Certain properties return an ``EmbedProxy``, a type
+    that acts similar to a regular :class:`dict` except using dotted access,
+    e.g. ``embed.author.icon_url``. If the attribute
     is invalid or empty, then a special sentinel value is returned,
     :attr:`Embed.Empty`.
 


### PR DESCRIPTION
### Summary
I found the notes on `EmbedProxy` objects somewhat grammatically incorrect.
<!-- What is this pull request for? Does it fix any issues? -->

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
