### PR TITLE
[Docs] `on_guild_emojis_update` is called with tuples not lists of emojis

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -571,9 +571,9 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param guild: The guild who got their emojis updated.
     :type guild: :class:`Guild`
     :param before: A list of emojis before the update.
-    :type before: List[:class:`Emoji`]
+    :type before: Tuple[:class:`Emoji`, ...]
     :param after: A list of emojis after the update.
-    :type after: List[:class:`Emoji`]
+    :type after: Tuple[:class:`Emoji`, ...]
 
 .. function:: on_guild_available(guild)
               on_guild_unavailable(guild)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -571,9 +571,9 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param guild: The guild who got their emojis updated.
     :type guild: :class:`Guild`
     :param before: A list of emojis before the update.
-    :type before: Tuple[:class:`Emoji`, ...]
+    :type before: Sequence[:class:`Emoji`]
     :param after: A list of emojis after the update.
-    :type after: Tuple[:class:`Emoji`, ...]
+    :type after: Sequence[:class:`Emoji`]
 
 .. function:: on_guild_available(guild)
               on_guild_unavailable(guild)


### PR DESCRIPTION
### Summary

`on_guild_emojis_update` is called with tuples of emojis in `before` and `after` arguments.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
