### PR TITLE
player: Close ffmpeg stdin during streaming

### DIFF
--- a/discord/player.py
+++ b/discord/player.py
@@ -203,7 +203,7 @@ class FFmpegPCMAudio(FFmpegAudio):
 
     def __init__(self, source, *, executable='ffmpeg', pipe=False, stderr=None, before_options=None, options=None):
         args = []
-        subprocess_kwargs = {'stdin': source if pipe else None, 'stderr': stderr}
+        subprocess_kwargs = {'stdin': source if pipe else subprocess.DEVNULL, 'stderr': stderr}
 
         if isinstance(before_options, str):
             args.extend(shlex.split(before_options))
@@ -293,7 +293,7 @@ class FFmpegOpusAudio(FFmpegAudio):
                  pipe=False, stderr=None, before_options=None, options=None):
 
         args = []
-        subprocess_kwargs = {'stdin': source if pipe else None, 'stderr': stderr}
+        subprocess_kwargs = {'stdin': source if pipe else subprocess.DEVNULL, 'stderr': stderr}
 
         if isinstance(before_options, str):
             args.extend(shlex.split(before_options))


### PR DESCRIPTION
### Summary

A `stdin` of `None` means the ffmpeg subprocess input inherits from the parent process, which may cause undesired control from a terminal (e.g. `C` causes ffmpeg to prompt for a command).  It also closes the parent's stdin when the subprocess exits.

This commit switches to `subprocess.DEVNULL`, which provides a separate pre-closed stdin for ffmpeg subprocesses.

### Checklist

- [x] If code changes were made then they have been tested.
    - No changes needed to the public API or documentation.
- [x] This PR fixes an issue.