### PR TITLE
Make Guild.default_role use get_role.

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -260,7 +260,7 @@ class Guild(Hashable):
 
     __slots__ = ('afk_timeout', 'afk_channel', '_members', '_channels', 'icon',
                  'name', 'id', 'unavailable', 'banner', 'region', '_state',
-                 '_default_role', '_roles', '_member_count', '_large',
+                 '_roles', '_member_count', '_large',
                  'owner_id', 'mfa_level', 'emojis', 'features',
                  'verification_level', 'explicit_content_filter', 'splash',
                  '_voice_states', '_system_channel_id', 'default_notifications',
@@ -616,10 +616,10 @@ class Guild(Hashable):
         """
         return self._roles.get(role_id)
 
-    @utils.cached_slot_property('_default_role')
+    @property
     def default_role(self):
         """Gets the @everyone role that all members have by default."""
-        return utils.find(lambda r: r.is_default(), self._roles.values())
+        return self.get_role(self.id)
 
     @property
     def owner(self):


### PR DESCRIPTION

### Summary

Prevents some stale caching by using the new O(log(n)) Guild.get_role.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
