### PR TITLE
Refactor `name` kwarg for `Emoji.edit()`

### DIFF
--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -281,7 +281,7 @@ class Emoji:
 
         await self._state.http.delete_custom_emoji(self.guild.id, self.id, reason=reason)
 
-    async def edit(self, *, name, roles=None, reason=None):
+    async def edit(self, *, name=None, roles=None, reason=None):
         r"""|coro|
 
         Edits the custom emoji.
@@ -306,6 +306,7 @@ class Emoji:
             An error occurred editing the emoji.
         """
 
+        name = name or self.name
         if roles:
             roles = [role.id for role in roles]
         await self._state.http.edit_custom_emoji(self.guild.id, self.id, name=name, roles=roles, reason=reason)


### PR DESCRIPTION
### Summary

This closes #2259. It refactors the fields for `Emoji.edit` so that the `name` parameter defaults to `Emoji.name`, which means it no longer throws a ``TypeError`` for not providing the keyword-only argument `name`.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
