### PR TITLE
Allow to clear author by passing `EmptyEmbed` to `name` arg in `set_author()`

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -374,7 +374,7 @@ class Embed:
         chaining.
 
         .. versionchanged:: 1.4
-            Passing :attr:`Empty` for `name` removes the author.
+            Passing :attr:`Empty` to all parameters removes the author.
 
         Parameters
         -----------
@@ -386,20 +386,19 @@ class Embed:
             The URL of the author icon. Only HTTP(S) is supported.
         """
 
-        if name is EmptyEmbed:
-            if url is not EmptyEmbed or icon_url is not EmptyEmbed:
-                raise ValueError("can't set author without name")
+        if all(param is EmptyEmbed for param in (name, url, icon_url)):
             del self._author
-        else:
-            self._author = {
-                'name': str(name)
-            }
+            return self
 
-            if url is not EmptyEmbed:
-                self._author['url'] = str(url)
+        self._author = {
+            'name': str(name)
+        }
 
-            if icon_url is not EmptyEmbed:
-                self._author['icon_url'] = str(icon_url)
+        if url is not EmptyEmbed:
+            self._author['url'] = str(url)
+
+        if icon_url is not EmptyEmbed:
+            self._author['icon_url'] = str(icon_url)
 
         return self
 

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -373,6 +373,9 @@ class Embed:
         This function returns the class instance to allow for fluent-style
         chaining.
 
+        .. versionchanged:: 1.4
+            Passing :attr:`Empty` for `name` removes the author.
+
         Parameters
         -----------
         name: :class:`str`

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -373,9 +373,6 @@ class Embed:
         This function returns the class instance to allow for fluent-style
         chaining.
 
-        .. versionchanged:: 1.4
-            Passing :attr:`Empty` to all parameters removes the author.
-
         Parameters
         -----------
         name: :class:`str`
@@ -386,10 +383,6 @@ class Embed:
             The URL of the author icon. Only HTTP(S) is supported.
         """
 
-        if all(param is EmptyEmbed for param in (name, url, icon_url)):
-            del self._author
-            return self
-
         self._author = {
             'name': str(name)
         }
@@ -399,6 +392,21 @@ class Embed:
 
         if icon_url is not EmptyEmbed:
             self._author['icon_url'] = str(icon_url)
+
+        return self
+
+    def clear_author(self):
+        """Clears embed's author information.
+
+        This function returns the class instance to allow for fluent-style
+        chaining.
+
+        .. versionadded:: 1.4
+        """
+        try:
+            del self._author
+        except AttributeError:
+            pass
 
         return self
 

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -383,15 +383,20 @@ class Embed:
             The URL of the author icon. Only HTTP(S) is supported.
         """
 
-        self._author = {
-            'name': str(name)
-        }
+        if name is EmptyEmbed:
+            if url is not EmptyEmbed or icon_url is not EmptyEmbed:
+                raise ValueError("can't set author without name")
+            del self._author
+        else:
+            self._author = {
+                'name': str(name)
+            }
 
-        if url is not EmptyEmbed:
-            self._author['url'] = str(url)
+            if url is not EmptyEmbed:
+                self._author['url'] = str(url)
 
-        if icon_url is not EmptyEmbed:
-            self._author['icon_url'] = str(icon_url)
+            if icon_url is not EmptyEmbed:
+                self._author['icon_url'] = str(icon_url)
 
         return self
 

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -395,7 +395,7 @@ class Embed:
 
         return self
 
-    def clear_author(self):
+    def remove_author(self):
         """Clears embed's author information.
 
         This function returns the class instance to allow for fluent-style


### PR DESCRIPTION
### Summary

This PR will allow to clear author in `Embed` by passing `EmptyEmbed` to `name` arg in `set_author()` (fixes #2610)

Alternatively, I could make a `clear_author()` function for clearing the author if you think that would be better.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
