### PR TITLE
Add class `Setup` and function `setup`

### DIFF
--- a/discord/ext/commands/__init__.py
+++ b/discord/ext/commands/__init__.py
@@ -10,7 +10,7 @@ An extension module to facilitate creation of bot commands.
 :license: MIT, see LICENSE for more details.
 """
 
-from .bot import Bot, AutoShardedBot, when_mentioned, when_mentioned_or
+from .bot import Bot, AutoShardedBot, when_mentioned, when_mentioned_or, setup
 from .context import Context
 from .core import *
 from .errors import *


### PR DESCRIPTION
You can add cog without function `setup(bot)` like this:
```py
@commands.setup
class TestCog(commands.Cog):
    def __init__(self, bot):
        self.bot = bot
```

### Summary

<!-- What is this pull request for? Does it fix any issues? -->
In this pull request, you don't have to write function `setup`.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)