### PR TITLE
Add support for xsalsa20_poly1305_lite

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -727,7 +727,7 @@ class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
         log.debug('detected ip: %s port: %s', state.ip, state.port)
 
         # there *should* always be at least one supported mode (xsalsa20_poly1305)
-        modes = list(set(self._connection.supported_modes).intersection(data['modes']))
+        modes = [mode for mode in data['modes'] if mode in self._connection.supported_modes]
         log.debug('received supported encryption modes: %s', ", ".join(modes))
 
         mode = modes[0]

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -727,7 +727,7 @@ class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
         log.debug('detected ip: %s port: %s', state.ip, state.port)
 
         # there *should* always be at least one supported mode (xsalsa20_poly1305)
-        modes = [mode for mode in data['modes'] if mode in self._connection.supported_modes]
+        modes = list(set(self._connection.supported_modes).intersection(data['modes']))
         log.debug('received supported encryption modes: %s', ", ".join(modes))
 
         mode = modes[0]

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -111,7 +111,7 @@ class VoiceClient:
         self._runner = None
         self._player = None
         self.encoder = None
-        self.lite_nonce = 0
+        self._lite_nonce = 0
 
     warn_nacl = not has_nacl
     supported_modes = (
@@ -337,12 +337,8 @@ class VoiceClient:
         box = nacl.secret.SecretBox(bytes(self.secret_key))
         nonce = bytearray(24)
 
-        # Upper limit of unsigned 4 byte int
-        if self.lite_nonce >= 0xffffffff:
-            self.lite_nonce = 0
-
-        nonce[:4] = struct.pack('>I', self.lite_nonce)
-        self.lite_nonce += 1
+        nonce[:4] = struct.pack('>I', self._lite_nonce)
+        self.checked_add('_lite_nonce', 1, 4294967295)
 
         return header + box.encrypt(bytes(data), bytes(nonce)).ciphertext + nonce[:4]
 

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -111,9 +111,11 @@ class VoiceClient:
         self._runner = None
         self._player = None
         self.encoder = None
+        self.lite_nonce = 0
 
     warn_nacl = not has_nacl
     supported_modes = (
+        'xsalsa20_poly1305_lite',
         'xsalsa20_poly1305_suffix',
         'xsalsa20_poly1305',
     )
@@ -330,6 +332,20 @@ class VoiceClient:
         nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
 
         return header + box.encrypt(bytes(data), nonce).ciphertext + nonce
+
+    def _encrypt_xsalsa20_poly1305_lite(self, header, data):
+        box = nacl.secret.SecretBox(bytes(self.secret_key))
+        nonce = bytearray(24)
+
+        # Upper limit of unsigned 4 byte int
+        if self.lite_nonce >= 0xff_ff_ff_ff:
+            self.lite_nonce = 0
+
+        nonce[:4] = struct.pack('>I', self.lite_nonce)
+        self.lite_nonce += 1
+
+        return header + box.encrypt(bytes(data), bytes(nonce)).ciphertext + nonce[:4]
+
 
     def play(self, source, *, after=None):
         """Plays an :class:`AudioSource`.

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -338,7 +338,7 @@ class VoiceClient:
         nonce = bytearray(24)
 
         # Upper limit of unsigned 4 byte int
-        if self.lite_nonce >= 0xff_ff_ff_ff:
+        if self.lite_nonce >= 0xffffffff:
             self.lite_nonce = 0
 
         nonce[:4] = struct.pack('>I', self.lite_nonce)


### PR DESCRIPTION
### Summary

Adds support for `xsalsa20_poly1305_lite` and changes the protocol selection method to support ranked choice.

Also adds `lite_nonce` to `VoiceClient`, used for the incremental nonce.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
