### PR TITLE
Add roles parameter for pruning.

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1296,7 +1296,7 @@ class Guild(Hashable):
         To check how many members you would prune without actually pruning,
         see the :meth:`estimate_pruned_members` function.
 
-        To prune members that have specific roles see the :meth:`roles` function.
+        To prune members that have specific roles see the ``roles`` parameter.
 
         .. versionchanged:: 1.4
             The ``roles`` keyword-only parameter was added.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1313,8 +1313,8 @@ class Guild(Hashable):
             to prevent timeouts, you must set this to ``False``. If this is
             set to ``False``\, then this function will always return ``None``.
         roles: Optional[list[:class:`Role`]]
-            A :class:`list` of :class:`Role`\s to include in the pruning process, if a member 
-            have a role that is not specified, they'll be excluded.
+            A :class:`list` of :class:`Role`\s to include in the pruning process. If a member 
+            has a role that is not specified, they'll be excluded.
 
         Raises
         -------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1313,7 +1313,7 @@ class Guild(Hashable):
             to prevent timeouts, you must set this to ``False``. If this is
             set to ``False``\, then this function will always return ``None``.
         roles: Optional[List[:class:`abc.Snowflake`]]
-            A :class:`list` of :class:`Role`\s to include in the pruning process. If a member 
+            A list of :class:`abc.Snowflake` that represent roles to include in the pruning process. If a member 
             has a role that is not specified, they'll be excluded.
 
         Raises

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1312,7 +1312,7 @@ class Guild(Hashable):
             which makes it prone to timeouts in very large guilds. In order
             to prevent timeouts, you must set this to ``False``. If this is
             set to ``False``\, then this function will always return ``None``.
-        roles: Optional[list[:class:`Role`]]
+        roles: Optional[List[:class:`abc.Snowflake`]]
             A :class:`list` of :class:`Role`\s to include in the pruning process. If a member 
             has a role that is not specified, they'll be excluded.
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1282,7 +1282,7 @@ class Guild(Hashable):
                          reason=e['reason'])
                 for e in data]
 
-    async def prune_members(self, *, days, compute_prune_count=True, reason=None):
+    async def prune_members(self, *, days, compute_prune_count=True, roles=None, reason=None):
         r"""|coro|
 
         Prunes the guild from its inactive members.
@@ -1296,6 +1296,11 @@ class Guild(Hashable):
         To check how many members you would prune without actually pruning,
         see the :meth:`estimate_pruned_members` function.
 
+        To prune members that have specific roles see the :meth:`roles` function.
+
+        .. versionchanged:: 1.4
+            The ``roles`` keyword-only parameter was added.
+
         Parameters
         -----------
         days: :class:`int`
@@ -1307,6 +1312,9 @@ class Guild(Hashable):
             which makes it prone to timeouts in very large guilds. In order
             to prevent timeouts, you must set this to ``False``. If this is
             set to ``False``\, then this function will always return ``None``.
+        roles: Optional[list[:class:`Role`]]
+            A :class:`list` of :class:`Role`\s to include in the pruning process, if a member 
+            have a role that is not specified, they'll be excluded.
 
         Raises
         -------
@@ -1327,7 +1335,10 @@ class Guild(Hashable):
         if not isinstance(days, int):
             raise InvalidArgument('Expected int for ``days``, received {0.__class__.__name__} instead.'.format(days))
 
-        data = await self._state.http.prune_members(self.id, days, compute_prune_count=compute_prune_count, reason=reason)
+        if roles:
+            roles = [role.id for role in roles]
+
+        data = await self._state.http.prune_members(self.id, days, compute_prune_count=compute_prune_count, roles=roles, reason=reason)
         return data['pruned']
 
     async def webhooks(self):

--- a/discord/http.py
+++ b/discord/http.py
@@ -657,10 +657,11 @@ class HTTPClient:
     def get_member(self, guild_id, member_id):
         return self.request(Route('GET', '/guilds/{guild_id}/members/{member_id}', guild_id=guild_id, member_id=member_id))
 
-    def prune_members(self, guild_id, days, compute_prune_count, *, reason=None):
+    def prune_members(self, guild_id, days, compute_prune_count, roles, *, reason=None):
         params = {
             'days': days,
-            'compute_prune_count': 'true' if compute_prune_count else 'false'
+            'compute_prune_count': 'true' if compute_prune_count else 'false',
+            'include_roles': roles
         }
         return self.request(Route('POST', '/guilds/{guild_id}/prune', guild_id=guild_id), params=params, reason=reason)
 


### PR DESCRIPTION
### Summary

Implements the new [pruning feature](https://github.com/discord/discord-api-docs/pull/1563) so you can prune people that have a specific role or roles.

I was quite unsure how to word it properly in the documentation. Lmk if it needs to be changed.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
