### PR TITLE
Removed Returns from all decorator docstrings

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -348,7 +348,7 @@ class Loop:
 
 def loop(*, seconds=0, minutes=0, hours=0, count=None, reconnect=True, loop=None):
     """A decorator that schedules a task in the background for you with
-    optional reconnect logic.
+    optional reconnect logic. The decorator returns a :class:`Loop`.
 
     Parameters
     ------------
@@ -375,11 +375,6 @@ def loop(*, seconds=0, minutes=0, hours=0, count=None, reconnect=True, loop=None
         An invalid value was given.
     TypeError
         The function was not a coroutine.
-
-    Returns
-    ---------
-    :class:`Loop`
-        The loop helper that handles the background task.
     """
     def decorator(func):
         return Loop(func, seconds=seconds, minutes=minutes, hours=hours,


### PR DESCRIPTION
### Summary

This removes all `Returns` in any docstring for a decorator. This is because they specify what the function returns, not the decorator, as the decorator returns a function. This also means that linters e.g. PyCharm's can work out the correct type of the return instead of receiving the wrong one, leading to errors when it thinks the decorator returns e.g. a `Loop` instance instead of a function.
It also makes it more consistent as `tasks.loop` is the only decorator with a `Returns` in the docstring. For example, `commands.command`:
https://github.com/Rapptz/discord.py/blob/0cf38241d00df3c89c74889a2a73a4c33bb649f9/discord/ext/commands/core.py#L1205-L1234

For example, if you use `tasks.loop()`, the linter will warn saying:
```
'Loop' object is not callable
Inspection info: This inspection highlights attempts to call objects which are not callable, like, for example, tuples.
```
as this is the return type described in the docstring instead of a callable that returns `Loop`.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
