### PR TITLE
Added docs for overwrites kwarg of CategoryChannel.edit

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -772,6 +772,11 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
             To mark the category as NSFW or not.
         reason: Optional[:class:`str`]
             The reason for editing this category. Shows up on the audit log.
+        overwrites: :class:`dict`
+            A :class:`dict` of target (either a role or a member) to
+            :class:`PermissionOverwrite` to apply to the channel.
+            
+            .. versionadded:: 1.3.0
 
         Raises
         ------


### PR DESCRIPTION
### Summary

`CategoryChannel.edit` does not have new overwrites kwarg documented like `TextChannel.edit` and `VoiceChannel.edit` does.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
