### PR TITLE
Fix discord.Object type hinting docs

### DIFF
--- a/discord/object.py
+++ b/discord/object.py
@@ -57,7 +57,7 @@ class Object(Hashable):
 
     Attributes
     -----------
-    id: :class:`str`
+    id: :class:`int`
         The ID of the object.
     """
 


### PR DESCRIPTION
discord.Object requires ID as an int not str

### Summary

<!-- What is this pull request for? Does it fix any issues? -->

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
