### PR TITLE
Allow some decorators to be used without calling them

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -473,6 +473,11 @@ class BotBase(GroupMixin):
             self.add_listener(func, name)
             return func
 
+        if callable(name):
+            func = name
+            name = None
+            return decorator(func)
+
         return decorator
 
     # cogs

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -248,7 +248,7 @@ class Cog(metaclass=CogMeta):
             the name.
         """
 
-        if name is not None and not isinstance(name, str):
+        if name is not None and not callable(name) and not isinstance(name, str):
             raise TypeError('Cog.listener expected str but received {0.__class__.__name__!r} instead.'.format(name))
 
         def decorator(func):
@@ -268,6 +268,12 @@ class Cog(metaclass=CogMeta):
             # to pick it up but the metaclass unfurls the function and
             # thus the assignments need to be on the actual function
             return func
+
+        if callable(name):
+            func = name
+            name = None
+            return decorator(func)
+
         return decorator
 
     @_cog_special_method

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1115,27 +1115,37 @@ class GroupMixin:
 
         return obj
 
-    def command(self, *args, **kwargs):
+    def command(self, name=None, *args, **kwargs):
         """A shortcut decorator that invokes :func:`.command` and adds it to
         the internal command list via :meth:`~.GroupMixin.add_command`.
         """
         def decorator(func):
             kwargs.setdefault('parent', self)
-            result = command(*args, **kwargs)(func)
+            result = command(name, *args, **kwargs)(func)
             self.add_command(result)
             return result
 
+        if callable(name):
+            func = name
+            name = None
+            return decorator(func)
+
         return decorator
 
-    def group(self, *args, **kwargs):
+    def group(self, name=None, *args, **kwargs):
         """A shortcut decorator that invokes :func:`.group` and adds it to
         the internal command list via :meth:`~.GroupMixin.add_command`.
         """
         def decorator(func):
             kwargs.setdefault('parent', self)
-            result = group(*args, **kwargs)(func)
+            result = group(name, *args, **kwargs)(func)
             self.add_command(result)
             return result
+
+        if callable(name):
+            func = name
+            name = None
+            return decorator(func)
 
         return decorator
 
@@ -1277,6 +1287,11 @@ def command(name=None, cls=None, **attrs):
         if isinstance(func, Command):
             raise TypeError('Callback is already a command.')
         return cls(func, name=name, **attrs)
+
+    if callable(name):
+        func = name
+        name = None
+        return decorator(func)
 
     return decorator
 
@@ -1652,7 +1667,7 @@ def bot_has_guild_permissions(**perms):
 
     return check(predicate)
 
-def dm_only():
+def dm_only(func=None):
     """A :func:`.check` that indicates this command must only be used in a
     DM context. Only private messages are allowed when
     using the command.
@@ -1672,9 +1687,14 @@ def dm_only():
             raise PrivateMessageOnly()
         return True
 
-    return check(predicate)
+    decorator = check(predicate)
 
-def guild_only():
+    if callable(func):
+        return decorator(func)
+
+    return decorator
+
+def guild_only(func=None):
     """A :func:`.check` that indicates this command must only be used in a
     guild context only. Basically, no private messages are allowed when
     using the command.
@@ -1692,9 +1712,14 @@ def guild_only():
             raise NoPrivateMessage()
         return True
 
-    return check(predicate)
+    decorator = check(predicate)
 
-def is_owner():
+    if callable(func):
+        return decorator(func)
+
+    return decorator
+
+def is_owner(func=None):
     """A :func:`.check` that checks if the person invoking this command is the
     owner of the bot.
 
@@ -1713,9 +1738,14 @@ def is_owner():
             raise NotOwner('You do not own this bot.')
         return True
 
-    return check(predicate)
+    decorator = check(predicate)
 
-def is_nsfw():
+    if callable(func):
+        return decorator(func)
+
+    return decorator
+
+def is_nsfw(func=None):
     """A :func:`.check` that checks if the channel is a NSFW channel.
 
     This check raises a special exception, :exc:`.NSFWChannelRequired`
@@ -1735,7 +1765,13 @@ def is_nsfw():
         if ctx.guild is None or (isinstance(ch, discord.TextChannel) and ch.is_nsfw()):
             return True
         raise NSFWChannelRequired(ch)
-    return check(pred)
+
+    decorator = check(pred)
+
+    if callable(func):
+        return decorator(func)
+
+    return decorator
 
 def cooldown(rate, per, type=BucketType.default):
     """A decorator that adds a cooldown to a :class:`.Command`

--- a/docs/ext/commands/cogs.rst
+++ b/docs/ext/commands/cogs.rst
@@ -49,6 +49,7 @@ A couple of technical notes to take into consideration:
 
 - All listeners must be explicitly marked via decorator, :meth:`~.commands.Cog.listener`.
 - The name of the cog is automatically derived from the class name but can be overridden. See :ref:`ext_commands_cogs_meta_options`.
+- :meth:`~.commands.Cog.listener` can be used without ``()`` if you aren't passing it a name.
 - All commands must now take a ``self`` parameter to allow usage of instance attributes that can be used to maintain state.
 
 Cog Registration

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -61,6 +61,14 @@ the name to something other than the function would be as simple as doing this:
     async def _list(ctx, arg):
         pass
 
+If no options are passed to :meth:`.Bot.command` or :func:`~ext.commands.command`, these methods may be used without ``()``:
+
+.. code-block:: python3
+
+    @bot.command
+    async def test(ctx, arg):
+        pass
+
 Parameters
 ------------
 
@@ -634,7 +642,8 @@ want to split it into its own decorator. To do that we can just add another leve
         await ctx.send(eval(code))
 
 
-Since an owner check is so common, the library provides it for you (:func:`~ext.commands.is_owner`):
+Since an owner check is so common, the library provides it for you (:func:`~ext.commands.is_owner`, which can be used
+both with and without ``()``):
 
 .. code-block:: python3
 
@@ -706,6 +715,7 @@ If you want a more robust error system, you can derive from the exception and ra
 .. note::
 
     Since having a ``guild_only`` decorator is pretty common, it comes built-in via :func:`~ext.commands.guild_only`.
+	It can be used both with and without ``()``.
 
 Global Checks
 ++++++++++++++


### PR DESCRIPTION
### Summary

This serves as a one-up to #1972. Also adds `commands.dm_only()` to the bunch. 

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
