### PR TITLE
Fix BaseUser.permissions_in

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -220,7 +220,7 @@ class BaseUser(_BaseUser):
         channel: :class:`abc.GuildChannel`
             The channel to check your permissions for.
         """
-        return channel.permissions_for(self)
+        return channel.permissions_for(channel.guild.get_member(self.id))
 
     @property
     def created_at(self):


### PR DESCRIPTION
### Summary

User objects don't have roles, so they need to be converted to Member objects first.

Example:
```
import discord

client = discord.Client()

@client.event
async def on_ready():
    for guild in client.guilds:
        print(f"{guild.name}")
        for channel in guild.channels:
            permissions = client.user.permissions_in(channel)
            print(f"\t{channel.name}:{permissions}")
    await client.logout()

client.run("token")
```
Results in:
```
Ignoring exception in on_ready
Traceback (most recent call last):
  File "/discord.py/discord/client.py", line 296, in _run_event
    await coro(*args, **kwargs)
  File "test.py", line 10, in on_ready
    permissions = client.user.permissions_in(channel)
  File "/discord.py/discord/user.py", line 223, in permissions_in
    return channel.permissions_for(self)
  File "/discord.py/discord/abc.py", line 426, in permissions_for
    roles = member.roles
AttributeError: 'ClientUser' object has no attribute 'roles'
```

### Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
