### PR TITLE
[Commands] Remove "humanity" requirement for `process_commands`

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -126,6 +126,9 @@ class BotBase(GroupMixin):
         else:
             self.help_command = help_command
 
+        if options.pop('bot_replies', True):
+            self._checks.append(lambda ctx: not ctx.message.author.bot)
+
     # internal helpers
 
     def dispatch(self, event_name, *args, **kwargs):
@@ -914,17 +917,11 @@ class BotBase(GroupMixin):
         This is built using other low level tools, and is equivalent to a
         call to :meth:`~.Bot.get_context` followed by a call to :meth:`~.Bot.invoke`.
 
-        This also checks if the message's author is a bot and doesn't
-        call :meth:`~.Bot.get_context` or :meth:`~.Bot.invoke` if so.
-
         Parameters
         -----------
         message: :class:`discord.Message`
             The message to process commands for.
         """
-        if message.author.bot:
-            return
-
         ctx = await self.get_context(message)
         await self.invoke(ctx)
 
@@ -996,6 +993,9 @@ class Bot(BotBase, discord.Client):
         fetched automatically using :meth:`~.Bot.application_info`.
         For performance reasons it is recommended to use a :class:`set`
         for the collection. You cannot set both `owner_id` and `owner_ids`.
+     bot_replies: Optional[:class:`bool`]
+        Should the bot be allowed to reply to other bots. This is ``False`` by default as it violates the Discord TOS.
+        This should only be used for automated testing purposes!
 
         .. versionadded:: 1.3
     """

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -126,7 +126,7 @@ class BotBase(GroupMixin):
         else:
             self.help_command = help_command
 
-        if options.pop('bot_replies', True):
+        if not options.pop('bot_replies', False):
             self._checks.append(lambda ctx: not ctx.message.author.bot)
 
     # internal helpers
@@ -994,7 +994,7 @@ class Bot(BotBase, discord.Client):
         For performance reasons it is recommended to use a :class:`set`
         for the collection. You cannot set both `owner_id` and `owner_ids`.
      bot_replies: Optional[:class:`bool`]
-        Should the bot be allowed to reply to other bots. This is ``False`` by default as it violates the Discord TOS.
+        Should the bot be allowed to reply to other bots? This is ``False`` by default as it violates the Discord TOS.
         This should only be used for automated testing purposes!
 
         .. versionadded:: 1.3


### PR DESCRIPTION
### Summary

To better allow user choice and the ability to test with libraries such as https://github.com/JakeCover/distest, the requirement for the user being replied to to not be a bot should be removed. This would also allow for the `self_bot` parameter to actually work as intended as the bot will not disregard messages from itself because they came from a bot.

Since this technically [violates the TOS](https://www.reddit.com/r/discordapp/comments/a35txa/bots_setting_other_bots_commands/eb3man4?utm_source=share&utm_medium=web2x) it should be restricted to only testing, and thus is added along with a default global check that disallows the behavior. Thus, for most users of commands, nothing will change, but for people who actually want more control over the bot, they are allowed to do so.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
