### PR TITLE
[commands] Fix an "either" with one option

### DIFF
--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -560,7 +560,7 @@ This command can be invoked any of the following ways:
 Error Handling
 ----------------
 
-When our commands fail to either parse we will, by default, receive a noisy error in ``stderr`` of our console that tells us
+When our commands fail to parse we will, by default, receive a noisy error in ``stderr`` of our console that tells us
 that an error has happened and has been silently ignored.
 
 In order to handle our errors, we must use something called an error handler. There is a global error handler, called


### PR DESCRIPTION
### Summary

In the phrase "When our commands fail to either parse we will", the "either" implies that there will be two things that "our commands" will fail to do. Since there is only one thing listed, this PR removes the either.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
