### PR TITLE
Add permissions_synced to abc.GuildChannel

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -391,7 +391,10 @@ class GuildChannel:
         If there is no category then this is ``False``.
         """
         category = self.guild.get_channel(self.category_id)
-        return self._overwrites == category._overwrites
+        if category is not None:
+            return self._overwrites == category._overwrites
+        else:
+            return False
 
     def permissions_for(self, member):
         """Handles permission resolution for the current :class:`~discord.Member`.

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -383,6 +383,16 @@ class GuildChannel:
         """
         return self.guild.get_channel(self.category_id)
 
+    @property
+    def permissions_synced(self):
+        """:class:`bool`: Whether or not the permissions for this channel are synced with the
+        category it belongs to.
+
+        If there is no category then this is ``False``.
+        """
+        category = self.guild.get_channel(self.category_id)
+        return self._overwrites == category._overwrites
+
     def permissions_for(self, member):
         """Handles permission resolution for the current :class:`~discord.Member`.
 

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -391,10 +391,7 @@ class GuildChannel:
         If there is no category then this is ``False``.
         """
         category = self.guild.get_channel(self.category_id)
-        if category is not None:
-            return self._overwrites == category._overwrites
-        else:
-            return False
+        return category and category._overwrites == self._overwrites
 
     def permissions_for(self, member):
         """Handles permission resolution for the current :class:`~discord.Member`.


### PR DESCRIPTION
### Summary

This allows users to check whether or not the permissions for a Guild Channel are synced with the permissions for its category. Discord automatically syncs the permissions when the overwrites are equal so just checking if the two overwrites are equal will determine if they are synced. 

I feel as if the name isn't perfect, but I couldn't think of something that worked better. If anyone has any suggestions you can just leave them in the comments.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)