### PR TITLE
Calculate suffix length at each add_line

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -83,7 +83,7 @@ class Paginator:
     def __init__(self, prefix='```', suffix='```', max_size=2000):
         self.prefix = prefix
         self.suffix = suffix
-        self.max_size = max_size - (0 if suffix is None else len(suffix))
+        self.max_size = max_size
         self.clear()
 
     def clear(self):
@@ -99,6 +99,10 @@ class Paginator:
     @property
     def _prefix_len(self):
         return len(self.prefix) if self.prefix else 0
+
+    @property
+    def _suffix_len(self):
+        return len(self.suffix) if self.suffix else 0
 
     def add_line(self, line='', *, empty=False):
         """Adds a line to the current page.
@@ -118,11 +122,11 @@ class Paginator:
         RuntimeError
             The line was too big for the current :attr:`max_size`.
         """
-        max_page_size = self.max_size - self._prefix_len - 2
+        max_page_size = self.max_size - self._prefix_len - self._suffix_len - 2
         if len(line) > max_page_size:
             raise RuntimeError('Line exceeds maximum page size %s' % (max_page_size))
 
-        if self._count + len(line) + 1 > self.max_size:
+        if self._count + len(line) + 1 > self.max_size - self._suffix_len:
             self.close_page()
 
         self._count += len(line) + 1


### PR DESCRIPTION
### Summary

Currently, only the length of the prefix is calculated at each `add_line`, whereas the length of the suffix is calculated when the paginator is instantiated.

This means in the current situation, you can update the prefix of the paginator before generating a set of custom lines/pages and it will work fine as it will adjust accordingly. However, if you make the suffix larger than it was originally instantiated, it won't account for this and so will generate a body larger than expected.

This PR resolves this issue by calculating the suffix size as well as the prefix size at each `add_line` call.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
