### PR TITLE
check if paginator prefix is None in .pages

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -157,7 +157,7 @@ class Paginator:
     def pages(self):
         """Returns the rendered list of pages."""
         # we have more than just the prefix in our current page
-        if len(self._current_page) > 1:
+        if len(self._current_page) > (0 if self.prefix is None else 1):
             self.close_page()
         return self._pages
 


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
This pull request fixes an issue with a paginator's .pages returning an empty list when the prefix is None and only one line has been added

```py
from discord.ext import commands

paginator = commands.Paginator(prefix=None, suffix=None)

paginator.add_line('A random string')

print(paginator.pages) # Without: prints [], With: prints ['A random string']
```

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
