### PR TITLE
[docs] document the exception-suppressing behaviour of Message.delete with a delay

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -696,7 +696,7 @@ class Message:
         -----------
         delay: Optional[:class:`float`]
             If provided, the number of seconds to wait in the background
-            before deleting the message.
+            before deleting the message. If the deletion fails then it is silently ignored.
 
         Raises
         ------


### PR DESCRIPTION

### Summary

The `except HTTPException: pass` behaviour of Messageable.send(delete_after=…) is documented, yet the same behavior is not documented for Message.delete. This could confuse some users, expecting the library to at least log exceptions raised by using this kwarg, and improves the consistency of the documentation.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
