### PR TITLE
Implement `Guild.fetch_roles`

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1469,6 +1469,30 @@ class Guild(Hashable):
         data = await self._state.http.create_custom_emoji(self.id, name, img, roles=roles, reason=reason)
         return self._state.store_emoji(self, data)
 
+    async def fetch_roles(self):
+        """|coro|
+
+        Retrieves all :class:`Role` that the guild has.
+
+        .. note::
+
+            This method is an API call. For general usage, consider :attr:`roles` instead.
+
+        .. versionadded:: 1.3.0
+
+        Raises
+        -------
+        HTTPException
+            Retrieving the roles failed.
+
+        Returns
+        -------
+        List[:class:`Role`]
+            All roles in the guild.
+        """
+        data = await self._state.http.get_roles(self.id)
+        return [Role(guild=self, state=self._state, data=d) for d in data]
+
     async def create_role(self, *, reason=None, **fields):
         """|coro|
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -712,6 +712,9 @@ class HTTPClient:
 
     # Role management
 
+    def get_roles(self, guild_id):
+        return self.request(Route('GET', '/guilds/{guild_id}/roles', guild_id=guild_id))
+
     def edit_role(self, guild_id, role_id, *, reason=None, **fields):
         r = Route('PATCH', '/guilds/{guild_id}/roles/{role_id}', guild_id=guild_id, role_id=role_id)
         valid_keys = ('name', 'permissions', 'color', 'hoist', 'mentionable')


### PR DESCRIPTION
### Summary

This implements yet another endpoint listed in #133, `/guilds/:id/roles`, in the form of `Guild.fetch_roles`. There are two reasons for why this is not an iterator:

- There can only be a finite amount of roles per guild.
- There are no parameters available for the endpoint.

However, I am willing to add any parameters to the function, since I planned to be able to reverse it but I wasn't too sure about it.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
