### PR TITLE
Fixed missing awaits in subclassed coroutines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ extras_require = {
     'voice': ['PyNaCl==1.3.0'],
     'docs': [
         'sphinx==1.8.5',
-        'sphinxcontrib_trio==1.1.0',
+        'sphinxcontrib_trio==1.1.1',
         'sphinxcontrib-websupport',
     ]
 }


### PR DESCRIPTION
### Summary

Fixes missing `await`s in documentation, where the method being documented is a coro that's been defined in one of the base classes of a subclass. Example:

`Client.application_info` (base class, await exists): https://discordpy.readthedocs.io/en/latest/api.html?highlight=application_info#discord.Client.application_info
`commands.Bot.application_info` (subclass, await missing): https://discordpy.readthedocs.io/en/latest/ext/commands/api.html?highlight=application_info#discord.ext.commands.Bot.application_info

Contributed here: https://github.com/python-trio/sphinxcontrib-trio/pull/141

Could be followed up with removing all of the "This function is a coroutine." instances, since it should now display correctly, but I didn't want to be too eager about it.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
