### PR TITLE
Reaction's emoji can be a partial one too

### DIFF
--- a/discord/reaction.py
+++ b/discord/reaction.py
@@ -54,7 +54,7 @@ class Reaction:
 
     Attributes
     -----------
-    emoji: Union[:class:`Emoji`, :class:`str`]
+    emoji: Union[:class:`Emoji`, :class:`PartialEmoji`, :class:`str`]
         The reaction emoji. May be a custom emoji, or a unicode emoji.
     count: :class:`int`
         Number of times this reaction was made


### PR DESCRIPTION
### Summary

Reaction's `.emoji` can be a `discord.PartialEmoji` if the client / bot doesn't share the server with it.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
