### PR TITLE
Documentation: Fix color properties being displayed as methods

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -549,14 +549,14 @@ class Spotify:
     def colour(self):
         """Returns the Spotify integration colour, as a :class:`Colour`.
 
-        There is an alias for this named :meth:`color`"""
+        There is an alias for this named `color`"""
         return Colour(0x1db954)
 
     @property
     def color(self):
         """Returns the Spotify integration colour, as a :class:`Colour`.
 
-        There is an alias for this named :meth:`colour`"""
+        There is an alias for this named `colour`"""
         return self.colour
 
     def to_dict(self):

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -549,14 +549,14 @@ class Spotify:
     def colour(self):
         """Returns the Spotify integration colour, as a :class:`Colour`.
 
-        There is an alias for this named `color`"""
+        There is an alias for this named :attr:`color`"""
         return Colour(0x1db954)
 
     @property
     def color(self):
         """Returns the Spotify integration colour, as a :class:`Colour`.
 
-        There is an alias for this named `colour`"""
+        There is an alias for this named :attr:`colour`"""
         return self.colour
 
     def to_dict(self):

--- a/discord/member.py
+++ b/discord/member.py
@@ -321,7 +321,7 @@ class Member(discord.abc.Messageable, _BaseUser):
         for the member. If the default colour is the one rendered then an instance
         of :meth:`Colour.default` is returned.
 
-        There is an alias for this named `color`.
+        There is an alias for this named :attr:`color`.
         """
 
         roles = self.roles[1:] # remove @everyone
@@ -340,7 +340,7 @@ class Member(discord.abc.Messageable, _BaseUser):
         the member. If the default color is the one rendered then an instance of :meth:`Colour.default`
         is returned.
 
-        There is an alias for this named `colour`.
+        There is an alias for this named :attr:`colour`.
         """
         return self.colour
 

--- a/discord/member.py
+++ b/discord/member.py
@@ -321,7 +321,7 @@ class Member(discord.abc.Messageable, _BaseUser):
         for the member. If the default colour is the one rendered then an instance
         of :meth:`Colour.default` is returned.
 
-        There is an alias for this named :meth:`color`.
+        There is an alias for this named `color`.
         """
 
         roles = self.roles[1:] # remove @everyone
@@ -340,7 +340,7 @@ class Member(discord.abc.Messageable, _BaseUser):
         the member. If the default color is the one rendered then an instance of :meth:`Colour.default`
         is returned.
 
-        There is an alias for this named :meth:`colour`.
+        There is an alias for this named `colour`.
         """
         return self.colour
 

--- a/discord/user.py
+++ b/discord/user.py
@@ -197,7 +197,7 @@ class BaseUser(_BaseUser):
         """:class:`Colour`: A property that returns a colour denoting the rendered colour
         for the user. This always returns :meth:`Colour.default`.
 
-        There is an alias for this named `color`.
+        There is an alias for this named :attr:`color`.
         """
         return Colour.default()
 
@@ -206,7 +206,7 @@ class BaseUser(_BaseUser):
         """:class:`Colour`: A property that returns a color denoting the rendered color
         for the user. This always returns :meth:`Colour.default`.
 
-        There is an alias for this named `colour`.
+        There is an alias for this named :attr:`colour`.
         """
         return self.colour
 

--- a/discord/user.py
+++ b/discord/user.py
@@ -197,7 +197,7 @@ class BaseUser(_BaseUser):
         """:class:`Colour`: A property that returns a colour denoting the rendered colour
         for the user. This always returns :meth:`Colour.default`.
 
-        There is an alias for this named :meth:`color`.
+        There is an alias for this named `color`.
         """
         return Colour.default()
 
@@ -206,7 +206,7 @@ class BaseUser(_BaseUser):
         """:class:`Colour`: A property that returns a color denoting the rendered color
         for the user. This always returns :meth:`Colour.default`.
 
-        There is an alias for this named :meth:`colour`.
+        There is an alias for this named `colour`.
         """
         return self.colour
 


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
Currently, the documentation makes it look like the aliases for `color` and `colour` are methods. However, that is not the case and this PR fixes this.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
