### PR TITLE
Edit docs to specify that Guild.owner may be None for very large guilds.

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -537,7 +537,7 @@ class Guild(Hashable):
 
     @property
     def owner(self):
-        """:class:`Member`: The member that owns the guild."""
+        """Optional[:class:`Member`]: The member that owns the guild."""
         return self.get_member(self.owner_id)
 
     @property


### PR DESCRIPTION
### Summary

Guild.owner was sometimes set to None, in case of very large guilds where the owner isn't in the members cache.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
