### PR TITLE
Add VoiceClient.latency and VoiceClient.average_latency Properties

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -155,9 +155,9 @@ class VoiceKeepAliveHandler(KeepAliveHandler):
         if len(self.recent_ack_latencies) > 20:
             del self.recent_ack_latencies[0]
 
-        self.latency = sum(self.recent_ack_latencies)/len(self.recent_ack_latencies)
+        self.latency = self.recent_ack_latencies
 
-        if self.latency > 10:
+        if self.latency[-1] > 10:
             log.warning(self.behind_msg, self.latency)
 
 
@@ -757,9 +757,10 @@ class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
 
     @property
     def latency(self):
-        """:class:`float`: Measures latency between a HEARTBEAT and a HEARTBEAT_ACK in seconds."""
+        """:class:`list`: List of latencies measuring latency between a HEARTBEAT and a
+        HEARTBEAT_ACK in seconds."""
         heartbeat = self._keep_alive
-        return float('inf') if heartbeat is None else heartbeat.latency
+        return [float('inf')] if heartbeat is None else heartbeat.latency
 
     async def load_secret_key(self, data):
         log.info('received secret key for voice connection')

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -58,9 +58,7 @@ class ResumeWebSocket(Exception):
     def __init__(self, shard_id):
         self.shard_id = shard_id
 
-
 EventListener = namedtuple('EventListener', 'predicate event result future')
-
 
 class KeepAliveHandler(threading.Thread):
     def __init__(self, *args, **kwargs):
@@ -132,7 +130,6 @@ class KeepAliveHandler(threading.Thread):
         if self.latency > 10:
             log.warning(self.behind_msg, self.latency)
 
-
 class VoiceKeepAliveHandler(KeepAliveHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -155,7 +152,6 @@ class VoiceKeepAliveHandler(KeepAliveHandler):
 
         if self.latency > 10:
             log.warning(self.behind_msg, self.latency)
-
 
 class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
     """Implements a WebSocket for Discord's gateway v6.
@@ -569,7 +565,6 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
             self._keep_alive.stop()
 
         await super().close_connection(*args, **kwargs)
-
 
 class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
     """Implements the websocket protocol for handling voice connections.

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -574,6 +574,7 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
 
         await super().close_connection(*args, **kwargs)
 
+
 class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
     """Implements the websocket protocol for handling voice connections.
 
@@ -753,6 +754,12 @@ class DiscordVoiceWebSocket(websockets.client.WebSocketClientProtocol):
         log.info('selected the voice protocol for use (%s)', mode)
 
         await self.client_connect()
+
+    @property
+    def latency(self):
+        """:class:`float`: Measures latency between a HEARTBEAT and a HEARTBEAT_ACK in seconds."""
+        heartbeat = self._keep_alive
+        return float('inf') if heartbeat is None else heartbeat.latency
 
     async def load_secret_key(self, data):
         log.info('received secret key for voice connection')

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -57,9 +57,7 @@ try:
 except ImportError:
     has_nacl = False
 
-
 log = logging.getLogger(__name__)
-
 
 class VoiceClient:
     """Represents a Discord voice connection.

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -82,10 +82,10 @@ class VoiceClient:
         The voice connection token.
     endpoint: :class:`str`
         The endpoint we are connecting to.
-    latency: :class:`list`
-        List of latencies between a HEARTBEAT and a HEARTBEAT_ACK in seconds.
+    latency: :class:`float`
+        Latency between a HEARTBEAT and a HEARTBEAT_ACK in seconds.
         This could be referred to as the Discord Voice WebSocket latency and is
-        an analogue of user's voice latencies.
+        an analogue of user's voice latencies as seen in the Discord client.
     channel: :class:`abc.Connectable`
         The voice channel connected to.
     loop: :class:`asyncio.AbstractEventLoop`
@@ -188,7 +188,7 @@ class VoiceClient:
         endpoint = data.get('endpoint')
 
         if endpoint is None or self.token is None:
-            log.warning('Awaiting endpoint... This requires waiting. '
+            log.warning('Awaiting endpoint... This requires waiting. ' \
                         'If timeout occurred considering raising the timeout and reconnecting.')
             return
 
@@ -214,14 +214,13 @@ class VoiceClient:
 
     @property
     def latency(self):
-        """:class:`list`: Up to 20 element list of latency between a HEARTBEAT and a
-        HEARTBEAT_ACK in seconds.
+        """:class:`float`: Latency between a HEARTBEAT and a HEARTBEAT_ACK in seconds.
 
-        This could be referred to as the Discord Voice latency and is an analogue to latency as
-        seen by normal discord users.
+        This could be referred to as the Discord Voice latency and is an analogue to voice
+        latency as displayed by the Discord user client.
         """
         ws = self.ws
-        return [float("inf")] if not ws else ws.latency
+        return float("inf") if not ws else ws.latency
 
     @property
     def average_latency(self):

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -100,7 +100,6 @@ class VoiceClient:
         self.timeout = timeout
         self.ws = None
         self.socket = None
-        self.latency = float('inf')
         self.loop = state.loop
         self._state = state
         # this will be used in the AudioPlayer thread
@@ -213,6 +212,17 @@ class VoiceClient:
 
         self._handshake_complete.set()
 
+    @property
+    def latency(self):
+        """:class:`float`: Moving average latency between a HEARTBEAT and a HEARTBEAT_ACK in
+        seconds.
+
+        This could be referred to as the Discord Voice latency and is an analogue to latency as
+        seen by normal discord users.
+        """
+        ws = self.ws
+        return float("inf") if not ws else ws.latency
+
     async def connect(self, *, reconnect=True, _tries=0, do_handshake=True):
         log.info('Connecting to voice...')
         try:
@@ -225,7 +235,6 @@ class VoiceClient:
 
         try:
             self.ws = await DiscordVoiceWebSocket.from_client(self)
-            self.latency = self.ws.latency
             self._handshaking = False
             self._connected.clear()
             while not hasattr(self, 'secret_key'):

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -80,10 +80,6 @@ class VoiceClient:
         The voice connection token.
     endpoint: :class:`str`
         The endpoint we are connecting to.
-    latency: :class:`float`
-        Latency between a HEARTBEAT and a HEARTBEAT_ACK in seconds.
-        This could be referred to as the Discord Voice WebSocket latency and is
-        an analogue of user's voice latencies as seen in the Discord client.
     channel: :class:`abc.Connectable`
         The voice channel connected to.
     loop: :class:`asyncio.AbstractEventLoop`
@@ -214,11 +210,17 @@ class VoiceClient:
     def latency(self):
         """:class:`float`: Latency between a HEARTBEAT and a HEARTBEAT_ACK in seconds.
 
-        This could be referred to as the Discord Voice latency and is an analogue to voice
-        latency as displayed by the Discord user client.
+        This could be referred to as the Discord Voice WebSocket latency and is
+        an analogue of user's voice latencies as seen in the Discord client.
         """
         ws = self.ws
         return float("inf") if not ws else ws.latency
+
+    @property
+    def average_latency(self):
+        """:class:`float`: Average of most recent 20 HEARTBEAT latencies in seconds."""
+        ws = self.ws
+        return float("inf") if not ws else ws.average_latency
 
     async def connect(self, *, reconnect=True, _tries=0, do_handshake=True):
         log.info('Connecting to voice...')

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -82,8 +82,8 @@ class VoiceClient:
         The voice connection token.
     endpoint: :class:`str`
         The endpoint we are connecting to.
-    latency: :class:`float`
-        Measures latency between a HEARTBEAT and a HEARTBEAT_ACK in seconds.
+    latency: :class:`list`
+        List of latencies between a HEARTBEAT and a HEARTBEAT_ACK in seconds.
         This could be referred to as the Discord Voice WebSocket latency and is
         an analogue of user's voice latencies.
     channel: :class:`abc.Connectable`
@@ -214,14 +214,20 @@ class VoiceClient:
 
     @property
     def latency(self):
-        """:class:`float`: Moving average latency between a HEARTBEAT and a HEARTBEAT_ACK in
-        seconds.
+        """:class:`list`: Up to 20 element list of latency between a HEARTBEAT and a
+        HEARTBEAT_ACK in seconds.
 
         This could be referred to as the Discord Voice latency and is an analogue to latency as
         seen by normal discord users.
         """
         ws = self.ws
-        return float("inf") if not ws else ws.latency
+        return [float("inf")] if not ws else ws.latency
+
+    @property
+    def average_latency(self):
+        """:class:`float`: Mean average of :list:`VoiceClient.latency`"""
+        ws = self.ws
+        return float("inf") if not ws else (sum(ws.latency)/len(ws.latency))
 
     async def connect(self, *, reconnect=True, _tries=0, do_handshake=True):
         log.info('Connecting to voice...')

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -222,12 +222,6 @@ class VoiceClient:
         ws = self.ws
         return float("inf") if not ws else ws.latency
 
-    @property
-    def average_latency(self):
-        """:class:`float`: Mean average of :list:`VoiceClient.latency`"""
-        ws = self.ws
-        return float("inf") if not ws else (sum(ws.latency)/len(ws.latency))
-
     async def connect(self, *, reconnect=True, _tries=0, do_handshake=True):
         log.info('Connecting to voice...')
         try:


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR adds the property `latency` to the `VoiceClient` object, similar to the property `Client.latency` but instead is `VoiceKeepAliveHandler`'s heartbeat and acknowledgement latency. `VoiceClient.latency` is `float('inf')` when `_keep_alive is None`, similar to behaviour of `Client.latency`.

In order to get reasonable resolution on latency measurements, the heartbeat interval has been set to a ceiling of 5000ms, meaning that if the `HELLO` heartbeat establishment requests a shorter interval, that will be used instead.

Example usage: this property may be used to monitor guild voice connection status to avoid voice latency issues plaguing the Europe nodes.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

_Apologies for the past tense commit titles and unwarranted newline changes._