### PR TITLE
Fix FFmpegAudio._process not existing if _spawn_process raises

### DIFF
--- a/discord/player.py
+++ b/discord/player.py
@@ -122,6 +122,8 @@ class FFmpegAudio(AudioSource):
     """
 
     def __init__(self, source, *, executable='ffmpeg', args, **subprocess_kwargs):
+        self._process = self._stdout = None
+
         args = [executable, *args]
         kwargs = {'stdout': subprocess.PIPE}
         kwargs.update(subprocess_kwargs)


### PR DESCRIPTION
### Summary

Fixes oversight on my part.

### Checklist

<!-- Put an x inside [ ] to check it -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
