### PR TITLE
Reform message consistency

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -835,7 +835,7 @@ class Messageable(metaclass=abc.ABCMeta):
         else:
             data = await state.http.send_message(channel.id, content, tts=tts, embed=embed, nonce=nonce)
 
-        ret = state.create_message(channel=channel, data=data)
+        ret = state.add_message(channel=channel, data=data)
         if delete_after is not None:
             await ret.delete(delay=delete_after)
         return ret

--- a/discord/state.py
+++ b/discord/state.py
@@ -399,10 +399,8 @@ class ConnectionState:
 
     def parse_message_create(self, data):
         channel, _ = self._get_guild_channel(data)
-        message = Message(channel=channel, data=data, state=self)
+        message = self.update_message(channel=channel, data=data)
         self.dispatch('message', message)
-        if self._messages is not None:
-            self._messages.append(message)
         if channel and channel.__class__ is TextChannel:
             channel.last_message_id = message.id
 
@@ -955,6 +953,18 @@ class ConnectionState:
             channel = guild.get_channel(id)
             if channel is not None:
                 return channel
+
+    def update_message(self, *, channel, data):
+        message = self._get_message(data['id'])
+        if message:
+            message._update(data)
+        return message or self.add_message(channel=channel, data=data)
+
+    def add_message(self, *, channel, data):
+        message = self.create_message(channel=channel, data=data)
+        if self._messages is not None:
+            self._messages.append(message)
+        return message
 
     def create_message(self, *, channel, data):
         return Message(state=self, channel=channel, data=data)


### PR DESCRIPTION
### Summary

This closes #1686. It basically caches the message from when the client sends the message, rather than when the ws receives it, at which point the cached message is just updated if it exists.

```py
In : add_reactions_to = await main.send(user.mention, embed = e)
...: await add_reactions_to.add_reaction("↖")
...: await add_reactions_to.add_reaction("➡")

In : add_reactions_to.reactions
Out: [<Reaction emoji='↖' me=True count=1>, <Reaction emoji='➡' me=True count=1>]
```

### Checklist

- [ ] If code changes were made then they have been tested.
     -  [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
