### PR TITLE
Escape backslashes in display name in `clean_prefix`

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -345,7 +345,7 @@ class HelpCommand:
         # for this common use case rather than waste performance for the
         # odd one.
         pattern = re.compile(r"<@!?%s>" % user.id)
-        return pattern.sub("@%s" % user.display_name, self.context.prefix)
+        return pattern.sub("@%s" % user.display_name.replace('\\', r'\\'), self.context.prefix)
 
     @property
     def invoked_with(self):


### PR DESCRIPTION
### Summary

Fixes #4058 by escaping backslashes in display name. I didn't use `re.escape` which was suggested in the issue as only backslashes should be escaped, not all regex special characters.

### Checklist


- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
