### PR TITLE
Patch clean_prefix for new text editor

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -344,7 +344,8 @@ class HelpCommand:
         # consider this to be an *incredibly* strange use case. I'd rather go
         # for this common use case rather than waste performance for the
         # odd one.
-        return self.context.prefix.replace(user.mention, '@' + user.display_name)
+        pattern = re.compile(r"<@!?%s>" % user.id)
+        return pattern.sub("@%s" % user.display_name, self.context.prefix)
 
     @property
     def invoked_with(self):


### PR DESCRIPTION

### Summary

Makes clean_prefix handle both forms of mention.
The new editor seems to force mentions to have ! even without a nick.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
