### PR TITLE
Implement removing specific reaction emojis.

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -170,3 +170,30 @@ class RawReactionClearEvent(_RawReprMixin):
             self.guild_id = int(data['guild_id'])
         except KeyError:
             self.guild_id = None
+
+class RawReactionEmojiClearEvent(_RawReprMixin):
+    """Represents the payload for a :func:`on_raw_reaction_clear_emoji` event.
+
+    Attributes
+    -----------
+    message_id: :class:`int`
+        The message ID that got a specific reaction emoji cleared.
+    channel_id: :class:`int`
+        The channel ID where the specific reaction emoji was cleared.
+    guild_id: Optional[:class:`int`]
+        The guild ID where the specific reaction emoji was cleared.
+    emoji: :class:`PartialEmoji`
+        The custom or unicode emoji being used.
+    """
+
+    __slots__ = ('message_id', 'channel_id', 'emoji', 'guild_id')
+
+    def __init__(self, data, emoji):
+        self.message_id = int(data['message_id'])
+        self.channel_id = int(data['channel_id'])
+        self.emoji = emoji
+
+        try:
+            self.guild_id = int(data['guild_id'])
+        except KeyError:
+            self.guild_id = None

--- a/discord/state.py
+++ b/discord/state.py
@@ -477,6 +477,23 @@ class ConnectionState:
             message.reactions.clear()
             self.dispatch('reaction_clear', message, old_reactions)
 
+    def parse_message_reaction_remove_emoji(self, data):
+        emoji = data['emoji']
+        emoji_id = utils._get_as_snowflake(emoji, 'id')
+        emoji = PartialEmoji.with_state(self, animated=emoji.get('animated', False), id=emoji_id, name=emoji['name'])
+        raw = RawReactionClearEmojiEvent(data, emoji)
+        self.dispatch('raw_reaction_clear_emoji', raw)
+
+        message = self._get_message(raw.message_id)
+        if message is not None:
+            old_reactions = message.reactions.copy()
+            new_reactions = []
+            for r in old_reactions:
+                if r.emoji != raw.emoji:
+                    new_reactions.append(r)
+            message.reactions = new_reactions
+            self.dispatch('reaction_clear_emoji', message, old_reactions, new_reactions)
+
     def parse_message_reaction_remove(self, data):
         emoji = data['emoji']
         emoji_id = utils._get_as_snowflake(emoji, 'id')

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -400,6 +400,27 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param payload: The raw event payload data.
     :type payload: :class:`RawReactionClearEvent`
 
+.. function:: on_reaction_clear_emoji(message, before, after)
+
+	Called when a message has a specific emoji reaction removed from it. Similar to :func:`on_message_edit`,
+    if the message is not found in the internal message cache, then this event
+    will not be called.
+
+	:param message: The message that had the specific emoji reaction cleared.
+	:type message: :class:`Message`
+	:param before: The reactions list before the specific emoji reaction was cleared.
+	:type before: List[:class:`Reaction`]
+	:param after: The reactions list after the specific emoji reaction was cleared.
+	:type after: List[:class:`Reaction`]
+
+.. function:: on_raw_reaction_clear_emoji(payload)
+
+    Called when a message has a specific emoji reaction removed. Unlike :func:`on_reaction_clear_emoji`,
+    this is called regardless of the state of the internal message cache.
+
+    :param payload: The raw event payload data.
+    :type payload: :class:`RawReactionClearEmojiEvent`
+
 .. function:: on_private_channel_delete(channel)
               on_private_channel_create(channel)
 


### PR DESCRIPTION
### Summary

This implements the upcoming dispatch event `MESSAGE_REACTION_REMOVE_EMOJI`. 
This event is dispatched as `message_reaction_clear_emoji` for the client. 

As this feature set is still not finalised, the PR is W.I.P.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
