### PR TITLE
[tasks] Allow Loop.cancel in Loop.before_loop

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -68,6 +68,7 @@ class Loop:
         sleep_until = discord.utils.sleep_until
         self._next_iteration = datetime.datetime.now(datetime.timezone.utc)
         try:
+            await asyncio.sleep(0) # allows canceling in before_loop
             while True:
                 self._last_iteration = self._next_iteration
                 self._next_iteration = self._get_next_sleep_time()


### PR DESCRIPTION
### Summary

Task cancel raises on the next awaited coro, so I've added this 0-sleep "hack"

I'm internally debating leaving the comment there, but I'm sure it would confuse the uninformed of this trick.

As d.py stands right now, canceling a task in its `before_loop` will run the main decorated loop coro once.

Repro cog: https://mystb.in/yohurolere.py

### Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
