### PR TITLE
Fix return type docstring for BaseUser.default_avatar

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -166,7 +166,7 @@ class BaseUser(_BaseUser):
 
     @property
     def default_avatar(self):
-        """class:`DefaultAvatar`: Returns the default avatar for a given user. This is calculated by the user's discriminator."""
+        """:class:`DefaultAvatar`: Returns the default avatar for a given user. This is calculated by the user's discriminator."""
         return try_enum(DefaultAvatar, int(self.discriminator) % len(DefaultAvatar))
 
     @property


### PR DESCRIPTION
### Summary

Fixes return type for BaseUser.default_avatar

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
