### PR TITLE
Fix PartialEmoji.url.read for reactions

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -992,7 +992,7 @@ class ConnectionState:
         try:
             return self._emojis[emoji_id]
         except KeyError:
-            return PartialEmoji(animated=data.get('animated', False), id=emoji_id, name=data['name'])
+            return PartialEmoji.with_state(self, animated=data.get('animated', False), id=emoji_id, name=data['name'])
 
     def _upgrade_partial_emoji(self, emoji):
         emoji_id = emoji.id


### PR DESCRIPTION
### Summary
Resolves #4015 
Fix PartialEmoji.url.read() for reaction emojis which doesn't belong to the guilds the bot is in.
### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
