### PR TITLE
[matrix] make documentation sphinx 3.x compatible

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ extlinks = {
 # Links used for cross-referencing stuff in other documentation
 intersphinx_mapping = {
   'py': ('https://docs.python.org/3', None),
-  'aio': ('https://aiohttp.readthedocs.io/en/stable/', None),
+  'aio': ('https://docs.aiohttp.org/en/stable/', None),
   'req': ('http://docs.python-requests.org/en/latest/', 'requests.inv')
 }
 
@@ -319,6 +319,6 @@ texinfo_documents = [
 #texinfo_no_detailmenu = False
 
 def setup(app):
-  app.add_javascript('custom.js')
+  app.add_js_file('custom.js')
   if app.config.language == 'ja':
     app.config.intersphinx_mapping['py'] = ('https://docs.python.org/ja/3', None)

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -107,7 +107,8 @@ def build_lookup_table(env):
     ignored = {
         'data', 'exception', 'module', 'class',
     }
-    for (fullname, (docname, objtype)) in domain.objects.items():
+
+    for (fullname, _, objtype, docname, _, _) in domain.get_objects():
         if objtype in ignored:
             continue
 


### PR DESCRIPTION
### Summary

This PR makes the documentation Sphinx 3.x compatible.
I tested with Sphinx 3.0.3 (latest) and Sphinx 3.1.0 (latest-wip)

This also changes the location of the aiohttp inventory.

I did, however, leave out fixes for the following warnings:
- [`migrating.rst-ext_commands_help_command missing-link`](https://github.com/Rapptz/discord.py/blob/neo-docs/docs/migrating.rst#L1005)
- [`ext/commands/bot.py-ext_commands_help_command missing-link`](https://github.com/Rapptz/discord.py/blob/neo-docs/discord/ext/commands/bot.py#L987-L988)
- [`ext/commands/core.py-checks two-possible-targets`](https://github.com/Rapptz/discord.py/blob/neo-docs/discord/ext/commands/core.py#L992)

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
