### PR TITLE
Fixing Typo in guild_subscriptions Docs

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -153,7 +153,7 @@ class Client:
         processing the initial packets take too long to the point of disconnecting
         you. The default timeout is 60 seconds.
     guild_subscriptions: :class:`bool`
-        Whether to dispatching of presence or typing events. Defaults to ``True``.
+        Whether or not to dispatch presence and typing events. Defaults to ``True``.
 
         .. versionadded:: 1.3
 


### PR DESCRIPTION
### Summary

Fixes typo in docs for guild_subscriptions.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
