### PR TITLE
[tasks] Fix tasks decorators being discarded

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -109,6 +109,9 @@ class Loop:
         copy = Loop(self.coro, seconds=self.seconds, hours=self.hours, minutes=self.minutes,
                                count=self.count, reconnect=self.reconnect, loop=self.loop)
         copy._injected = obj
+        copy._before_loop = self._before_loop
+        copy._after_loop = self._after_loop
+        copy._error = self._error
         setattr(obj, self.coro.__name__, copy)
         return copy
 


### PR DESCRIPTION
At this moment, when a task seems to be first loaded, it immediately throws away the decorators you give it, and just generates a new instance of itself.

In your cog's `__init__`, once you do `self.my_task.start()`, the Loop is remade when it gets to `self.my_task` before executing the `start` function. The original Loop that the cog starts with is where the decorated values are. This fixes that.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
