### PR TITLE
[commands] Add role mentions to when_mentioned prefixes.

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -47,7 +47,12 @@ def when_mentioned(bot, msg):
 
     These are meant to be passed into the :attr:`.Bot.command_prefix` attribute.
     """
-    return [bot.user.mention + ' ', '<@!%s> ' % bot.user.id]
+    prefixes = [bot.user.mention + ' ', '<@!%s> ' % bot.user.id]
+
+    role = discord.utils.get(msg.guild.roles, name=bot.user.name)
+    if role is not None:
+        prefixes.append('<@&%s> ' % role.id)
+    return prefixes
 
 def when_mentioned_or(*prefixes):
     """A callable that implements when mentioned or other prefixes provided.


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds the role mention `<@&{role_id}>` to the list of `when_mentioned` prefixes if the role's name is the same as the bot.

Note: This isn't escaped by `clean_prefix` in `DefaultHelpCommand`.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
