### PR TITLE
Prevent premium_subscription_count being None

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -385,7 +385,7 @@ class Guild(Hashable):
         self.max_presences = guild.get('max_presences')
         self.max_members = guild.get('max_members')
         self.premium_tier = guild.get('premium_tier', 0)
-        self.premium_subscription_count = guild.get('premium_subscription_count', 0)
+        self.premium_subscription_count = guild.get('premium_subscription_count') or 0
         self._system_channel_flags = guild.get('system_channel_flags', 0)
         self.preferred_locale = guild.get('preferred_locale')
 


### PR DESCRIPTION
### Summary
Fixes #2331 

`Guild.premium_subscription_count` can sometimes return None, for an unknown reason (as far as I've researched). This PR fixes this to never be None, and 0 instead.

### Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
