### PR TITLE
fix for slow shutdown

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -611,8 +611,8 @@ class Client:
         loop = self.loop
 
         try:
-            loop.add_signal_handler(signal.SIGINT, lambda: loop.stop())
-            loop.add_signal_handler(signal.SIGTERM, lambda: loop.stop())
+            loop.add_signal_handler(signal.SIGINT, lambda: asyncio.create_task(self.close()))
+            loop.add_signal_handler(signal.SIGTERM, lambda: asyncio.create_task(self.close()))
         except NotImplementedError:
             pass
 


### PR DESCRIPTION
### Summary

The existing code will stop the event loop on receiving a SIGINT or SIGTERM, but will not properly close the bot client. This means that the program will only exit once the current websocket connections have timed out, which takes approximately 10 seconds.

My change instead calls client.close(), which cleanly shuts down the bot. This means that the websockets are closed properly, and the program will exit without having to wait.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
