### PR TITLE
Print exception tracebacks in voice threads

### DIFF
--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -338,7 +338,8 @@ class VoiceClient:
         or an error occurred.
 
         If an error happens while the audio player is running, the exception is
-        caught and the audio player is then stopped.
+        caught and the audio player is then stopped.  If no after callback is
+        passed, any caught exception will be displayed as if it were raised.
 
         Parameters
         -----------
@@ -346,9 +347,8 @@ class VoiceClient:
             The audio source we're reading from.
         after: Callable[[:class:`Exception`], Any]
             The finalizer that is called after the stream is exhausted.
-            All exceptions it throws are silently discarded. This function
-            must have a single parameter, ``error``, that denotes an
-            optional exception that was raised during playing.
+            This function must have a single parameter, ``error``, that 
+            denotes an optional exception that was raised during playing.
 
         Raises
         -------


### PR DESCRIPTION
### Summary

Errors occurring within `AudioSource.read()` and `after()` callbacks will now display their tracebacks as if they were unhandled exceptions.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
