### PR TITLE
Return invites as https, various URL normalization

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -350,7 +350,7 @@ class GuildChannel:
         """Returns all of the channel's overwrites.
 
         This is returned as a dictionary where the key contains the target which
-        can be either a :class:`~discord.Role` or a :class:`~discord.Member` and the key is the
+        can be either a :class:`~discord.Role` or a :class:`~discord.Member` and the value is the
         overwrite as a :class:`~discord.PermissionOverwrite`.
 
         Returns

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -206,7 +206,7 @@ class Activity(_ActivityTag):
         except KeyError:
             return None
         else:
-            return Asset.BASE + 'app-assets/{0}/{1}.png'.format(self.application_id, large_image)
+            return Asset.BASE + '/app-assets/{0}/{1}.png'.format(self.application_id, large_image)
 
     @property
     def small_image_url(self):
@@ -219,7 +219,7 @@ class Activity(_ActivityTag):
         except KeyError:
             return None
         else:
-            return Asset.BASE + 'app-assets/{0}/{1}.png'.format(self.application_id, small_image)
+            return Asset.BASE + '/app-assets/{0}/{1}.png'.format(self.application_id, small_image)
     @property
     def large_image_text(self):
         """Optional[:class:`str`]: Returns the large image asset hover text of this activity if applicable."""

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -26,6 +26,7 @@ DEALINGS IN THE SOFTWARE.
 
 import datetime
 
+from .asset import Asset
 from .enums import ActivityType, try_enum
 from .colour import Colour
 from .utils import _get_as_snowflake
@@ -205,7 +206,7 @@ class Activity(_ActivityTag):
         except KeyError:
             return None
         else:
-            return 'https://cdn.discordapp.com/app-assets/{0}/{1}.png'.format(self.application_id, large_image)
+            return Asset.BASE + 'app-assets/{0}/{1}.png'.format(self.application_id, large_image)
 
     @property
     def small_image_url(self):
@@ -218,7 +219,7 @@ class Activity(_ActivityTag):
         except KeyError:
             return None
         else:
-            return 'https://cdn.discordapp.com/app-assets/{0}/{1}.png'.format(self.application_id, small_image)
+            return Asset.BASE + 'app-assets/{0}/{1}.png'.format(self.application_id, small_image)
     @property
     def large_image_text(self):
         """Optional[:class:`str`]: Returns the large image asset hover text of this activity if applicable."""

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -63,6 +63,8 @@ class Asset:
     """
     __slots__ = ('_state', '_url')
 
+    BASE = 'https://cdn.discordapp.com/'
+
     def __init__(self, state, url=None):
         self._state = state
         self._url = url
@@ -84,14 +86,14 @@ class Asset:
         if format is None:
             format = 'gif' if user.is_avatar_animated() else static_format
 
-        return cls(state, 'https://cdn.discordapp.com/avatars/{0.id}/{0.avatar}.{1}?size={2}'.format(user, format, size))
+        return cls(state, 'avatars/{0.id}/{0.avatar}.{1}?size={2}'.format(user, format, size))
 
     @classmethod
     def _from_icon(cls, state, object, path):
         if object.icon is None:
             return cls(state)
 
-        url = 'https://cdn.discordapp.com/{0}-icons/{1.id}/{1.icon}.jpg'.format(path, object)
+        url = '{0}-icons/{1.id}/{1.icon}.jpg'.format(path, object)
         return cls(state, url)
 
     @classmethod
@@ -99,7 +101,7 @@ class Asset:
         if obj.cover_image is None:
             return cls(state)
 
-        url = 'https://cdn.discordapp.com/app-assets/{0.id}/store/{0.cover_image}.jpg'.format(obj)
+        url = 'app-assets/{0.id}/store/{0.cover_image}.jpg'.format(obj)
         return cls(state, url)
 
     @classmethod
@@ -112,7 +114,7 @@ class Asset:
         if hash is None:
             return cls(state)
 
-        url = 'https://cdn.discordapp.com/{key}/{0}/{1}.{2}?size={3}'
+        url = '{key}/{0}/{1}.{2}?size={3}'
         return cls(state, url.format(id, hash, format, size, key=key))
 
     @classmethod
@@ -132,15 +134,15 @@ class Asset:
         if format is None:
             format = 'gif' if guild.is_icon_animated() else static_format
 
-        return cls(state, 'https://cdn.discordapp.com/icons/{0.id}/{0.icon}.{1}?size={2}'.format(guild, format, size))
+        return cls(state, 'icons/{0.id}/{0.icon}.{1}?size={2}'.format(guild, format, size))
 
 
     def __str__(self):
-        return self._url if self._url is not None else ''
+        return self.BASE + self._url if self._url is not None else ''
 
     def __len__(self):
         if self._url:
-            return len(self._url)
+            return len(self.BASE + self._url)
         return 0
 
     def __bool__(self):
@@ -198,7 +200,7 @@ class Asset:
         if self._state is None:
             raise DiscordException('Invalid state (no ConnectionState provided)')
 
-        return await self._state.http.get_from_cdn(self._url)
+        return await self._state.http.get_from_cdn(self.BASE + self._url)
 
     async def save(self, fp, *, seek_begin=True):
         """|coro|

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -63,7 +63,7 @@ class Asset:
     """
     __slots__ = ('_state', '_url')
 
-    BASE = 'https://cdn.discordapp.com/'
+    BASE = 'https://cdn.discordapp.com'
 
     def __init__(self, state, url=None):
         self._state = state
@@ -86,14 +86,14 @@ class Asset:
         if format is None:
             format = 'gif' if user.is_avatar_animated() else static_format
 
-        return cls(state, 'avatars/{0.id}/{0.avatar}.{1}?size={2}'.format(user, format, size))
+        return cls(state, '/avatars/{0.id}/{0.avatar}.{1}?size={2}'.format(user, format, size))
 
     @classmethod
     def _from_icon(cls, state, object, path):
         if object.icon is None:
             return cls(state)
 
-        url = '{0}-icons/{1.id}/{1.icon}.jpg'.format(path, object)
+        url = '/{0}-icons/{1.id}/{1.icon}.jpg'.format(path, object)
         return cls(state, url)
 
     @classmethod
@@ -101,7 +101,7 @@ class Asset:
         if obj.cover_image is None:
             return cls(state)
 
-        url = 'app-assets/{0.id}/store/{0.cover_image}.jpg'.format(obj)
+        url = '/app-assets/{0.id}/store/{0.cover_image}.jpg'.format(obj)
         return cls(state, url)
 
     @classmethod
@@ -114,7 +114,7 @@ class Asset:
         if hash is None:
             return cls(state)
 
-        url = '{key}/{0}/{1}.{2}?size={3}'
+        url = '/{key}/{0}/{1}.{2}?size={3}'
         return cls(state, url.format(id, hash, format, size, key=key))
 
     @classmethod
@@ -134,7 +134,7 @@ class Asset:
         if format is None:
             format = 'gif' if guild.is_icon_animated() else static_format
 
-        return cls(state, 'icons/{0.id}/{0.icon}.{1}?size={2}'.format(guild, format, size))
+        return cls(state, '/icons/{0.id}/{0.icon}.{1}?size={2}'.format(guild, format, size))
 
 
     def __str__(self):

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -122,7 +122,7 @@ class PartialEmoji:
             return Asset(self._state)
 
         _format = 'gif' if self.animated else 'png'
-        url = "https://cdn.discordapp.com/emojis/{0.id}.{1}".format(self, _format)
+        url = "emojis/{0.id}.{1}".format(self, _format)
         return Asset(self._state, url)
 
 class Emoji:
@@ -229,7 +229,7 @@ class Emoji:
     def url(self):
         """:class:`Asset`: Returns the asset of the emoji."""
         _format = 'gif' if self.animated else 'png'
-        url = "https://cdn.discordapp.com/emojis/{0.id}.{1}".format(self, _format)
+        url = "emojis/{0.id}.{1}".format(self, _format)
         return Asset(self._state, url)
 
     @property

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -122,7 +122,7 @@ class PartialEmoji:
             return Asset(self._state)
 
         _format = 'gif' if self.animated else 'png'
-        url = "emojis/{0.id}.{1}".format(self, _format)
+        url = "/emojis/{0.id}.{1}".format(self, _format)
         return Asset(self._state, url)
 
 class Emoji:
@@ -229,7 +229,7 @@ class Emoji:
     def url(self):
         """:class:`Asset`: Returns the asset of the emoji."""
         _format = 'gif' if self.animated else 'png'
-        url = "emojis/{0.id}.{1}".format(self, _format)
+        url = "/emojis/{0.id}.{1}".format(self, _format)
         return Asset(self._state, url)
 
     @property

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -256,6 +256,8 @@ class Invite(Hashable):
                  'temporary', 'max_uses', 'inviter', 'channel', '_state',
                  'approximate_member_count', 'approximate_presence_count' )
 
+    BASE = 'https://discord.gg/'
+
     def __init__(self, *, state, data):
         self._state = state
         self.max_age = data.get('max_age')
@@ -309,7 +311,7 @@ class Invite(Hashable):
     @property
     def url(self):
         """:class:`str`: A property that retrieves the invite URL."""
-        return 'http://discord.gg/' + self.code
+        return self.BASE + self.code
 
     async def delete(self, *, reason=None):
         """|coro|

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -256,7 +256,7 @@ class Invite(Hashable):
                  'temporary', 'max_uses', 'inviter', 'channel', '_state',
                  'approximate_member_count', 'approximate_presence_count' )
 
-    BASE = 'https://discord.gg/'
+    BASE = 'https://discord.gg'
 
     def __init__(self, *, state, data):
         self._state = state
@@ -311,7 +311,7 @@ class Invite(Hashable):
     @property
     def url(self):
         """:class:`str`: A property that retrieves the invite URL."""
-        return self.BASE + self.code
+        return self.BASE + '/' + self.code
 
     async def delete(self, *, reason=None):
         """|coro|

--- a/discord/user.py
+++ b/discord/user.py
@@ -181,7 +181,7 @@ class BaseUser(_BaseUser):
     @property
     def default_avatar_url(self):
         """:class:`Asset`: Returns a URL for a user's default avatar."""
-        return Asset(self._state, 'embed/avatars/{}.png'.format(self.default_avatar.value))
+        return Asset(self._state, '/embed/avatars/{}.png'.format(self.default_avatar.value))
 
     @property
     def colour(self):

--- a/discord/user.py
+++ b/discord/user.py
@@ -181,7 +181,7 @@ class BaseUser(_BaseUser):
     @property
     def default_avatar_url(self):
         """:class:`Asset`: Returns a URL for a user's default avatar."""
-        return Asset(self._state, 'https://cdn.discordapp.com/embed/avatars/{}.png'.format(self.default_avatar.value))
+        return Asset(self._state, 'embed/avatars/{}.png'.format(self.default_avatar.value))
 
     @property
     def colour(self):

--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -567,7 +567,7 @@ class Webhook:
         """
         if self.avatar is None:
             # Default is always blurple apparently
-            return Asset(self._state, 'https://cdn.discordapp.com/embed/avatars/0.png')
+            return Asset(self._state, 'embed/avatars/0.png')
 
         if not utils.valid_icon_size(size):
             raise InvalidArgument("size must be a power of 2 between 16 and 1024")
@@ -577,7 +577,7 @@ class Webhook:
         if format not in ('png', 'jpg', 'jpeg'):
             raise InvalidArgument("format must be one of 'png', 'jpg', or 'jpeg'.")
 
-        url = 'https://cdn.discordapp.com/avatars/{0.id}/{0.avatar}.{1}?size={2}'.format(self, format, size)
+        url = 'avatars/{0.id}/{0.avatar}.{1}?size={2}'.format(self, format, size)
         return Asset(self._state, url)
 
     def delete(self):

--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -567,7 +567,7 @@ class Webhook:
         """
         if self.avatar is None:
             # Default is always blurple apparently
-            return Asset(self._state, 'embed/avatars/0.png')
+            return Asset(self._state, '/embed/avatars/0.png')
 
         if not utils.valid_icon_size(size):
             raise InvalidArgument("size must be a power of 2 between 16 and 1024")
@@ -577,7 +577,7 @@ class Webhook:
         if format not in ('png', 'jpg', 'jpeg'):
             raise InvalidArgument("format must be one of 'png', 'jpg', or 'jpeg'.")
 
-        url = 'avatars/{0.id}/{0.avatar}.{1}?size={2}'.format(self, format, size)
+        url = '/avatars/{0.id}/{0.avatar}.{1}?size={2}'.format(self, format, size)
         return Asset(self._state, url)
 
     def delete(self):

--- a/docs/locale/ja/LC_MESSAGES/api.po
+++ b/docs/locale/ja/LC_MESSAGES/api.po
@@ -5696,7 +5696,7 @@ msgstr ""
 msgid ""
 "This is returned as a dictionary where the key contains the target which "
 "can be either a :class:`~discord.Role` or a :class:`~discord.Member` and "
-"the key is the overwrite as a :class:`~discord.PermissionOverwrite`."
+"the value is the overwrite as a :class:`~discord.PermissionOverwrite`."
 msgstr ""
 
 #: discord.CategoryChannel.overwrites:7 discord.TextChannel.overwrites:7


### PR DESCRIPTION
### Summary

This pull request:
- Makes invites use `https://discord.gg/` instead of `http://discord.gg/`
- Normalizes URLs for the CDN in `Asset` using a `BASE` url (like Route)
- Normalizes URLs for invites using a `BASE` url (like Route)
- Fixes a minor documentation mistake related to `GuildChannel.overwrites`

This changes the behavior of Asset to natively refer to URLs under the CDN instead of absolute URLs like they used to be. `str(asset)` will still give you the full URL as normal, and constructors have been adjusted, but `Asset._url` and the repr will now show the URL relative to the root of the domain.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
