### PR TITLE
[docs] category_id is Optional

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -79,8 +79,8 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         The guild the channel belongs to.
     id: :class:`int`
         The channel ID.
-    category_id: :class:`int`
-        The category channel ID this channel belongs to.
+    category_id: Optional[:class:`int`]
+        The category channel ID this channel belongs to, if applicable.
     topic: Optional[:class:`str`]
         The channel's topic. None if it doesn't exist.
     position: :class:`int`
@@ -484,8 +484,8 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
         The guild the channel belongs to.
     id: :class:`int`
         The channel ID.
-    category_id: :class:`int`
-        The category channel ID this channel belongs to.
+    category_id: Optional[:class:`int`]
+        The category channel ID this channel belongs to, if applicable.
     position: :class:`int`
         The position in the channel list. This is a number that starts at 0. e.g. the
         top channel is position 0.


### PR DESCRIPTION
### Summary
`TextChannel.category_id` and `VoiceChannel.category_id` can be None if the channel doesn't have a category it belongs to.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
