### PR TITLE
allow passing color int to role.edit

### DIFF
--- a/discord/role.py
+++ b/discord/role.py
@@ -225,7 +225,7 @@ class Role(Hashable):
             The new role name to change to.
         permissions: :class:`Permissions`
             The new permissions to change to.
-        colour: :class:`Colour`
+        colour: Union[:class:`Colour`, :class:`int`]
             The new colour to change to. (aliased to color as well)
         hoist: :class:`bool`
             Indicates if the role should be shown separately in the member list.
@@ -257,6 +257,9 @@ class Role(Hashable):
             colour = fields['colour']
         except KeyError:
             colour = fields.get('color', self.colour)
+        
+        if isinstance(colour, int):
+            colour = Colour(value=colour)
 
         payload = {
             'name': fields.get('name', self.name),

--- a/discord/role.py
+++ b/discord/role.py
@@ -218,6 +218,9 @@ class Role(Hashable):
         use this.
 
         All fields are optional.
+        
+        .. versionchanged:: 1.4
+            Can now pass ``int`` to ``colour`` keyword-only parameter.
 
         Parameters
         -----------


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
this PR allows passing `int` as a parameter to `role.edit(color=)` instead of just `discord.Color`

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
