### PR TITLE
Add FFmpegOpusAudio and other improvements

### DIFF
--- a/discord/oggparse.py
+++ b/discord/oggparse.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-2019 Rapptz
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+import struct
+
+from .errors import DiscordException
+
+class OggError(DiscordException):
+    """An exception that is thrown for Ogg stream parsing errors."""
+    pass
+
+# https://tools.ietf.org/html/rfc3533
+# https://tools.ietf.org/html/rfc7845
+
+class OggPage:
+    _header = struct.Struct('<xBQIIIB')
+
+    def __init__(self, stream):
+        try:
+            header = stream.read(struct.calcsize(self._header.format))
+
+            self.flag, self.gran_pos, self.serial, \
+            self.pagenum, self.crc, self.segnum = self._header.unpack(header)
+
+            self.segtable = stream.read(self.segnum)
+            bodylen = sum(struct.unpack('B'*self.segnum, self.segtable))
+            self.data = stream.read(bodylen)
+        except:
+            raise OggError('bad data stream') from None
+
+    def iter_packets(self):
+        packetlen = offset = 0
+        partial = True
+
+        for seg in self.segtable:
+            if seg == 255:
+                packetlen += 255
+                partial = True
+            else:
+                packetlen += seg
+                yield self.data[offset:offset+packetlen], True
+                offset += packetlen
+                packetlen = 0
+                partial = False
+
+        if partial:
+            yield self.data[offset:], False
+
+class OggStream:
+    def __init__(self, stream):
+        self.stream = stream
+
+    def _next_page(self):
+        head = self.stream.read(4)
+        if head == b'OggS':
+            return OggPage(self.stream)
+        else:
+            raise OggError('invalid header magic')
+
+    def _iter_pages(self):
+        page = self._next_page()
+        while page:
+            yield page
+            page = self._next_page()
+
+    def iter_packets(self):
+        partial = b''
+        for page in self._iter_pages():
+            for data, complete in page.iter_packets():
+                partial += data
+                if complete:
+                    yield partial
+                    partial = b''

--- a/discord/oggparse.py
+++ b/discord/oggparse.py
@@ -48,7 +48,7 @@ class OggPage:
             self.segtable = stream.read(self.segnum)
             bodylen = sum(struct.unpack('B'*self.segnum, self.segtable))
             self.data = stream.read(bodylen)
-        except:
+        except Exception:
             raise OggError('bad data stream') from None
 
     def iter_packets(self):

--- a/discord/opus.py
+++ b/discord/opus.py
@@ -121,10 +121,10 @@ def load_opus(name):
     """Loads the libopus shared library for use with voice.
 
     If this function is not called then the library uses the function
-    :func:`ctypes.util.find_library` and then loads that one
-    if available.
+    :func:`ctypes.util.find_library` and then loads that one if available.
 
-    Not loading a library leads to voice not working.
+    Not loading a library and attempting to use PCM based AudioSources will
+    lead to voice not working.
 
     This function propagates the exceptions thrown.
 

--- a/discord/opus.py
+++ b/discord/opus.py
@@ -38,6 +38,8 @@ c_int_ptr = ctypes.POINTER(ctypes.c_int)
 c_int16_ptr = ctypes.POINTER(ctypes.c_int16)
 c_float_ptr = ctypes.POINTER(ctypes.c_float)
 
+_lib = None
+
 class EncoderStruct(ctypes.Structure):
     pass
 
@@ -100,16 +102,20 @@ def libopus_loader(name):
 
     return lib
 
-try:
-    if sys.platform == 'win32':
-        _basedir = os.path.dirname(os.path.abspath(__file__))
-        _bitness = 'x64' if sys.maxsize > 2**32 else 'x86'
-        _filename = os.path.join(_basedir, 'bin', 'libopus-0.{}.dll'.format(_bitness))
-        _lib = libopus_loader(_filename)
-    else:
-        _lib = libopus_loader(ctypes.util.find_library('opus'))
-except Exception:
-    _lib = None
+def _load_default():
+    global _lib
+    try:
+        if sys.platform == 'win32':
+            _basedir = os.path.dirname(os.path.abspath(__file__))
+            _bitness = 'x64' if sys.maxsize > 2**32 else 'x86'
+            _filename = os.path.join(_basedir, 'bin', 'libopus-0.{}.dll'.format(_bitness))
+            _lib = libopus_loader(_filename)
+        else:
+            _lib = libopus_loader(ctypes.util.find_library('opus'))
+    except Exception:
+        _lib = None
+
+    return _lib is not None
 
 def load_opus(name):
     """Loads the libopus shared library for use with voice.
@@ -221,7 +227,8 @@ class Encoder:
         self.application = application
 
         if not is_loaded():
-            raise OpusNotLoaded()
+            if not _load_default():
+                raise OpusNotLoaded()
 
         self._state = self._create_state()
         self.set_bitrate(128)

--- a/discord/player.py
+++ b/discord/player.py
@@ -522,7 +522,7 @@ class AudioPlayer(threading.Thread):
 
     def _do_run(self):
         self.loops = 0
-        self._start = time.time()
+        self._start = time.perf_counter()
 
         # getattr lookup speed ups
         play_audio = self.client.send_audio_packet
@@ -541,7 +541,7 @@ class AudioPlayer(threading.Thread):
                 self._connected.wait()
                 # reset our internal data
                 self.loops = 0
-                self._start = time.time()
+                self._start = time.perf_counter()
 
             self.loops += 1
             data = self.source.read()
@@ -552,7 +552,7 @@ class AudioPlayer(threading.Thread):
 
             play_audio(data, encode=not self.source.is_opus())
             next_time = self._start + self.DELAY * self.loops
-            delay = max(0, self.DELAY + (next_time - time.time()))
+            delay = max(0, self.DELAY + (next_time - time.perf_counter()))
             time.sleep(delay)
 
     def run(self):
@@ -584,7 +584,7 @@ class AudioPlayer(threading.Thread):
 
     def resume(self, *, update_speaking=True):
         self.loops = 0
-        self._start = time.time()
+        self._start = time.perf_counter()
         self._resumed.set()
         if update_speaking:
             self._speak(True)

--- a/discord/player.py
+++ b/discord/player.py
@@ -43,7 +43,9 @@ log = logging.getLogger(__name__)
 __all__ = (
     'AudioSource',
     'PCMAudio',
+    'FFmpegAudio',
     'FFmpegPCMAudio',
+    'FFmpegOpusAudio',
     'PCMVolumeTransformer',
 )
 

--- a/discord/player.py
+++ b/discord/player.py
@@ -113,8 +113,8 @@ class PCMAudio(AudioSource):
 class FFmpegAudio(AudioSource):
     """Represents an FFmpeg based AudioSource."""
 
-    def __init__(self, source, *, ffmpeg_args, **subprocess_kwargs):
-        args = [executable, *ffmpeg_args]
+    def __init__(self, source, *, args, **subprocess_kwargs):
+        args = [executable, *args]
         kwargs = {'stdout': subprocess.PIPE}
         kwargs.update(subprocess_kwargs)
 
@@ -211,7 +211,7 @@ class FFmpegPCMAudio(FFmpegAudio):
 
         args.append('pipe:1')
 
-        super().__init__(source, executable=executable, ffmpeg_args=args, **subprocess_kwargs)
+        super().__init__(source, executable=executable, args=args, **subprocess_kwargs)
 
     def read(self):
         ret = self._stdout.read(OpusEncoder.FRAME_SIZE)
@@ -228,6 +228,7 @@ class FFmpegOpusAudio(FFmpegAudio):
     def __init__(self, source, *, bitrate=None, probe=False, executable='ffmpeg',
                  pipe=False, stderr=None, before_options=None, options=None):
 
+        self.executable = executable
         args = [executable]
         subprocess_kwargs = {'stdin': None if not pipe else source, 'stderr': stderr}
 
@@ -257,16 +258,21 @@ class FFmpegOpusAudio(FFmpegAudio):
 
         args.append('pipe:1')
 
-        super().__init__(source, executable=executable, ffmpeg_args=args, **subprocess_kwargs)
+        super().__init__(source, executable=executable, args=args, **subprocess_kwargs)
         self._packet_iter = OggStream(self._stdout).iter_packets()
 
     def probe(self, source, *, method='ffprobe'):
         """TODO"""
 
         if isinstance(method, str):
+            if self.executable == 'avconv':
+                self._probe_codec_avprobe = self._probe_codec_ffprobe
+                self._probe_codec_avconv = self._probe_codec_ffmpeg
+
             probefunc = getattr(self, '_probe_codec_' + method, None)
             if probefunc is None:
                 raise AttributeError("Invalid probe method: %s" % method)
+
         elif callable(method):
             probefunc = method
         else:
@@ -277,26 +283,29 @@ class FFmpegOpusAudio(FFmpegAudio):
         try:
             codec, bitrate = probefunc(source)
         except:
-            log.exception("Failed to probe with %s, falling back to ffmpeg probe", method)
+            log.exception("Failed to probe with %s, falling back to %s probe", method, self.executable)
             try:
                 codec, bitrate = self._probe_codec_ffmpeg(source)
             except:
-                log.exception("Fallback ffmpeg probe failed")
+                log.exception("Fallback %s probe failed", self.executable)
 
         log.info("Probe found codec=%s, bitrate=%s", codec, bitrate)
         return codec, bitrate
 
     def _probe_codec_ffprobe(self, source):
-        args = ['ffprobe', '-v', 'quiet', '-print_format', 'json', '-show_streams', '-select_streams', 'a:0', source]
+        exe = 'ffprobe' if self.executable == 'ffmpeg' else 'avprobe'
+        args = [exe, '-v', 'quiet', '-print_format', 'json', '-show_streams', '-select_streams', 'a:0', source]
         output = subprocess.check_output(args)
+
         if output:
             data = json.loads(output)
             streamdata = data['streams'][0]
             bitrate = int(streamdata.get('bit_rate'))
-            return codec = streamdata.get('codec_name'), max(round(bitrate/1000, 0), 128)
+
+            return streamdata.get('codec_name'), max(round(bitrate/1000, 0), 128)
 
     def _probe_codec_ffmpeg(self, source):
-        args = ['ffmpeg','-hide_banner', '-i',  source]
+        args = [self.executable, '-hide_banner', '-i',  source]
         proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         output, _ = proc.communicate()
 

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -68,11 +68,10 @@ class VoiceClient:
 
     Warning
     --------
-    In order to play audio, you must have loaded the opus library
-    through :func:`opus.load_opus`.
-
-    If you don't do this then the library will not be able to
-    transmit audio.
+    In order to use PCM based AudioSources, you must have the opus library
+    installed on your system and loaded through :func:`opus.load_opus`.
+    Otherwise, your AudioSources must be opus encoded (e.g. using :class:`FFmpegOpusAudio`)
+    or the library will not be able to transmit audio.
 
     Attributes
     -----------

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -111,7 +111,7 @@ class VoiceClient:
         self.timestamp = 0
         self._runner = None
         self._player = None
-        self.encoder = opus.Encoder()
+        self.encoder = None
 
     warn_nacl = not has_nacl
     supported_modes = (
@@ -356,7 +356,9 @@ class VoiceClient:
         ClientException
             Already playing audio or not connected.
         TypeError
-            source is not a :class:`AudioSource` or after is not a callable.
+            Source is not a :class:`AudioSource` or after is not a callable.
+        OpusNotLoaded
+            Source is not opus encoded and opus is not loaded.
         """
 
         if not self.is_connected():
@@ -367,6 +369,9 @@ class VoiceClient:
 
         if not isinstance(source, AudioSource):
             raise TypeError('source must an AudioSource not {0.__class__.__name__}'.format(source))
+
+        if not self.encoder and not source.is_opus():
+            self.encoder = opus.Encoder()
 
         self._player = AudioPlayer(source, self, after=after)
         self._player.start()
@@ -444,4 +449,4 @@ class VoiceClient:
         except BlockingIOError:
             log.warning('A packet has been dropped (seq: %s, timestamp: %s)', self.sequence, self.timestamp)
 
-        self.checked_add('timestamp', self.encoder.SAMPLES_PER_FRAME, 4294967295)
+        self.checked_add('timestamp', opus.Encoder.SAMPLES_PER_FRAME, 4294967295)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -60,7 +60,13 @@ Voice
 .. autoclass:: PCMAudio
     :members:
 
+.. autoclass:: FFmpegAudio
+    :members:
+
 .. autoclass:: FFmpegPCMAudio
+    :members:
+
+.. autoclass:: FFmpegOpusAudio
     :members:
 
 .. autoclass:: PCMVolumeTransformer


### PR DESCRIPTION
### Summary

This PR adds several voice related improvements, the main one being the addition of the `FFmpegOpusAudio` AudioSource.  This source skips the opus encoding step in the library by having ffmpeg encode to opus and parsing the output.  This way libopus is not a hard library requirement when using voice.  Other improvements include:
- New `FFmpegAudio` base class to assist with making custom ffmpeg based audio sources.
- Using more accurate and monotonic `time.perf_counter()` in AudioPlayer instead of `time.time()`.
- Lazy opus loading.  The library no longer loads libopus on import, now only on `opus.Encoder` creation or manually.  Additionally, `VoiceClient` now creates its encoder object in `play()` instead of in `__init__`.
  - This also fixes the issue (on Windows at least) where importing the library in a repl or having a bot running loads the libopus binary, placing a file lock it it even when not actively using voice, preventing updates to the library.

### Checklist

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue. (Fixes #1846, more or less.)
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
