### PR TITLE
Fix webhooks not re-raising after retries run out

### DIFF
--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -222,6 +222,8 @@ class AsyncWebhookAdapter(WebhookAdapter):
                     raise NotFound(r, response)
                 else:
                     raise HTTPException(r, response)
+        # no more retries
+        raise HTTPException(r, response)
 
     async def handle_execution_response(self, response, *, wait):
         data = await response
@@ -308,6 +310,8 @@ class RequestsWebhookAdapter(WebhookAdapter):
                 raise NotFound(r, response)
             else:
                 raise HTTPException(r, response)
+        # no more retries
+        raise HTTPException(r, response)
 
     def handle_execution_response(self, response, *, wait):
         if not wait:


### PR DESCRIPTION
### Summary
Fixes #2272 
Not a ratelimit error by the way, Discord was returning 502.

### Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
