### PR TITLE
Add discord.ChannelType.category to documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -816,6 +816,9 @@ of :class:`enum.Enum`.
     .. attribute:: group
 
         A private group text channel.
+    .. attribute:: category
+
+       A category channel.
     .. attribute:: news
 
         A guild news channel.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -818,7 +818,7 @@ of :class:`enum.Enum`.
         A private group text channel.
     .. attribute:: category
 
-       A category channel.
+        A category channel.
     .. attribute:: news
 
         A guild news channel.


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
`discord.ChannelType.category` was missing from the documentation.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
