### PR TITLE
Allow HistoryIterator to take limit of 1 even when around is passed

### DIFF
--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -237,8 +237,6 @@ class HistoryIterator(_AsyncIterator):
                 raise ValueError("history max limit 101 when specifying around parameter")
             elif self.limit == 101:
                 self.limit = 100  # Thanks discord
-            elif self.limit == 1:
-                raise ValueError("Use fetch_message.")
 
             self._retrieve_messages = self._retrieve_messages_around_strategy
             if self.before and self.after:


### PR DESCRIPTION
### Summary

This pull request adds the allows `HistoryIterator` to take `limit=1` and `around`. This is allowed by the [API endpoint](https://discordapp.com/developers/docs/resources/channel#get-channel-messages) and allows users to fetch a single message using the `history` method

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
