### PR TITLE
[commands] Allow multiple checks to be added at once.

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1447,8 +1447,8 @@ def group(name=None, **attrs):
     attrs.setdefault('cls', Group)
     return command(name=name, **attrs)
 
-def check(predicate):
-    r"""A decorator that adds a check to the :class:`.Command` or its
+def check(*predicates):
+    r"""A decorator that adds a check or more to the :class:`.Command` or its
     subclasses. These checks could be accessed via :attr:`.Command.checks`.
 
     These checks should be predicates that take in a single parameter taking
@@ -1483,6 +1483,9 @@ def check(predicate):
     .. versionchanged:: 1.3
         The ``predicate`` attribute was added.
 
+    .. versionchanged:: 1.7
+        Allow several checks to be added at once.
+
     Examples
     ---------
 
@@ -1512,20 +1515,35 @@ def check(predicate):
         async def only_me(ctx):
             await ctx.send('Only you!')
 
+    Adding several checks to a command at once.
+
+    ..code-block:: python3
+
+        def check_if_it_is_me(ctx):
+            return ctx.message.author.id == 85309593344815104
+
+        def check_if_in_dpy(ctx):
+            return ctx.message.guild.id == 336642139381301249
+
+        @bot.command()
+        @commands.check(check_if_it_is_me, check_if_in_dpy)
+        async def only_me_in_dpy(ctx):
+            await ctx.send('I know you are in the discord.py guild!')
+
     Parameters
     -----------
-    predicate: Callable[[:class:`Context`], :class:`bool`]
-        The predicate to check if the command should be invoked.
+    *predicates: Callable[[:class:`Context`], :class:`bool`]
+        An argument list of the predicate to check if the command should be invoked.
     """
 
     def decorator(func):
         if isinstance(func, Command):
-            func.checks.append(predicate)
+            func.checks.extend(predicates)
         else:
             if not hasattr(func, '__commands_checks__'):
                 func.__commands_checks__ = []
 
-            func.__commands_checks__.append(predicate)
+            func.__commands_checks__.extend(predicates)
 
         return func
 


### PR DESCRIPTION
This PR allows multiple checks to be added at once, making code a little bit more compact and pretty: 
```py
def check_if_it_is_me(ctx):
    return ctx.message.author.id == 85309593344815104

def check_if_in_discord_py(ctx):
    return ctx.message.guild.id == 336642139381301249

@bot.command()
@commands.check(check_if_it_is_me, check_if_in_discord_py)
async def only_for_me(ctx):
    await ctx.send('I know you are in the discord.py guild!')
```
It does this by turning the predicate argument into an argument list and iterating through it when adding the checks.

If have tested the code i have changed and adding mutliple checks works, adding just one works, and turning one into it's own decorator works. I have also updated the documentation and added an example that i have tested.