### PR TITLE
[tasks] Allow for custom error handlers in tasks extension

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -347,6 +347,8 @@ class Loop:
 
         The coroutine must take only one argument the exception raised (except ``self`` in a class context).
 
+        .. versionadded:: 1.4
+
         Parameters
         ------------
         coro: :ref:`coroutine <coroutine>`

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -279,14 +279,7 @@ class Loop:
         return self._has_failed
 
     async def _error(self, exception):
-        """|coro|
-
-        The default error handler provided by the task.
-
-        By default this prints to :data:`sys.stderr` however it could be
-        overridden to have a different implementation.
-        """
-        print('Internal background task failed and was cancelled.', file=sys.stderr)
+        print('Unhandled exception in internal background task {0.__name__!r}.'.format(self.coro), file=sys.stderr)
         traceback.print_exception(type(exception), exception, exception.__traceback__, file=sys.stderr)
 
     def before_loop(self, coro):

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -343,7 +343,7 @@ class Loop:
         return coro
 
     def error(self, coro):
-        """A decorator that register a coroutine to be called if the task encounters an unhandled exception.
+        """A decorator that registers a coroutine to be called if the task encounters an unhandled exception.
 
         The coroutine must take only one argument the exception raised (except ``self`` in a class context).
 


### PR DESCRIPTION
### Summary

Implements a new Loop.error decorator for custom error handlers when tasks raise an unhandled exception.

The default error handler prints a traceback to stderr.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
