### PR TITLE
Rename error type for `X.fetch_channel(s)`.

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -1211,7 +1211,7 @@ class Client:
 
         Raises
         -------
-        TypeError
+        :exc:`.InvalidData`
             An unknown channel type was received from Discord.
         :exc:`.HTTPException`
             Retrieving the channel failed.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1130,7 +1130,7 @@ class Guild(Hashable):
 
         Raises
         -------
-        TypeError
+        InvalidData
             An unknown channel type was received from Discord.
         HTTPException
             Retrieving the channels failed.


### PR DESCRIPTION
### Summary

This changes the documentation for `Client.fetch_channel` and `Guild.fetch_channels`. It appears that I completely forgot to rename the custom exception made for it. ~~As always.~~

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
