### PR TITLE
Always add to sys.modules in load_extension

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -637,7 +637,7 @@ class BotBase(GroupMixin):
         NoEntryPointError
             The extension does not have a setup function.
         ExtensionFailed
-            The extension setup function had an execution error.
+            The extension or its setup function had an execution error.
         """
 
         if name in self.__extensions:


### PR DESCRIPTION
### Summary

Loading an extension not contained in a subpackage now correctly adds the module to `sys.modules`.
Example:

```
bot.load_extension('foo')
assert 'foo' in sys.modules
```
With `def setup(bot): pass` as the contents of `foo.py` no longer errors.

Additionally, the documentation for load_extension has been clarified to point out that any part of the extension may fail for ExtensionFailed to be raised.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
