### PR TITLE
Stop yielding duplicate commands from walk_commands due to aliases

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1110,7 +1110,7 @@ class GroupMixin:
 
     def walk_commands(self):
         """An iterator that recursively walks through all commands and subcommands."""
-        for command in tuple(self.all_commands.values()):
+        for command in self.commands:
             yield command
             if isinstance(command, GroupMixin):
                 yield from command.walk_commands()


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->

`GroupMixin.walk_commands` was yielding duplicate `Command` objects because it was processing aliases too. Aliases have the same `Command` object so it's redundant to yield them.

Documentation was not updated because it was never implied to begin with that it would yield aliases. If anything, it implied the opposite (i.e. the behaviour that will result from the changes I made).

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
