### PR TITLE
Final mention cleanup in message.clean_content

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -39,6 +39,8 @@ from .errors import InvalidArgument, ClientException, HTTPException
 from .embeds import Embed
 from .member import Member
 from .flags import MessageFlags
+from .utils import escape_mentions
+
 
 class Attachment:
     """Represents an attachment from Discord.
@@ -557,7 +559,8 @@ class Message:
             return transformations.get(obj.group(0), '')
 
         pattern = re.compile('|'.join(transformations.keys()))
-        return pattern.sub(repl2, result)
+        replaced = pattern.sub(repl2, result)
+        return escape_mentions(replaced)
 
     @property
     def created_at(self):


### PR DESCRIPTION
  - Adds use of `discord.utils.escape_mentions` as the last step of `discord.Message.clean_content`
  - It was already the last step of `discord.ext.commands.clean_content`~~

### Summary

This resolves an edge case in message.clean_content where a user is mentioned while having a nickname that resolves as a mention.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
