### PR TITLE
Update docs to note Enum derivation change

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -716,7 +716,8 @@ Enumerations
 The API provides some enumerations for certain types of strings to avoid the API
 from being stringly typed in case the strings change in the future.
 
-All enumerations are subclasses of :class:`enum.Enum`.
+All enumerations are subclasses of an internal class which mimics the behaviour
+of :class:`enum.Enum`.
 
 .. class:: ChannelType
 


### PR DESCRIPTION
### Summary

The docs previously stated that all enumerations derived from `enums.Enum`. I've updated the docs to state this isn't technically true.

### Checklist

- [x] I have updated documentation.
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
