### PR TITLE
Disambiguate and normalize documentation for non-bot only methods

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -1228,7 +1228,11 @@ class Client:
     async def fetch_user_profile(self, user_id):
         """|coro|
 
-        Gets an arbitrary user's profile. This can only be used by non-bot accounts.
+        Gets an arbitrary user's profile.
+
+        .. note::
+
+            This can only be used by non-bot accounts.
 
         Parameters
         ------------

--- a/discord/user.py
+++ b/discord/user.py
@@ -331,7 +331,7 @@ class ClientUser(BaseUser):
 
         .. note::
 
-            This only applies to non-bot accounts.
+            This can only be used by non-bot accounts.
 
         Parameters
         -----------
@@ -351,7 +351,7 @@ class ClientUser(BaseUser):
 
         .. note::
 
-            This only applies to non-bot accounts.
+            This can only be used by non-bot accounts.
         """
         return list(self._relationships.values())
 
@@ -361,7 +361,7 @@ class ClientUser(BaseUser):
 
         .. note::
 
-            This only applies to non-bot accounts.
+            This can only be used by non-bot accounts.
         """
         return [r.user for r in self._relationships.values() if r.type is RelationshipType.friend]
 
@@ -371,7 +371,7 @@ class ClientUser(BaseUser):
 
         .. note::
 
-            This only applies to non-bot accounts.
+            This can only be used by non-bot accounts.
         """
         return [r.user for r in self._relationships.values() if r.type is RelationshipType.blocked]
 
@@ -483,7 +483,7 @@ class ClientUser(BaseUser):
 
         .. note::
 
-            This only applies to non-bot accounts.
+            This can only be used by non-bot accounts.
 
         Parameters
         -----------
@@ -521,7 +521,7 @@ class ClientUser(BaseUser):
 
         .. note::
 
-            This only applies to non-bot accounts.
+            This can only be used by non-bot accounts.
 
         Parameters
         -------
@@ -698,7 +698,7 @@ class User(BaseUser, discord.abc.Messageable):
 
         .. note::
 
-            This only applies to non-bot accounts.
+            This can only be used by non-bot accounts.
         """
         return self._state.user.get_relationship(self.id)
 
@@ -709,7 +709,7 @@ class User(BaseUser, discord.abc.Messageable):
 
         .. note::
 
-            This only applies to non-bot accounts.
+            This can only be used by non-bot accounts.
 
         Raises
         -------
@@ -732,7 +732,7 @@ class User(BaseUser, discord.abc.Messageable):
 
         .. note::
 
-            This only applies to non-bot accounts.
+            This can only be used by non-bot accounts.
         """
         r = self.relationship
         if r is None:
@@ -744,7 +744,7 @@ class User(BaseUser, discord.abc.Messageable):
 
         .. note::
 
-            This only applies to non-bot accounts.
+            This can only be used by non-bot accounts.
         """
         r = self.relationship
         if r is None:
@@ -758,7 +758,7 @@ class User(BaseUser, discord.abc.Messageable):
 
         .. note::
 
-            This only applies to non-bot accounts.
+            This can only be used by non-bot accounts.
 
         Raises
         -------
@@ -777,7 +777,7 @@ class User(BaseUser, discord.abc.Messageable):
 
         .. note::
 
-            This only applies to non-bot accounts.
+            This can only be used by non-bot accounts.
 
         Raises
         -------
@@ -795,7 +795,7 @@ class User(BaseUser, discord.abc.Messageable):
 
         .. note::
 
-            This only applies to non-bot accounts.
+            This can only be used by non-bot accounts.
 
         Raises
         -------
@@ -813,7 +813,7 @@ class User(BaseUser, discord.abc.Messageable):
 
         .. note::
 
-            This only applies to non-bot accounts.
+            This can only be used by non-bot accounts.
 
         Raises
         -------
@@ -831,7 +831,7 @@ class User(BaseUser, discord.abc.Messageable):
 
         .. note::
 
-            This only applies to non-bot accounts.
+            This can only be used by non-bot accounts.
 
         Raises
         -------

--- a/docs/locale/ja/LC_MESSAGES/api.po
+++ b/docs/locale/ja/LC_MESSAGES/api.po
@@ -6530,7 +6530,7 @@ msgstr "該当すれば :class:`Relationship` が返ります。"
 #: discord.User.mutual_friends:7 discord.User.profile:7
 #: discord.User.relationship:5 discord.User.remove_friend:7
 #: discord.User.send_friend_request:7 discord.User.unblock:7 of
-msgid "This only applies to non-bot accounts."
+msgid "This can only be used by non-bot accounts."
 msgstr ""
 
 #: discord.ClientUser.get_relationship:7 of


### PR DESCRIPTION
### Summary

This PR slightly modifies documentation regarding methods that are only accessible
by non-bot only accounts.

These changes are intended to reduce future confusion regarding the usage of
these methods.

<!-- What is this pull request for? Does it fix any issues? -->

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
