### PR TITLE
Fix documentation for abc.GuildChannel.set_permissions

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -552,8 +552,9 @@ class GuildChannel:
         -----------
         target: Union[:class:`~discord.Member`, :class:`~discord.Role`]
             The member or role to overwrite permissions for.
-        overwrite: :class:`~discord.PermissionOverwrite`
-            The permissions to allow and deny to the target.
+        overwrite: Optional[:class:`~discord.PermissionOverwrite`]
+            The permissions to allow and deny to the target, or `None` to
+            delete the overwrite.
         \*\*permissions
             A keyword argument list of permissions to set for ease of use.
             Cannot be mixed with ``overwrite``.


### PR DESCRIPTION
### Summary

Changes the `overwrite` parameter in GuildChannel.set_permissions to `Optional[PermissionOverwrite]` as you can pass `None` to delete the permissions.
This was mostly reflective in PyCharm. ![img](https://i.imgur.com/pw7lEHE.png)

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
