### PR TITLE
Added Optional to docs for VoiceState.channel and ClientUser.premium_type

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -59,7 +59,7 @@ class VoiceState:
         Indicates if the user is currently broadcasting video.
     afk: :class:`bool`
         Indicates if the user is currently in the AFK channel in the guild.
-    channel: :class:`VoiceChannel`
+    channel: Optional[:class:`VoiceChannel`]
         The voice channel that the user is currently connected to. None if the user
         is not currently in a voice channel.
     """

--- a/discord/user.py
+++ b/discord/user.py
@@ -300,7 +300,7 @@ class ClientUser(BaseUser):
         Specifies if the user has MFA turned on and working.
     premium: :class:`bool`
         Specifies if the user is a premium user (e.g. has Discord Nitro).
-    premium_type: :class:`PremiumType`
+    premium_type: Optional[:class:`PremiumType`]
         Specifies the type of premium a user has (e.g. Nitro or Nitro Classic). Could be None if the user is not premium.
     """
     __slots__ = BaseUser.__slots__ + \


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
Added Optional[...] to docs for `VoiceState.channel` and `ClientUser.premium_type` as they can be None but docs do not say Optional[...] as their types.

Note: I did not search for every instance of missing Optional[] in the docs, but these were 2 that I had noticed.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
