### PR TITLE
Fix animated attribute type in PartialEmoji docstring

### DIFF
--- a/discord/partial_emoji.py
+++ b/discord/partial_emoji.py
@@ -61,7 +61,7 @@ class PartialEmoji(_EmojiTag):
         The custom emoji name, if applicable, or the unicode codepoint
         of the non-custom emoji. This can be ``None`` if the emoji
         got deleted (e.g. removing a reaction with a deleted emoji).
-    animated: :class:`bool`
+    animated: Optional[:class:`bool`]
         Whether the emoji is animated or not.
     id: Optional[:class:`int`]
         The ID of the custom emoji, if applicable.


### PR DESCRIPTION
### Summary

`animated` is optional in PartialEmoji

### Checklist
- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
