### PR TITLE
Clarify that TeamMember.id is the Discord user ID

### DIFF
--- a/discord/team.py
+++ b/discord/team.py
@@ -104,7 +104,7 @@ class TeamMember(BaseUser):
     name: :class:`str`
         The team member's username.
     id: :class:`int`
-        The team member's unique ID.
+        The team member's unique Discord user ID.
     discriminator: :class:`str`
         The team member's discriminator. This is given when the username has conflicts.
     avatar: Optional[:class:`str`]


### PR DESCRIPTION
### Summary

This is just a very small improvement in the documentation that notes that a `TeamMember`'s ID is indeed the user's Discord ID.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
