### PR TITLE
UDP port is a big endian unsigned short

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -721,9 +721,7 @@ class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
         ip_end = recv.index(0, ip_start)
         state.ip = recv[ip_start:ip_end].decode('ascii')
 
-        # the port is a little endian unsigned short in the last two bytes
-        # yes, this is different endianness from everything else
-        state.port = struct.unpack_from('<H', recv, len(recv) - 2)[0]
+        state.port = struct.unpack_from('>H', recv, len(recv) - 2)[0]
         log.debug('detected ip: %s port: %s', state.ip, state.port)
 
         # there *should* always be at least one supported mode (xsalsa20_poly1305)


### PR DESCRIPTION
### Summary

This pull request makes the library interpret the voice UDP port as a big endian unsigned short as stated in https://github.com/discordapp/discord-api-docs/pull/1244

May be related to #2469

### Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
