### PR TITLE
on_invite_create requires Manage Channels

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -649,7 +649,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 .. function:: on_invite_create(invite)
 
     Called when an :class:`Invite` is created.
-    You must have the :attr:`~Permissions.manage_channels` permission to use this.
+    You must have the :attr:`~Permissions.manage_channels` permission to receive this.
 
     .. versionadded:: 1.3
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -664,7 +664,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 .. function:: on_invite_delete(invite)
 
     Called when an :class:`Invite` is deleted.
-    You must have the :attr:`~Permissions.manage_channels` permission to use this.
+    You must have the :attr:`~Permissions.manage_channels` permission to receive this.
 
     .. versionadded:: 1.3
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -649,6 +649,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 .. function:: on_invite_create(invite)
 
     Called when an :class:`Invite` is created.
+    You must have the :attr:`~Permissions.manage_channels` permission to use this.
 
     .. versionadded:: 1.3
 
@@ -663,6 +664,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 .. function:: on_invite_delete(invite)
 
     Called when an :class:`Invite` is deleted.
+    You must have the :attr:`~Permissions.manage_channels` permission to use this.
 
     .. versionadded:: 1.3
 


### PR DESCRIPTION
Event on_invite_create (and presumably _delete) require Manage Channels permission.

### Summary

Minor docs edit to reflect requirements.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
