### PR TITLE
Make VoiceClient class inheritable

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1039,7 +1039,7 @@ class Connectable(metaclass=abc.ABCMeta):
     def _get_voice_state_pair(self):
         raise NotImplementedError
 
-    async def connect(self, *, timeout=60.0, reconnect=True):
+    async def connect(self, *, timeout=60.0, reconnect=True, cls=VoiceClient):
         """|coro|
 
         Connects to voice and creates a :class:`VoiceClient` to establish
@@ -1053,6 +1053,10 @@ class Connectable(metaclass=abc.ABCMeta):
             Whether the bot should automatically attempt
             a reconnect if a part of the handshake fails
             or the gateway goes down.
+        cls:
+            The factory class that will be used to create the voice connection.
+            By default, this is :class:`VoiceClient`. Should a custom
+            class be provided, it must be inherited from :class:`VoiceClient`
 
         Raises
         -------
@@ -1074,7 +1078,10 @@ class Connectable(metaclass=abc.ABCMeta):
         if state._get_voice_client(key_id):
             raise ClientException('Already connected to a voice channel.')
 
-        voice = VoiceClient(state=state, timeout=timeout, channel=self)
+        if not issubclass(cls, VoiceClient):
+            raise TypeError('Custom class {0.__name__!r} is not inherited from class {1.__name__!r}.'.format(cls, VoiceClient))
+
+        voice = cls(client=state.client, timeout=timeout, channel=self)
         state._add_voice_client(key_id, voice)
 
         try:

--- a/discord/client.py
+++ b/discord/client.py
@@ -223,7 +223,7 @@ class Client:
             'ready': self._handle_ready
         }
 
-        self._connection = ConnectionState(dispatch=self.dispatch, chunker=self._chunker, handlers=self._handlers,
+        self._connection = ConnectionState(client=self, dispatch=self.dispatch, chunker=self._chunker, handlers=self._handlers,
                                            syncer=self._syncer, http=self.http, loop=self.loop, **options)
 
         self._connection.shard_count = self.shard_count

--- a/discord/player.py
+++ b/discord/player.py
@@ -552,7 +552,7 @@ class AudioPlayer(threading.Thread):
         self._resumed = threading.Event()
         self._resumed.set() # we are not paused
         self._current_error = None
-        self._connected = client._connected
+        self._connected = client._VoiceClient__connected
         self._lock = threading.Lock()
 
         if after is not None and not callable(after):
@@ -650,6 +650,6 @@ class AudioPlayer(threading.Thread):
 
     def _speak(self, speaking):
         try:
-            asyncio.run_coroutine_threadsafe(self.client.ws.speak(speaking), self.client.loop)
+            asyncio.run_coroutine_threadsafe(self.client._VoiceClient__ws.speak(speaking), self.client.loop)
         except Exception as e:
             log.info("Speaking call in player failed: %s", e)

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -126,7 +126,7 @@ class AutoShardedClient(Client):
             elif not isinstance(self.shard_ids, (list, tuple)):
                 raise ClientException('shard_ids parameter must be a list or a tuple.')
 
-        self._connection = AutoShardedConnectionState(dispatch=self.dispatch, chunker=self._chunker,
+        self._connection = AutoShardedConnectionState(client=self, dispatch=self.dispatch, chunker=self._chunker,
                                                       handlers=self._handlers, syncer=self._syncer,
                                                       http=self.http, loop=self.loop, **kwargs)
 

--- a/discord/state.py
+++ b/discord/state.py
@@ -62,13 +62,14 @@ log = logging.getLogger(__name__)
 ReadyState = namedtuple('ReadyState', ('launch', 'guilds'))
 
 class ConnectionState:
-    def __init__(self, *, dispatch, chunker, handlers, syncer, http, loop, **options):
+    def __init__(self, *, client, dispatch, chunker, handlers, syncer, http, loop, **options):
         self.loop = loop
         self.http = http
         self.max_messages = options.get('max_messages', 1000)
         if self.max_messages is not None and self.max_messages <= 0:
             self.max_messages = 1000
 
+        self.client = client
         self.dispatch = dispatch
         self.chunker = chunker
         self.syncer = syncer

--- a/discord/state.py
+++ b/discord/state.py
@@ -941,7 +941,7 @@ class ConnectionState:
 
         vc = self._get_voice_client(key_id)
         if vc is not None:
-            asyncio.ensure_future(vc._create_socket(key_id, data))
+            asyncio.ensure_future(vc._VoiceClient__create_socket(key_id, data))
 
     def parse_typing_start(self, data):
         channel, guild = self._get_guild_channel(data)

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -85,7 +85,7 @@ class VoiceClient:
     loop: :class:`asyncio.AbstractEventLoop`
         The event loop that the voice client is running on.
     """
-    def __init__(self, state, timeout, channel):
+    def __init__(self, client, timeout, channel):
         if not has_nacl:
             raise RuntimeError("PyNaCl library needed in order to use voice")
 
@@ -94,8 +94,8 @@ class VoiceClient:
         self.__timeout = timeout
         self.__ws = None
         self.__socket = None
-        self.loop = state.loop
-        self.__state = state
+        self.loop = client.loop
+        self.__state = client._connection
         # this will be used in the AudioPlayer thread
         self.__connected = threading.Event()
 


### PR DESCRIPTION
### Summary

The following PR is a draft. It makes some substantial changes to variable naming throughout the library, I have tested these changes but expect that at this time there may be bugs.

It's not expected to be merged in its current state, if ever.

This PR does the following things:

 - Makes the `VoiceClient` class inheritable
   - Makes currently undocumented attributes of said class private.
   - Changes the `__init__` to take an instance of the `Client` rather than `ConnectionState`
     - For this to work `ConnectionState` now has a `client=` kwarg.
       - It may be in the scope of this PR to change how variables in ConnectionState are utilised due to this new additional kwarg.

 - Adds a `cls=` kwarg to `abc.Connectable.connect` (`VoiceChannel.connect`)
   - Obviously, this defaults to `VoiceClient`

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
