### PR TITLE
Add ability to fetch public guild previews

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -1033,10 +1033,13 @@ class Client:
         """
         return GuildIterator(self, limit=limit, before=before, after=after)
 
-    async def fetch_guild(self, guild_id):
+    async def fetch_guild(self, guild_id, *, preview=False):
         """|coro|
 
         Retrieves a :class:`.Guild` from an ID.
+
+        .. versionchanged:: 1.4
+            The ``preview`` keyword-only parameter was added.
 
         .. note::
 
@@ -1051,6 +1054,20 @@ class Client:
         -----------
         guild_id: :class:`int`
             The guild's ID to fetch from.
+        preview: Optional[:class:`bool`]
+            Provides a preview of the guild. Does not require you to be in the guild. By default,
+            it is set to ``False``.
+
+            .. note::
+
+                Using this, you will only receive :attr:`.Guild.id`, :attr:`.Guild.name`,
+                :attr:`.Guild.icon`, :attr:`.Guild.splash`, :attr:`.Guild.emojis`, :attr:`.Guild.features`,
+                :attr:`.Guild.description`, :attr:`.Guild.approximate_member_count`, and 
+                :attr:`.Guild.approximate_presence_count`.
+
+            .. note::
+
+                This is only available for public guilds.
 
         Raises
         ------
@@ -1064,7 +1081,10 @@ class Client:
         :class:`.Guild`
             The guild from the ID.
         """
-        data = await self.http.get_guild(guild_id)
+        if preview:
+            data = await self.http.get_guild_preview(guild_id)
+        else:
+            data = await self.http.get_guild(guild_id)
         return Guild(data=data, state=self._connection)
 
     async def create_guild(self, name, region=None, icon=None):

--- a/discord/client.py
+++ b/discord/client.py
@@ -1033,7 +1033,7 @@ class Client:
         """
         return GuildIterator(self, limit=limit, before=before, after=after)
 
-    async def fetch_guild(self, guild_id, *, preview=False):
+    async def fetch_guild(self, guild_id):
         """|coro|
 
         Retrieves a :class:`.Guild` from an ID.
@@ -1054,20 +1054,6 @@ class Client:
         -----------
         guild_id: :class:`int`
             The guild's ID to fetch from.
-        preview: Optional[:class:`bool`]
-            Provides a preview of the guild. Does not require you to be in the guild. By default,
-            it is set to ``False``.
-
-            .. note::
-
-                Using this, you will only receive :attr:`.Guild.id`, :attr:`.Guild.name`,
-                :attr:`.Guild.icon`, :attr:`.Guild.splash`, :attr:`.Guild.emojis`, :attr:`.Guild.features`,
-                :attr:`.Guild.description`, :attr:`.Guild.approximate_member_count`, and 
-                :attr:`.Guild.approximate_presence_count`.
-
-            .. note::
-
-                This is only available for public guilds.
 
         Raises
         ------
@@ -1081,10 +1067,46 @@ class Client:
         :class:`.Guild`
             The guild from the ID.
         """
-        if preview:
-            data = await self.http.get_guild_preview(guild_id)
-        else:
-            data = await self.http.get_guild(guild_id)
+        data = await self.http.get_guild(guild_id)
+        return Guild(data=data, state=self._connection)
+
+    async def fetch_guild_preview(self, guild_id):
+        """|coro|
+
+        Retrieves a preview of a :class:`.Guild` from an ID. 
+        
+        You do not have to be in the guild.
+
+        .. versionadded:: 1.4
+
+        .. note::
+
+            Using this, you will only receive :attr:`.Guild.id`, :attr:`.Guild.name`, :attr:`.Guild.icon`, 
+            :attr:`.Guild.splash`, :attr:`.Guild.emojis`, :attr:`.Guild.features`, :attr:`.Guild.description`, 
+            :attr:`.Guild.approximate_member_count`, and :attr:`.Guild.approximate_presence_count`.
+
+        .. note::
+
+                This is only available for public guilds.
+
+        Parameters
+        -----------
+        guild_id: :class:`int`
+            The guild's ID to fetch from.
+
+        Raises
+        ------
+        :exc:`.Forbidden`
+            You do not have access to the guild.
+        :exc:`.HTTPException`
+            Getting the guild failed.
+
+        Returns
+        --------
+        :class:`.Guild`
+            The guild from the ID.
+        """
+        data = await self.http.get_guild_preview(guild_id)
         return Guild(data=data, state=self._connection)
 
     async def create_guild(self, name, region=None, icon=None):

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -150,6 +150,16 @@ class Guild(Hashable):
         The guild's discovery splash.
 
         .. versionadded:: 1.3
+    approximate_member_count: Optional[:class:`int`]
+        The approximate number of members in this guild. This is only available through 
+        :meth:`Client.fetch_guild` with ``preview`` enabled.
+
+        .. versionadded: 1.4
+    approximate_presence_count: Optional[:class:`int`]
+        The approximate number of online members in this guild. This is only available through 
+        :meth:`Client.fetch_guild` with ``preview`` enabled.
+
+        .. versionadded: 1.4
     """
 
     __slots__ = ('afk_timeout', 'afk_channel', '_members', '_channels', 'icon',
@@ -160,7 +170,8 @@ class Guild(Hashable):
                  '_voice_states', '_system_channel_id', 'default_notifications',
                  'description', 'max_presences', 'max_members', 'premium_tier',
                  'premium_subscription_count', '_system_channel_flags',
-                 'preferred_locale', 'discovery_splash', '_rules_channel_id')
+                 'preferred_locale', 'discovery_splash', '_rules_channel_id',
+                 'approximate_member_count', 'approximate_presence_count')
 
     _PREMIUM_GUILD_LIMITS = {
         None: _GuildLimit(emoji=50, bitrate=96e3, filesize=8388608),
@@ -300,6 +311,9 @@ class Guild(Hashable):
 
         self.owner_id = utils._get_as_snowflake(guild, 'owner_id')
         self.afk_channel = self.get_channel(utils._get_as_snowflake(guild, 'afk_channel_id'))
+
+        self.approximate_member_count = guild.get('approximate_member_count')
+        self.approximate_presence_count = guild.get('approximate_presence_count')
 
         for obj in guild.get('voice_states', []):
             self._update_voice_state(obj, int(obj['channel_id']))

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -152,12 +152,12 @@ class Guild(Hashable):
         .. versionadded:: 1.3
     approximate_member_count: Optional[:class:`int`]
         The approximate number of members in this guild. This is only available through 
-        :meth:`Client.fetch_guild` with ``preview`` enabled.
+        :meth:`Client.fetch_guild_preview`.
 
         .. versionadded: 1.4
     approximate_presence_count: Optional[:class:`int`]
         The approximate number of online members in this guild. This is only available through 
-        :meth:`Client.fetch_guild` with ``preview`` enabled.
+        :meth:`Client.fetch_guild_preview`.
 
         .. versionadded: 1.4
     """

--- a/discord/http.py
+++ b/discord/http.py
@@ -603,6 +603,9 @@ class HTTPClient:
     def get_guild(self, guild_id):
         return self.request(Route('GET', '/guilds/{guild_id}', guild_id=guild_id))
 
+    def get_guild_preview(self, guild_id):
+        return self.request(Route('GET', '/guilds/{guild_id}/preview', guild_id=guild_id))
+
     def delete_guild(self, guild_id):
         return self.request(Route('DELETE', '/guilds/{guild_id}', guild_id=guild_id))
 


### PR DESCRIPTION
### Summary

[A new guild object has been documented](https://discordapp.com/developers/docs/resources/guild#guild-preview-object), and it allows for basic information for a public guilds. This implements it via a `preview` kwarg in `Client.fetch_guild`.

```py
>>> await bot.fetch_guild(577548441878790146, preview=True)
<Guild id=577548441878790146 name='Ori The Game' shard_id=None chunked=False member_count=None>
```

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
