### PR TITLE
Fix KeyError on Member Channels not being in JSON

### DIFF
--- a/discord/widget.py
+++ b/discord/widget.py
@@ -204,8 +204,10 @@ class Widget:
         channels = {channel.id: channel for channel in self.channels}
         for member in data.get('members', []):
             connected_channel = _get_as_snowflake(member, 'channel_id')
-            if connected_channel:
+            if connected_channel in channels:
                 connected_channel = channels[connected_channel]
+            else:
+                connected_channel = WidgetChannel(id=connected_channel, name=None, position=None)
 
             self.members.append(WidgetMember(state=self._state, data=member, connected_channel=connected_channel))
 

--- a/discord/widget.py
+++ b/discord/widget.py
@@ -206,7 +206,7 @@ class Widget:
             connected_channel = _get_as_snowflake(member, 'channel_id')
             if connected_channel in channels:
                 connected_channel = channels[connected_channel]
-            else:
+            elif connected_channel:
                 connected_channel = WidgetChannel(id=connected_channel, name=None, position=None)
 
             self.members.append(WidgetMember(state=self._state, data=member, connected_channel=connected_channel))

--- a/discord/widget.py
+++ b/discord/widget.py
@@ -56,9 +56,9 @@ class WidgetChannel(namedtuple('WidgetChannel', 'id name position')):
     -----------
     id: :class:`int`
         The channel's ID.
-    name: :class:`str`
+    name: Optional[:class:`str`]
         The channel's name.
-    position: :class:`int`
+    position: Optional[:class:`int`]
         The channel's position
     """
     __slots__ = ()
@@ -232,7 +232,7 @@ class Widget:
 
     @property
     def invite_url(self):
-        """Optiona[:class:`str`]: The invite URL for the guild, if available."""
+        """Optional[:class:`str`]: The invite URL for the guild, if available."""
         return self._invite
 
     async def fetch_invite(self, *, with_counts=True):

--- a/discord/widget.py
+++ b/discord/widget.py
@@ -56,9 +56,9 @@ class WidgetChannel(namedtuple('WidgetChannel', 'id name position')):
     -----------
     id: :class:`int`
         The channel's ID.
-    name: Optional[:class:`str`]
+    name: :class:`str`
         The channel's name.
-    position: Optional[:class:`int`]
+    position: :class:`int`
         The channel's position
     """
     __slots__ = ()
@@ -207,7 +207,7 @@ class Widget:
             if connected_channel in channels:
                 connected_channel = channels[connected_channel]
             elif connected_channel:
-                connected_channel = WidgetChannel(id=connected_channel, name=None, position=None)
+                connected_channel = WidgetChannel(id=connected_channel, name='', position=0)
 
             self.members.append(WidgetMember(state=self._state, data=member, connected_channel=connected_channel))
 


### PR DESCRIPTION
### Summary

This PR fixes KeyError Caused by Member Channels not available in `channels`.
fixes #4114
### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
