### PR TITLE
Fix documentation problem with color

### DIFF
--- a/discord/role.py
+++ b/discord/role.py
@@ -161,7 +161,10 @@ class Role(Hashable):
         """:class:`Colour`: Returns the role colour. An alias exists under ``color``."""
         return Colour(self._colour)
 
-    color = colour
+    @property
+    def color(self):
+        """:class:`Colour`: Returns the role color. An alias exists under ``colour``."""
+        return Colour(self._colour)
 
     @property
     def created_at(self):

--- a/discord/role.py
+++ b/discord/role.py
@@ -164,7 +164,7 @@ class Role(Hashable):
     @property
     def color(self):
         """:class:`Colour`: Returns the role color. An alias exists under ``colour``."""
-        return Colour(self._colour)
+        return self.colour
 
     @property
     def created_at(self):


### PR DESCRIPTION
At readthedocs.io, for role `color`, it says "Returns the role colour. An alias exists under `color`". This PR fixes that to say "Returns the role color. An alias exists under `colour`".

### Summary

<!-- What is this pull request for? Does it fix any issues? -->

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
