### PR TITLE
member.joined_ago and user.created_ago

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -33,6 +33,7 @@ from . import utils
 from .user import BaseUser, User
 from .activity import create_activity
 from .permissions import Permissions
+from .utils import get_timedelta
 from .enums import Status, try_enum
 from .colour import Colour
 from .object import Object
@@ -285,6 +286,14 @@ class Member(discord.abc.Messageable, _BaseUser):
                 # Signal to dispatch on_user_update
                 return to_return, u
         return False
+
+    @property
+    def joined_ago(self):
+        """Optional[:class:`datetime.timedelta`]: A timedelta object that specifies the
+        difference between the current time and the time that the member joined the
+        guild for the first time. In certain cases, this can be ``None``.
+        """
+        return get_timedelta(self.joined_at)
 
     @property
     def status(self):

--- a/discord/user.py
+++ b/discord/user.py
@@ -27,7 +27,7 @@ DEALINGS IN THE SOFTWARE.
 from collections import namedtuple
 
 import discord.abc
-from .utils import snowflake_time, _bytes_to_base64_data, parse_time
+from .utils import snowflake_time, _bytes_to_base64_data, parse_time, get_timedelta
 from .enums import DefaultAvatar, RelationshipType, UserFlags, HypeSquadHouse, PremiumType, try_enum
 from .errors import ClientException
 from .colour import Colour
@@ -237,6 +237,14 @@ class BaseUser(_BaseUser):
 
         This is when the user's Discord account was created."""
         return snowflake_time(self.id)
+
+    @property
+    def created_ago(self):
+        """:class:`datetime.timedelta`: Returns the difference between the current
+        time and the user's creation time.
+
+        This is how much time has passed since the user's Discord account was created."""
+        return get_timedelta(self.created_at)
 
     @property
     def display_name(self):

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -112,6 +112,11 @@ def parse_time(timestamp):
         return datetime.datetime(*map(int, re.split(r'[^\d]', timestamp.replace('+00:00', ''))))
     return None
 
+def get_timedelta(datetime_obj):
+    if datetime_obj:
+        return datetime.datetime.utcnow() - datetime_obj
+    return None
+
 def deprecated(instead=None):
     def actual_decorator(func):
         @functools.wraps(func)


### PR DESCRIPTION
### Summary

This pull request adds:
- `BaseUser` property `.created_ago` which returns the `timedelta` between `utcnow()` and `.created_at()`
- `Member` property `.joined_ago` which returns the *optional* `timedelta` between `utcnow()` and `.joined_at()`
- Helper function for calculating this difference (utils)

These properties allow users to get rid of the error-prone routine associated with calculating these values.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
