### PR TITLE
Use GuildChannel abc for CategoryChannel edit

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -791,17 +791,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
             Editing the category failed.
         """
 
-        try:
-            position = options.pop('position')
-        except KeyError:
-            pass
-        else:
-            await self._move(position, reason=reason)
-            self.position = position
-
-        if options:
-            data = await self._state.http.edit_channel(self.id, reason=reason, **options)
-            self._update(self.guild, data)
+        await self._edit(options=options, reason=reason)
 
     @property
     def channels(self):


### PR DESCRIPTION
### Summary

I noticed nothing happened when I did `CategoryChannel.edit(overwrites=OtherCategoryChannel.overwrites)`

`http.edit_channel` doesn't do anything with the `overwrites` keyword, it's processed as `permission_overwrites` instead which `self._edit` takes care of.

### Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
