### PR TITLE
Set premium_since when copying and updating Member

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -213,6 +213,7 @@ class Member(discord.abc.Messageable, _BaseUser):
 
         self._roles = utils.SnowflakeList(member._roles, is_sorted=True)
         self.joined_at = member.joined_at
+        self.premium_since = member.premium_since
         self._client_status = member._client_status.copy()
         self.guild = member.guild
         self.nick = member.nick
@@ -239,6 +240,7 @@ class Member(discord.abc.Messageable, _BaseUser):
         except KeyError:
             pass
 
+        self.premium_since = utils.parse_time(data.get('premium_since'))
         self._update_roles(data)
 
     def _presence_update(self, data, user):


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->

Currently updates to a members ``premium_since`` value are discarded by discord.py, and attempting to compare the value in on_member_update raises an ``AttributeError`` due to it not being copied.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
