### PR TITLE
Add discord.utils.sleep_until helper function

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -338,6 +338,22 @@ async def sane_wait_for(futures, *, timeout):
 
     return done
 
+async def sleep_until(when):
+    """Sleep until a specified time.
+
+    If the time supplied is in the past this function will yield instantly.
+    
+    Parameters
+    -----------
+    when: :class:`datetime.datetime`
+        The timestamp in which to sleep until.
+
+    .. versionadded:: 1.3.0
+    """
+    now = datetime.datetime.now(datetime.timezone.utc)
+    delta = (when - now).total_seconds()
+    await asyncio.sleep(max(delta, 0))
+
 def valid_icon_size(size):
     """Icons must be power of 2 within [16, 4096]."""
     return not size & (size - 1) and size in range(16, 4097)

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -350,6 +350,8 @@ async def sleep_until(when):
 
     .. versionadded:: 1.3.0
     """
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=datetime.timezone.utc)
     now = datetime.datetime.now(datetime.timezone.utc)
     delta = (when - now).total_seconds()
     await asyncio.sleep(max(delta, 0))


### PR DESCRIPTION
### Summary

Adds a helper function `discord.utils.sleep_until` to allow for sleeping until a specified datetime.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
