### PR TITLE
Note that on_ready isn't called when logging in as a user

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -113,7 +113,8 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 .. function:: on_connect()
 
     Called when the client has successfully connected to Discord. This is not
-    the same as the client being fully prepared, see :func:`on_ready` for that.
+    the same as the client being fully prepared, see :func:`
+    ` for that.
 
     The warnings on :func:`on_ready` also apply.
 
@@ -136,6 +137,12 @@ to handle it, which defaults to print a traceback and ignoring the exception.
         Likewise, this function is **not** guaranteed to only be called
         once. This library implements reconnection logic and thus will
         end up calling this event whenever a RESUME request fails.
+        
+    .. warning::
+    
+        This function will  not be called if logging in with
+        `bot=False`, as Discord does not send a READY communication
+        to the client in that case.
 
 .. function:: on_shard_ready(shard_id)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -140,7 +140,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
         
     .. warning::
     
-        This function will  not be called if logging in with
+        This function will not be called if logging in with
         `bot=False`, as Discord does not send a READY communication
         to the client in that case.
 


### PR DESCRIPTION
### Summary

This solves #2567, since there is nothing that can be done about that issue, as it is on Discord's end. So, I decided to update the documentation to reflect that.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
