### PR TITLE
Document and modify behavior of socket_response

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -368,7 +368,7 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
                 return
 
         self._dispatch('socket_response', msg)
-        
+
         msg = json.loads(msg)
 
         log.debug('For Shard ID %s: WebSocket Event: %s', self.shard_id, msg)

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -367,10 +367,11 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
             else:
                 return
 
+        self._dispatch('socket_response', msg)
+        
         msg = json.loads(msg)
 
         log.debug('For Shard ID %s: WebSocket Event: %s', self.shard_id, msg)
-        self._dispatch('socket_response', msg)
 
         op = msg.get('op')
         data = msg.get('d')

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -187,10 +187,41 @@ to handle it, which defaults to print a traceback and ignoring the exception.
         This is only for the messages received from the client
         WebSocket. The voice WebSocket will not trigger this event.
 
+    .. note::
+
+        Similar to :func:`on_socket_response` but the message will generally
+        be compressed.
+
+
     :param msg: The message passed in from the WebSocket library.
                 Could be :class:`bytes` for a binary message or :class:`str`
                 for a regular message.
     :type msg: Union[:class:`bytes`, :class:`str`]
+
+.. function:: on_socket_response(msg)
+
+    Called whenever a message is received from the WebSocket, after
+    being decompressed but before being parsed.
+    This event is always dispatched when a message is
+    received and the passed data is not processed in any way.
+
+    This is only really useful for grabbing the WebSocket stream and
+    debugging purposes.
+
+    .. note::
+
+        This is only for the messages received from the client
+        WebSocket. The voice WebSocket will not trigger this event.
+
+    .. note::
+
+        Similar to :func:`on_socket_raw_receive` but the message will be decompressed.
+
+    .. versionchanged:: 2.0
+        This event receives a json-encoded :class:`str` of the message instead of a :class:`dict`
+
+    :param msg: The decompressed message passed in from the WebSocket library.
+    :type msg: :class:`str`
 
 .. function:: on_socket_raw_send(payload)
 


### PR DESCRIPTION
### Summary

This PR modifies the behavior of on_socket_response such that it is dispatched prior to being parsed as json, which prevents the problems raised in #4097 #323 in a non performance-affecting way. 

Interestingly, preforming a deep copy of the dictionary takes 4x longer (20 μs) than calling json.loads on the string, (5 μs) so preforming json.loads twice would be a not-too-hard-on-performance change that wouldn't be breaking. Regardless, I've marked it as changed in 2.0.

Further: does the websocket ever receive a non-compressed payload anymore? If it's always compressed and never a string, it seems to me this chunk of code could be sped up by removing the instance check. This could also be documented. 


### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
