### PR TITLE
Implement `Guild.edit_role_positions`

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1591,6 +1591,68 @@ class Guild(Hashable):
         # TODO: add to cache
         return role
 
+    async def edit_role_positions(self, *, positions=None, reason=None):
+        """|coro|
+        
+        Changes the positions of a set of :class:`Role` for the guild.
+
+        You must have the :attr:`~Permissions.manage_roles` permission to
+        do this.
+
+        Example:
+
+        .. code-block:: python3
+
+            positions = {
+                bots_role: 1, # penultimate role
+                tester_role: 2,
+                admin_role: 6
+            }
+
+            await guild.edit_role_positions(positions=positions)
+
+        Parameters
+        -----------
+        positions
+            A :class:`dict` of :class:`Role` to :class:`int` to change the positions
+            of each given role.
+        reason: Optional[:class:`str`]
+            The reason for creating this channel. Shows up on the audit log.
+
+        Raises
+        -------
+        Forbidden
+            You do not have permissions to move the roles.
+        HTTPException
+            Moving the roles failed.
+        InvalidArgument
+            An invalid keyword argument was given.
+
+        Returns
+        --------
+        List[:class:`Role`]
+            A list of all the roles in the guild.
+        """
+        if positions is None:
+            positions = {}
+        elif not isinstance(positions, dict):
+            raise InvalidArgument('positions parameter expects a dict.')
+
+        role_positions = []
+        for role, position in positions.items():
+
+            payload = {
+                'id': role.id, 
+                'position': position
+            }
+
+            role_positions.append(payload)
+
+        data = await self._state.http.move_role_position(self.id, role_positions, reason=reason)
+        roles = [Role(guild=self, data=d, state=self._state) for d in data]
+
+        return roles
+
     async def kick(self, user, *, reason=None):
         """|coro|
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1617,7 +1617,7 @@ class Guild(Hashable):
             A :class:`dict` of :class:`Role` to :class:`int` to change the positions
             of each given role.
         reason: Optional[:class:`str`]
-            The reason for creating this channel. Shows up on the audit log.
+            The reason for editing the role positions. Shows up on the audit log.
 
         Raises
         -------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1591,13 +1591,15 @@ class Guild(Hashable):
         # TODO: add to cache
         return role
 
-    async def edit_role_positions(self, *, positions=None, reason=None):
+    async def edit_role_positions(self, *, positions, reason=None):
         """|coro|
         
-        Changes the positions of a set of :class:`Role` for the guild.
+        Bulk edits a list of :class:`Role` in the guild.
 
         You must have the :attr:`~Permissions.manage_roles` permission to
         do this.
+
+        .. versionadded:: 1.4
 
         Example:
 
@@ -1633,23 +1635,25 @@ class Guild(Hashable):
         List[:class:`Role`]
             A list of all the roles in the guild.
         """
-        if positions is None:
-            positions = {}
-        elif not isinstance(positions, dict):
+        if not isinstance(positions, dict):
             raise InvalidArgument('positions parameter expects a dict.')
 
         role_positions = []
         for role, position in positions.items():
 
             payload = {
-                'id': role.id, 
+                'id': role.id,
                 'position': position
             }
 
             role_positions.append(payload)
 
         data = await self._state.http.move_role_position(self.id, role_positions, reason=reason)
-        roles = [Role(guild=self, data=d, state=self._state) for d in data]
+        roles = []
+        for d in data:
+            role = Role(guild=self, data=d, state=self._state)
+            roles.append(role)
+            self._roles[role.id] = role
 
         return roles
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1591,7 +1591,7 @@ class Guild(Hashable):
         # TODO: add to cache
         return role
 
-    async def edit_role_positions(self, *, positions, reason=None):
+    async def edit_role_positions(self, positions, *, reason=None):
         """|coro|
         
         Bulk edits a list of :class:`Role` in the guild.


### PR DESCRIPTION
### Summary

This closes #2143. The syntax for this method allows you to provide specific roles and their new role positions, however, I did think about providing an ordered list of all roles in their new role positions, and I felt like that would need more variables than providing specific role position changes. The syntax can still be changed if requested.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
