### PR TITLE
[commands] Allow passing a Cooldown class into the cooldown deco

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1826,6 +1826,15 @@ def cooldown(rate, per, type=BucketType.default, *, cls=Cooldown, mapping=Cooldo
         The amount of seconds to wait for a cooldown when it's been triggered.
     type: :class:`.BucketType`
         The type of cooldown to have.
+    cls: :class:`.Cooldown`
+        The factory class that will be used to create cooldown. 
+        By default, this is :class:`.Cooldown`. Should a custom class 
+        be provided, it must be similar enough to :class:`.Cooldown`\'s interface.
+    mapping: :class:`.CooldownMapping`
+        The factory class that will be used to create cooldown mapping. 
+        By default, this is :class:`.CooldownMapping`. Should a custom 
+        class be provided, it must be similar enough to :class:`.CooldownMapping`\'s 
+        interface.
     """
 
     def decorator(func):

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1803,7 +1803,7 @@ def is_nsfw():
         raise NSFWChannelRequired(ch)
     return check(pred)
 
-def cooldown(rate, per, type=BucketType.default):
+def cooldown(rate, per, type=BucketType.default, *, cls=Cooldown, mapping=CooldownMapping):
     """A decorator that adds a cooldown to a :class:`.Command`
     or its subclasses.
 
@@ -1830,9 +1830,9 @@ def cooldown(rate, per, type=BucketType.default):
 
     def decorator(func):
         if isinstance(func, Command):
-            func._buckets = CooldownMapping(Cooldown(rate, per, type))
+            func._buckets = mapping(cls(rate, per, type))
         else:
-            func.__commands_cooldown__ = Cooldown(rate, per, type)
+            func.__commands_cooldown__ = cls(rate, per, type)
         return func
     return decorator
 


### PR DESCRIPTION
### Summary

Small change to the `@cooldown` deco to allow users to pass in their own `Cooldown` and `CooldownMapping` classes. This is a similar change to ones that were made before, eg allowing custom classes for `Bot.get_context` and `@commands.command`.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
