### PR TITLE
[docs] Fix sphinx warning about heading

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -77,7 +77,7 @@ General
 General questions regarding library usage belong here.
 
 Where can I find usage examples?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Example code can be found in the `examples folder <https://github.com/Rapptz/discord.py/tree/master/examples>`_
 in the repository.


### PR DESCRIPTION
### Summary

Fixes this issue when trying to run sphinx build locally:
```python
/workspace/discord.py/docs/faq.rst:80: WARNING: Title underline too short.

Where can I find usage examples?
~~~~~~~~~~~~~~~~~~~~~~~~
```

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
