### PR TITLE
[commands] default Bot.owner_ids to a set

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -108,7 +108,7 @@ class BotBase(GroupMixin):
         self._help_command = None
         self.description = inspect.cleandoc(description) if description else ''
         self.owner_id = options.get('owner_id')
-        self.owner_ids = options.get('owner_ids', {})
+        self.owner_ids = options.get('owner_ids', set())
 
         if self.owner_id and self.owner_ids:
             raise TypeError('Both owner_id and owner_ids are set.')


### PR DESCRIPTION
### Summary

This appears to be a typo, as everywhere else, owner_ids is set to a set.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
