### PR TITLE
Removing from FAQ that there's not an event for invites being created

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -321,7 +321,7 @@ Quick example: ::
 
     Due to a Discord limitation, filenames may not include underscores.
 
-Is there an event for invites or audit log entries being created?
+Is there an event for audit log entries being created?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Since Discord does not dispatch this information in the gateway, the library cannot provide this information.


### PR DESCRIPTION
### Summary

Since on_invite_create is now a thing, the docs should be updated removing that Discord doesn't provide this information.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
