### PR TITLE
Add channel_id to RawMessageUpdateEvent

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -89,16 +89,19 @@ class RawMessageUpdateEvent(_RawReprMixin):
     -----------
     message_id: :class:`int`
         The message ID that got updated.
+    channel_id: :class:`int`
+        The channel ID where the update took place.
     data: :class:`dict`
         The raw data given by the `gateway <https://discordapp.com/developers/docs/topics/gateway#message-update>`_
     cached_message: Optional[:class:`Message`]
         The cached message, if found in the internal message cache.
     """
 
-    __slots__ = ('message_id', 'data', 'cached_message')
+    __slots__ = ('message_id', 'channel_id', 'data', 'cached_message')
 
     def __init__(self, data):
         self.message_id = int(data['id'])
+        self.channel_id = int(data['channel_id'])
         self.data = data
         self.cached_message = None
 


### PR DESCRIPTION
### Summary

Before this a `RawMessageUpdateEvent` had no `channel_id` property. It could, however, be accessed with `.data["channel_id"]`

This is my first PR to anything ever so it's just a tiny change. Sorry if something is wrong.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes. (I think it updates automatically for what I did)
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
