### PR TITLE
bot.load_extension: don't raise ExtensionNotFound for ImportErrors inside the module

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -586,7 +586,7 @@ class BotBase(GroupMixin):
         except Exception as e:
             self._remove_module_references(lib.__name__)
             self._call_module_finalizers(lib, key)
-            raised errors.ExtensionFailed(key, e) from e
+            raise errors.ExtensionFailed(key, e) from e
         else:
             sys.modules[key] = self.__extensions[key] = lib
 

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -503,7 +503,7 @@ class NoEntryPointError(ExtensionError):
         super().__init__("Extension {!r} has no 'setup' function.".format(name), name=name)
 
 class ExtensionFailed(ExtensionError):
-    """An exception raised when an extension failed to load during execution of the ``setup`` entry point.
+    """An exception raised when an extension failed to load during execution of the module or ``setup`` entry point.
 
     This inherits from :exc:`ExtensionError`
 
@@ -521,7 +521,7 @@ class ExtensionFailed(ExtensionError):
         super().__init__(fmt.format(name, original), name=name)
 
 class ExtensionNotFound(ExtensionError):
-    """An exception raised when an extension failed to be imported.
+    """An exception raised when an extension is not found.
 
     This inherits from :exc:`ExtensionError`
 
@@ -529,11 +529,7 @@ class ExtensionNotFound(ExtensionError):
     -----------
     name: :class:`str`
         The extension that had the error.
-    original: :exc:`ImportError`
-        The original exception that was raised. You can also get this via
-        the ``__cause__`` attribute.
     """
-    def __init__(self, name, original):
-        self.original = original
+    def __init__(self, name):
         fmt = 'Extension {0!r} could not be loaded.'
         super().__init__(fmt.format(name), name=name)

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -532,7 +532,7 @@ class ExtensionNotFound(ExtensionError):
     original: :class:`NoneType`
         Always ``None`` for backwards compatibility.
     """
-    def __init__(self, name):
+    def __init__(self, name, original=None):
         self.original = None
         fmt = 'Extension {0!r} could not be loaded.'
         super().__init__(fmt.format(name), name=name)

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -525,6 +525,9 @@ class ExtensionNotFound(ExtensionError):
 
     This inherits from :exc:`ExtensionError`
 
+    .. versionchanged:: 1.3.0
+        Made the ``original`` attribute always None.
+
     Attributes
     -----------
     name: :class:`str`

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -529,7 +529,10 @@ class ExtensionNotFound(ExtensionError):
     -----------
     name: :class:`str`
         The extension that had the error.
+    original: :class:`NoneType`
+        Always ``None`` for backwards compatibility.
     """
     def __init__(self, name):
+        self.original = None
         fmt = 'Extension {0!r} could not be loaded.'
         super().__init__(fmt.format(name), name=name)


### PR DESCRIPTION
Now loading an extension that _contains_ a failed import will fail with ExtensionFailed, rather than ExtensionNotFound.

Open question: I'm not sure if that `unload()` local function inside Bot#_load_from_module_spec should be there, or if its code should be duplicated.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
