### PR TITLE
catch asyncio.CancelledError in 3.8 when calling fut.exception() on a Task object

### DIFF
--- a/discord/context_managers.py
+++ b/discord/context_managers.py
@@ -30,7 +30,7 @@ def _typing_done_callback(fut):
     # just retrieve any exception and call it a day
     try:
         fut.exception()
-    except Exception:
+    except (asyncio.CancelledError, Exception):
         pass
 
 class Typing:


### PR DESCRIPTION
In python 3.8, asyncio.CancelledError is a subclass of BaseException rather than Exception,
so `except Exception:` will not swallow CancelledError. This change prevents an error in 3.8 from being printed
to the console when the following is run:

```
async with ctx.typing():
	pass
```

### Summary

<!-- What is this pull request for? Does it fix any issues? -->

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
