### PR TITLE
Implement `Guild/TextChannel.edit(type=...)`

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -281,10 +281,14 @@ class GuildChannel:
                 perms.append(payload)
             options['permission_overwrites'] = perms
 
-        ch_type = options.get('type', self.type)
-        if not isinstance(ch_type, ChannelType):
-            raise InvalidArgument('type field must be of type ChannelType')
-        options['type'] = ch_type.value
+        try:
+            ch_type = options['type']
+        except KeyError:
+            pass
+        else:
+            if not isinstance(ch_type, ChannelType):
+                raise InvalidArgument('type field must be of type ChannelType')
+            options['type'] = ch_type.value
 
         if options:
             data = await self._state.http.edit_channel(self.id, reason=reason, **options)

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -31,6 +31,7 @@ from collections import namedtuple
 
 from .iterators import HistoryIterator
 from .context_managers import Typing
+from .enums import ChannelType
 from .errors import InvalidArgument, ClientException, HTTPException
 from .permissions import PermissionOverwrite, Permissions
 from .role import Role
@@ -279,6 +280,11 @@ class GuildChannel:
 
                 perms.append(payload)
             options['permission_overwrites'] = perms
+
+        ch_type = options.get('type', self.type)
+        if not isinstance(ch_type, ChannelType):
+            raise InvalidArgument('type field must be of type ChannelType')
+        options['type'] = ch_type.value
 
         if options:
             data = await self._state.http.edit_channel(self.id, reason=reason, **options)

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -197,6 +197,9 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         .. versionchanged:: 1.3
             The ``overwrites`` keyword-only parameter was added.
 
+        .. versionchanged:: 1.4
+            The ``type`` keyword-only parameter was added.
+
         Parameters
         ----------
         name: :class:`str`
@@ -216,6 +219,10 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         slowmode_delay: :class:`int`
             Specifies the slowmode rate limit for user in this channel, in seconds.
             A value of `0` disables slowmode. The maximum value possible is `21600`.
+        type: :class:`ChannelType`
+            Change the type of this text channel. Currently, only conversion between
+            :attr:`ChannelType.text` and :attr:`ChannelType.news` is supported. This 
+            is only available to guilds that contain `NEWS` in :attr:`Guild.features`.
         reason: Optional[:class:`str`]
             The reason for editing this channel. Shows up on the audit log.
         overwrites: :class:`dict`

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -222,7 +222,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         type: :class:`ChannelType`
             Change the type of this text channel. Currently, only conversion between
             :attr:`ChannelType.text` and :attr:`ChannelType.news` is supported. This 
-            is only available to guilds that contain `NEWS` in :attr:`Guild.features`.
+            is only available to guilds that contain ``NEWS`` in :attr:`Guild.features`.
         reason: Optional[:class:`str`]
             The reason for editing this channel. Shows up on the audit log.
         overwrites: :class:`dict`

--- a/discord/http.py
+++ b/discord/http.py
@@ -529,7 +529,8 @@ class HTTPClient:
     def edit_channel(self, channel_id, *, reason=None, **options):
         r = Route('PATCH', '/channels/{channel_id}', channel_id=channel_id)
         valid_keys = ('name', 'parent_id', 'topic', 'bitrate', 'nsfw',
-                      'user_limit', 'position', 'permission_overwrites', 'rate_limit_per_user')
+                      'user_limit', 'position', 'permission_overwrites', 'rate_limit_per_user',
+                      'type')
         payload = {
             k: v for k, v in options.items() if k in valid_keys
         }


### PR DESCRIPTION
### Summary

This allows for text channels to be converted to news channels and vice versa.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
