### PR TITLE
src: Proper case for X-RateLimit-Reset header

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -304,7 +304,7 @@ def to_json(obj):
 
 def _parse_ratelimit_header(request):
     now = parsedate_to_datetime(request.headers['Date'])
-    reset = datetime.datetime.fromtimestamp(int(request.headers['X-Ratelimit-Reset']), datetime.timezone.utc)
+    reset = datetime.datetime.fromtimestamp(int(request.headers['X-RateLimit-Reset']), datetime.timezone.utc)
     return (reset - now).total_seconds()
 
 async def maybe_coroutine(f, *args, **kwargs):


### PR DESCRIPTION
### Summary

The Discord docs state the reset header as `X-RateLimit-Reset`, while the `_parse_ratelimit_header` function used `X-Ratelimit-Reset`. I don't exactly know how to test this change (or if it's even necessary), but maybe this fixes a bug!

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
