### PR TITLE
Client: stop the loop before closing it.

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -94,6 +94,7 @@ def _cleanup_loop(loop):
             loop.run_until_complete(loop.shutdown_asyncgens())
     finally:
         log.info('Closing the event loop.')
+        loop.stop()
         loop.close()
 
 class _ClientEventTask(asyncio.Task):


### PR DESCRIPTION
According to the documentation for [loop.close()] it is not supposed to be called while the loop is still running.
It must be stopped first. Additionally this causes compatibility issues with trio-asyncio which unconditionally raises a RuntimeError
when a running loop is closed.

[loop.close()]: https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.close

### Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
