### PR TITLE
Change opcode as to not invalidate the session

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -367,7 +367,7 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
                 # so we terminate our connection and raise an
                 # internal exception signalling to reconnect.
                 log.info('Received RECONNECT opcode.')
-                await self.close()
+                await self.close(4000)
                 raise ResumeWebSocket(self.shard_id)
 
             if op == self.HEARTBEAT_ACK:


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
Discord recently started sending *a lot* of reconnect events. Discord.py closed the connection with code 1000 which invalidates the session. This makes it not invalidate the session.
### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
