### PR TITLE
[commands] Make Command.brief default to the first line of the help doc

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -215,7 +215,7 @@ class Command(_BaseCommand):
 
         self.help = help_doc
 
-        self.brief = kwargs.get('brief')
+        self.brief = kwargs.get('brief', self.help.split('\n')[0])
         self.usage = kwargs.get('usage')
         self.rest_is_raw = kwargs.get('rest_is_raw', False)
         self.aliases = kwargs.get('aliases', [])


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->

According to the documentation for `Command.brief`, it defaults to the first line of `Command.help`:
```
brief
str – The short help text for the command. If this is not specified then the first line of the long help text is used instead.
```

In reality, that is not the case. This PR makes it so.  
No documentation changes were needed.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
