### PR TITLE
Implement (bot_)has_guild_permissions

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1560,7 +1560,9 @@ def bot_has_permissions(**perms):
 
 def has_guild_permissions(**perms):
     """Similar to :func:`.has_permissions`, but operates on guild wide
-    permissions instead of the current channel permissions."""
+    permissions instead of the current channel permissions.
+    
+    .. versionadded:: 1.3.0"""
     def predicate(ctx):
         guild = ctx.guild
         permissions = ctx.author.guild_permissions if guild else ctx.author.permissions_in(ctx.channel)
@@ -1575,7 +1577,9 @@ def has_guild_permissions(**perms):
 
 def bot_has_guild_permissions(**perms):
     """Similar to :func:`.bot_has_permissions`, but operates on guild wide
-    permissions instead of the current channel permissions."""
+    permissions instead of the current channel permissions.
+    
+    .. versionadded:: 1.3.0"""
     def predicate(ctx):
         guild = ctx.guild
         me = ctx.me if guild else ctx.bot.user

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1562,10 +1562,16 @@ def has_guild_permissions(**perms):
     """Similar to :func:`.has_permissions`, but operates on guild wide
     permissions instead of the current channel permissions.
     
-    .. versionadded:: 1.3.0"""
+    If this check is called in a DM context, it will raise an
+    exception, :exc:`.NoPrivateMessage`.
+   
+    .. versionadded:: 1.3.0
+    """
     def predicate(ctx):
-        guild = ctx.guild
-        permissions = ctx.author.guild_permissions if guild else ctx.author.permissions_in(ctx.channel)
+        if not ctx.guild:
+            raise NoPrivateMessage
+            
+        permissions = ctx.author.guild_permissions
         missing = [perm for perm, value in perms.items() if getattr(permissions, perm, None) != value]
         
         if not missing:
@@ -1576,14 +1582,16 @@ def has_guild_permissions(**perms):
     return check(predicate)
 
 def bot_has_guild_permissions(**perms):
-    """Similar to :func:`.bot_has_permissions`, but operates on guild wide
-    permissions instead of the current channel permissions.
+    """Similar to :func:`.has_guild_permissions`, but checks the bot
+    members guild permissions.
     
-    .. versionadded:: 1.3.0"""
+    .. versionadded:: 1.3.0
+    """
     def predicate(ctx):
-        guild = ctx.guild
-        me = ctx.me if guild else ctx.bot.user
-        permissions = me.guild_permissions if guild else me.permissions_in(ctx.channel)
+        if not ctx.guild:
+            raise NoPrivateMessage
+        
+        permissions = ctx.me.guild_permissions
         missing = [perm for perm, value in perms.items() if getattr(permissions, perm, None) != value]
         
         if not missing:

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -56,6 +56,8 @@ __all__ = (
     'guild_only',
     'is_owner',
     'is_nsfw',
+    'has_guild_permissions',
+    'bot_has_guild_permissions'
 )
 
 def wrap_callback(coro):
@@ -1496,6 +1498,9 @@ def bot_has_any_role(*items):
 def has_permissions(**perms):
     """A :func:`.check` that is added that checks if the member has all of
     the permissions necessary.
+    
+    Note that this check operates on the current channel permissions, not the
+    guild wide permissions.
 
     The permissions passed in must be exactly like the properties shown under
     :class:`.discord.Permissions`.
@@ -1551,6 +1556,37 @@ def bot_has_permissions(**perms):
 
         raise BotMissingPermissions(missing)
 
+    return check(predicate)
+
+def has_guild_permissions(**perms):
+    """Similar to :func:`.has_permissions`, but operates on guild wide
+    permissions instead of the current channel permissions."""
+    def predicate(ctx):
+        guild = ctx.guild
+        permissions = ctx.author.guild_permissions if guild else ctx.author.permissions_in(ctx.channel)
+        missing = [perm for perm, value in perms.items() if getattr(permissions, perm, None) != value]
+        
+        if not missing:
+            return True
+        
+        raise MissingPermissions(missing)
+    
+    return check(predicate)
+
+def bot_has_guild_permissions(**perms):
+    """Similar to :func:`.bot_has_permissions`, but opetates on guild wide
+    permissions instead of the current channel permissions."""
+    def predicate(ctx):
+        guild = ctx.guild
+        me = ctx.me if guild else ctx.bot.user
+        permissions = me.guild_permissions if guild else me.permissions_in(ctx.channel)
+        missing = [perm for perm, value in perms.items() if getattr(permissions, perm, None) != value]
+        
+        if not missing:
+            return True
+        
+        raise BotMissingPermissions(missing)
+    
     return check(predicate)
 
 def dm_only():

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1574,7 +1574,7 @@ def has_guild_permissions(**perms):
     return check(predicate)
 
 def bot_has_guild_permissions(**perms):
-    """Similar to :func:`.bot_has_permissions`, but opetates on guild wide
+    """Similar to :func:`.bot_has_permissions`, but operates on guild wide
     permissions instead of the current channel permissions."""
     def predicate(ctx):
         guild = ctx.guild


### PR DESCRIPTION
### Summary

Adds two new decorators for checking guild wide permissions, as opposed to the current has_permissions decorator which runs on the invocation channel permissions.
This allows for better checking of certain permissions, such as `mute_members` for voice, and `manage_roles` which is different for channel overrides.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
