### PR TITLE
Add string check before conversion

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -157,7 +157,13 @@ class UserConverter(IDConverter):
             result = ctx.bot.get_user(user_id) or _utils_get(ctx.message.mentions, id=user_id)
         else:
             arg = argument
-            # check for discriminator if it exists
+
+            # Remove the '@' character if this is the first character from the argument
+            if arg[:1] == '@':
+                # Remove first character
+                arg = arg[1:]
+
+            # check for discriminator if it exists,
             if len(arg) > 5 and arg[-5] == '#':
                 discrim = arg[-4:]
                 name = arg[:-5]
@@ -173,7 +179,6 @@ class UserConverter(IDConverter):
             raise BadArgument('User "{}" not found'.format(argument))
 
         return result
-
 class MessageConverter(Converter):
     """Converts to a :class:`discord.Message`.
 

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -159,7 +159,7 @@ class UserConverter(IDConverter):
             arg = argument
 
             # Remove the '@' character if this is the first character from the argument
-            if arg[:1] == '@':
+            if arg[0] == '@':
                 # Remove first character
                 arg = arg[1:]
 


### PR DESCRIPTION
### Summary
My bot has a functionality to interact with people through both a server and DM. 
A command could look like `!interact <user>`. In a server, users are almost always passed by user mention. In Direct Messages however, the user is most commonly presented as `name#tag`. One of the problems however is that most users will copy an username directly from a server. This will paste as `@user#0000`. Conversion in this format will fail, as it will try to lookup `@user#0000`, rather than `user#0000`. To fix this, I've added a simple check where first character from the argument is truncated if this character is '@'. 

Something that is worth noting that I've only implemented this in `UserConverter`. _The `MemberConverter` is left untouched_

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (not needed)
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)


### Testing
Before code changes:
![image](https://user-images.githubusercontent.com/10338882/71785206-214ac100-2ffd-11ea-9724-0c5251514989.png)

After code changes:
![image](https://user-images.githubusercontent.com/10338882/71785211-36275480-2ffd-11ea-870f-abfc39d2167f.png)

Script used for testing available [here](https://gist.github.com/hugopilot/d04ad3fb6209a162aac7fcfeb2777aa3)