### PR TITLE
Note that bot accounts cannot set a CustomActivity

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -672,6 +672,10 @@ class CustomActivity(BaseActivity):
 
             Returns the custom status text.
 
+    .. note::
+
+        Bot accounts cannot currently set a CustomActivity as their presence.
+
     .. versionadded:: 1.3
 
     Attributes

--- a/discord/client.py
+++ b/discord/client.py
@@ -950,6 +950,10 @@ class Client:
         ------
         :exc:`.InvalidArgument`
             If the ``activity`` parameter is not the proper type.
+
+        .. note::
+
+            Bot accounts cannot currently set a CustomActivity as their presence.
         """
 
         if status is None:


### PR DESCRIPTION
### Summary

This adds a doc note that bots cannot set a CustomActivity, a common misunderstanding seen in both the Discord and in #4051, #4049, #2550 and (kinda) #2400. 

Maybe clarifying as "customstatues are ignored" or similar might be better? 

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
