### PR TITLE
Return 'username' instead of 'name'

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -114,7 +114,7 @@ class BaseUser(_BaseUser):
 
     def _to_minimal_user_json(self):
         return {
-            'name': self.name,
+            'username': self.name,
             'id': self.id,
             'avatar': self.avatar,
             'discriminator': self.discriminator,


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->

When the message author is not yet in the cache, `User._to_minimal_user_json` is used to get the basic information from a user object. It's currently returning the username with the 'name' key. But when it is passed to the constructor of `BaseUser` it's trying to access the username with the 'username' key. (Because that's how discord returns it)

This causes a KeyError and the bot crashes.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
