### PR TITLE
Update Member.top_role

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -434,7 +434,14 @@ class Member(discord.abc.Messageable, _BaseUser):
         This is useful for figuring where a member stands in the role
         hierarchy chain.
         """
-        return self.roles[-1]
+        highest_role = 0
+        highest_position = 0
+
+        for loc, r in enumerate(self.roles):
+            if r.position > highest_position:
+                highest_position = r.position
+                highest_role = loc
+        return self.roles[highest_role]
 
     @property
     def guild_permissions(self):


### PR DESCRIPTION
### Summary

Changed the behaviour of the Member top_role property, before it simply returned the role at the last index of self.roles, now it iterates over all the roles to find the role with the highest position and returns that instead, this seems more expensive and doesn't make sense initially, however there is some cases where self.roles isn't sorted correctly (presumably due to a caching issue) and in these cases the top_role function returned the wrong role, I've added a way to reproduce this behaviour below which seems to work for me.

I setup a test server, and added a bot with an integrated role, I then added another role and put it above the integrated role (in this case at the top of the roles list), and then started the bot (program below). I then sent `roles` to see what the bot considered its own roles were (their name and position), which should have been sorted by position and in this case they were. I then moved the new role (non integrated) below the integrated role and sent `roles` again, this time it had the positions of the roles correct again but the order of them wrong, resulting in top_role returning the wrong role.

Test program:
```python
import discord

class Client(discord.Client):
    async def on_ready(self):
        print("Ready")

    async def on_message(self, msg):
        if msg.content == "roles":
            roles = "\n".join([f"Name: {r.name} - Position: {r.position}" for r in msg.guild.me.roles])
            
            await msg.channel.send(f"top_role: {msg.guild.me.top_role.name}\n{roles}")

client = Client()
client.run("token")
```

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)