### PR TITLE
[commands] Change exception raised when cog not found

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -712,7 +712,7 @@ class BotBase(GroupMixin):
 
         lib = self.__extensions.get(name)
         if lib is None:
-            raise errors.ExtensionNotLoaded(name)
+            raise errors.ExtensionNotFound(name)
 
         # get the previous module states from sys modules
         modules = {


### PR DESCRIPTION
### Summary

When executing `commands.Bot.reload_extension` with an invalid extension name, it raises `ExtensionNotLoaded` when it seems like `ExtensionNotFound` would be a more useful exception to raise.

### Checklist
_Unchecked items are not applicable_
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

This is my first PR so I hope I didn't mess it up too much.