### PR TITLE
bot.is_owner() should be marked as coroutine in documentation

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -285,7 +285,9 @@ class BotBase(GroupMixin):
         return await discord.utils.async_all(f(ctx) for f in data)
 
     async def is_owner(self, user):
-        """Checks if a :class:`~discord.User` or :class:`~discord.Member` is the owner of
+        """|coro|
+        
+        Checks if a :class:`~discord.User` or :class:`~discord.Member` is the owner of
         this bot.
 
         If an :attr:`owner_id` is not set, it is fetched automatically


### PR DESCRIPTION
### Summary

`is_owner` is a coroutine (needs to be `await`ed) but it is not marked as such in the documentation.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
