### PR TITLE
Remove sub-module from self.__extensions in bot._call_module_finalizers()

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -590,8 +590,14 @@ class BotBase(GroupMixin):
                         func = getattr(sys.modules[module], 'teardown')
                     except AttributeError:
                         pass
-                    del sys.modules[module]
-                    del self.__extensions[module]
+                    else:
+                        try:
+                            func(self)
+                        except Exception:
+                            pass
+                    finally:
+                        del sys.modules[module]
+                        del self.__extensions[module]
 
     def _load_from_module_spec(self, spec, key):
         # precondition: key not in self.__extensions

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -586,6 +586,10 @@ class BotBase(GroupMixin):
             name = lib.__name__
             for module in list(sys.modules.keys()):
                 if _is_submodule(name, module):
+                    try:
+                        func = getattr(module, 'teardown')
+                    except AttributeError:
+                        pass
                     del sys.modules[module]
                     del self.__extensions[module]
 

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -587,7 +587,7 @@ class BotBase(GroupMixin):
             for module in list(sys.modules.keys()):
                 if _is_submodule(name, module):
                     try:
-                        func = getattr(module, 'teardown')
+                        func = getattr(sys.modules[module], 'teardown')
                     except AttributeError:
                         pass
                     del sys.modules[module]

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -587,6 +587,7 @@ class BotBase(GroupMixin):
             for module in list(sys.modules.keys()):
                 if _is_submodule(name, module):
                     del sys.modules[module]
+                    del self.__extensions[module]
 
     def _load_from_module_spec(self, spec, key):
         # precondition: key not in self.__extensions


### PR DESCRIPTION
Removes sub-module from self.__extensions as well as sys.modules

### Summary

Fixed issue I opened #2563 
- Removes submodules from `self.__extensions` as well as `sys.modules` in `bot._call_module_finalizers()`
- Attempts to call `teardown()` of a submodule before unloading.

### Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
