### PR TITLE
state: use bytes.hex() instead of binascii.hexlify().decode()

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -36,7 +36,6 @@ import inspect
 import gc
 
 import os
-import binascii
 
 from .guild import Guild
 from .activity import BaseActivity
@@ -135,7 +134,7 @@ class ConnectionState:
         gc.collect()
 
     def get_nonce(self):
-        return binascii.hexlify(os.urandom(16)).decode('ascii')
+        return os.urandom(16).hex()
 
     def process_listeners(self, listener_type, argument, result):
         removed = []


### PR DESCRIPTION
## Summary

This just uses a simpler way to turn a byte string into a hex string.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
