### PR TITLE
Implement support for command argument separators.

### DIFF
--- a/discord/ext/commands/__init__.py
+++ b/discord/ext/commands/__init__.py
@@ -18,3 +18,4 @@ from .help import *
 from .converter import *
 from .cooldowns import *
 from .cog import *
+from .view import Separator, Encapsulator

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -163,7 +163,7 @@ class Context(discord.abc.Messageable):
             raise ValueError('This context is not valid.')
 
         # some state to revert to when we're done
-        index, previous = view.index, view.previous
+        index, previous, separator = view.index, view.previous, view.separator
         invoked_with = self.invoked_with
         invoked_subcommand = self.invoked_subcommand
         subcommand_passed = self.subcommand_passed
@@ -182,6 +182,7 @@ class Context(discord.abc.Messageable):
             self.command = cmd
             view.index = index
             view.previous = previous
+            view.separator = separator
             self.invoked_with = invoked_with
             self.invoked_subcommand = invoked_subcommand
             self.subcommand_passed = subcommand_passed

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -37,6 +37,7 @@ from .cooldowns import Cooldown, BucketType, CooldownMapping
 from . import converter as converters
 from ._types import _BaseCommand
 from .cog import Cog
+from .view import Separator, Encapsulator
 
 __all__ = (
     'Command',
@@ -180,6 +181,9 @@ class Command(_BaseCommand):
         If ``True``\, cooldown processing is done after argument parsing,
         which calls converters. If ``False`` then cooldown processing is done
         first and then the converters are called second. Defaults to ``False``.
+    qualifier: Union[:class:`Separator`, :class:`Encapsulator`]
+        The qualifier for how arguments should be delimited. By default, it is
+        :class:`Separator`.
     """
 
     def __new__(cls, *args, **kwargs):
@@ -254,6 +258,7 @@ class Command(_BaseCommand):
         self.parent = parent if isinstance(parent, _BaseCommand) else None
         self._before_invoke = None
         self._after_invoke = None
+        self.qualifier = kwargs.pop('qualifier', Separator())
 
     @property
     def callback(self):
@@ -613,6 +618,11 @@ class Command(_BaseCommand):
 
         view = ctx.view
         iterator = iter(self.params.items())
+        qual = ctx.command.qualifier
+        if isinstance(qual, Separator):
+            view.separator = qual
+        elif isinstance(qual, Encapsulator):
+            view.available_quotes = {qual.start: qual.end}
 
         if self.cog is not None:
             # we have 'self' as the first parameter so just advance
@@ -900,6 +910,7 @@ class Command(_BaseCommand):
             return ''
 
         result = []
+        result_params = []
         for name, param in params.items():
             greedy = isinstance(param.annotation, converters._Greedy)
 
@@ -908,20 +919,22 @@ class Command(_BaseCommand):
                 # do [name] since [name=None] or [name=] are not exactly useful for the user.
                 should_print = param.default if isinstance(param.default, str) else param.default is not None
                 if should_print:
-                    result.append('[%s=%s]' % (name, param.default) if not greedy else
-                                  '[%s=%s]...' % (name, param.default))
+                    result_params.append('[%s=%s]' % (name, param.default) if not greedy else
+                                         '[%s=%s]...' % (name, param.default))
                     continue
                 else:
-                    result.append('[%s]' % name)
+                    result_params.append('[%s]' % name)
 
             elif param.kind == param.VAR_POSITIONAL:
-                result.append('[%s...]' % name)
+                result_params.append('[%s...]' % name)
             elif greedy:
-                result.append('[%s]...' % name)
+                result_params.append('[%s]...' % name)
             elif self._is_typing_optional(param.annotation):
                 result.append('[%s]' % name)
             else:
-                result.append('<%s>' % name)
+                result_params.append('<%s>' % name)
+        
+        result.append(self.qualifier.key.join(result_params))
 
         return ' '.join(result)
 
@@ -1179,7 +1192,10 @@ class Group(GroupMixin, Command):
         view = ctx.view
         previous = view.index
         view.skip_ws()
+        sep = view.separator
+        view.separator = None
         trigger = view.get_word()
+        view.separator = sep
 
         if trigger:
             ctx.subcommand_passed = trigger
@@ -1211,7 +1227,10 @@ class Group(GroupMixin, Command):
         view = ctx.view
         previous = view.index
         view.skip_ws()
+        sep = view.separator
+        view.separator = None
         trigger = view.get_word()
+        view.separator = sep
 
         if trigger:
             ctx.subcommand_passed = trigger

--- a/discord/ext/commands/view.py
+++ b/discord/ext/commands/view.py
@@ -48,12 +48,73 @@ _quotes = {
 }
 _all_quotes = set(_quotes.keys()) | set(_quotes.values())
 
+class Separator:
+    """An argument qualifier, which acts as the delimiter for arguments.
+    
+    .. code-block:: python3
+    
+        @bot.command(qualifier=Separator(',')
+        async def foo(ctx, *c):
+            await ctx.send(', '.join(c))
+        
+        # ?foo a b, c, d, e
+
+        @bot.command(qualifier=Separator('|', strip_ws=False)
+        async def bar(ctx, *c):
+            await ctx.send(','.join(c))
+
+        # ?bar a b test | c | e | f
+
+    Attributes
+    -----------
+    key: :class:`str`
+        The key that separates each argument. By default, it is ``' '``.
+    strip_ws: :class:`bool`
+        Whether or not to strip whitespace from the arguments. By default,
+        it is ``True``.
+    """
+    def __init__(self, key=' ', *, strip_ws=True):
+        self.key = key
+        self.strip_ws = strip_ws
+
+class Encapsulator:
+    """An argument qualifier, which acts as a drop-in replacement for quotes.
+
+    .. code-block:: python3
+
+        @bot.command(qualifier=Encapsulator('-')
+        async def foo(ctx, *c):
+            await ctx.send(', '.join(c))
+
+        # ?foo -a b c- b
+
+        @bot.command(qualifier=Encapsulator('(', ')')
+        async def bar(ctx, *c):
+            await ctx.send(', '.join(c))
+
+        # ?bar a b (c d e) f g
+
+    Attributes
+    -----------
+    start: :class:`str`
+        The starting key that represents the first quote character.
+    end: Optional[:class:`str`]
+        The ending key that represents the last quote character. If ``None``\,
+        it will be set as the same key as ``start``.
+    """
+    def __init__(self, start, end=None):
+        self.start = start
+        self.end = end or start
+
+
 class StringView:
     def __init__(self, buffer):
         self.index = 0
         self.buffer = buffer
         self.end = len(buffer)
         self.previous = 0
+        self.available_quotes = _quotes
+        self.separator = Separator()
 
     @property
     def current(self):
@@ -63,6 +124,9 @@ class StringView:
     def eof(self):
         return self.index >= self.end
 
+    def is_separator(self, c):
+        return c == self.separator.key
+
     def undo(self):
         self.index = self.previous
 
@@ -71,7 +135,7 @@ class StringView:
         while not self.eof:
             try:
                 current = self.buffer[self.index + pos]
-                if not current.isspace():
+                if not self.is_separator(current):
                     break
                 pos += 1
             except IndexError:
@@ -116,7 +180,7 @@ class StringView:
         while not self.eof:
             try:
                 current = self.buffer[self.index + pos]
-                if current.isspace():
+                if self.is_separator(current):
                     break
                 pos += 1
             except IndexError:
@@ -131,7 +195,7 @@ class StringView:
         if current is None:
             return None
 
-        close_quote = _quotes.get(current)
+        close_quote = self.available_quotes.get(current)
         is_quoted = bool(close_quote)
         if is_quoted:
             result = []
@@ -146,10 +210,16 @@ class StringView:
                 if is_quoted:
                     # unexpected EOF
                     raise ExpectedClosingQuoteError(close_quote)
-                return ''.join(result)
+
+                r = ''.join(result)
+                if self.separator.strip_ws:
+                    r = r.strip()
+                return r 
 
             # currently we accept strings in the format of "hello world"
             # to embed a quote inside the string you must escape it: "a \"world\""
+            # separator characters (either a white space character or
+            # a custom separator string) can also be escaped : hello\ world
             if current == '\\':
                 next_char = self.get()
                 if not next_char:
@@ -160,8 +230,8 @@ class StringView:
                     # if we aren't then we just let it through
                     return ''.join(result)
 
-                if next_char in _escaped_quotes:
-                    # escaped quote
+                if next_char == '"' or self.is_separator(next_char):
+                    # escaped separator or quote
                     result.append(next_char)
                 else:
                     # different escape character, ignore it
@@ -169,23 +239,27 @@ class StringView:
                     result.append(current)
                 continue
 
-            if not is_quoted and current in _all_quotes:
+            if not is_quoted and current in self.available_quotes:
                 # we aren't quoted
                 raise UnexpectedQuoteError(current)
 
             # closing quote
             if is_quoted and current == close_quote:
                 next_char = self.get()
-                valid_eof = not next_char or next_char.isspace()
+                valid_eof = not next_char or self.is_separator(next_char)
                 if not valid_eof:
                     raise InvalidEndOfQuotedStringError(next_char)
 
                 # we're quoted so it's okay
                 return ''.join(result)
 
-            if current.isspace() and not is_quoted:
+            if self.is_separator(current) and not is_quoted:
                 # end of word found
-                return ''.join(result)
+                r = ''.join(result)
+                if self.separator.strip_ws:
+                    r = r.strip()
+
+                return r
 
             result.append(current)
 

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -156,6 +156,15 @@ Context
     .. automethod:: discord.ext.commands.Context.typing
         :async-with:
 
+.. _ext_commands_api_qualifiers:
+
+Qualifiers
+-----------
+
+.. autoclass:: discord.ext.commands.Separator
+
+.. autoclass:: discord.ext.commands.Encapsulator
+
 .. _ext_commands_api_converters:
 
 Converters


### PR DESCRIPTION
### Summary

This is an adaptation of the now defunt PR - #645. It allows for two ways of command customization:

- Separator: Essentially lets you separate the arguments using something other than `` ``, requiring the use of quotes for multiple word arguments. `?foo a b, c, d, e` -> `('a', 'b', 'c', 'd', 'e')`
- Encapsulator: Another way of using quotes. `?bar a b [c d e] f g` -> `('a', 'b', 'c d e', 'f', 'g')`

As this changes quite a bit of the parsing of commands behind the scenes, I will try to test this as extensively as possible before marking it ready for review.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
