### PR TITLE
Support team members data in application info

### DIFF
--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -26,6 +26,7 @@ DEALINGS IN THE SOFTWARE.
 
 from .user import User
 from .asset import Asset
+from .team import Team
 
 
 class AppInfo:
@@ -40,6 +41,8 @@ class AppInfo:
         The application name.
     owner: :class:`User`
         The application owner.
+    team: Optional[:class:`Team`]
+        The application's team.
     icon: Optional[:class:`str`]
         The icon hash, if it exists.
     description: Optional[:class:`str`]
@@ -52,9 +55,28 @@ class AppInfo:
         grant flow to join.
     rpc_origins: Optional[List[:class:`str`]]
         A list of RPC origin URLs, if RPC is enabled.
+    summary: Optional[:class:`str`]
+        If this application is a game sold on Discord,
+        this field will be the summary field for the store page of its primary sku
+    verify_key: Optional[:class:`str`]
+        The base64 encoded key for the GameSDK's GetTicket
+    guild_id: Optional[:class:`int`]
+        If this application is a game sold on Discord,
+        this field will be the guild to which it has been linked
+    primary_sku_id: Optional[:class:`int`]
+        If this application is a game sold on Discord,
+        his field will be the id of the "Game SKU" that is created, if exists
+    slug: Optional[:class:`str`]
+        If this application is a game sold on Discord,
+        this field will be the URL slug that links to the store page  
+    cover_image: Optional[:class:`str`]
+        If this application is a game sold on Discord,
+        this field will be the hash of the image on store embeds    
     """
     __slots__ = ('_state', 'description', 'id', 'name', 'rpc_origins',
-                 'bot_public', 'bot_require_code_grant', 'owner', 'icon')
+                 'bot_public', 'bot_require_code_grant', 'owner', 'icon',
+                 'summary', 'verify_key', 'team', 'guild_id', 'primary_sku_id',
+                 'slug', 'cover_image')
 
     def __init__(self, state, data):
         self._state = state
@@ -67,6 +89,16 @@ class AppInfo:
         self.bot_public = data['bot_public']
         self.bot_require_code_grant = data['bot_require_code_grant']
         self.owner = User(state=self._state, data=data['owner'])
+        team = data.get('team')
+        self.team = Team(state, team) if team else None
+        self.summary = data['summary']
+        self.verify_key = data['verify_key']
+        guild_id = data.get('guild_id')
+        self.guild_id = int(guild_id) if guild_id else None
+        primary_sku_id = data.get('primary_sku_id')
+        self.primary_sku_id = int(primary_sku_id) if primary_sku_id else None
+        self.slug = data.get('slug')
+        self.cover_image = data.get('cover_image')
 
     def __repr__(self):
         return '<{0.__class__.__name__} id={0.id} name={0.name!r} description={0.description!r} public={0.bot_public} ' \
@@ -76,3 +108,8 @@ class AppInfo:
     def icon_url(self):
         """:class:`.Asset`: Retrieves the application's icon asset."""
         return Asset._from_icon(self._state, self, 'app')
+
+    @property
+    def cover_image_url(self):
+        """:class:`.Asset`: Retrieves the cover image on a store embed."""
+        return Asset._from_cover_image(self._state, self)

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -57,15 +57,15 @@ class AppInfo:
         A list of RPC origin URLs, if RPC is enabled.
     summary: Optional[:class:`str`]
         If this application is a game sold on Discord,
-        this field will be the summary field for the store page of its primary sku
+        this field will be the summary field for the store page of its primary SKU
     verify_key: Optional[:class:`str`]
         The base64 encoded key for the GameSDK's GetTicket
-    guild_id: Optional[:class:`int`]
+    guild: Optional[:class:`Guild`]
         If this application is a game sold on Discord,
         this field will be the guild to which it has been linked
     primary_sku_id: Optional[:class:`int`]
         If this application is a game sold on Discord,
-        his field will be the id of the "Game SKU" that is created, if exists
+        this field will be the id of the "Game SKU" that is created, if exists
     slug: Optional[:class:`str`]
         If this application is a game sold on Discord,
         this field will be the URL slug that links to the store page

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -78,42 +78,6 @@ class AppInfo:
         team = data.get('team')
         self.team = Team(state, team) if team else None
 
-        self.game_info = GameInfo(state, data) if data['summary'] else None
-
-    def __repr__(self):
-        return '<{0.__class__.__name__} id={0.id} name={0.name!r} description={0.description!r} public={0.bot_public} ' \
-               'owner={0.owner!r}>'.format(self)
-
-    @property
-    def icon_url(self):
-        """:class:`.Asset`: Retrieves the application's icon asset."""
-        return Asset._from_icon(self._state, self, 'app')
-
-
-class GameInfo:
-
-    """Represents the game information if the
-    application is a game sold on Discord.
-
-    Attributes
-    -------------
-    summary: :class:`str`
-        The summary field for the store page of its primary SKU.
-    verify_key: :class:`str`
-        The base64 encoded key for the GameSDK's GetTicket.
-    guild: Optional[:class:`Guild`]
-        The guild to which it has been linked.
-    primary_sku_id: Optional[:class:`int`]
-        The id of the "Game SKU" that is created, if exists.
-    slug: Optional[:class:`str`]
-        The URL slug that links to the store page.
-    cover_image: Optional[:class:`str`]
-        The hash of the image on store embeds.
-    """
-
-    def __init__(self, state, data):
-        self._state = state
-
         self.summary = data['summary']
         self.verify_key = data['verify_key']
 
@@ -125,7 +89,18 @@ class GameInfo:
         self.slug = data.get('slug')
         self.cover_image = data.get('cover_image')
 
+    def __repr__(self):
+        return '<{0.__class__.__name__} id={0.id} name={0.name!r} description={0.description!r} public={0.bot_public} ' \
+               'owner={0.owner!r}>'.format(self)
+
+    @property
+    def icon_url(self):
+        """:class:`.Asset`: Retrieves the application's icon asset."""
+        return Asset._from_icon(self._state, self, 'app')
+
     @property
     def cover_image_url(self):
         """:class:`.Asset`: Retrieves the cover image on a store embed."""
         return Asset._from_cover_image(self._state, self)
+
+

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -55,10 +55,10 @@ class AppInfo:
         grant flow to join.
     rpc_origins: Optional[List[:class:`str`]]
         A list of RPC origin URLs, if RPC is enabled.
-    summary: Optional[:class:`str`]
+    summary: :class:`str`
         If this application is a game sold on Discord,
         this field will be the summary field for the store page of its primary SKU
-    verify_key: Optional[:class:`str`]
+    verify_key: :class:`str`
         The base64 encoded key for the GameSDK's GetTicket
     guild_id: Optional[:class:`int`]
         If this application is a game sold on Discord,
@@ -96,11 +96,9 @@ class AppInfo:
         self.summary = data['summary']
         self.verify_key = data['verify_key']
 
-        guild_id = data.get('guild_id')
-        self.guild_id = int(guild_id) if guild_id else None
+        self.guild_id = utils._get_as_snowflake(data, 'guild_id')
 
-        primary_sku_id = data.get('primary_sku_id')
-        self.primary_sku_id = int(primary_sku_id) if primary_sku_id else None
+        self.primary_sku_id = utils._get_as_snowflake(data, 'primary_sku_id')
         self.slug = data.get('slug')
         self.cover_image = data.get('cover_image')
 
@@ -122,4 +120,4 @@ class AppInfo:
     def guild(self):
         """Optional[:class:`Guild`]: If this application is a game sold on Discord,
         this field will be the guild to which it has been linked"""
-        return self._state._get_guild(int(guild_id))
+        return self._state._get_guild(int(self.uild_id))

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -68,10 +68,10 @@ class AppInfo:
         his field will be the id of the "Game SKU" that is created, if exists
     slug: Optional[:class:`str`]
         If this application is a game sold on Discord,
-        this field will be the URL slug that links to the store page  
+        this field will be the URL slug that links to the store page
     cover_image: Optional[:class:`str`]
         If this application is a game sold on Discord,
-        this field will be the hash of the image on store embeds    
+        this field will be the hash of the image on store embeds
     """
     __slots__ = ('_state', 'description', 'id', 'name', 'rpc_origins',
                  'bot_public', 'bot_require_code_grant', 'owner', 'icon',
@@ -89,12 +89,15 @@ class AppInfo:
         self.bot_public = data['bot_public']
         self.bot_require_code_grant = data['bot_require_code_grant']
         self.owner = User(state=self._state, data=data['owner'])
+
         team = data.get('team')
         self.team = Team(state, team) if team else None
         self.summary = data['summary']
         self.verify_key = data['verify_key']
+
         guild_id = data.get('guild_id')
-        self.guild_id = int(guild_id) if guild_id else None
+        self.guild = self._state._get_guild(int(guild_id)) if guild_id else None
+
         primary_sku_id = data.get('primary_sku_id')
         self.primary_sku_id = int(primary_sku_id) if primary_sku_id else None
         self.slug = data.get('slug')

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -55,13 +55,28 @@ class AppInfo:
         grant flow to join.
     rpc_origins: Optional[List[:class:`str`]]
         A list of RPC origin URLs, if RPC is enabled.
-    game_info: Optional[:class:GameInfo]
+    summary: Optional[:class:`str`]
         If this application is a game sold on Discord,
-        this field will be the information related to the game.
+        this field will be the summary field for the store page of its primary SKU
+    verify_key: Optional[:class:`str`]
+        The base64 encoded key for the GameSDK's GetTicket
+    guild_id: Optional[:class:`int`]
+        If this application is a game sold on Discord,
+        this field will be the guild to which it has been linked
+    primary_sku_id: Optional[:class:`int`]
+        If this application is a game sold on Discord,
+        this field will be the id of the "Game SKU" that is created, if exists
+    slug: Optional[:class:`str`]
+        If this application is a game sold on Discord,
+        this field will be the URL slug that links to the store page
+    cover_image: Optional[:class:`str`]
+        If this application is a game sold on Discord,
+        this field will be the hash of the image on store embeds
     """
     __slots__ = ('_state', 'description', 'id', 'name', 'rpc_origins',
                  'bot_public', 'bot_require_code_grant', 'owner', 'icon',
-                 'game_info')
+                 'summary', 'verify_key', 'team', 'guild_id', 'primary_sku_id',
+                  'slug', 'cover_image')
 
     def __init__(self, state, data):
         self._state = state
@@ -82,7 +97,7 @@ class AppInfo:
         self.verify_key = data['verify_key']
 
         guild_id = data.get('guild_id')
-        self.guild = self._state._get_guild(int(guild_id)) if guild_id else None
+        self.guild_id = int(guild_id) if guild_id else None
 
         primary_sku_id = data.get('primary_sku_id')
         self.primary_sku_id = int(primary_sku_id) if primary_sku_id else None
@@ -103,4 +118,8 @@ class AppInfo:
         """:class:`.Asset`: Retrieves the cover image on a store embed."""
         return Asset._from_cover_image(self._state, self)
 
-
+    @property
+    def guild(self):
+        """Optional[:class:`Guild`]: If this application is a game sold on Discord,
+        this field will be the guild to which it has been linked"""
+        return self._state._get_guild(int(guild_id))

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -55,28 +55,13 @@ class AppInfo:
         grant flow to join.
     rpc_origins: Optional[List[:class:`str`]]
         A list of RPC origin URLs, if RPC is enabled.
-    summary: Optional[:class:`str`]
+    game_info: Optional[:class:GameInfo]
         If this application is a game sold on Discord,
-        this field will be the summary field for the store page of its primary SKU
-    verify_key: Optional[:class:`str`]
-        The base64 encoded key for the GameSDK's GetTicket
-    guild: Optional[:class:`Guild`]
-        If this application is a game sold on Discord,
-        this field will be the guild to which it has been linked
-    primary_sku_id: Optional[:class:`int`]
-        If this application is a game sold on Discord,
-        this field will be the id of the "Game SKU" that is created, if exists
-    slug: Optional[:class:`str`]
-        If this application is a game sold on Discord,
-        this field will be the URL slug that links to the store page
-    cover_image: Optional[:class:`str`]
-        If this application is a game sold on Discord,
-        this field will be the hash of the image on store embeds
+        this field will be the information related to the game.
     """
     __slots__ = ('_state', 'description', 'id', 'name', 'rpc_origins',
                  'bot_public', 'bot_require_code_grant', 'owner', 'icon',
-                 'summary', 'verify_key', 'team', 'guild_id', 'primary_sku_id',
-                 'slug', 'cover_image')
+                 'game_info')
 
     def __init__(self, state, data):
         self._state = state
@@ -92,6 +77,43 @@ class AppInfo:
 
         team = data.get('team')
         self.team = Team(state, team) if team else None
+
+        self.game_info = GameInfo(state, data) if data['summary'] else None
+
+    def __repr__(self):
+        return '<{0.__class__.__name__} id={0.id} name={0.name!r} description={0.description!r} public={0.bot_public} ' \
+               'owner={0.owner!r}>'.format(self)
+
+    @property
+    def icon_url(self):
+        """:class:`.Asset`: Retrieves the application's icon asset."""
+        return Asset._from_icon(self._state, self, 'app')
+
+
+class GameInfo:
+
+    """Represents the game information if the
+    application is a game sold on Discord.
+
+    Attributes
+    -------------
+    summary: :class:`str`
+        The summary field for the store page of its primary SKU.
+    verify_key: :class:`str`
+        The base64 encoded key for the GameSDK's GetTicket.
+    guild: Optional[:class:`Guild`]
+        The guild to which it has been linked.
+    primary_sku_id: Optional[:class:`int`]
+        The id of the "Game SKU" that is created, if exists.
+    slug: Optional[:class:`str`]
+        The URL slug that links to the store page.
+    cover_image: Optional[:class:`str`]
+        The hash of the image on store embeds.
+    """
+
+    def __init__(self, state, data):
+        self._state = state
+
         self.summary = data['summary']
         self.verify_key = data['verify_key']
 
@@ -102,15 +124,6 @@ class AppInfo:
         self.primary_sku_id = int(primary_sku_id) if primary_sku_id else None
         self.slug = data.get('slug')
         self.cover_image = data.get('cover_image')
-
-    def __repr__(self):
-        return '<{0.__class__.__name__} id={0.id} name={0.name!r} description={0.description!r} public={0.bot_public} ' \
-               'owner={0.owner!r}>'.format(self)
-
-    @property
-    def icon_url(self):
-        """:class:`.Asset`: Retrieves the application's icon asset."""
-        return Asset._from_icon(self._state, self, 'app')
 
     @property
     def cover_image_url(self):

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -24,6 +24,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
+from . import utils
 from .user import User
 from .asset import Asset
 from .team import Team
@@ -120,4 +121,4 @@ class AppInfo:
     def guild(self):
         """Optional[:class:`Guild`]: If this application is a game sold on Discord,
         this field will be the guild to which it has been linked"""
-        return self._state._get_guild(int(self.uild_id))
+        return self._state._get_guild(int(self.guild_id))

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -95,11 +95,11 @@ class Asset:
         return cls(state, url)
 
     @classmethod
-    def _from_cover_image(cls, state, object):
-        if object.cover_image is None:
+    def _from_cover_image(cls, state, obj):
+        if obj.cover_image is None:
             return cls(state)
 
-        url = 'https://cdn.discordapp.com/app-assets/{0.id}/store/{0.cover_image}.jpg'.format(object)
+        url = 'https://cdn.discordapp.com/app-assets/{0.id}/store/{0.cover_image}.jpg'.format(obj)
         return cls(state, url)
 
     @classmethod

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -95,6 +95,14 @@ class Asset:
         return cls(state, url)
 
     @classmethod
+    def _from_cover_image(cls, state, object):
+        if object.cover_image is None:
+            return cls(state)
+
+        url = 'https://cdn.discordapp.com/app-assets/{0.id}/store/{0.cover_image}.jpg'.format(object)
+        return cls(state, url)
+
+    @classmethod
     def _from_guild_image(cls, state, id, hash, key, *, format='webp', size=1024):
         if not utils.valid_icon_size(size):
             raise InvalidArgument("size must be a power of 2 between 16 and 4096")

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -47,6 +47,7 @@ __all__ = (
     'PremiumType',
     'UserContentFilter',
     'FriendFlags',
+    'TeamMembershipState',
     'Theme',
 )
 
@@ -388,6 +389,10 @@ class HypeSquadHouse(Enum):
 class PremiumType(Enum):
     nitro_classic = 1
     nitro = 2
+
+class TeamMembershipState(Enum):
+    invited = 1
+    accepted = 2
 
 def try_enum(cls, val):
     """A function that tries to turn the value into enum ``cls``.

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -108,7 +108,7 @@ class BotBase(GroupMixin):
         self._help_command = None
         self.description = inspect.cleandoc(description) if description else ''
         self.owner_id = options.get('owner_id')
-        self.team_ids = {}
+        self.team_member_ids = {}
 
         if options.pop('self_bot', False):
             self._skip_check = lambda x, y: x != y
@@ -301,13 +301,13 @@ class BotBase(GroupMixin):
 
         if self.owner_id:
             return user.id == self.owner_id
-        elif self.team_ids:
-            return user.id in self.team_ids
+        elif self.team_member_ids:
+            return user.id in self.team_member_ids
         else:
             app = await self.application_info()
             if app.team:
-                self.team_ids = {m.id for m in app.team.members}
-                return user.id in self.team_ids
+                self.team_member_ids = {m.id for m in app.team.members}
+                return user.id in self.team_member_ids
             else:
                 self.owner_id = owner_id = app.owner.id
                 return user.id == owner_id

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -108,7 +108,16 @@ class BotBase(GroupMixin):
         self._help_command = None
         self.description = inspect.cleandoc(description) if description else ''
         self.owner_id = options.get('owner_id')
-        self.owner_ids = options.get('owner_ids, {})
+        self.owner_ids = options.get('owner_ids', {})
+
+        if self.owner_id and self.owner_ids:
+            raise ValueError('Both owner_id and owner_ids are set.')
+        elif not isinstance(self.owner_id, int):
+            raise ValueError('owner_id is not an int.')
+        elif not isinstance(self.owner_ids, (set, list, tuple)):
+            raise ValueError('owner_ids is not a set, list or tuple.')
+        elif not all(isinstance(i, int) for i in self.owner_ids):
+            raise ValueError('owner_ids has to be an iterable of int.')
 
         if options.pop('self_bot', False):
             self._skip_check = lambda x, y: x != y
@@ -301,7 +310,7 @@ class BotBase(GroupMixin):
 
         if self.owner_id:
             return user.id == self.owner_id
-        elif isinstance(self.owner_ids, (list, tuple, set)):
+        elif self.owner_ids:
             return user.id in self.owner_ids
         else:
             app = await self.application_info()
@@ -972,7 +981,7 @@ class Bot(BotBase, discord.Client):
         :meth:`~.Bot.application_info`.
     owner_ids: Optional[:class:`set`]
         The IDs that owns the bot. This is similar to `owner_id`.
-        If both `owner_id` and `owner_ids` are set, `owner_id` is preferred.
+        If both `owner_id` and `owner_ids` are set, ValueError would be raised.
     """
     pass
 

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -108,7 +108,7 @@ class BotBase(GroupMixin):
         self._help_command = None
         self.description = inspect.cleandoc(description) if description else ''
         self.owner_id = options.get('owner_id')
-        self.team_member_ids = {}
+        self.owner_ids = options.get('owner_ids, {})
 
         if options.pop('self_bot', False):
             self._skip_check = lambda x, y: x != y
@@ -301,13 +301,13 @@ class BotBase(GroupMixin):
 
         if self.owner_id:
             return user.id == self.owner_id
-        elif self.team_member_ids:
-            return user.id in self.team_member_ids
+        elif isinstance(self.owner_ids, (list, tuple, set)):
+            return user.id in self.owner_ids
         else:
             app = await self.application_info()
             if app.team:
-                self.team_member_ids = {m.id for m in app.team.members}
-                return user.id in self.team_member_ids
+                self.owner_ids = {m.id for m in app.team.members}
+                return user.id in self.owner_ids
             else:
                 self.owner_id = owner_id = app.owner.id
                 return user.id == owner_id
@@ -970,6 +970,9 @@ class Bot(BotBase, discord.Client):
         The ID that owns the bot. If this is not set and is then queried via
         :meth:`.is_owner` then it is fetched automatically using
         :meth:`~.Bot.application_info`.
+    owner_ids: Optional[:class:`set`]
+        The IDs that owns the bot. This is similar to `owner_id`.
+        If both `owner_id` and `owner_ids` are set, `owner_id` is preferred.
     """
     pass
 

--- a/discord/team.py
+++ b/discord/team.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-2019 Rapptz
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from .user import User
+from .asset import Asset
+from .enums import TeamMembershipState, try_enum
+
+
+class Team:
+    """Represents an application team for a bot provided by Discord.
+
+
+    Attributes
+    -------------
+    id: :class:`int`
+        The team ID.
+    name: :class:`str`
+        The team name
+    icon: Optional[:class:`str`]
+        The icon hash, if it exists.
+    owner_id: :class:`int`
+        The team's owner ID
+    members: List[:class:`TeamMember`]
+        A list of the members in the team
+    """
+    __slots__ = ('_state', 'id', 'name', 'icon', 'owner_id', 'members')
+
+    def __init__(self, state, data):
+        self._state = state
+
+        self._data = data
+        self.id = int(data['id'])
+        self.name = data['name']
+        self.icon = data['icon']
+        self.owner_id = int(data['owner_user_id'])
+        self.members = [TeamMember(self, self._state, member) for member in data['members']]
+
+    def __repr__(self):
+        return '<{0.__class__.__name__} id={0.id} name={0.name}>'.format(self)
+
+    @property
+    def icon_url(self):
+        """:class:`.Asset`: Retrieves the team's icon asset."""
+        return Asset._from_icon(self._state, self, 'team')
+
+
+class TeamMember:
+    """Represents an team member in a team.
+
+
+    Attributes
+    -------------
+    id: :class:`int`
+        The application ID.
+    team: :class:`team`
+        The team that the member is from.
+    membership_state: :class:`TeamMembershipState`
+        The membership state of the member (e.g. invited or accepted)
+    permissions: List[:class:`str`]
+        The permissions granted to the user in the team.
+        Will always be `[*]`,
+    user: :class:`User`
+        The team member
+    """
+    __slots__ = ('_state', 'team', 'membership_state',
+                 'permissions', 'user')
+
+    def __init__(self, team, state, data):
+        self._state = state
+        self.team = team
+
+        self.membership_state = try_enum(TeamMembershipState, data['membership_state'])
+        self.permissions = data['permissions']
+        self.user = User(state=self._state, data=data['user'])
+
+    def __repr__(self):
+        return '<{0.__class__.__name__} id={0.user.id} name={0.user.name!r}>'.format(self)

--- a/discord/team.py
+++ b/discord/team.py
@@ -67,7 +67,7 @@ class Team:
 
 
 class TeamMember:
-    """Represents an team member in a team.
+    """Represents a team member in a team.
 
 
     Attributes

--- a/discord/team.py
+++ b/discord/team.py
@@ -55,7 +55,7 @@ class Team:
         self.id = int(data['id'])
         self.name = data['name']
         self.icon = data['icon']
-        self.owner_id = int(data['owner_user_id'])
+        self.owner = self._state.get_user(int(data['owner_user_id']))
         self.members = [TeamMember(self, self._state, member) for member in data['members']]
 
     def __repr__(self):

--- a/discord/team.py
+++ b/discord/team.py
@@ -41,7 +41,7 @@ class Team:
         The team name
     icon: Optional[:class:`str`]
         The icon hash, if it exists.
-    owner_id: :class:`int`
+    owner: :class:`User`
         The team's owner ID
     members: List[:class:`TeamMember`]
         A list of the members in the team

--- a/discord/team.py
+++ b/discord/team.py
@@ -41,8 +41,8 @@ class Team:
         The team name
     icon: Optional[:class:`str`]
         The icon hash, if it exists.
-    owner: :class:`User`
-        The team's owner ID
+    owner_id: :class:`int`
+        The team's owner ID.
     members: List[:class:`TeamMember`]
         A list of the members in the team
     """
@@ -54,7 +54,7 @@ class Team:
         self.id = int(data['id'])
         self.name = data['name']
         self.icon = data['icon']
-        self.owner = self._state.get_user(int(data['owner_user_id']))
+        self.owner_id = int(data['owner_user_id'])
         self.members = [TeamMember(self, self._state, member) for member in data['members']]
 
     def __repr__(self):

--- a/discord/team.py
+++ b/discord/team.py
@@ -51,7 +51,6 @@ class Team:
     def __init__(self, state, data):
         self._state = state
 
-        self._data = data
         self.id = int(data['id'])
         self.name = data['name']
         self.icon = data['icon']

--- a/discord/team.py
+++ b/discord/team.py
@@ -24,6 +24,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
+from . import utils
 from .user import User
 from .asset import Asset
 from .enums import TeamMembershipState, try_enum
@@ -51,10 +52,10 @@ class Team:
     def __init__(self, state, data):
         self._state = state
 
-        self.id = int(data['id'])
+        self.id = utils._get_as_snowflake(data, 'id')
         self.name = data['name']
         self.icon = data['icon']
-        self.owner_id = int(data['owner_user_id'])
+        self.owner_id = utils._get_as_snowflake(data, 'owner_user_id')
         self.members = [TeamMember(self, self._state, member) for member in data['members']]
 
     def __repr__(self):

--- a/discord/team.py
+++ b/discord/team.py
@@ -72,8 +72,6 @@ class TeamMember:
 
     Attributes
     -------------
-    id: :class:`int`
-        The application ID.
     team: :class:`team`
         The team that the member is from.
     membership_state: :class:`TeamMembershipState`

--- a/discord/team.py
+++ b/discord/team.py
@@ -81,9 +81,6 @@ class TeamMember:
         The team that the member is from.
     membership_state: :class:`TeamMembershipState`
         The membership state of the member (e.g. invited or accepted)
-    permissions: List[:class:`str`]
-        The permissions granted to the user in the team.
-        Will always be `[*]`,
     user: :class:`User`
         The team member
     """

--- a/discord/team.py
+++ b/discord/team.py
@@ -65,6 +65,11 @@ class Team:
         """:class:`.Asset`: Retrieves the team's icon asset."""
         return Asset._from_icon(self._state, self, 'team')
 
+    @property
+    def owner(self):
+        """Optional[:class:`User`]: The team's owner, if available from the cache."""
+        return self._state.get_user(self.owner_id)
+
 
 class TeamMember:
     """Represents a team member in a team.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -42,6 +42,15 @@ Client
 .. autoclass:: AppInfo
     :members:
 
+.. autoclass:: GameInfo
+    :members:
+
+.. autoclass:: Team
+    :members:
+
+.. autoclass:: TeamMember
+    :members:
+
 Voice
 ------
 
@@ -1536,6 +1545,18 @@ of :class:`enum.Enum`.
 
         Represents the Dark theme on Discord.
 
+
+.. class:: TeamMembershipState
+    
+    Represents the membership state of a team member retrieved through :func:Bot.application_info.
+
+    .. attribue:: invited
+
+        Represents an invited member.
+
+    .. attribute:: accepted
+
+        Represents a member currently in the team.
 
 Async Iterator
 ----------------


### PR DESCRIPTION
### Summary
New data has been added to `/oauth2/applications/@me` with team data (See https://github.com/discordapp/discord-api-docs/issues/787#issuecomment-503660497)

This PR allows for access within the team and adds some shop-related attributes into AppInfo.

<!-- What is this pull request for? Does it fix any issues? -->

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
