### PR TITLE
Added on_socket_response to the events

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -210,6 +210,21 @@ to handle it, which defaults to print a traceback and ignoring the exception.
                     WebSocket library. It can be :class:`bytes` to denote a binary
                     message or :class:`str` to denote a regular text message.
 
+.. function:: on_socket_response(payload)
+    
+    Called after the socket data is decoded. This data is decoded
+    from discord's ETF format.
+    
+    This is useful for debugging purposes if you do not want to manually
+    decode the ETF through the on_socket_raw_send event or if you want
+    to intercept payloads from the gateway and do something with it.
+    
+    .. note::
+        This is only for the messages received from the client
+        WebSocket. The voice WebSocket will not trigger this event.
+     
+    :param payload: The websocket payload decoded into a :class `dictionary`.
+
 .. function:: on_typing(channel, user, when)
 
     Called when someone begins typing a message.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -223,7 +223,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
         This is only for the messages received from the client
         WebSocket. The voice WebSocket will not trigger this event.
      
-    :param payload: The websocket payload decoded into a :class `dictionary`.
+    :param payload: The websocket payload decoded into a :class:`dict`.
 
 .. function:: on_typing(channel, user, when)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -220,6 +220,10 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     to intercept payloads from the gateway and do something with it.
     
     .. note::
+        This event is considered extremely unstable due to the fact
+        that events could fire at any time and by the time the event
+        fires, the library might have already modified the payload.
+        
         This is only for the messages received from the client
         WebSocket. The voice WebSocket will not trigger this event.
      


### PR DESCRIPTION
This adds the un-documented on_socket_response event to the api docs

### Summary

<!-- What is this pull request for? Does it fix any issues? -->
It adds the undocumented event on_socket_response to the api documentation

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
