### PR TITLE
Implement basic intents system.

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -28,7 +28,7 @@ from .partial_emoji import PartialEmoji
 from .activity import *
 from .channel import *
 from .guild import Guild
-from .flags import SystemChannelFlags, MessageFlags
+from .flags import Intents, SystemChannelFlags, MessageFlags
 from .relationship import Relationship
 from .member import Member, VoiceState
 from .message import Message, Attachment

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -102,6 +102,196 @@ class BaseFlags:
         else:
             raise TypeError('Value to set for %s must be a bool.' % self.__class__.__name__)
 
+@fill_with_flags()
+class Intents(BaseFlags):
+    r"""Wraps up the intents for the gateway.
+
+    Each flag represents the events that you will receive when the 
+    client connects to the gateway.
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two flags are equal.
+        .. describe:: x != y
+
+            Checks if two flags are not equal.
+        .. describe:: hash(x)
+
+               Return the flag's hash.
+        .. describe:: iter(x)
+
+               Returns an iterator of ``(name, value)`` pairs. This allows it
+               to be, for example, constructed as a dict or a list of pairs.
+
+    Attributes
+    -----------
+    value: :class:`int`
+        The raw value. This value is a bit array field of a 53-bit integer
+        representing the currently available flags. You should query
+        flags via the properties rather than using this raw value.
+    """
+    __slots__ = ()
+
+    def _set_guild_subscriptions(self):
+        self.guild_members = True
+        # self.guild_presences = True
+        self.guild_message_typing = True
+
+    @flag_value
+    def guilds(self):
+        """:class:`bool`: This enables:
+
+        - :func:`on_guild_join`
+        - :func:`on_guild_remove`
+        - :func:`on_guild_role_create`
+        - :func:`on_guild_role_create`
+        - :func:`on_guild_role_delete`
+        - :func:`on_guild_role_update`
+        - :func:`on_guild_channel_create`
+        - :func:`on_guild_channel_delete`
+        - :func:`on_guild_channel_update`
+        - :func:`on_guild_channel_pins_update`
+        """
+        return 1
+
+    @flag_value
+    def guild_members(self):
+        """:class:`bool`: This enables:
+        
+        - :func:`on_member_join`
+        - :func:`on_member_remove`
+        - :func:`on_member_update`
+        """
+        return 2
+
+    @flag_value
+    def guild_bans(self):
+        """:class:`bool`: This enables:
+        
+        - :func:`on_member_ban`
+        - :func:`on_member_unban`
+        """
+        return 4
+
+    @flag_value
+    def guild_emojis(self):
+        """:class:`bool`: This enables:
+        
+        - :func:`on_guild_emojis_update`
+        """
+        return 8
+
+    @flag_value
+    def guild_integrations(self):
+        """:class:`bool`: This enables:
+
+        - :func:`on_guild_integrations_update`
+        """
+        return 16
+
+    @flag_value
+    def guild_webhooks(self):
+        """:class:`bool`: This enables:
+
+        - :func:`on_webhooks_update`
+        """
+        return 32
+
+    @flag_value
+    def guild_invites(self):
+        """:class:`bool`: This enables:
+        
+        - :func:`on_invite_create`
+        - :func:`on_invite_delete`
+        """
+        return 64
+
+    @flag_value
+    def guild_voice_states(self):
+        """:class:`bool`: This enables:
+        
+        - :func:`on_voice_state_update`
+        """
+        return 128
+
+    @flag_value
+    def guild_presences(self):
+        """:class:`bool`: This enables:
+        
+        - :func:`on_member_update`
+        """
+        return 256
+
+    @flag_value
+    def guild_messages(self):
+        """:class:`bool`: This enables:
+
+        - :func:`on_message`
+        - :func:`on_message_edit`
+        - :func:`on_message_delete`
+
+        for guilds.
+        """
+        return 512
+
+    @flag_value
+    def guild_message_reactions(self):
+        """:class:`bool`: This enables:
+
+        - :func:`on_reaction_add`
+        - :func:`on_reaction_remove`
+        - :func:`on_reaction_clear`
+
+        for guilds.
+        """
+        return 1024
+
+    @flag_value
+    def guild_message_typing(self):
+        """:class:`bool`: This enables:
+
+        - :func:`on_typing`
+
+        for guilds.
+        """
+        return 2048
+
+    @flag_value
+    def direct_messages(self):
+        """:class:`bool`: This enables:
+
+        - :func:`on_message`
+        - :func:`on_message_edit`
+        - :func:`on_message_delete`
+
+        for DM channels.
+        """
+        return 4096
+
+    @flag_value
+    def direct_message_reactions(self):
+        """:class:`bool`: This enables:
+
+        - :func:`on_reaction_add`
+        - :func:`on_reaction_remove`
+        - :func:`on_reaction_clear`
+
+        for DM channels.
+        """
+        return 8192
+
+    @flag_value
+    def direct_message_typing(self):
+        """:class:`bool`: This enables:
+
+        - :func:`on_typing`
+
+        for DM channels.
+        """
+        return 16384
+
 @fill_with_flags(inverted=True)
 class SystemChannelFlags(BaseFlags):
     r"""Wraps up a Discord system channel flag value.

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -234,6 +234,7 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
         ws.shard_count = client._connection.shard_count
         ws.session_id = session
         ws.sequence = sequence
+        ws.intents = client._intents
         ws._max_heartbeat_timeout = client._connection.heartbeat_timeout
 
         client._connection._update_references(ws)
@@ -297,7 +298,7 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
                 },
                 'compress': True,
                 'large_threshold': 250,
-                'guild_subscriptions': self._connection.guild_subscriptions,
+                'intents': self.intents.value,
                 'v': 3
             }
         }

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2525,6 +2525,12 @@ PermissionOverwrite
 .. autoclass:: PermissionOverwrite
     :members:
 
+Intents
+~~~~~~~~
+
+.. autoclass:: Intents
+	:members:
+
 SystemChannelFlags
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
### Summary

This implements the upcoming intents system into discord.py (discordapp/discord-api-docs#1307). Mason has promised to implement the undocumented events, and #2440 will fully implement `message_reaction_remove_emoji` once it is completed, which leaves `invite_create/delete` to be implemented. As presences requires whitelisting, it has been commented out of the `_set_guild_subscriptions`, but can be added at a later date to act as a transfer from `guild_subscriptions` to the new intents system.

As the system is still W.I.P. this PR will also be W.I.P. Feel free to jot down any requested changes.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
