### PR TITLE
add support for allowed_mentions with message edit

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -844,17 +844,13 @@ class Message:
         try:
             allowed_mentions = fields.pop('allowed_mentions')
         except KeyError:
-            allowed_mentions = self._state.allowed_mentions and self._state.allowed_mentions.to_dict()
+            pass
         else:
             if allowed_mentions is not None:
                 if self._state.allowed_mentions is not None:
                     allowed_mentions = self._state.allowed_mentions.merge(allowed_mentions).to_dict()
                 else:
                     allowed_mentions = allowed_mentions.to_dict()
-            else:
-                allowed_mentions = self._state.allowed_mentions and self._state.allowed_mentions.to_dict()
-        finally:
-            if allowed_mentions is not None:
                 fields['allowed_mentions'] = allowed_mentions
 
         if fields:

--- a/discord/message.py
+++ b/discord/message.py
@@ -800,6 +800,10 @@ class Message:
             If provided, the number of seconds to wait in the background
             before deleting the message we just edited. If the deletion fails,
             then it is silently ignored.
+        allowed_mentions: Optional[:class:`~discord.AllowedMentions`]
+            Controls the mentions being processed in this message.
+
+            .. versionadded:: 1.4
 
         Raises
         -------
@@ -836,6 +840,22 @@ class Message:
              fields['flags'] = flags.value
 
         delete_after = fields.pop('delete_after', None)
+
+        try:
+            allowed_mentions = fields.pop('allowed_mentions')
+        except KeyError:
+            allowed_mentions = self._state.allowed_mentions and self._state.allowed_mentions.to_dict()
+        else:
+            if allowed_mentions is not None:
+                if self._state.allowed_mentions is not None:
+                    allowed_mentions = self._state.allowed_mentions.merge(allowed_mentions).to_dict()
+                else:
+                    allowed_mentions = allowed_mentions.to_dict()
+            else:
+                allowed_mentions = self._state.allowed_mentions and self._state.allowed_mentions.to_dict()
+        finally:
+            if allowed_mentions is not None:
+                fields['allowed_mentions'] = allowed_mentions
 
         if fields:
             data = await self._state.http.edit_message(self.channel.id, self.id, **fields)


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
This pull request adds support for passing allowed_mentions to message.edit like with messageable.send. It also uses the global allowed_mentions like with messageable.send.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)