### PR TITLE
cog_command_error must be async

### DIFF
--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -312,7 +312,7 @@ class Cog(metaclass=CogMeta):
         return True
 
     @_cog_special_method
-    def cog_command_error(self, ctx, error):
+    async def cog_command_error(self, ctx, error):
         """A special method that is called whenever an error
         is dispatched inside this cog.
 

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -319,7 +319,7 @@ class Cog(metaclass=CogMeta):
         This is similar to :func:`.on_command_error` except only applying
         to the commands inside this cog.
 
-        This function **can** be a coroutine.
+        This **must** be a coroutine.
 
         Parameters
         -----------


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
Documentation stated that ``Cog.cog_command_error`` didn't have to be a coroutine. In code, it does.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
