### PR TITLE
Make permissions_synced actually return False

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -396,7 +396,7 @@ class GuildChannel:
         .. versionadded:: 1.3
         """
         category = self.guild.get_channel(self.category_id)
-        return category and category._overwrites == self._overwrites
+        return bool(category and category._overwrites == self._overwrites)
 
     def permissions_for(self, member):
         """Handles permission resolution for the current :class:`~discord.Member`.


### PR DESCRIPTION
The code before this returned None when there is no category. This adds `bool()` to ensure only True/False are returned.

### Summary
Learn Python, understand `and` operator, don't miss the case.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] You have already updated the documentation without making the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
