### PR TITLE
allow passing EmptyEmbed to set_image and set_thumbnail

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -276,6 +276,9 @@ class Embed:
         This function returns the class instance to allow for fluent-style
         chaining.
 
+        .. versionchanged:: 1.4
+            Passing :attr:`Empty` removes the image.
+
         Parameters
         -----------
         url: :class:`str`
@@ -311,6 +314,9 @@ class Embed:
 
         This function returns the class instance to allow for fluent-style
         chaining.
+
+        .. versionchanged:: 1.4
+            Passing :attr:`Empty` removes the thumbnail.
 
         Parameters
         -----------

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -282,9 +282,12 @@ class Embed:
             The source URL for the image. Only HTTP(S) is supported.
         """
 
-        self._image = {
-            'url': str(url)
-        }
+        if url is EmptyEmbed:
+            del self._image
+        else:
+            self._image = {
+                'url': str(url)
+            }
 
         return self
 
@@ -315,9 +318,12 @@ class Embed:
             The source URL for the thumbnail. Only HTTP(S) is supported.
         """
 
-        self._thumbnail = {
-            'url': str(url)
-        }
+        if url is EmptyEmbed:
+            del self._thumbnail
+        else:
+            self._thumbnail = {
+                'url': str(url)
+            }
 
         return self
 


### PR DESCRIPTION
### Summary

this PR allows passing `Embed.Empty` to `Embed.set_image/thumbnail` to remove the attributes.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
