### PR TITLE
Fix typo in help.py docs

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -840,7 +840,7 @@ class DefaultHelpCommand(HelpCommand):
         The number of characters the paginator must accumulate before getting DM'd to the
         user if :attr:`dm_help` is set to ``None``. Defaults to 1000.
     indent: :class:`int`
-        How much to intend the commands from a heading. Defaults to ``2``.
+        How much to indent the commands from a heading. Defaults to ``2``.
     commands_heading: :class:`str`
         The command list's heading string used when the help command is invoked with a category name.
         Useful for i18n. Defaults to ``"Commands:"``


### PR DESCRIPTION
Changed "intend" to "indent"

### Summary

Fix doc for DefaultHelpCommand.indent and change word 'intend' to 'indent'

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
