### PR TITLE
Fix TypeError in chunker

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -747,7 +747,7 @@ class ConnectionState:
 
     async def _chunk_and_dispatch(self, guild, unavailable):
         chunks = list(self.chunks_needed(guild))
-        await self.chunker(guild)
+        await self.chunker(guild.id)
         if chunks:
             try:
                 await utils.sane_wait_for(chunks, timeout=len(chunks))


### PR DESCRIPTION
### Summary
This fixes https://discordapp.com/channels/336642139381301249/669155775700271126/709441940797652994

Previously, `Guild` object was passed directly to "guild_id" parameter, which, of course, expects guild ID (or list of IDs), causing TypeError.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
