### PR TITLE
Edit message publish documentation

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -847,11 +847,8 @@ class Message:
 
         Publishes this message to your announcement channel.
 
-        You must have the :attr:`~Permissions.manage_messages` permission to use this.
-
-        .. note::
-
-            This can only be used by non-bot accounts.
+        If the message is not your own then the :attr:`~Permissions.manage_messages`
+        permission is needed.
 
         Raises
         -------


### PR DESCRIPTION
### Summary

This pull request changes the documentation associated with ``Message.publish``.

Discord recently made a hidden change that allows bots to publish these types of messages to the announcement feeds. Also as outlined by the [knowledge document here](https://support.discordapp.com/hc/en-us/articles/360032008192-Announcement-Channels-) (See step 2 under "How do I make an existing channel into an Announcement Channel?") this function requires either send_messages if you own the message or, manage_messages for when you don't.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
