### PR TITLE
Support subclasses in Enum instance check

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -134,7 +134,8 @@ class EnumMeta(type):
         # isinstance(x, Y)
         # -> __instancecheck__(Y, x)
         try:
-            return instance._actual_enum_cls_ is self
+            cls = instance._actual_enum_cls_
+            return cls is self or issubclass(cls, self)
         except AttributeError:
             return False
 


### PR DESCRIPTION
### Summary

This improves `isinstance` with `Enum`s by checking for instances of subclasses as well, matching `isinstance`'s default built-in behavior.

An example of how this would be useful is that it would allow subclassing of `BucketType`, so as to add custom buckets, such as channel *and* member. Currently, `isinstance` checks would fail when that custom subclass is used for a cooldown or maximum concurrency.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [N/A] I have updated the documentation to reflect the changes.
- [N/A] This PR fixes an issue.
- [N/A] This PR adds something new (e.g. new method or parameters).
- [N/A] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [N/A] This PR is **not** a code change (e.g. documentation, README, ...)
