### PR TITLE
Update player.py to fix ffmpeg terminating on EOF

### DIFF
--- a/discord/player.py
+++ b/discord/player.py
@@ -194,6 +194,8 @@ class FFmpegPCMAudio(FFmpegAudio):
         Extra command line arguments to pass to ffmpeg before the ``-i`` flag.
     options: Optional[:class:`str`]
         Extra command line arguments to pass to ffmpeg after the ``-i`` flag.
+    log_level: :class:`str`
+        The logging level to use for ffmpeg. Defaults to ``info``.
 
     Raises
     --------
@@ -201,8 +203,14 @@ class FFmpegPCMAudio(FFmpegAudio):
         The subprocess failed to be created.
     """
 
-    def __init__(self, source, *, executable='ffmpeg', pipe=False, stderr=None, before_options=None, options=None):
-        args = []
+    def __init__(self, source, *, executable='ffmpeg', pipe=False, 
+                 stderr=None, before_options=None, options=None,
+                 log_level = "info"):
+        args = [
+            '-reconnect_at_eof', '1',
+            '-reconnect_delay_max', '4',
+            '-analyzeduration', '0',
+        ]
         subprocess_kwargs = {'stdin': source if pipe else None, 'stderr': stderr}
 
         if isinstance(before_options, str):
@@ -210,7 +218,7 @@ class FFmpegPCMAudio(FFmpegAudio):
 
         args.append('-i')
         args.append('-' if pipe else source)
-        args.extend(('-f', 's16le', '-ar', '48000', '-ac', '2', '-loglevel', 'warning'))
+        args.extend(('-f', 's16le', '-ar', '48000', '-ac', '2', '-loglevel', log_level))
 
         if isinstance(options, str):
             args.extend(shlex.split(options))


### PR DESCRIPTION
There has been a bug for about 18 months that I know of now where
this handling will actively fail around 10-15 seconds before the end of
streams provided by YouTube. This appears to be because the CDN
closes the connection early on ffmpeg, causing it to receive an EOF
and thus terminate:

```
[mov,mp4,m4a,3gp,3g2,mj2 @ 0x56300e3cf240] found sidx time -9223372036854775808, using it for pts
[tls @ 0x56300e3d24c0] Error in the pull function.
[aac @ 0x56300e477a40] Input buffer exhausted before END element found
Error while decoding stream #0:0: Invalid data found when processing input
[mov,mp4,m4a,3gp,3g2,mj2 @ 0x56300e3cf240] stream 0, offset 0x30c0a4: partial file
[out_0_0 @ 0x56300e9efc00] EOF on sink link out_0_0:default.
No more output streams to write to, finishing.
size=   37682kB time=00:03:20.96 bitrate=1536.0kbits/s speed=0.998x    
video:0kB audio:37682kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: 0.000000%
  Input stream #0:0 (audio): 8656 packets read (3155616 bytes); 8655 frames decoded (8862720 samples); 
  Total: 8656 packets (3155616 bytes) demuxed
Output file #0 (pipe:1):
  Output stream #0:0 (audio): 8656 frames encoded (9646498 samples); 8656 packets muxed (38585992 bytes); 
  Total: 8656 packets (38585992 bytes) muxed
8655 frames successfully decoded, 1 decoding errors
[AVIOContext @ 0x56300e9f2d40] Statistics: 0 seeks, 8656 writeouts
[AVIOContext @ 0x56300ea1ebc0] Statistics: 3194864 bytes read, 0 seeks
Preparing to terminate ffmpeg process 26529.
```

Seems the solution that fixes this is to advise FFMPEG to reconnect at any EOF
that is received, with a max delay of 4, and to enable analysis (not sure why this
fixes it, but these flags enable me to get a full stream to play without it terminating).

Also made the log level for FFMPEG PCM audio to be customisable, as being able
to debug this kind of this is useful without having to physically change the existing
source code to find out why something is crashing.

### Summary

<!-- What is this pull request for? Does it fix any issues? -->

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - ~~[ ] I have updated the documentation to reflect the changes.~~
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
