### PR TITLE
Remove MORE_EMOJI guild feature

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -125,7 +125,6 @@ class Guild(Hashable):
         - ``INVITE_SPLASH``: Guild's invite page can have a special splash.
         - ``VERIFIED``: Guild is a verified server.
         - ``PARTNERED``: Guild is a partnered server.
-        - ``MORE_EMOJI``: Guild is allowed to have more than 50 custom emoji.
         - ``DISCOVERABLE``: Guild shows up in Server Discovery.
         - ``COMMERCE``: Guild can sell things using store channels.
         - ``PUBLIC``: Users can lurk in this guild via Server Discovery.
@@ -465,7 +464,7 @@ class Guild(Hashable):
     @property
     def emoji_limit(self):
         """:class:`int`: The maximum number of emoji slots this guild has."""
-        more_emoji = 200 if 'MORE_EMOJI' in self.features else 50
+        more_emoji = 50
         return max(more_emoji, self._PREMIUM_GUILD_LIMITS[self.premium_tier].emoji)
 
     @property
@@ -1469,9 +1468,6 @@ class Guild(Hashable):
         r"""|coro|
 
         Creates a custom :class:`Emoji` for the guild.
-
-        There is currently a limit of 50 static and animated emojis respectively per guild,
-        unless the guild has the ``MORE_EMOJI`` feature which extends the limit to 200.
 
         You must have the :attr:`~Permissions.manage_emojis` permission to
         do this.


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->

Removes the `MORE_EMOJI` guild feature as it is not being used anymore.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
