### PR TITLE
Make general improvements to utils.sleep_until

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -8,8 +8,6 @@ import logging
 
 from discord.backoff import ExponentialBackoff
 
-MAX_ASYNCIO_SECONDS = 3456000
-
 log = logging.getLogger(__name__)
 
 class Loop:
@@ -360,10 +358,6 @@ class Loop:
         """
 
         sleep = seconds + (minutes * 60.0) + (hours * 3600.0)
-        if sleep >= MAX_ASYNCIO_SECONDS:
-            fmt = 'Total number of seconds exceeds asyncio imposed limit of {0} seconds.'
-            raise ValueError(fmt.format(MAX_ASYNCIO_SECONDS))
-
         if sleep < 0:
             raise ValueError('Total number of seconds cannot be less than zero.')
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -339,7 +339,7 @@ async def sane_wait_for(futures, *, timeout):
 
     return done
 
-async def sleep_until(when):
+async def sleep_until(when, result=None):
     """Sleep until a specified time.
 
     If the time supplied is in the past this function will yield instantly.
@@ -348,6 +348,8 @@ async def sleep_until(when):
     -----------
     when: :class:`datetime.datetime`
         The timestamp in which to sleep until.
+    result: Any
+        If provided is returned to the caller when the coroutine comples.
 
     .. versionadded:: 1.3
     """
@@ -358,7 +360,7 @@ async def sleep_until(when):
     while delta > MAX_ASYNCIO_SECONDS:
         await asyncio.sleep(MAX_ASYNCIO_SECONDS)
         delta -= MAX_ASYNCIO_SECONDS
-    await asyncio.sleep(max(delta, 0))
+    return await asyncio.sleep(max(delta, 0), result)
 
 def valid_icon_size(size):
     """Icons must be power of 2 within [16, 4096]."""

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -349,7 +349,7 @@ async def sleep_until(when, result=None):
     when: :class:`datetime.datetime`
         The timestamp in which to sleep until.
     result: Any
-        If provided is returned to the caller when the coroutine comples.
+        If provided is returned to the caller when the coroutine completes.
 
     .. versionadded:: 1.3
     """

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -43,6 +43,7 @@ from .errors import InvalidArgument
 from .object import Object
 
 DISCORD_EPOCH = 1420070400000
+MAX_ASYNCIO_SECONDS = 3456000
 
 class cached_property:
     def __init__(self, function):
@@ -354,6 +355,9 @@ async def sleep_until(when):
         when = when.replace(tzinfo=datetime.timezone.utc)
     now = datetime.datetime.now(datetime.timezone.utc)
     delta = (when - now).total_seconds()
+    while delta > MAX_ASYNCIO_SECONDS:
+        await asyncio.sleep(MAX_ASYNCIO_SECONDS)
+        delta -= MAX_ASYNCIO_SECONDS
     await asyncio.sleep(max(delta, 0))
 
 def valid_icon_size(size):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -725,6 +725,7 @@ Utility Functions
 
 .. autofunction:: discord.utils.resolve_invite
 
+.. autofunction:: discord.utils.sleep_until
 
 Profile
 ---------


### PR DESCRIPTION
### Summary

Fixes an issue with sleeping for an extended period of time with python 3.5.

Additionally removes a limitation from the tasks ext loop caused by this issue.

This also adds a new optional result argument to be returned to the caller upon completion.

This exposes the function in the docs.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
