### PR TITLE
Allow editing of overwrites in Channel.edit()

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -256,6 +256,28 @@ class GuildChannel:
                 options['permission_overwrites'] = [c._asdict() for c in category._overwrites]
         else:
             await self._move(position, parent_id=parent_id, lock_permissions=lock_permissions, reason=reason)
+        
+        overwrites = options.pop('overwrites')
+        if overwrites:
+            perms = []
+            for target, perm in overwrites.items():
+                if not isinstance(perm, PermissionOverwrite):
+                    raise InvalidArgument('Expected PermissionOverwrite received {0.__name__}'.format(type(perm)))
+
+                allow, deny = perm.pair()
+                payload = {
+                    'allow': allow.value,
+                    'deny': deny.value,
+                    'id': target.id
+                }
+
+                if isinstance(target, Role):
+                    payload['type'] = 'role'
+                else:
+                    payload['type'] = 'member'
+
+                perms.append(payload)
+            options['permission_overwrites'] = perms
 
         if options:
             data = await self._state.http.edit_channel(self.id, reason=reason, **options)

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -257,7 +257,7 @@ class GuildChannel:
         else:
             await self._move(position, parent_id=parent_id, lock_permissions=lock_permissions, reason=reason)
         
-        overwrites = options.pop('overwrites')
+        overwrites = options.get('overwrites', None)
         if overwrites:
             perms = []
             for target, perm in overwrites.items():

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -210,11 +210,15 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             A value of `0` disables slowmode. The maximum value possible is `21600`.
         reason: Optional[:class:`str`]
             The reason for editing this channel. Shows up on the audit log.
+        overwrites: :class:`dict`
+            A :class:`dict` of target (either a role or a member) to
+            :class:`PermissionOverwrite` to apply to the channel.
 
         Raises
         ------
         InvalidArgument
-            If position is less than 0 or greater than the number of channels.
+            If position is less than 0 or greater than the number of channels, or if 
+            the permission overwrite information is not in proper form.
         Forbidden
             You do not have permissions to edit the channel.
         HTTPException
@@ -590,9 +594,14 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
             category.
         reason: Optional[:class:`str`]
             The reason for editing this channel. Shows up on the audit log.
+        overwrites: :class:`dict`
+            A :class:`dict` of target (either a role or a member) to
+            :class:`PermissionOverwrite` to apply to the channel.
 
         Raises
         ------
+        InvalidArgument
+            If the permission overwrite information is not in proper form.
         Forbidden
             You do not have permissions to edit the channel.
         HTTPException
@@ -867,11 +876,15 @@ class StoreChannel(discord.abc.GuildChannel, Hashable):
             category.
         reason: Optional[:class:`str`]
             The reason for editing this channel. Shows up on the audit log.
+        overwrites: :class:`dict`
+            A :class:`dict` of target (either a role or a member) to
+            :class:`PermissionOverwrite` to apply to the channel.
 
         Raises
         ------
         InvalidArgument
-            If position is less than 0 or greater than the number of channels.
+            If position is less than 0 or greater than the number of channels, or if 
+            the permission overwrite information is not in proper form.
         Forbidden
             You do not have permissions to edit the channel.
         HTTPException

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -214,6 +214,8 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             A :class:`dict` of target (either a role or a member) to
             :class:`PermissionOverwrite` to apply to the channel.
 
+            .. versionadded:: 1.3.0
+
         Raises
         ------
         InvalidArgument
@@ -598,6 +600,8 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
             A :class:`dict` of target (either a role or a member) to
             :class:`PermissionOverwrite` to apply to the channel.
 
+            .. versionadded:: 1.3.0
+
         Raises
         ------
         InvalidArgument
@@ -879,18 +883,9 @@ class StoreChannel(discord.abc.GuildChannel, Hashable):
         overwrites: :class:`dict`
             A :class:`dict` of target (either a role or a member) to
             :class:`PermissionOverwrite` to apply to the channel.    
+
             .. versionadded:: 1.3
-       
-        Example
-        ----------
-        
-        Disallowing sending messages for a user: ::
-            
-            member = channel.guild.get_member(422181415598161921)
-            overwrite = PermissionOverwrite(send_messages=False)
-            overwrites = {member: overwrite}
-            await channel.edit(overwrites=overwrites)
-         
+
         Raises
         ------
         InvalidArgument

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -878,8 +878,19 @@ class StoreChannel(discord.abc.GuildChannel, Hashable):
             The reason for editing this channel. Shows up on the audit log.
         overwrites: :class:`dict`
             A :class:`dict` of target (either a role or a member) to
-            :class:`PermissionOverwrite` to apply to the channel.
-
+            :class:`PermissionOverwrite` to apply to the channel.    
+            .. versionadded:: 1.3
+       
+        Example
+        ----------
+        
+        Disallowing sending messages for a user: ::
+            
+            member = channel.guild.get_member(422181415598161921)
+            overwrite = PermissionOverwrite({"send_messages": False})
+            overwrites = {member: overwrite}
+            await channel.edit(overwrites=overwrites)
+         
         Raises
         ------
         InvalidArgument

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -887,7 +887,7 @@ class StoreChannel(discord.abc.GuildChannel, Hashable):
         Disallowing sending messages for a user: ::
             
             member = channel.guild.get_member(422181415598161921)
-            overwrite = PermissionOverwrite({"send_messages": False})
+            overwrite = PermissionOverwrite(send_messages=False)
             overwrites = {member: overwrite}
             await channel.edit(overwrites=overwrites)
          


### PR DESCRIPTION
### Summary

Allows the editing of permission overwrites in Channel.edit(). Resolves #2197 

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
