### PR TITLE
Add discord.Emoji.use()

### DIFF
--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -249,6 +249,10 @@ class Emoji:
         """:class:`Guild`: The guild this emoji belongs to."""
         return self._state._get_guild(self.guild_id)
 
+    def use(self):
+        """:class:`str`: Returns the emoji in a usable state."""
+        return "<:{0.name}:{0.id}>".format(self) if not self.animated else "<a:{0.name}:{0.id}>".format(self)
+
     def is_usable(self):
         """:class:`bool`: Whether the bot can use this emoji."""
         if not self.available:


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
This pull request adds a `use()` method for the discord.Emoji class.

It makes it easier to send an emoji, so you don't need to manually format everything if you want to send an emoji in a chat from e.g. a reaction event.

One thing I wasn't sure of was emojis that has `require_colons` set to false. I wasn't sure how that would look, but I was told by a friend that bots can't use them anyway.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
