### PR TITLE
Add O(log n) Member.has_role(id) method

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1352,7 +1352,7 @@ def has_role(item):
             raise NoPrivateMessage()
 
         if isinstance(item, int):
-            role = discord.utils.get(ctx.author.roles, id=item)
+            role = ctx.author.has_role(item) or None
         else:
             role = discord.utils.get(ctx.author.roles, name=item)
         if role is None:
@@ -1396,8 +1396,9 @@ def has_any_role(*items):
         if not isinstance(ctx.channel, discord.abc.GuildChannel):
             raise NoPrivateMessage()
 
-        getter = functools.partial(discord.utils.get, ctx.author.roles)
-        if any(getter(id=item) is not None if isinstance(item, int) else getter(name=item) is not None for item in items):
+        author = ctx.author
+        getter = functools.partial(discord.utils.get, author.roles)
+        if any(author.has_role(item) is True if isinstance(item, int) else getter(name=item) is not None for item in items):
             return True
         raise MissingAnyRole(items)
 
@@ -1424,7 +1425,7 @@ def bot_has_role(item):
 
         me = ch.guild.me
         if isinstance(item, int):
-            role = discord.utils.get(me.roles, id=item)
+            role = me.has_role(item) or None
         else:
             role = discord.utils.get(me.roles, name=item)
         if role is None:
@@ -1452,7 +1453,7 @@ def bot_has_any_role(*items):
 
         me = ch.guild.me
         getter = functools.partial(discord.utils.get, me.roles)
-        if any(getter(id=item) is not None if isinstance(item, int) else getter(name=item) is not None for item in items):
+        if any(me.has_role(item) is True if isinstance(item, int) else getter(name=item) is not None for item in items):
             return True
         raise BotMissingAnyRole(items)
     return check(predicate)

--- a/discord/member.py
+++ b/discord/member.py
@@ -402,6 +402,22 @@ class Member(discord.abc.Messageable, _BaseUser):
         """
         return channel.permissions_for(self)
 
+    def has_role(self, role_id):
+        """Check if a user has a role with the given ID.
+
+        Parameters
+        ----------
+        role_id: :class:`int`
+            The ID for the role.
+
+        Returns
+        -------
+        bool
+            :code:`True` if the user has a role with the
+            given ID.
+        """
+        return self._roles.has(role_id)
+
     @property
     def top_role(self):
         """:class:`Role`: Returns the member's highest role.


### PR DESCRIPTION
### Summary

Adds a method for quickly checking if a user has a role with the given ID.

I did find #1762 and I agree that this is less pythonic than `role in member.roles`, but also note that it's a somewhat costly operation of creating a new sorted list of roles, then doing a linear search on it, as opposed to just an O(log n) binary search on an already sorted array of ints.

I've updated the `@has_role`, `@bot_has_role` et al. check decorators to use this new method, when a snowflake is provided. My (Red's) use case is somewhat similar to the `@has_any_roles` decorator, where a lot of commands will require checking whether a user has "mod" or "admin" role - this would be a welcome performance boost for those sorts of commands.

### Checklist

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
