### PR TITLE
Explicitly check for guild object in _handle_author

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -41,6 +41,7 @@ from .member import Member
 from .flags import MessageFlags
 from .file import File
 from .utils import escape_mentions
+from .guild import Guild
 
 
 class Attachment:
@@ -441,7 +442,7 @@ class Message:
 
     def _handle_author(self, author):
         self.author = self._state.store_user(author)
-        if self.guild is not None:
+        if isinstance(self.guild, Guild):
             found = self.guild.get_member(self.author.id)
             if found is not None:
                 self.author = found


### PR DESCRIPTION
### Summary

`Client.fetch_channel` sets the guild attribute of the new channel object to a `discord.Object` if the guild is not in the cache. (For example if the guild belongs to a different shard)
`Message._handle_author` tries to call the `get_member` method if the guild attribute is not None.

So when I fetch a channel, the guild is not in cache and try to send a message to it, it fails because the `Channel.guild` and therefore `Message.guild` is neither None nor a Guild object.
This PR fixes that by explicitly checking if the guild is an instance of `discord.Guild`.
It's not necessary for `Message._handle_mentions` or `_handle_mention_roles` because they are only used in events and the guild is therefore already in the cache.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
