### PR TITLE
[commands] Implement subcommand root_parent error handling

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -412,6 +412,17 @@ class Command(_BaseCommand):
                 await injected(ctx, error)
 
         try:
+            coro = self.root_parent.on_error
+        except AttributeError:
+            pass
+        else:
+            injected = wrap_callback(coro)
+            if cog is not None:
+                await injected(cog, ctx, error)
+            else:
+                await injected(ctx, error)
+
+        try:
             if cog is not None:
                 local = Cog._get_overridden_method(cog.cog_command_error)
                 if local is not None:

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -668,17 +668,25 @@ raise a custom :exc:`~ext.commands.CommandError` derived exception, then it will
 
 .. code-block:: python3
 
-    @bot.command()
-    @commands.is_owner()
+    @bot.group()
     @is_in_guild(41771983423143937)
     async def secretguilddata(ctx):
         """super secret stuff"""
         await ctx.send('secret stuff')
 
+    @secretguilddata.command()
+    @commands.is_owner()
+    async def actualsecrets(ctx):
+        """the actual goods"""
+        await ctx.send('the double bluff')
+
     @secretguilddata.error
     async def secretguilddata_error(ctx, error):
         if isinstance(error, commands.CheckFailure):
             await ctx.send('nothing to see here comrade.')
+
+.. versionchanged:: 1.4
+    Subcommands can now use their root parent's error handler.
 
 If you want a more robust error system, you can derive from the exception and raise it instead of returning ``False``:
 
@@ -695,6 +703,7 @@ If you want a more robust error system, you can derive from the exception and ra
         return commands.check(predicate)
 
     @guild_only()
+    @bot.command()
     async def test(ctx):
         await ctx.send('Hey this is not a DM! Nice.')
 


### PR DESCRIPTION
### Summary

Closes #2112. Allows for subcommands to have a catch all error handler attached to the root parent command as an alternative to having an error handler for each subcommand.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
