### PR TITLE
Add `RawReactionActionEvent.member`

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -127,7 +127,7 @@ class RawReactionActionEvent(_RawReprMixin):
         The guild ID where the reaction got added or removed, if applicable.
     emoji: :class:`PartialEmoji`
         The custom or unicode emoji being used.
-    member: Optional[:class:`dict`]
+    user: Optional[:class:`dict`]
         The member who added the reaction. 
 
         .. note::
@@ -155,7 +155,7 @@ class RawReactionActionEvent(_RawReprMixin):
         except KeyError:
             self.guild_id = None
 
-        self.member = data.get('member', None)
+        self.user = data.get('member')
 
 class RawReactionClearEvent(_RawReprMixin):
     """Represents the payload for a :func:`on_raw_reaction_clear` event.

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -24,8 +24,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-from .member import Member
-
 class _RawReprMixin:
     def __repr__(self):
         value = ' '.join('%s=%r' % (attr, getattr(self, attr)) for attr in self.__slots__)

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -127,13 +127,21 @@ class RawReactionActionEvent(_RawReprMixin):
         The guild ID where the reaction got added or removed, if applicable.
     emoji: :class:`PartialEmoji`
         The custom or unicode emoji being used.
+    member: Optional[:class:`dict`]
+        The member who added the reaction. 
+
+        .. note::
+
+            This is only available for :func:`on_raw_reaction_add`, and when the reaction 
+            is added in a guild.
     event_type: :class:`str`
         The event type that triggered this action. Can be
         ``REACTION_ADD`` for reaction addition or
         ``REACTION_REMOVE`` for reaction removal.
     """
 
-    __slots__ = ('message_id', 'user_id', 'channel_id', 'guild_id', 'emoji')
+    __slots__ = ('message_id', 'user_id', 'channel_id', 'guild_id', 'emoji',
+                 'event_type', 'member')
 
     def __init__(self, data, emoji, event_type):
         self.message_id = int(data['message_id'])
@@ -146,6 +154,8 @@ class RawReactionActionEvent(_RawReprMixin):
             self.guild_id = int(data['guild_id'])
         except KeyError:
             self.guild_id = None
+
+        self.member = data.get('member', None)
 
 class RawReactionClearEvent(_RawReprMixin):
     """Represents the payload for a :func:`on_raw_reaction_clear` event.

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -128,12 +128,10 @@ class RawReactionActionEvent(_RawReprMixin):
     emoji: :class:`PartialEmoji`
         The custom or unicode emoji being used.
     member: Optional[:class:`Member`]
-        The member who added the reaction. 
+        The member who added the reaction. Only available if `event_type` is `REACTION_ADD`.
 
-        .. note::
+        .. versionadded:: 1.3
 
-            This is only available for :func:`on_raw_reaction_add`, and when the reaction 
-            is added in a guild.
     event_type: :class:`str`
         The event type that triggered this action. Can be
         ``REACTION_ADD`` for reaction addition or

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -145,25 +145,18 @@ class RawReactionActionEvent(_RawReprMixin):
     __slots__ = ('message_id', 'user_id', 'channel_id', 'guild_id', 'emoji',
                  'event_type', 'member')
 
-    def __init__(self, data, emoji, event_type, *, state):
+    def __init__(self, data, emoji, event_type):
         self.message_id = int(data['message_id'])
         self.channel_id = int(data['channel_id'])
         self.user_id = int(data['user_id'])
         self.emoji = emoji
         self.event_type = event_type
+        self.member = None
 
         try:
             self.guild_id = int(data['guild_id'])
         except KeyError:
             self.guild_id = None
-        
-        member_data = data.get('member')
-        guild = state._get_guild(self.guild_id)
-
-        if guild and member_data:
-            self.member = Member(data=member_data, guild=guild, state=state)
-        else: 
-            self.member = None
 
 class RawReactionClearEvent(_RawReprMixin):
     """Represents the payload for a :func:`on_raw_reaction_clear` event.

--- a/discord/state.py
+++ b/discord/state.py
@@ -463,7 +463,11 @@ class ConnectionState:
         if message is not None:
             emoji = self._upgrade_partial_emoji(emoji)
             reaction = message._add_reaction(data, emoji, raw.user_id)
-            user = self._get_reaction_user(message.channel, raw.user_id)
+            if raw.member:
+                user = Member(data=data, guild=message.channel.guild, state=self)
+            else:
+                user = self._get_reaction_user(message.channel, raw.user_id)
+
             if user:
                 self.dispatch('reaction_add', reaction, user)
 

--- a/discord/state.py
+++ b/discord/state.py
@@ -455,7 +455,7 @@ class ConnectionState:
         emoji = data['emoji']
         emoji_id = utils._get_as_snowflake(emoji, 'id')
         emoji = PartialEmoji.with_state(self, animated=emoji.get('animated', False), id=emoji_id, name=emoji['name'])
-        raw = RawReactionActionEvent(data, emoji, 'REACTION_ADD')
+        raw = RawReactionActionEvent(data, emoji, 'REACTION_ADD', state=self)
         self.dispatch('raw_reaction_add', raw)
 
         # rich interface here
@@ -463,10 +463,7 @@ class ConnectionState:
         if message is not None:
             emoji = self._upgrade_partial_emoji(emoji)
             reaction = message._add_reaction(data, emoji, raw.user_id)
-            if raw.member:
-                user = Member(data=raw.member, guild=message.guild, state=self)
-            else:
-                user = self._get_reaction_user(message.channel, raw.user_id)
+            user = raw.member or self._get_reaction_user(message.channel, raw.user_id)
 
             if user:
                 self.dispatch('reaction_add', reaction, user)

--- a/discord/state.py
+++ b/discord/state.py
@@ -464,7 +464,7 @@ class ConnectionState:
             emoji = self._upgrade_partial_emoji(emoji)
             reaction = message._add_reaction(data, emoji, raw.user_id)
             if raw.member:
-                user = Member(data=data, guild=message.channel.guild, state=self)
+                user = Member(data=data, guild=message.guild, state=self)
             else:
                 user = self._get_reaction_user(message.channel, raw.user_id)
 

--- a/discord/state.py
+++ b/discord/state.py
@@ -455,7 +455,14 @@ class ConnectionState:
         emoji = data['emoji']
         emoji_id = utils._get_as_snowflake(emoji, 'id')
         emoji = PartialEmoji.with_state(self, animated=emoji.get('animated', False), id=emoji_id, name=emoji['name'])
-        raw = RawReactionActionEvent(data, emoji, 'REACTION_ADD', state=self)
+        raw = RawReactionActionEvent(data, emoji, 'REACTION_ADD')
+
+        member_data = data.get('member')
+        if member_data:
+            guild = self._get_guild(raw.guild_id)
+            raw.member = Member(data=member_data, guild=guild, state=self)
+        else:
+            raw.member = None
         self.dispatch('raw_reaction_add', raw)
 
         # rich interface here

--- a/discord/state.py
+++ b/discord/state.py
@@ -464,7 +464,7 @@ class ConnectionState:
             emoji = self._upgrade_partial_emoji(emoji)
             reaction = message._add_reaction(data, emoji, raw.user_id)
             if raw.member:
-                user = Member(data=data, guild=message.guild, state=self)
+                user = Member(data=raw.member, guild=message.guild, state=self)
             else:
                 user = self._get_reaction_user(message.channel, raw.user_id)
 


### PR DESCRIPTION
### Summary

This implements the `member` field for the message reaction add event, which is mentioned in discordapp/discord-api-docs#1202.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
