### PR TITLE
Raise max encoder bitrate to 512kbps

### DIFF
--- a/discord/opus.py
+++ b/discord/opus.py
@@ -240,7 +240,7 @@ class Encoder:
         return _lib.opus_encoder_create(self.SAMPLING_RATE, self.CHANNELS, self.application, ctypes.byref(ret))
 
     def set_bitrate(self, kbps):
-        kbps = min(128, max(16, int(kbps)))
+        kbps = min(512, max(16, int(kbps)))
 
         _lib.opus_encoder_ctl(self._state, CTL_SET_BITRATE, kbps * 1024)
         return kbps


### PR DESCRIPTION
### Summary

Raises max encoder bitrate.  Anything past 512 is pointless for opus anyways.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
