### PR TITLE
animated key is never given to reaction_remove(_emoji)

### DIFF
--- a/discord/partial_emoji.py
+++ b/discord/partial_emoji.py
@@ -88,8 +88,8 @@ class PartialEmoji(_EmojiTag):
         return o
 
     @classmethod
-    def with_state(cls, state, *, animated, name, id=None):
-        self = cls(animated=animated, name=name, id=id)
+    def with_state(cls, state, *, name, animated=False, id=None):
+        self = cls(name=name, animated=animated, id=id)
         self._state = state
         return self
 

--- a/discord/state.py
+++ b/discord/state.py
@@ -466,7 +466,7 @@ class ConnectionState:
     def parse_message_reaction_add(self, data):
         emoji = data['emoji']
         emoji_id = utils._get_as_snowflake(emoji, 'id')
-        emoji = PartialEmoji.with_state(self, animated=emoji.get('animated', False), id=emoji_id, name=emoji['name'])
+        emoji = PartialEmoji.with_state(self, id=emoji_id, animated=emoji.get('animated', False), name=emoji['name'])
         raw = RawReactionActionEvent(data, emoji, 'REACTION_ADD')
 
         member_data = data.get('member')
@@ -500,7 +500,7 @@ class ConnectionState:
     def parse_message_reaction_remove(self, data):
         emoji = data['emoji']
         emoji_id = utils._get_as_snowflake(emoji, 'id')
-        emoji = PartialEmoji.with_state(self, animated=emoji.get('animated', False), id=emoji_id, name=emoji['name'])
+        emoji = PartialEmoji.with_state(self, id=emoji_id, name=emoji['name'])
         raw = RawReactionActionEvent(data, emoji, 'REACTION_REMOVE')
         self.dispatch('raw_reaction_remove', raw)
 
@@ -519,7 +519,7 @@ class ConnectionState:
     def parse_message_reaction_remove_emoji(self, data):
         emoji = data['emoji']
         emoji_id = utils._get_as_snowflake(emoji, 'id')
-        emoji = PartialEmoji.with_state(self, animated=emoji.get('animated', False), id=emoji_id, name=emoji['name'])
+        emoji = PartialEmoji.with_state(self, id=emoji_id, name=emoji['name'])
         raw = RawReactionClearEmojiEvent(data, emoji)
         self.dispatch('raw_reaction_clear_emoji', raw)
 


### PR DESCRIPTION
### Summary

[In the docs](https://discordapp.com/developers/docs/resources/emoji#emoji-object-gateway-reaction-custom-emoji-examples), it says that `MESSAGE_REACTION_ADD` would receive the `animated` key, but not for the others. I have confirmed this for `MESSAGE_REACTION_REMOVE(_EMOJI)`, and have removed the need to get it from the data and default onto `False`.

### Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
