### PR TITLE
Add `Activity.created_at`

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -136,12 +136,13 @@ class Activity(_ActivityTag):
         - ``size``: A list of up to two integer elements denoting (current_size, maximum_size).
     """
 
-    __slots__ = ('state', 'details', 'timestamps', 'assets', 'party',
+    __slots__ = ('state', 'details', '_created_at', 'timestamps', 'assets', 'party',
                  'flags', 'sync_id', 'session_id', 'type', 'name', 'url', 'application_id')
 
     def __init__(self, **kwargs):
         self.state = kwargs.pop('state', None)
         self.details = kwargs.pop('details', None)
+        self._created_at = kwargs.pop('created_at')
         self.timestamps = kwargs.pop('timestamps', {})
         self.assets = kwargs.pop('assets', {})
         self.party = kwargs.pop('party', {})
@@ -178,6 +179,11 @@ class Activity(_ActivityTag):
             ret[attr] = value
         ret['type'] = int(self.type)
         return ret
+
+    @property
+    def created_at(self):
+        """:class:`datetime.datetime`: When the user started doing this activity in UTC."""
+        return datetime.datetime.utcfromtimestamp(self._created_at / 1000)
 
     @property
     def start(self):
@@ -269,10 +275,12 @@ class Game(_ActivityTag):
         The game's name.
     """
 
-    __slots__ = ('name', '_end', '_start')
+    __slots__ = ('name', '_end', '_start', '_created_at')
 
     def __init__(self, name, **extra):
         self.name = name
+
+        self._created_at = extra['created_at']
 
         try:
             timestamps = extra['timestamps']
@@ -298,6 +306,11 @@ class Game(_ActivityTag):
         It always returns :attr:`ActivityType.playing`.
         """
         return ActivityType.playing
+
+    @property
+    def created_at(self):
+        """:class:`datetime.datetime`: When the user started playing this game in UTC."""
+        return datetime.datetime.utcfromtimestamp(self._created_at / 1000)
 
     @property
     def start(self):
@@ -378,13 +391,14 @@ class Streaming(_ActivityTag):
         A dictionary comprising of similar keys than those in :attr:`Activity.assets`.
     """
 
-    __slots__ = ('name', 'url', 'details', 'assets')
+    __slots__ = ('name', 'url', 'details', 'assets', '_created_at')
 
     def __init__(self, *, name, url, **extra):
         self.name = name
         self.url = url
         self.details = extra.pop('details', None)
         self.assets = extra.pop('assets', {})
+        self._created_at = extra.pop('created_at')
 
     @property
     def type(self):
@@ -399,6 +413,11 @@ class Streaming(_ActivityTag):
 
     def __repr__(self):
         return '<Streaming name={0.name!r}>'.format(self)
+
+    @property
+    def created_at(self):
+        """:class:`datetime.datetime`: When the user started streaming in UTC."""
+        return datetime.datetime.utcfromtimestamp(self._created_at / 1000)
 
     @property
     def twitch_name(self):
@@ -458,7 +477,8 @@ class Spotify:
             Returns the string 'Spotify'.
     """
 
-    __slots__ = ('_state', '_details', '_timestamps', '_assets', '_party', '_sync_id', '_session_id')
+    __slots__ = ('_state', '_details', '_timestamps', '_assets', '_party', '_sync_id', '_session_id',
+                 '_created_at')
 
     def __init__(self, **data):
         self._state = data.pop('state', None)
@@ -468,6 +488,7 @@ class Spotify:
         self._party = data.pop('party', {})
         self._sync_id = data.pop('sync_id')
         self._session_id = data.pop('session_id')
+        self._created_at = data.pop('created_at')
 
     @property
     def type(self):
@@ -476,6 +497,11 @@ class Spotify:
         It always returns :attr:`ActivityType.listening`.
         """
         return ActivityType.listening
+
+    @property
+    def created_at(self):
+        """:class:`datetime.datetime`: When the user started listening in UTC."""
+        return datetime.datetime.utcfromtimestamp(self._created_at / 1000)
 
     @property
     def colour(self):

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -84,7 +84,15 @@ t.ActivityFlags = {
 """
 
 class _ActivityTag:
-    __slots__ = ()
+    __slots__ = ('_created_at',)
+
+    def __init__(self, **kwargs):
+        self._created_at = kwargs.pop('created_at')
+
+    @property
+    def created_at(self):
+        """:class:`datetime.datetime`: When the user started doing this activity in UTC."""
+        return datetime.datetime.utcfromtimestamp(self._created_at / 1000)
 
 class Activity(_ActivityTag):
     """Represents an activity in Discord.
@@ -140,9 +148,9 @@ class Activity(_ActivityTag):
                  'flags', 'sync_id', 'session_id', 'type', 'name', 'url', 'application_id')
 
     def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.state = kwargs.pop('state', None)
         self.details = kwargs.pop('details', None)
-        self._created_at = kwargs.pop('created_at')
         self.timestamps = kwargs.pop('timestamps', {})
         self.assets = kwargs.pop('assets', {})
         self.party = kwargs.pop('party', {})
@@ -179,11 +187,6 @@ class Activity(_ActivityTag):
             ret[attr] = value
         ret['type'] = int(self.type)
         return ret
-
-    @property
-    def created_at(self):
-        """:class:`datetime.datetime`: When the user started doing this activity in UTC."""
-        return datetime.datetime.utcfromtimestamp(self._created_at / 1000)
 
     @property
     def start(self):
@@ -275,12 +278,11 @@ class Game(_ActivityTag):
         The game's name.
     """
 
-    __slots__ = ('name', '_end', '_start', '_created_at')
+    __slots__ = ('name', '_end', '_start')
 
     def __init__(self, name, **extra):
+        super().__init__(**extra)
         self.name = name
-
-        self._created_at = extra['created_at']
 
         try:
             timestamps = extra['timestamps']
@@ -306,11 +308,6 @@ class Game(_ActivityTag):
         It always returns :attr:`ActivityType.playing`.
         """
         return ActivityType.playing
-
-    @property
-    def created_at(self):
-        """:class:`datetime.datetime`: When the user started playing this game in UTC."""
-        return datetime.datetime.utcfromtimestamp(self._created_at / 1000)
 
     @property
     def start(self):
@@ -391,14 +388,14 @@ class Streaming(_ActivityTag):
         A dictionary comprising of similar keys than those in :attr:`Activity.assets`.
     """
 
-    __slots__ = ('name', 'url', 'details', 'assets', '_created_at')
+    __slots__ = ('name', 'url', 'details', 'assets')
 
     def __init__(self, *, name, url, **extra):
+        super().__init__(**extra)
         self.name = name
         self.url = url
         self.details = extra.pop('details', None)
         self.assets = extra.pop('assets', {})
-        self._created_at = extra.pop('created_at')
 
     @property
     def type(self):
@@ -413,11 +410,6 @@ class Streaming(_ActivityTag):
 
     def __repr__(self):
         return '<Streaming name={0.name!r}>'.format(self)
-
-    @property
-    def created_at(self):
-        """:class:`datetime.datetime`: When the user started streaming in UTC."""
-        return datetime.datetime.utcfromtimestamp(self._created_at / 1000)
 
     @property
     def twitch_name(self):


### PR DESCRIPTION
### Summary

This implements `Activity#created_at`, which is present for all types of activities. 

Reviews are welcome.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
