### PR TITLE
Alphabetical (grouped) order in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ extensions = [
     'exception_hierarchy'
 ]
 
-autodoc_member_order = 'bysource'
+autodoc_member_order = 'groupwise'
 
 extlinks = {
     'issue': ('https://github.com/Rapptz/discord.py/issues/%s', 'GH-'),


### PR DESCRIPTION
### Summary

This pull request upgrades the docs readability by sorting entries in groups (first fields, the methods...) and sort each group in alphabetical order.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
