### PR TITLE
Show events as `Client.on_event` rather than `discord.on_event`

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -142,7 +142,7 @@ class Client:
     shard_count: Optional[:class:`int`]
         The total number of shards.
     fetch_offline_members: :class:`bool`
-        Indicates if :func:`.on_ready` should be delayed to fetch all offline
+        Indicates if :meth`.on_ready` should be delayed to fetch all offline
         members from the guilds the client belongs to. If this is ``False``\, then
         no offline members are received and :meth:`request_offline_members`
         must be used to fetch the offline members of the guild.
@@ -168,13 +168,13 @@ class Client:
 
             If this is set to ``False`` then the following features will be disabled:
 
-                - No user related updates (:func:`on_user_update` will not dispatch)
+                - No user related updates (:meth`on_user_update` will not dispatch)
                 - All member related events will be disabled.
-                    - :func:`on_member_update`
-                    - :func:`on_member_join`
-                    - :func:`on_member_remove`
+                    - :meth`on_member_update`
+                    - :meth`on_member_join`
+                    - :meth`on_member_remove`
 
-                - Typing events will be disabled (:func:`on_typing`).
+                - Typing events will be disabled (:meth`on_typing`).
                 - If ``fetch_offline_members`` is set to ``False`` then the user cache will not exist.
                   This makes it difficult or impossible to do many things, for example:
 
@@ -1343,9 +1343,9 @@ class Client:
     async def on_connect(self):
         """|coro|
         Called when the client has successfully connected to Discord. This is not
-        the same as the client being fully prepared, see :func:`on_ready` for that.
+        the same as the client being fully prepared, see :meth:`on_ready` for that.
 
-        The warnings on :func:`on_ready` also apply.
+        The warnings on :meth:`on_ready` also apply.
         """
 
     async def on_disconnect(self):
@@ -1355,9 +1355,10 @@ class Client:
         one way or the other.
 
         This function can be called many times.
+        """
 
-        async def on_ready()
-
+    async def on_ready(self):
+        """|coro|
         Called when the client is done preparing the data received from Discord. Usually after login is successful
         and the :attr:`Client.guilds` and co. are filled up.
 
@@ -1371,7 +1372,7 @@ class Client:
 
     async def on_shard_ready(self, shard_id):
         """|coro|
-        Similar to :func:`on_ready` except used by :class:`~discord.AutoShardedClient`
+        Similar to :meth`on_ready` except used by :class:`~discord.AutoShardedClient`
         to denote when a particular shard ID has become ready.
 
         Parameters
@@ -1509,7 +1510,7 @@ class Client:
         or the client is participating in high traffic guilds.
 
         If this occurs increase the :attr:`Client.max_messages` attribute
-        or use the :func:`on_raw_message_delete` event instead.
+        or use the :meth:`on_raw_message_delete` event instead.
 
         Parameters
         ------------
@@ -1527,7 +1528,7 @@ class Client:
         or the client is participating in high traffic guilds.
 
         If this occurs increase the :attr:`Client.max_messages` attribute
-        or use the :func:`on_raw_bulk_message_delete` event instead.
+        or use the :meth`on_raw_bulk_message_delete` event instead.
 
         Parameters
         ------------
@@ -1537,7 +1538,7 @@ class Client:
 
     async def on_raw_message_delete(self, payload):
         """|coro|
-        Called when a message is deleted. Unlike :func:`on_message_delete`, this is
+        Called when a message is deleted. Unlike :meth`on_message_delete`, this is
         called regardless of the message being in the internal message cache or not.
 
         If the message is found in the message cache,
@@ -1551,7 +1552,7 @@ class Client:
 
     async def on_raw_bulk_message_delete(self, payload):
         """|coro|
-        Called when a bulk delete is triggered. Unlike :func:`on_bulk_message_delete`, this is
+        Called when a bulk delete is triggered. Unlike :meth`on_bulk_message_delete`, this is
         called regardless of the messages being in the internal message cache or not.
 
         If the messages are found in the message cache,
@@ -1571,7 +1572,7 @@ class Client:
         or the client is participating in high traffic guilds.
 
         If this occurs increase the :attr:`Client.max_messages` attribute
-        or use the :func:`on_raw_message_edit` event instead.
+        or use the :meth`on_raw_message_edit` event instead.
 
         The following non-exhaustive cases trigger this event:
 
@@ -1594,7 +1595,7 @@ class Client:
 
     async def on_raw_message_edit(self, payload):
         """|coro|
-        Called when a message is edited. Unlike :func:`on_message_edit`, this is called
+        Called when a message is edited. Unlike :meth`on_message_edit`, this is called
         regardless of the state of the internal message cache.
 
         If the message is found in the message cache,
@@ -1616,9 +1617,9 @@ class Client:
 
     async def on_reaction_add(self, reaction, user):
         """|coro|
-        Called when a message has a reaction added to it. Similar to :func:`on_message_edit`,
+        Called when a message has a reaction added to it. Similar to :meth`on_message_edit`,
         if the message is not found in the internal message cache, then this
-        event will not be called. Consider using :func:`on_raw_reaction_add` instead.
+        event will not be called. Consider using :meth`on_raw_reaction_add` instead.
 
         .. note::
 
@@ -1634,7 +1635,7 @@ class Client:
 
     async def on_raw_reaction_add(self, payload):
         """|coro|
-        Called when a message has a reaction added. Unlike :func:`on_reaction_add`, this is
+        Called when a message has a reaction added. Unlike :meth`on_reaction_add`, this is
         called regardless of the state of the internal message cache.
 
         Parameters
@@ -1663,7 +1664,7 @@ class Client:
 
     async def on_raw_reaction_remove(self, payload):
         """|coro|
-        Called when a message has a reaction removed. Unlike :func:`on_reaction_remove`, this is
+        Called when a message has a reaction removed. Unlike :meth`on_reaction_remove`, this is
         called regardless of the state of the internal message cache.
 
         Parameters
@@ -1674,9 +1675,9 @@ class Client:
 
     async def on_reaction_clear(self, message, reactions):
         """|coro|
-        Called when a message has all its reactions removed from it. Similar to :func:`on_message_edit`,
+        Called when a message has all its reactions removed from it. Similar to :meth`on_message_edit`,
         if the message is not found in the internal message cache, then this event
-        will not be called. Consider using :func:`on_raw_reaction_clear` instead.
+        will not be called. Consider using :meth`on_raw_reaction_clear` instead.
 
         Parameters
         ------------
@@ -1688,7 +1689,7 @@ class Client:
 
     async def on_raw_reaction_clear(self, payload):
         """|coro|
-        Called when a message has all its reactions removed. Unlike :func:`on_reaction_clear`,
+        Called when a message has all its reactions removed. Unlike :meth`on_reaction_clear`,
         this is called regardless of the state of the internal message cache.
 
         Parameters
@@ -1699,9 +1700,9 @@ class Client:
 
     async def on_reaction_clear_emoji(self, reaction):
         """|coro|
-        Called when a message has a specific reaction removed from it. Similar to :func:`on_message_edit`,
+        Called when a message has a specific reaction removed from it. Similar to :meth`on_message_edit`,
         if the message is not found in the internal message cache, then this event
-        will not be called. Consider using :func:`on_raw_reaction_clear_emoji` instead.
+        will not be called. Consider using :meth`on_raw_reaction_clear_emoji` instead.
 
         .. versionadded:: 1.3
 
@@ -1714,7 +1715,7 @@ class Client:
     async def on_raw_reaction_clear_emoji(self, payload):
         """|coro|
         Called when a message has a specific reaction removed from it.
-        Unlike :func:`on_reaction_clear_emoji` this is called
+        Unlike :meth`on_reaction_clear_emoji` this is called
         regardless of the state of the internal message cache.
 
         .. versionadded:: 1.3

--- a/discord/client.py
+++ b/discord/client.py
@@ -142,7 +142,7 @@ class Client:
     shard_count: Optional[:class:`int`]
         The total number of shards.
     fetch_offline_members: :class:`bool`
-        Indicates if :meth`.on_ready` should be delayed to fetch all offline
+        Indicates if :meth:`.on_ready` should be delayed to fetch all offline
         members from the guilds the client belongs to. If this is ``False``\, then
         no offline members are received and :meth:`request_offline_members`
         must be used to fetch the offline members of the guild.
@@ -168,13 +168,13 @@ class Client:
 
             If this is set to ``False`` then the following features will be disabled:
 
-                - No user related updates (:meth`on_user_update` will not dispatch)
+                - No user related updates (:meth:`on_user_update` will not dispatch)
                 - All member related events will be disabled.
-                    - :meth`on_member_update`
-                    - :meth`on_member_join`
-                    - :meth`on_member_remove`
+                    - :meth:`on_member_update`
+                    - :meth:`on_member_join`
+                    - :meth:`on_member_remove`
 
-                - Typing events will be disabled (:meth`on_typing`).
+                - Typing events will be disabled (:meth:`on_typing`).
                 - If ``fetch_offline_members`` is set to ``False`` then the user cache will not exist.
                   This makes it difficult or impossible to do many things, for example:
 
@@ -1372,7 +1372,7 @@ class Client:
 
     async def on_shard_ready(self, shard_id):
         """|coro|
-        Similar to :meth`on_ready` except used by :class:`~discord.AutoShardedClient`
+        Similar to :meth:`on_ready` except used by :class:`~discord.AutoShardedClient`
         to denote when a particular shard ID has become ready.
 
         Parameters
@@ -1528,7 +1528,7 @@ class Client:
         or the client is participating in high traffic guilds.
 
         If this occurs increase the :attr:`Client.max_messages` attribute
-        or use the :meth`on_raw_bulk_message_delete` event instead.
+        or use the :meth:`on_raw_bulk_message_delete` event instead.
 
         Parameters
         ------------
@@ -1538,7 +1538,7 @@ class Client:
 
     async def on_raw_message_delete(self, payload):
         """|coro|
-        Called when a message is deleted. Unlike :meth`on_message_delete`, this is
+        Called when a message is deleted. Unlike :meth:`on_message_delete`, this is
         called regardless of the message being in the internal message cache or not.
 
         If the message is found in the message cache,
@@ -1552,7 +1552,7 @@ class Client:
 
     async def on_raw_bulk_message_delete(self, payload):
         """|coro|
-        Called when a bulk delete is triggered. Unlike :meth`on_bulk_message_delete`, this is
+        Called when a bulk delete is triggered. Unlike :meth:`on_bulk_message_delete`, this is
         called regardless of the messages being in the internal message cache or not.
 
         If the messages are found in the message cache,
@@ -1572,7 +1572,7 @@ class Client:
         or the client is participating in high traffic guilds.
 
         If this occurs increase the :attr:`Client.max_messages` attribute
-        or use the :meth`on_raw_message_edit` event instead.
+        or use the :meth:`on_raw_message_edit` event instead.
 
         The following non-exhaustive cases trigger this event:
 
@@ -1595,7 +1595,7 @@ class Client:
 
     async def on_raw_message_edit(self, payload):
         """|coro|
-        Called when a message is edited. Unlike :meth`on_message_edit`, this is called
+        Called when a message is edited. Unlike :meth:`on_message_edit`, this is called
         regardless of the state of the internal message cache.
 
         If the message is found in the message cache,
@@ -1617,9 +1617,9 @@ class Client:
 
     async def on_reaction_add(self, reaction, user):
         """|coro|
-        Called when a message has a reaction added to it. Similar to :meth`on_message_edit`,
+        Called when a message has a reaction added to it. Similar to :meth:`on_message_edit`,
         if the message is not found in the internal message cache, then this
-        event will not be called. Consider using :meth`on_raw_reaction_add` instead.
+        event will not be called. Consider using :meth:`on_raw_reaction_add` instead.
 
         .. note::
 
@@ -1635,7 +1635,7 @@ class Client:
 
     async def on_raw_reaction_add(self, payload):
         """|coro|
-        Called when a message has a reaction added. Unlike :meth`on_reaction_add`, this is
+        Called when a message has a reaction added. Unlike :meth:`on_reaction_add`, this is
         called regardless of the state of the internal message cache.
 
         Parameters
@@ -1664,7 +1664,7 @@ class Client:
 
     async def on_raw_reaction_remove(self, payload):
         """|coro|
-        Called when a message has a reaction removed. Unlike :meth`on_reaction_remove`, this is
+        Called when a message has a reaction removed. Unlike :meth:`on_reaction_remove`, this is
         called regardless of the state of the internal message cache.
 
         Parameters
@@ -1675,9 +1675,9 @@ class Client:
 
     async def on_reaction_clear(self, message, reactions):
         """|coro|
-        Called when a message has all its reactions removed from it. Similar to :meth`on_message_edit`,
+        Called when a message has all its reactions removed from it. Similar to :meth:`on_message_edit`,
         if the message is not found in the internal message cache, then this event
-        will not be called. Consider using :meth`on_raw_reaction_clear` instead.
+        will not be called. Consider using :meth:`on_raw_reaction_clear` instead.
 
         Parameters
         ------------
@@ -1689,7 +1689,7 @@ class Client:
 
     async def on_raw_reaction_clear(self, payload):
         """|coro|
-        Called when a message has all its reactions removed. Unlike :meth`on_reaction_clear`,
+        Called when a message has all its reactions removed. Unlike :meth:`on_reaction_clear`,
         this is called regardless of the state of the internal message cache.
 
         Parameters
@@ -1700,9 +1700,9 @@ class Client:
 
     async def on_reaction_clear_emoji(self, reaction):
         """|coro|
-        Called when a message has a specific reaction removed from it. Similar to :meth`on_message_edit`,
+        Called when a message has a specific reaction removed from it. Similar to :meth:`on_message_edit`,
         if the message is not found in the internal message cache, then this event
-        will not be called. Consider using :meth`on_raw_reaction_clear_emoji` instead.
+        will not be called. Consider using :meth:`on_raw_reaction_clear_emoji` instead.
 
         .. versionadded:: 1.3
 
@@ -1715,7 +1715,7 @@ class Client:
     async def on_raw_reaction_clear_emoji(self, payload):
         """|coro|
         Called when a message has a specific reaction removed from it.
-        Unlike :meth`on_reaction_clear_emoji` this is called
+        Unlike :meth:`on_reaction_clear_emoji` this is called
         regardless of the state of the internal message cache.
 
         .. versionadded:: 1.3

--- a/discord/client.py
+++ b/discord/client.py
@@ -354,18 +354,6 @@ class Client:
         else:
             self._schedule_event(coro, method, *args, **kwargs)
 
-    async def on_error(self, event_method, *args, **kwargs):
-        """|coro|
-
-        The default error handler provided by the client.
-
-        By default this prints to :data:`sys.stderr` however it could be
-        overridden to have a different implementation.
-        Check :func:`~discord.on_error` for more details.
-        """
-        print('Ignoring exception in {}'.format(event_method), file=sys.stderr)
-        traceback.print_exc()
-
     async def request_offline_members(self, *guilds):
         r"""|coro|
 
@@ -1349,3 +1337,823 @@ class Client:
         """
         data = await self.http.get_webhook(webhook_id)
         return Webhook.from_state(data, state=self._connection)
+
+    # Events to be subclassed/dispatched
+
+    async def on_connect(self):
+        """|coro|
+        Called when the client has successfully connected to Discord. This is not
+        the same as the client being fully prepared, see :func:`on_ready` for that.
+
+        The warnings on :func:`on_ready` also apply.
+        """
+
+    async def on_disconnect(self):
+        """|coro|
+        Called when the client has disconnected from Discord. This could happen either through
+        the internet being disconnected, explicit calls to logout, or Discord terminating the connection
+        one way or the other.
+
+        This function can be called many times.
+
+        async def on_ready()
+
+        Called when the client is done preparing the data received from Discord. Usually after login is successful
+        and the :attr:`Client.guilds` and co. are filled up.
+
+        .. warning::
+
+            This function is not guaranteed to be the first event called.
+            Likewise, this function is **not** guaranteed to only be called
+            once. This library implements reconnection logic and thus will
+            end up calling this event whenever a RESUME request fails.
+        """
+
+    async def on_shard_ready(self, shard_id):
+        """|coro|
+        Similar to :func:`on_ready` except used by :class:`~discord.AutoShardedClient`
+        to denote when a particular shard ID has become ready.
+
+        Parameters
+        ------------
+        shard_id: :class:`int`
+            The shard ID that is ready.
+        """
+
+    async def on_resumed(self):
+        """|coro|
+        Called when the client has resumed a session.
+        """
+
+    async def on_error(self, event, *args, **kwargs):
+        r"""|coro|
+        The default error handler provided by the client.
+
+        By default this prints to :data:`sys.stderr` however it could be
+        overridden to have a different implementation.
+
+        Usually when an event raises an uncaught exception, a traceback is
+        printed to stderr and the exception is ignored. If you want to
+        change this behaviour and handle the exception for whatever reason
+        yourself, this event can be overridden. Which, when done, will
+        suppress the default action of printing the traceback.
+
+        The information of the exception raised and the exception itself can
+        be retrieved with a standard call to :func:`sys.exc_info`.
+
+        If you want exception to propagate out of the :class:`~discord.Client` class
+        you can define an ``on_error`` handler consisting of a single empty
+        :ref:`py:raise`.  Exceptions raised by ``on_error`` will not be
+        handled in any way by :class:`~discord.Client`.
+
+        Parameters
+        ------------
+        event: :class:`str`
+            The name of the event that raised the exception.
+        \*args:
+            The positional arguments for the event that raised the exception.
+        \*\*kwargs:
+            The keyword arguments for the event that raised the exception.
+        """
+        print('Ignoring exception in {}'.format(event), file=sys.stderr)
+        traceback.print_exc()
+
+    async def on_socket_raw_receive(self, msg):
+        """|coro|
+        Called whenever a message is received from the WebSocket, before
+        it's processed. This event is always dispatched when a message is
+        received and the passed data is not processed in any way.
+
+        This is only really useful for grabbing the WebSocket stream and
+        debugging purposes.
+
+        .. note::
+
+            This is only for the messages received from the client
+            WebSocket. The voice WebSocket will not trigger this event.
+            
+        Parameters
+        ------------
+        msg: Union[:class:`bytes`, :class:`str`]
+            The message passed in from the WebSocket library.
+            Could be :class:`bytes` for a binary message or :class:`str` 
+            for a regular message.
+        """
+
+    async def on_socket_raw_send(self, payload):
+        """|coro|
+        Called whenever a send operation is done on the WebSocket before the
+        message is sent. The passed parameter is the message that is being
+        sent to the WebSocket.
+
+        This is only really useful for grabbing the WebSocket stream and
+        debugging purposes.
+
+        .. note::
+
+            This is only for the messages received from the client
+            WebSocket. The voice WebSocket will not trigger this event.
+
+        Parameters
+        ------------
+        payload: Union[:class:`bytes`, :class:`str`]
+            The message that is about to be passed on to the
+            WebSocket library. It can be :class:`bytes` to denote a binary
+            message or :class:`str` to denote a regular text message.
+        """
+
+    async def on_typing(self, channel, user, when):
+        """|coro|
+        Called when someone begins typing a message.
+
+        The ``channel`` parameter can be a :class:`~discord.abc.Messageable` instance.
+        Which could either be :class:`~discord.TextChannel`, :class:`~discord.GroupChannel`, or
+        :class:`~discord.DMChannel`.
+
+        If the ``channel`` is a :class:`~discord.TextChannel` then the ``user`` parameter
+        is a :class:`~discord.Member`, otherwise it is a :class:`~discord.User`.
+
+        Parameters
+        ------------
+        channel: :class:`~discord.abc.Messageable`
+            The location where the typing originated from.
+        user: Union[:class:`~discord.User`, :class:`~discord.Member`]
+            The user that started typing.
+        when: :class:`datetime.datetime`
+            When the typing started as a naive datetime in UTC.
+        """
+
+    async def on_message(self, message):
+        """|coro|
+        Called when a :class:`~discord.Message` is created or sent.
+
+        .. warning::
+
+            Your bot's own messages and private messages are sent through this
+            event. This can lead cases of 'recursion' depending on how your bot was
+            programmed. If you want the bot to not reply to itself, consider
+            checking the user IDs. Note that :class:`~discord.ext.commands.Bot` does not
+            have this problem.
+
+        Parameters
+        ------------
+        message: :class:`~discord.Message`
+            The message that was created or sent.
+        """
+
+    async def on_message_delete(self, message):
+        """|coro|
+        Called when a message is deleted. If the message is not found in the
+        internal message cache, then this event will not be called.
+        Messages might not be in cache if the message is too old
+        or the client is participating in high traffic guilds.
+
+        If this occurs increase the :attr:`Client.max_messages` attribute
+        or use the :func:`on_raw_message_delete` event instead.
+
+        Parameters
+        ------------
+        message: :class:`~discord.Message`
+            The deleted message.
+        """
+
+    async def on_bulk_message_delete(self, messages):
+        """|coro|
+        Called when messages are bulk deleted. If none of the messages deleted
+        are found in the internal message cache, then this event will not be called.
+        If individual messages were not found in the internal message cache,
+        this event will still be called, but the messages not found will not be included in
+        the messages list. Messages might not be in cache if the message is too old
+        or the client is participating in high traffic guilds.
+
+        If this occurs increase the :attr:`Client.max_messages` attribute
+        or use the :func:`on_raw_bulk_message_delete` event instead.
+
+        Parameters
+        ------------
+        messages: List[:class:`~discord.Message`]
+            The messages that have been deleted.
+        """
+
+    async def on_raw_message_delete(self, payload):
+        """|coro|
+        Called when a message is deleted. Unlike :func:`on_message_delete`, this is
+        called regardless of the message being in the internal message cache or not.
+
+        If the message is found in the message cache,
+        it can be accessed via :attr:`~discord.RawMessageDeleteEvent.cached_message`
+
+        Parameters
+        ------------
+        payload: :class:`~discord.RawMessageDeleteEvent`
+            The raw event payload data.
+        """
+
+    async def on_raw_bulk_message_delete(self, payload):
+        """|coro|
+        Called when a bulk delete is triggered. Unlike :func:`on_bulk_message_delete`, this is
+        called regardless of the messages being in the internal message cache or not.
+
+        If the messages are found in the message cache,
+        they can be accessed via :attr:`RawBulkMessageDeleteEvent.cached_messages`
+
+        Parameters
+        ------------
+        payload: :class:`~discord.RawBulkMessageDeleteEvent`
+            The raw event payload data.
+        """
+
+    async def on_message_edit(self, before, after):
+        """|coro|
+        Called when a :class:`~discord.Message` receives an update event. If the message is not found
+        in the internal message cache, then these events will not be called.
+        Messages might not be in cache if the message is too old
+        or the client is participating in high traffic guilds.
+
+        If this occurs increase the :attr:`Client.max_messages` attribute
+        or use the :func:`on_raw_message_edit` event instead.
+
+        The following non-exhaustive cases trigger this event:
+
+        - A message has been pinned or unpinned.
+        - The message content has been changed.
+        - The message has received an embed.
+
+            - For performance reasons, the embed server does not do this in a "consistent" manner.
+
+        - The message's embeds were suppressed or unsuppressed.
+        - A call message has received an update to its participants or ending time.
+
+        Parameters
+        ------------
+        before: :class:`~discord.Message`
+            The previous version of the message.
+        after: :class:`~discord.Message`
+            The current version of the message.
+        """
+
+    async def on_raw_message_edit(self, payload):
+        """|coro|
+        Called when a message is edited. Unlike :func:`on_message_edit`, this is called
+        regardless of the state of the internal message cache.
+
+        If the message is found in the message cache,
+        it can be accessed via :attr:`~discord.RawMessageUpdateEvent.cached_message`
+
+        Due to the inherently raw nature of this event, the data parameter coincides with
+        the raw data given by the `gateway <https://discord.com/developers/docs/topics/gateway#message-update>`_.
+
+        Since the data payload can be partial, care must be taken when accessing stuff in the dictionary.
+        One example of a common case of partial data is when the ``'content'`` key is inaccessible. This
+        denotes an "embed" only edit, which is an edit in which only the embeds are updated by the Discord
+        embed server.
+
+        Parameters
+        ------------
+        payload: :class:`~discord.RawMessageUpdateEvent`
+            The raw event payload data.
+        """
+
+    async def on_reaction_add(self, reaction, user):
+        """|coro|
+        Called when a message has a reaction added to it. Similar to :func:`on_message_edit`,
+        if the message is not found in the internal message cache, then this
+        event will not be called. Consider using :func:`on_raw_reaction_add` instead.
+
+        .. note::
+
+            To get the :class:`~discord.Message` being reacted, access it via :attr:`~discord.Reaction.message`.
+
+        Parameters
+        ------------
+        reaction: :class:`~discord.Reaction`
+            The current state of the reaction.
+        user: Union[:class:`~discord.Member`, :class:`~discord.User`]
+            The user who added the reaction.
+        """
+
+    async def on_raw_reaction_add(self, payload):
+        """|coro|
+        Called when a message has a reaction added. Unlike :func:`on_reaction_add`, this is
+        called regardless of the state of the internal message cache.
+
+        Parameters
+        ------------
+        payload: :class:`~discord.RawReactionActionEvent`
+            The raw event payload data.
+        """
+
+    async def on_reaction_remove(self, reaction, user):
+        """|coro|
+        Called when a message has a reaction removed from it. Similar to on_message_edit,
+        if the message is not found in the internal message cache, then this event
+        will not be called.
+
+        .. note::
+
+            To get the message being reacted, access it via :attr:`Reaction.message`.
+
+        Parameters
+        ------------
+        reaction: :class:`~discord.Reaction`
+            The current state of the reaction.
+        user: Union[:class:`~discord.Member`, :class:`~discord.User`]
+            The user who added the reaction.
+        """
+
+    async def on_raw_reaction_remove(self, payload):
+        """|coro|
+        Called when a message has a reaction removed. Unlike :func:`on_reaction_remove`, this is
+        called regardless of the state of the internal message cache.
+
+        Parameters
+        ------------
+        payload: :class:`~discord.RawReactionActionEvent`
+            The raw event payload data.
+        """
+
+    async def on_reaction_clear(self, message, reactions):
+        """|coro|
+        Called when a message has all its reactions removed from it. Similar to :func:`on_message_edit`,
+        if the message is not found in the internal message cache, then this event
+        will not be called. Consider using :func:`on_raw_reaction_clear` instead.
+
+        Parameters
+        ------------
+        message: :class:`~discord.Message`
+            The message that had its reactions cleared.
+        reactions: List[:class:`~discord.Reaction`]
+            The reactions that were removed.
+        """
+
+    async def on_raw_reaction_clear(self, payload):
+        """|coro|
+        Called when a message has all its reactions removed. Unlike :func:`on_reaction_clear`,
+        this is called regardless of the state of the internal message cache.
+
+        Parameters
+        ------------
+        payload: :class:`~discord.RawReactionClearEvent`
+            The raw event payload data.
+        """
+
+    async def on_reaction_clear_emoji(self, reaction):
+        """|coro|
+        Called when a message has a specific reaction removed from it. Similar to :func:`on_message_edit`,
+        if the message is not found in the internal message cache, then this event
+        will not be called. Consider using :func:`on_raw_reaction_clear_emoji` instead.
+
+        .. versionadded:: 1.3
+
+        Parameters
+        ------------
+        reaction: :class:`~discord.Reaction`
+            The reaction that got cleared.
+        """
+
+    async def on_raw_reaction_clear_emoji(self, payload):
+        """|coro|
+        Called when a message has a specific reaction removed from it.
+        Unlike :func:`on_reaction_clear_emoji` this is called
+        regardless of the state of the internal message cache.
+
+        .. versionadded:: 1.3
+
+        Parameters
+        ------------
+        payload: :class:`~discord.RawReactionClearEmojiEvent`
+            The raw event payload data.
+        """
+
+    async def on_private_channel_delete(self, channel):
+        """|coro|
+        Called whenever a private channel is deleted.
+
+        Parameters
+        ------------
+        channel: :class:`~discord.abc.PrivateChannel`
+            The private channel that got deleted.
+        """
+
+    async def on_private_channel_create(self, channel):
+        """|coro|
+        Called whenever a private channel is created.
+
+        Parameters
+        ------------
+        channel: :class:`~discord.abc.PrivateChannel`
+            The private channel that got created.
+        """
+
+    async def on_private_channel_update(self, before, after):
+        """|coro|
+        Called whenever a private group DM is updated. e.g. changed name or topic.
+
+        Parameters
+        ------------
+        before: :class:`~discord.GroupChannel`
+            The updated group channel's old info.
+        after: :class:`~discord.GroupChannel`
+            The updated group channel's new info.
+        """
+
+    async def on_private_channel_pins_update(self, channel, last_pin):
+        """|coro|
+        Called whenever a message is pinned or unpinned from a private channel.
+
+        Parameters
+        ------------
+        channel: :class:`~discord.abc.PrivateChannel`
+            The private channel that had its pins updated.
+        last_pin: Optional[:class:`~discord.datetime.datetime`]
+            The latest message that was pinned as a naive datetime in UTC. Could be ``None``.
+        """
+
+    async def on_guild_channel_delete(self, channel):
+        """|coro|
+        Called whenever a guild channel is deleted.
+
+        Note that you can get the guild from :attr:`~abc.GuildChannel.guild`.
+
+        Parameters
+        ------------
+        channel: :class:`~discord.abc.GuildChannel`
+            The guild channel that got deleted.
+        """
+
+    async def on_guild_channel_create(self, channel):
+        """|coro|
+        Called whenever a guild channel is created.
+
+        Note that you can get the guild from :attr:`~abc.GuildChannel.guild`.
+
+        Parameters
+        ------------
+        channel: :class:`~discord.abc.GuildChannel`
+            The guild channel that got created.
+        """
+
+    async def on_guild_channel_update(self, before, after):
+        """|coro|
+        Called whenever a guild channel is updated. e.g. changed name, topic, permissions.
+
+        Parameters
+        ------------
+        before: :class:`~discord.abc.GuildChannel`
+            The updated guild channel's old info.
+        after: :class:`~discord.abc.GuildChannel`
+            The updated guild channel's new info.
+        """
+
+    async def on_guild_channel_pins_update(self, channel, last_pin):
+        """|coro|
+        Called whenever a message is pinned or unpinned from a guild channel.
+
+        Parameters
+        ------------
+        channel: :class:`~discord.abc.GuildChannel`
+            The guild channel that had its pins updated.
+        last_pin: Optional[:class:`~discord.datetime.datetime`]
+            The latest message that was pinned as a naive datetime in UTC. Could be ``None``.
+        """
+
+    async def on_guild_integrations_update(self, guild):
+        """|coro|
+        Called whenever an integration is created, modified, or removed from a guild.
+
+        Parameters
+        ------------
+        guild: :class:`~discord.Guild`
+            The guild that had its integrations updated.
+        """
+
+    async def on_webhooks_update(self, channel):
+        """|coro|
+        Called whenever a webhook is created, modified, or removed from a guild channel.
+
+        Parameters
+        ------------
+        channel: :class:`~discord.abc.GuildChannel`
+            The channel that had its webhooks updated.
+        """
+
+    async def on_member_join(self, member):
+        """|coro|
+        Called when a :class:`~discord.Member` joins a :class:`~discord.Guild`.
+
+        Parameters
+        ------------
+        member: :class:`~discord.Member`
+            The member who joined.
+        """
+
+    async def on_member_remove(self, member):
+        """|coro|
+        Called when a :class:`~discord.Member` leaves a :class:`~discord.Guild`.
+
+        Parameters
+        ------------
+        member: :class:`~discord.Member`
+            The member who left.
+        """
+
+    async def on_member_update(self, before, after):
+        """|coro|
+        Called when a :class:`~discord.Member` updates their profile.
+
+        This is called when one or more of the following things change:
+
+        - status
+        - activity
+        - nickname
+        - roles
+
+        Parameters
+        ------------
+        before: :class:`~discord.Member`
+            The updated member's old info.
+        after: :class:`~discord.Member`
+            The updated member's updated info.
+        """
+
+    async def on_user_update(self, before, after):
+        """|coro|
+        Called when a :class:`~discord.User` updates their profile.
+
+        This is called when one or more of the following things change:
+
+        - avatar
+        - username
+        - discriminator
+
+        Parameters
+        ------------
+        before: :class:`~discord.User`
+            The updated user's old info.
+        after: :class:`~discord.User`
+            The updated user's updated info.
+        """
+
+    async def on_guild_join(self, guild):
+        """|coro|
+        Called when a :class:`~discord.Guild` is either created by the :class:`~discord.Client` or when the
+        :class:`~discord.Client` joins a guild.
+
+        Parameters
+        ------------
+        guild: :class:`~discord.Guild`
+            The guild that was joined.
+        """
+
+    async def on_guild_remove(self, guild):
+        """|coro|
+        Called when a :class:`~discord.Guild` is removed from the :class:`~discord.Client`.
+
+        This happens through, but not limited to, these circumstances:
+
+        - The client got banned.
+        - The client got kicked.
+        - The client left the guild.
+        - The client or the guild owner deleted the guild.
+
+        In order for this event to be invoked then the :class:`~discord.Client` must have
+        been part of the guild to begin with. (i.e. it is part of :attr:`Client.guilds`)
+
+        Parameters
+        ------------
+        guild: :class:`~discord.Guild`
+            The guild that got removed.
+        """
+
+    async def on_guild_update(self, before, after):
+        """|coro|
+        Called when a :class:`~discord.Guild` updates, for example:
+
+        - Changed name
+        - Changed AFK channel
+        - Changed AFK timeout
+        - etc
+
+        Parameters
+        ------------
+        before: :class:`~discord.Guild`
+            The guild prior to being updated.
+        after: :class:`~discord.Guild`
+            The guild after being updated.
+        """
+
+    async def on_guild_role_create(self, role):
+        """|coro|
+        Called when a :class:`~discord.Guild` creates or deletes a new :class:`~discord.Role`.
+
+        To get the guild it belongs to, use :attr:`Role.guild`.
+
+        Parameters
+        ------------
+        role: :class:`~discord.Role`
+            The role that was created or deleted.
+        """
+
+    async def on_guild_role_delete(self, role):
+        """|coro|
+        Called when a :class:`~discord.Guild` creates or deletes a new :class:`~discord.Role`.
+
+        To get the guild it belongs to, use :attr:`Role.guild`.
+
+        Parameters
+        ------------
+        role: :class:`~discord.Role`
+            The role that was created or deleted.
+        """
+
+    async def on_guild_role_update(self, before, after):
+        """|coro|
+        Called when a :class:`~discord.Role` is changed guild-wide.
+
+        Parameters
+        ------------
+        before: :class:`~discord.Role`
+            The updated role's old info.
+        after: :class:`~discord.Role`
+            The updated role's updated info.
+        """
+
+    async def on_guild_emojis_update(self, guild, before, after):
+        """|coro|
+        Called when a :class:`~discord.Guild` adds or removes :class:`~discord.Emoji`.
+
+        Parameters
+        ------------
+        guild: :class:`~discord.Guild`
+            The guild who got their emojis updated.
+        before: Sequence[:class:`~discord.Emoji`]
+            A list of emojis before the update.
+        after: Sequence[:class:`~discord.Emoji`]
+            A list of emojis after the update.
+        """
+
+    async def on_guild_available(self, guild):
+        """|coro|
+        Called when a guild becomes available. The guild must have
+        existed in the :attr:`Client.guilds` cache.
+
+        Parameters
+        ------------
+        guild: :class:`~discord.Guild`
+            The guild that has changed availability.
+        """
+
+    async def on_guild_unavailable(self, guild):
+        """|coro|
+        Called when a guild becomes unavailable. The guild must have
+        existed in the :attr:`Client.guilds` cache.
+
+        Parameters
+        ------------
+        guild: :class:`~discord.Guild`
+            The guild that has changed availability.
+        """
+
+    async def on_voice_state_update(self, member, before, after):
+        """|coro|
+        Called when a :class:`~discord.Member` changes their :class:`~discord.VoiceState`.
+
+        The following, but not limited to, examples illustrate when this event is called:
+
+        - A member joins a voice channel.
+        - A member leaves a voice channel.
+        - A member is muted or deafened by their own accord.
+        - A member is muted or deafened by a guild administrator.
+
+        Parameters
+        ------------
+        member: :class:`~discord.Member`
+            The member whose voice states changed.
+        before: :class:`~discord.VoiceState`
+            The voice state prior to the changes.
+        after: :class:`~discord.VoiceState`
+            The voice state after to the changes.
+        """
+
+    async def on_member_ban(self, guild, user):
+        """|coro|
+        Called when user gets banned from a :class:`~discord.Guild`.
+
+        Parameters
+        ------------
+        guild: :class:`~discord.Guild`
+            The guild the user got banned from.
+        user: Union[:class:`~discord.User`, :class:`~discord.Member`]
+            The user that got banned.
+            Can be either :class:`~discord.User` or :class:`~discord.Member` depending if
+            the user was in the guild or not at the time of removal.
+        """
+
+    async def on_member_unban(self, guild, user):
+        """|coro|
+        Called when a :class:`~discord.User` gets unbanned from a :class:`~discord.Guild`.
+
+        Parameters
+        ------------
+        guild: :class:`~discord.Guild`
+            The guild the user got unbanned from.
+        user: :class:`~discord.User`
+            The user that got unbanned.
+        """
+
+    async def on_invite_create(self, invite):
+        """|coro|
+        Called when an :class:`~discord.Invite` is created.
+        You must have the :attr:`~Permissions.manage_channels` permission to receive this.
+
+        .. versionadded:: 1.3
+
+        .. note::
+
+            There is a rare possibility that the :attr:`Invite.guild` and :attr:`Invite.channel`
+            attributes will be of :class:`~discord.Object` rather than the respective models.
+
+        Parameters
+        ------------
+        invite: :class:`~discord.Invite`
+            The invite that was created.
+        """
+
+    async def on_invite_delete(self, invite):
+        """|coro|
+        Called when an :class:`~discord.Invite` is deleted.
+        You must have the :attr:`~Permissions.manage_channels` permission to receive this.
+
+        .. versionadded:: 1.3
+
+        .. note::
+
+            There is a rare possibility that the :attr:`Invite.guild` and :attr:`Invite.channel`
+            attributes will be of :class:`~discord.Object` rather than the respective models.
+
+            Outside of those two attributes, the only other attribute guaranteed to be
+            filled by the Discord gateway for this event is :attr:`Invite.code`.
+
+        Parameters
+        ------------
+        invite: :class:`~discord.Invite`
+            The invite that was deleted.
+        """
+
+    async def on_group_join(self, channel, user):
+        """|coro|
+        Called when someone joins or leaves a :class:`~discord.GroupChannel`.
+
+        Parameters
+        ------------
+        channel: :class:`~discord.GroupChannel`
+            The group that the user joined or left.
+        user: :class:`~discord.User`
+            The user that joined or left.
+        """
+
+    async def on_group_remove(self, channel, user):
+        """|coro|
+        Called when someone joins or leaves a :class:`~discord.GroupChannel`.
+
+        Parameters
+        ------------
+        channel: :class:`~discord.GroupChannel`
+            The group that the user joined or left.
+        user: :class:`~discord.User`
+            The user that joined or left.
+        """
+
+    async def on_relationship_add(self, relationship):
+        """|coro|
+        Called when a :class:`~discord.Relationship` is added or removed from the
+        :class:`~discord.ClientUser`.
+
+        Parameters
+        ------------
+        relationship: :class:`~discord.Relationship`
+            The relationship that was added or removed.
+        """
+
+    async def on_relationship_remove(self, relationship):
+        """|coro|
+        Called when a :class:`~discord.Relationship` is added or removed from the
+        :class:`~discord.ClientUser`.
+
+        Parameters
+        ------------
+        relationship: :class:`~discord.Relationship`
+            The relationship that was added or removed.
+        """
+
+    async def on_relationship_update(self, before, after):
+        """Called when a :class:`~discord.Relationship` is updated, e.g. when you
+        block a friend or a friendship is accepted.
+
+        Parameters
+        ------------
+        before: :class:`~discord.Relationship`
+            The previous relationship status.
+        after: :class:`~discord.Relationship`
+            The updated relationship status.
+        """

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -129,119 +129,119 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     In order to turn a function into a coroutine they must be ``async def``
     functions.
 
-.. autofunction:: Client.on_connect
+.. autofunction:: discord.Client.on_connect
 
-.. autofunction:: Client.on_disconnect
+.. autofunction:: discord.Client.on_disconnect
 
-.. autofunction:: Client.on_ready
+.. autofunction:: discord.Client.on_ready
 
-.. autofunction:: Client.on_shard_ready
+.. autofunction:: discord.Client.on_shard_ready
 
-.. autofunction:: Client.on_resumed
+.. autofunction:: discord.Client.on_resumed
 
-.. autofunction:: Client.on_error
+.. autofunction:: discord.Client.on_error
 
-.. autofunction:: Client.on_socket_raw_receive
+.. autofunction:: discord.Client.on_socket_raw_receive
 
-.. autofunction:: Client.on_socket_raw_send
+.. autofunction:: discord.Client.on_socket_raw_send
 
-.. autofunction:: Client.on_typing
+.. autofunction:: discord.Client.on_typing
 
-.. autofunction:: Client.on_message
+.. autofunction:: discord.Client.on_message
 
-.. autofunction:: Client.on_message_delete
+.. autofunction:: discord.Client.on_message_delete
 
-.. autofunction:: Client.on_bulk_message_delete
+.. autofunction:: discord.Client.on_bulk_message_delete
 
-.. autofunction:: Client.on_raw_message_delete
+.. autofunction:: discord.Client.on_raw_message_delete
 
-.. autofunction:: Client.on_raw_bulk_message_delete
+.. autofunction:: discord.Client.on_raw_bulk_message_delete
 
-.. autofunction:: Client.on_message_edit
+.. autofunction:: discord.Client.on_message_edit
 
-.. autofunction:: Client.on_raw_message_edit
+.. autofunction:: discord.Client.on_raw_message_edit
 
-.. autofunction:: Client.on_reaction_add
+.. autofunction:: discord.Client.on_reaction_add
 
-.. autofunction:: Client.on_raw_reaction_add
+.. autofunction:: discord.Client.on_raw_reaction_add
 
-.. autofunction:: Client.on_reaction_remove
+.. autofunction:: discord.Client.on_reaction_remove
 
-.. autofunction:: Client.on_raw_reaction_remove
+.. autofunction:: discord.Client.on_raw_reaction_remove
 
-.. autofunction:: Client.on_reaction_clear
+.. autofunction:: discord.Client.on_reaction_clear
 
-.. autofunction:: Client.on_raw_reaction_clear
+.. autofunction:: discord.Client.on_raw_reaction_clear
 
-.. autofunction:: Client.on_reaction_clear_emoji
+.. autofunction:: discord.Client.on_reaction_clear_emoji
 
-.. autofunction:: Client.on_raw_reaction_clear_emoji
+.. autofunction:: discord.Client.on_raw_reaction_clear_emoji
 
-.. autofunction:: Client.on_private_channel_delete
+.. autofunction:: discord.Client.on_private_channel_delete
 
-.. autofunction:: Client.on_private_channel_create
+.. autofunction:: discord.Client.on_private_channel_create
 
-.. autofunction:: Client.on_private_channel_update
+.. autofunction:: discord.Client.on_private_channel_update
 
-.. autofunction:: Client.on_private_channel_pins_update
+.. autofunction:: discord.Client.on_private_channel_pins_update
 
-.. autofunction:: Client.on_guild_channel_delete
+.. autofunction:: discord.Client.on_guild_channel_delete
 
-.. autofunction:: Client.on_guild_channel_create
+.. autofunction:: discord.Client.on_guild_channel_create
 
-.. autofunction:: Client.on_guild_channel_update
+.. autofunction:: discord.Client.on_guild_channel_update
 
-.. autofunction:: Client.on_guild_channel_pins_update
+.. autofunction:: discord.Client.on_guild_channel_pins_update
 
-.. autofunction:: Client.on_guild_integrations_update
+.. autofunction:: discord.Client.on_guild_integrations_update
 
-.. autofunction:: Client.on_webhooks_update
+.. autofunction:: discord.Client.on_webhooks_update
 
-.. autofunction:: Client.on_member_join
+.. autofunction:: discord.Client.on_member_join
 
-.. autofunction:: Client.on_member_remove
+.. autofunction:: discord.Client.on_member_remove
 
-.. autofunction:: Client.on_member_update
+.. autofunction:: discord.Client.on_member_update
 
-.. autofunction:: Client.on_user_update
+.. autofunction:: discord.Client.on_user_update
 
-.. autofunction:: Client.on_guild_join
+.. autofunction:: discord.Client.on_guild_join
 
-.. autofunction:: Client.on_guild_remove
+.. autofunction:: discord.Client.on_guild_remove
 
-.. autofunction:: Client.on_guild_update
+.. autofunction:: discord.Client.on_guild_update
 
-.. autofunction:: Client.on_guild_role_create
+.. autofunction:: discord.Client.on_guild_role_create
 
-.. autofunction:: Client.on_guild_role_delete
+.. autofunction:: discord.Client.on_guild_role_delete
 
-.. autofunction:: Client.on_guild_role_update
+.. autofunction:: discord.Client.on_guild_role_update
 
-.. autofunction:: Client.on_guild_emojis_update
+.. autofunction:: discord.Client.on_guild_emojis_update
 
-.. autofunction:: Client.on_guild_available
+.. autofunction:: discord.Client.on_guild_available
 
-.. autofunction:: Client.on_guild_unavailable
+.. autofunction:: discord.Client.on_guild_unavailable
 
-.. autofunction:: Client.on_voice_state_update
+.. autofunction:: discord.Client.on_voice_state_update
 
-.. autofunction:: Client.on_member_ban
+.. autofunction:: discord.Client.on_member_ban
 
-.. autofunction:: Client.on_member_unban
+.. autofunction:: discord.Client.on_member_unban
 
-.. autofunction:: Client.on_invite_create
+.. autofunction:: discord.Client.on_invite_create
 
-.. autofunction:: Client.on_invite_delete
+.. autofunction:: discord.Client.on_invite_delete
 
-.. autofunction:: Client.on_group_join
+.. autofunction:: discord.Client.on_group_join
 
-.. autofunction:: Client.on_group_remove
+.. autofunction:: discord.Client.on_group_remove
 
-.. autofunction:: Client.on_relationship_add
+.. autofunction:: discord.Client.on_relationship_add
 
-.. autofunction:: Client.on_relationship_remove
+.. autofunction:: discord.Client.on_relationship_remove
 
-.. autofunction:: Client.on_relationship_update
+.. autofunction:: discord.Client.on_relationship_update
 
 
 .. _discord-api-utils:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -129,119 +129,119 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     In order to turn a function into a coroutine they must be ``async def``
     functions.
 
-.. autofunction Client.on_connect
+.. autofunction:: Client.on_connect
 
-.. autofunction Client.on_disconnect
+.. autofunction:: Client.on_disconnect
 
-.. autofunction Client.on_ready
+.. autofunction:: Client.on_ready
 
-.. autofunction Client.on_shard_ready
+.. autofunction:: Client.on_shard_ready
 
-.. autofunction Client.on_resumed
+.. autofunction:: Client.on_resumed
 
-.. autofunction Client.on_error
+.. autofunction:: Client.on_error
 
-.. autofunction Client.on_socket_raw_receive
+.. autofunction:: Client.on_socket_raw_receive
 
-.. autofunction Client.on_socket_raw_send
+.. autofunction:: Client.on_socket_raw_send
 
-.. autofunction Client.on_typing
+.. autofunction:: Client.on_typing
 
-.. autofunction Client.on_message
+.. autofunction:: Client.on_message
 
-.. autofunction Client.on_message_delete
+.. autofunction:: Client.on_message_delete
 
-.. autofunction Client.on_bulk_message_delete
+.. autofunction:: Client.on_bulk_message_delete
 
-.. autofunction Client.on_raw_message_delete
+.. autofunction:: Client.on_raw_message_delete
 
-.. autofunction Client.on_raw_bulk_message_delete
+.. autofunction:: Client.on_raw_bulk_message_delete
 
-.. autofunction Client.on_message_edit
+.. autofunction:: Client.on_message_edit
 
-.. autofunction Client.on_raw_message_edit
+.. autofunction:: Client.on_raw_message_edit
 
-.. autofunction Client.on_reaction_add
+.. autofunction:: Client.on_reaction_add
 
-.. autofunction Client.on_raw_reaction_add
+.. autofunction:: Client.on_raw_reaction_add
 
-.. autofunction Client.on_reaction_remove
+.. autofunction:: Client.on_reaction_remove
 
-.. autofunction Client.on_raw_reaction_remove
+.. autofunction:: Client.on_raw_reaction_remove
 
-.. autofunction Client.on_reaction_clear
+.. autofunction:: Client.on_reaction_clear
 
-.. autofunction Client.on_raw_reaction_clear
+.. autofunction:: Client.on_raw_reaction_clear
 
-.. autofunction Client.on_reaction_clear_emoji
+.. autofunction:: Client.on_reaction_clear_emoji
 
-.. autofunction Client.on_raw_reaction_clear_emoji
+.. autofunction:: Client.on_raw_reaction_clear_emoji
 
-.. autofunction Client.on_private_channel_delete
+.. autofunction:: Client.on_private_channel_delete
 
-.. autofunction Client.on_private_channel_create
+.. autofunction:: Client.on_private_channel_create
 
-.. autofunction Client.on_private_channel_update
+.. autofunction:: Client.on_private_channel_update
 
-.. autofunction Client.on_private_channel_pins_update
+.. autofunction:: Client.on_private_channel_pins_update
 
-.. autofunction Client.on_guild_channel_delete
+.. autofunction:: Client.on_guild_channel_delete
 
-.. autofunction Client.on_guild_channel_create
+.. autofunction:: Client.on_guild_channel_create
 
-.. autofunction Client.on_guild_channel_update
+.. autofunction:: Client.on_guild_channel_update
 
-.. autofunction Client.on_guild_channel_pins_update
+.. autofunction:: Client.on_guild_channel_pins_update
 
-.. autofunction Client.on_guild_integrations_update
+.. autofunction:: Client.on_guild_integrations_update
 
-.. autofunction Client.on_webhooks_update
+.. autofunction:: Client.on_webhooks_update
 
-.. autofunction Client.on_member_join
+.. autofunction:: Client.on_member_join
 
-.. autofunction Client.on_member_remove
+.. autofunction:: Client.on_member_remove
 
-.. autofunction Client.on_member_update
+.. autofunction:: Client.on_member_update
 
-.. autofunction Client.on_user_update
+.. autofunction:: Client.on_user_update
 
-.. autofunction Client.on_guild_join
+.. autofunction:: Client.on_guild_join
 
-.. autofunction Client.on_guild_remove
+.. autofunction:: Client.on_guild_remove
 
-.. autofunction Client.on_guild_update
+.. autofunction:: Client.on_guild_update
 
-.. autofunction Client.on_guild_role_create
+.. autofunction:: Client.on_guild_role_create
 
-.. autofunction Client.on_guild_role_delete
+.. autofunction:: Client.on_guild_role_delete
 
-.. autofunction Client.on_guild_role_update
+.. autofunction:: Client.on_guild_role_update
 
-.. autofunction Client.on_guild_emojis_update
+.. autofunction:: Client.on_guild_emojis_update
 
-.. autofunction Client.on_guild_available
+.. autofunction:: Client.on_guild_available
 
-.. autofunction Client.on_guild_unavailable
+.. autofunction:: Client.on_guild_unavailable
 
-.. autofunction Client.on_voice_state_update
+.. autofunction:: Client.on_voice_state_update
 
-.. autofunction Client.on_member_ban
+.. autofunction:: Client.on_member_ban
 
-.. autofunction Client.on_member_unban
+.. autofunction:: Client.on_member_unban
 
-.. autofunction Client.on_invite_create
+.. autofunction:: Client.on_invite_create
 
-.. autofunction Client.on_invite_delete
+.. autofunction:: Client.on_invite_delete
 
-.. autofunction Client.on_group_join
+.. autofunction:: Client.on_group_join
 
-.. autofunction Client.on_group_remove
+.. autofunction:: Client.on_group_remove
 
-.. autofunction Client.on_relationship_add
+.. autofunction:: Client.on_relationship_add
 
-.. autofunction Client.on_relationship_remove
+.. autofunction:: Client.on_relationship_remove
 
-.. autofunction Client.on_relationship_update
+.. autofunction:: Client.on_relationship_update
 
 
 .. _discord-api-utils:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -129,119 +129,119 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     In order to turn a function into a coroutine they must be ``async def``
     functions.
 
-.. autofunction:: discord.Client.on_connect
+.. automethod:: discord.Client.on_connect
 
-.. autofunction:: discord.Client.on_disconnect
+.. automethod:: discord.Client.on_disconnect
 
-.. autofunction:: discord.Client.on_ready
+.. automethod:: discord.Client.on_ready
 
-.. autofunction:: discord.Client.on_shard_ready
+.. automethod:: discord.Client.on_shard_ready
 
-.. autofunction:: discord.Client.on_resumed
+.. automethod:: discord.Client.on_resumed
 
-.. autofunction:: discord.Client.on_error
+.. automethod:: discord.Client.on_error
 
-.. autofunction:: discord.Client.on_socket_raw_receive
+.. automethod:: discord.Client.on_socket_raw_receive
 
-.. autofunction:: discord.Client.on_socket_raw_send
+.. automethod:: discord.Client.on_socket_raw_send
 
-.. autofunction:: discord.Client.on_typing
+.. automethod:: discord.Client.on_typing
 
-.. autofunction:: discord.Client.on_message
+.. automethod:: discord.Client.on_message
 
-.. autofunction:: discord.Client.on_message_delete
+.. automethod:: discord.Client.on_message_delete
 
-.. autofunction:: discord.Client.on_bulk_message_delete
+.. automethod:: discord.Client.on_bulk_message_delete
 
-.. autofunction:: discord.Client.on_raw_message_delete
+.. automethod:: discord.Client.on_raw_message_delete
 
-.. autofunction:: discord.Client.on_raw_bulk_message_delete
+.. automethod:: discord.Client.on_raw_bulk_message_delete
 
-.. autofunction:: discord.Client.on_message_edit
+.. automethod:: discord.Client.on_message_edit
 
-.. autofunction:: discord.Client.on_raw_message_edit
+.. automethod:: discord.Client.on_raw_message_edit
 
-.. autofunction:: discord.Client.on_reaction_add
+.. automethod:: discord.Client.on_reaction_add
 
-.. autofunction:: discord.Client.on_raw_reaction_add
+.. automethod:: discord.Client.on_raw_reaction_add
 
-.. autofunction:: discord.Client.on_reaction_remove
+.. automethod:: discord.Client.on_reaction_remove
 
-.. autofunction:: discord.Client.on_raw_reaction_remove
+.. automethod:: discord.Client.on_raw_reaction_remove
 
-.. autofunction:: discord.Client.on_reaction_clear
+.. automethod:: discord.Client.on_reaction_clear
 
-.. autofunction:: discord.Client.on_raw_reaction_clear
+.. automethod:: discord.Client.on_raw_reaction_clear
 
-.. autofunction:: discord.Client.on_reaction_clear_emoji
+.. automethod:: discord.Client.on_reaction_clear_emoji
 
-.. autofunction:: discord.Client.on_raw_reaction_clear_emoji
+.. automethod:: discord.Client.on_raw_reaction_clear_emoji
 
-.. autofunction:: discord.Client.on_private_channel_delete
+.. automethod:: discord.Client.on_private_channel_delete
 
-.. autofunction:: discord.Client.on_private_channel_create
+.. automethod:: discord.Client.on_private_channel_create
 
-.. autofunction:: discord.Client.on_private_channel_update
+.. automethod:: discord.Client.on_private_channel_update
 
-.. autofunction:: discord.Client.on_private_channel_pins_update
+.. automethod:: discord.Client.on_private_channel_pins_update
 
-.. autofunction:: discord.Client.on_guild_channel_delete
+.. automethod:: discord.Client.on_guild_channel_delete
 
-.. autofunction:: discord.Client.on_guild_channel_create
+.. automethod:: discord.Client.on_guild_channel_create
 
-.. autofunction:: discord.Client.on_guild_channel_update
+.. automethod:: discord.Client.on_guild_channel_update
 
-.. autofunction:: discord.Client.on_guild_channel_pins_update
+.. automethod:: discord.Client.on_guild_channel_pins_update
 
-.. autofunction:: discord.Client.on_guild_integrations_update
+.. automethod:: discord.Client.on_guild_integrations_update
 
-.. autofunction:: discord.Client.on_webhooks_update
+.. automethod:: discord.Client.on_webhooks_update
 
-.. autofunction:: discord.Client.on_member_join
+.. automethod:: discord.Client.on_member_join
 
-.. autofunction:: discord.Client.on_member_remove
+.. automethod:: discord.Client.on_member_remove
 
-.. autofunction:: discord.Client.on_member_update
+.. automethod:: discord.Client.on_member_update
 
-.. autofunction:: discord.Client.on_user_update
+.. automethod:: discord.Client.on_user_update
 
-.. autofunction:: discord.Client.on_guild_join
+.. automethod:: discord.Client.on_guild_join
 
-.. autofunction:: discord.Client.on_guild_remove
+.. automethod:: discord.Client.on_guild_remove
 
-.. autofunction:: discord.Client.on_guild_update
+.. automethod:: discord.Client.on_guild_update
 
-.. autofunction:: discord.Client.on_guild_role_create
+.. automethod:: discord.Client.on_guild_role_create
 
-.. autofunction:: discord.Client.on_guild_role_delete
+.. automethod:: discord.Client.on_guild_role_delete
 
-.. autofunction:: discord.Client.on_guild_role_update
+.. automethod:: discord.Client.on_guild_role_update
 
-.. autofunction:: discord.Client.on_guild_emojis_update
+.. automethod:: discord.Client.on_guild_emojis_update
 
-.. autofunction:: discord.Client.on_guild_available
+.. automethod:: discord.Client.on_guild_available
 
-.. autofunction:: discord.Client.on_guild_unavailable
+.. automethod:: discord.Client.on_guild_unavailable
 
-.. autofunction:: discord.Client.on_voice_state_update
+.. automethod:: discord.Client.on_voice_state_update
 
-.. autofunction:: discord.Client.on_member_ban
+.. automethod:: discord.Client.on_member_ban
 
-.. autofunction:: discord.Client.on_member_unban
+.. automethod:: discord.Client.on_member_unban
 
-.. autofunction:: discord.Client.on_invite_create
+.. automethod:: discord.Client.on_invite_create
 
-.. autofunction:: discord.Client.on_invite_delete
+.. automethod:: discord.Client.on_invite_delete
 
-.. autofunction:: discord.Client.on_group_join
+.. automethod:: discord.Client.on_group_join
 
-.. autofunction:: discord.Client.on_group_remove
+.. automethod:: discord.Client.on_group_remove
 
-.. autofunction:: discord.Client.on_relationship_add
+.. automethod:: discord.Client.on_relationship_add
 
-.. autofunction:: discord.Client.on_relationship_remove
+.. automethod:: discord.Client.on_relationship_remove
 
-.. autofunction:: discord.Client.on_relationship_update
+.. automethod:: discord.Client.on_relationship_update
 
 
 .. _discord-api-utils:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -35,6 +35,25 @@ Client
 
 .. autoclass:: Client
     :members:
+    :exclude-members: on_connect, on_disconnect, on_ready, on_shard_ready,
+                      on_resumed, on_error, on_socket_raw_receive, on_socket_raw_send,
+                      on_typing, on_message, on_message_delete, on_bulk_message_delete,
+                      on_raw_message_delete, on_raw_bulk_message_delete, on_message_edit,
+                      on_raw_message_edit, on_reaction_add, on_raw_reaction_add,
+                      on_reaction_remove, on_raw_reaction_remove, on_reaction_clear,
+                      on_raw_reaction_clear, on_reaction_clear_emoji,
+                      on_raw_reaction_clear_emoji, on_private_channel_delete,
+                      on_private_channel_create, on_private_channel_update,
+                      on_private_channel_pins_update, on_guild_channel_delete,
+                      on_guild_channel_create, on_guild_channel_update,
+                      on_guild_channel_pins_update, on_guild_integrations_update,
+                      on_webhooks_update, on_member_join, on_member_remove, on_member_update,
+                      on_user_update, on_guild_join, on_guild_remove, on_guild_update,
+                      on_guild_role_create, on_guild_role_delete, on_guild_role_update,
+                      on_guild_emojis_update, on_guild_available, on_guild_unavailable,
+                      on_voice_state_update, on_member_ban, on_member_unban, on_invite_create,
+                      on_invite_delete, on_group_join, on_group_remove, on_relationship_add,
+                      on_relationship_remove, on_relationship_update
 
 .. autoclass:: AutoShardedClient
     :members:
@@ -106,607 +125,124 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
 .. warning::
 
-    All the events must be a |coroutine_link|_. If they aren't, then you might get unexpected
-    errors. In order to turn a function into a coroutine they must be ``async def``
+    All the events must be a |coroutine_link|_. If they aren't, a :exc:`TypeError` will be raised.
+    In order to turn a function into a coroutine they must be ``async def``
     functions.
 
-.. function:: on_connect()
+.. autofunction Client.on_connect
 
-    Called when the client has successfully connected to Discord. This is not
-    the same as the client being fully prepared, see :func:`on_ready` for that.
+.. autofunction Client.on_disconnect
 
-    The warnings on :func:`on_ready` also apply.
+.. autofunction Client.on_ready
 
-.. function:: on_disconnect()
+.. autofunction Client.on_shard_ready
 
-    Called when the client has disconnected from Discord. This could happen either through
-    the internet being disconnected, explicit calls to logout, or Discord terminating the connection
-    one way or the other.
+.. autofunction Client.on_resumed
 
-    This function can be called many times.
+.. autofunction Client.on_error
 
-.. function:: on_ready()
+.. autofunction Client.on_socket_raw_receive
 
-    Called when the client is done preparing the data received from Discord. Usually after login is successful
-    and the :attr:`Client.guilds` and co. are filled up.
+.. autofunction Client.on_socket_raw_send
 
-    .. warning::
+.. autofunction Client.on_typing
 
-        This function is not guaranteed to be the first event called.
-        Likewise, this function is **not** guaranteed to only be called
-        once. This library implements reconnection logic and thus will
-        end up calling this event whenever a RESUME request fails.
+.. autofunction Client.on_message
 
-.. function:: on_shard_ready(shard_id)
+.. autofunction Client.on_message_delete
 
-    Similar to :func:`on_ready` except used by :class:`AutoShardedClient`
-    to denote when a particular shard ID has become ready.
+.. autofunction Client.on_bulk_message_delete
 
-    :param shard_id: The shard ID that is ready.
-    :type shard_id: :class:`int`
+.. autofunction Client.on_raw_message_delete
 
-.. function:: on_resumed()
+.. autofunction Client.on_raw_bulk_message_delete
 
-    Called when the client has resumed a session.
+.. autofunction Client.on_message_edit
 
-.. function:: on_error(event, \*args, \*\*kwargs)
+.. autofunction Client.on_raw_message_edit
 
-    Usually when an event raises an uncaught exception, a traceback is
-    printed to stderr and the exception is ignored. If you want to
-    change this behaviour and handle the exception for whatever reason
-    yourself, this event can be overridden. Which, when done, will
-    suppress the default action of printing the traceback.
+.. autofunction Client.on_reaction_add
 
-    The information of the exception raised and the exception itself can
-    be retrieved with a standard call to :func:`sys.exc_info`.
+.. autofunction Client.on_raw_reaction_add
 
-    If you want exception to propagate out of the :class:`Client` class
-    you can define an ``on_error`` handler consisting of a single empty
-    :ref:`py:raise`.  Exceptions raised by ``on_error`` will not be
-    handled in any way by :class:`Client`.
+.. autofunction Client.on_reaction_remove
 
-    :param event: The name of the event that raised the exception.
-    :type event: :class:`str`
+.. autofunction Client.on_raw_reaction_remove
 
-    :param args: The positional arguments for the event that raised the
-        exception.
-    :param kwargs: The keyword arguments for the event that raised the
-        exception.
+.. autofunction Client.on_reaction_clear
 
-.. function:: on_socket_raw_receive(msg)
+.. autofunction Client.on_raw_reaction_clear
 
-    Called whenever a message is received from the WebSocket, before
-    it's processed. This event is always dispatched when a message is
-    received and the passed data is not processed in any way.
+.. autofunction Client.on_reaction_clear_emoji
 
-    This is only really useful for grabbing the WebSocket stream and
-    debugging purposes.
+.. autofunction Client.on_raw_reaction_clear_emoji
 
-    .. note::
+.. autofunction Client.on_private_channel_delete
 
-        This is only for the messages received from the client
-        WebSocket. The voice WebSocket will not trigger this event.
+.. autofunction Client.on_private_channel_create
 
-    :param msg: The message passed in from the WebSocket library.
-                Could be :class:`bytes` for a binary message or :class:`str`
-                for a regular message.
-    :type msg: Union[:class:`bytes`, :class:`str`]
+.. autofunction Client.on_private_channel_update
 
-.. function:: on_socket_raw_send(payload)
+.. autofunction Client.on_private_channel_pins_update
 
-    Called whenever a send operation is done on the WebSocket before the
-    message is sent. The passed parameter is the message that is being
-    sent to the WebSocket.
+.. autofunction Client.on_guild_channel_delete
 
-    This is only really useful for grabbing the WebSocket stream and
-    debugging purposes.
+.. autofunction Client.on_guild_channel_create
 
-    .. note::
+.. autofunction Client.on_guild_channel_update
 
-        This is only for the messages received from the client
-        WebSocket. The voice WebSocket will not trigger this event.
+.. autofunction Client.on_guild_channel_pins_update
 
-    :param payload: The message that is about to be passed on to the
-                    WebSocket library. It can be :class:`bytes` to denote a binary
-                    message or :class:`str` to denote a regular text message.
+.. autofunction Client.on_guild_integrations_update
 
-.. function:: on_typing(channel, user, when)
+.. autofunction Client.on_webhooks_update
 
-    Called when someone begins typing a message.
+.. autofunction Client.on_member_join
 
-    The ``channel`` parameter can be a :class:`abc.Messageable` instance.
-    Which could either be :class:`TextChannel`, :class:`GroupChannel`, or
-    :class:`DMChannel`.
+.. autofunction Client.on_member_remove
 
-    If the ``channel`` is a :class:`TextChannel` then the ``user`` parameter
-    is a :class:`Member`, otherwise it is a :class:`User`.
+.. autofunction Client.on_member_update
 
-    :param channel: The location where the typing originated from.
-    :type channel: :class:`abc.Messageable`
-    :param user: The user that started typing.
-    :type user: Union[:class:`User`, :class:`Member`]
-    :param when: When the typing started as a naive datetime in UTC.
-    :type when: :class:`datetime.datetime`
+.. autofunction Client.on_user_update
 
-.. function:: on_message(message)
+.. autofunction Client.on_guild_join
 
-    Called when a :class:`Message` is created and sent.
+.. autofunction Client.on_guild_remove
 
-    .. warning::
+.. autofunction Client.on_guild_update
 
-        Your bot's own messages and private messages are sent through this
-        event. This can lead cases of 'recursion' depending on how your bot was
-        programmed. If you want the bot to not reply to itself, consider
-        checking the user IDs. Note that :class:`~ext.commands.Bot` does not
-        have this problem.
+.. autofunction Client.on_guild_role_create
 
-    :param message: The current message.
-    :type message: :class:`Message`
+.. autofunction Client.on_guild_role_delete
 
-.. function:: on_message_delete(message)
+.. autofunction Client.on_guild_role_update
 
-    Called when a message is deleted. If the message is not found in the
-    internal message cache, then this event will not be called.
-    Messages might not be in cache if the message is too old
-    or the client is participating in high traffic guilds.
+.. autofunction Client.on_guild_emojis_update
 
-    If this occurs increase the :attr:`Client.max_messages` attribute
-    or use the :func:`on_raw_message_delete` event instead.
+.. autofunction Client.on_guild_available
 
-    :param message: The deleted message.
-    :type message: :class:`Message`
+.. autofunction Client.on_guild_unavailable
 
-.. function:: on_bulk_message_delete(messages)
+.. autofunction Client.on_voice_state_update
 
-    Called when messages are bulk deleted. If none of the messages deleted
-    are found in the internal message cache, then this event will not be called.
-    If individual messages were not found in the internal message cache,
-    this event will still be called, but the messages not found will not be included in
-    the messages list. Messages might not be in cache if the message is too old
-    or the client is participating in high traffic guilds.
+.. autofunction Client.on_member_ban
 
-    If this occurs increase the :attr:`Client.max_messages` attribute
-    or use the :func:`on_raw_bulk_message_delete` event instead.
+.. autofunction Client.on_member_unban
 
-    :param messages: The messages that have been deleted.
-    :type messages: List[:class:`Message`]
+.. autofunction Client.on_invite_create
 
-.. function:: on_raw_message_delete(payload)
+.. autofunction Client.on_invite_delete
 
-    Called when a message is deleted. Unlike :func:`on_message_delete`, this is
-    called regardless of the message being in the internal message cache or not.
+.. autofunction Client.on_group_join
 
-    If the message is found in the message cache,
-    it can be accessed via :attr:`RawMessageDeleteEvent.cached_message`
+.. autofunction Client.on_group_remove
 
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawMessageDeleteEvent`
+.. autofunction Client.on_relationship_add
 
-.. function:: on_raw_bulk_message_delete(payload)
+.. autofunction Client.on_relationship_remove
 
-    Called when a bulk delete is triggered. Unlike :func:`on_bulk_message_delete`, this is
-    called regardless of the messages being in the internal message cache or not.
+.. autofunction Client.on_relationship_update
 
-    If the messages are found in the message cache,
-    they can be accessed via :attr:`RawBulkMessageDeleteEvent.cached_messages`
-
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawBulkMessageDeleteEvent`
-
-.. function:: on_message_edit(before, after)
-
-    Called when a :class:`Message` receives an update event. If the message is not found
-    in the internal message cache, then these events will not be called.
-    Messages might not be in cache if the message is too old
-    or the client is participating in high traffic guilds.
-
-    If this occurs increase the :attr:`Client.max_messages` attribute
-    or use the :func:`on_raw_message_edit` event instead.
-
-    The following non-exhaustive cases trigger this event:
-
-    - A message has been pinned or unpinned.
-    - The message content has been changed.
-    - The message has received an embed.
-
-        - For performance reasons, the embed server does not do this in a "consistent" manner.
-
-    - The message's embeds were suppressed or unsuppressed.
-    - A call message has received an update to its participants or ending time.
-
-    :param before: The previous version of the message.
-    :type before: :class:`Message`
-    :param after: The current version of the message.
-    :type after: :class:`Message`
-
-.. function:: on_raw_message_edit(payload)
-
-    Called when a message is edited. Unlike :func:`on_message_edit`, this is called
-    regardless of the state of the internal message cache.
-
-    If the message is found in the message cache,
-    it can be accessed via :attr:`RawMessageUpdateEvent.cached_message`
-
-    Due to the inherently raw nature of this event, the data parameter coincides with
-    the raw data given by the `gateway <https://discord.com/developers/docs/topics/gateway#message-update>`_.
-
-    Since the data payload can be partial, care must be taken when accessing stuff in the dictionary.
-    One example of a common case of partial data is when the ``'content'`` key is inaccessible. This
-    denotes an "embed" only edit, which is an edit in which only the embeds are updated by the Discord
-    embed server.
-
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawMessageUpdateEvent`
-
-.. function:: on_reaction_add(reaction, user)
-
-    Called when a message has a reaction added to it. Similar to :func:`on_message_edit`,
-    if the message is not found in the internal message cache, then this
-    event will not be called. Consider using :func:`on_raw_reaction_add` instead.
-
-    .. note::
-
-        To get the :class:`Message` being reacted, access it via :attr:`Reaction.message`.
-
-    :param reaction: The current state of the reaction.
-    :type reaction: :class:`Reaction`
-    :param user: The user who added the reaction.
-    :type user: Union[:class:`Member`, :class:`User`]
-
-.. function:: on_raw_reaction_add(payload)
-
-    Called when a message has a reaction added. Unlike :func:`on_reaction_add`, this is
-    called regardless of the state of the internal message cache.
-
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawReactionActionEvent`
-
-.. function:: on_reaction_remove(reaction, user)
-
-    Called when a message has a reaction removed from it. Similar to on_message_edit,
-    if the message is not found in the internal message cache, then this event
-    will not be called.
-
-    .. note::
-
-        To get the message being reacted, access it via :attr:`Reaction.message`.
-
-    :param reaction: The current state of the reaction.
-    :type reaction: :class:`Reaction`
-    :param user: The user who added the reaction.
-    :type user: Union[:class:`Member`, :class:`User`]
-
-.. function:: on_raw_reaction_remove(payload)
-
-    Called when a message has a reaction removed. Unlike :func:`on_reaction_remove`, this is
-    called regardless of the state of the internal message cache.
-
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawReactionActionEvent`
-
-.. function:: on_reaction_clear(message, reactions)
-
-    Called when a message has all its reactions removed from it. Similar to :func:`on_message_edit`,
-    if the message is not found in the internal message cache, then this event
-    will not be called. Consider using :func:`on_raw_reaction_clear` instead.
-
-    :param message: The message that had its reactions cleared.
-    :type message: :class:`Message`
-    :param reactions: The reactions that were removed.
-    :type reactions: List[:class:`Reaction`]
-
-.. function:: on_raw_reaction_clear(payload)
-
-    Called when a message has all its reactions removed. Unlike :func:`on_reaction_clear`,
-    this is called regardless of the state of the internal message cache.
-
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawReactionClearEvent`
-
-.. function:: on_reaction_clear_emoji(reaction)
-
-    Called when a message has a specific reaction removed from it. Similar to :func:`on_message_edit`,
-    if the message is not found in the internal message cache, then this event
-    will not be called. Consider using :func:`on_raw_reaction_clear_emoji` instead.
-
-    .. versionadded:: 1.3
-
-    :param reaction: The reaction that got cleared.
-    :type reaction: :class:`Reaction`
-
-.. function:: on_raw_reaction_clear_emoji(payload)
-
-    Called when a message has a specific reaction removed from it. Unlike :func:`on_reaction_clear_emoji` this is called
-    regardless of the state of the internal message cache.
-
-    .. versionadded:: 1.3
-
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawReactionClearEmojiEvent`
-
-.. function:: on_private_channel_delete(channel)
-              on_private_channel_create(channel)
-
-    Called whenever a private channel is deleted or created.
-
-    :param channel: The private channel that got created or deleted.
-    :type channel: :class:`abc.PrivateChannel`
-
-.. function:: on_private_channel_update(before, after)
-
-    Called whenever a private group DM is updated. e.g. changed name or topic.
-
-    :param before: The updated group channel's old info.
-    :type before: :class:`GroupChannel`
-    :param after: The updated group channel's new info.
-    :type after: :class:`GroupChannel`
-
-.. function:: on_private_channel_pins_update(channel, last_pin)
-
-    Called whenever a message is pinned or unpinned from a private channel.
-
-    :param channel: The private channel that had its pins updated.
-    :type channel: :class:`abc.PrivateChannel`
-    :param last_pin: The latest message that was pinned as a naive datetime in UTC. Could be ``None``.
-    :type last_pin: Optional[:class:`datetime.datetime`]
-
-.. function:: on_guild_channel_delete(channel)
-              on_guild_channel_create(channel)
-
-    Called whenever a guild channel is deleted or created.
-
-    Note that you can get the guild from :attr:`~abc.GuildChannel.guild`.
-
-    :param channel: The guild channel that got created or deleted.
-    :type channel: :class:`abc.GuildChannel`
-
-.. function:: on_guild_channel_update(before, after)
-
-    Called whenever a guild channel is updated. e.g. changed name, topic, permissions.
-
-    :param before: The updated guild channel's old info.
-    :type before: :class:`abc.GuildChannel`
-    :param after: The updated guild channel's new info.
-    :type after: :class:`abc.GuildChannel`
-
-.. function:: on_guild_channel_pins_update(channel, last_pin)
-
-    Called whenever a message is pinned or unpinned from a guild channel.
-
-    :param channel: The guild channel that had its pins updated.
-    :type channel: :class:`abc.GuildChannel`
-    :param last_pin: The latest message that was pinned as a naive datetime in UTC. Could be ``None``.
-    :type last_pin: Optional[:class:`datetime.datetime`]
-
-.. function:: on_guild_integrations_update(guild)
-
-    Called whenever an integration is created, modified, or removed from a guild.
-
-    :param guild: The guild that had its integrations updated.
-    :type guild: :class:`Guild`
-
-.. function:: on_webhooks_update(channel)
-
-    Called whenever a webhook is created, modified, or removed from a guild channel.
-
-    :param channel: The channel that had its webhooks updated.
-    :type channel: :class:`abc.GuildChannel`
-
-.. function:: on_member_join(member)
-              on_member_remove(member)
-
-    Called when a :class:`Member` leaves or joins a :class:`Guild`.
-
-    :param member: The member who joined or left.
-    :type member: :class:`Member`
-
-.. function:: on_member_update(before, after)
-
-    Called when a :class:`Member` updates their profile.
-
-    This is called when one or more of the following things change:
-
-    - status
-    - activity
-    - nickname
-    - roles
-
-    :param before: The updated member's old info.
-    :type before: :class:`Member`
-    :param after: The updated member's updated info.
-    :type after: :class:`Member`
-
-.. function:: on_user_update(before, after)
-
-    Called when a :class:`User` updates their profile.
-
-    This is called when one or more of the following things change:
-
-    - avatar
-    - username
-    - discriminator
-
-    :param before: The updated user's old info.
-    :type before: :class:`User`
-    :param after: The updated user's updated info.
-    :type after: :class:`User`
-
-.. function:: on_guild_join(guild)
-
-    Called when a :class:`Guild` is either created by the :class:`Client` or when the
-    :class:`Client` joins a guild.
-
-    :param guild: The guild that was joined.
-    :type guild: :class:`Guild`
-
-.. function:: on_guild_remove(guild)
-
-    Called when a :class:`Guild` is removed from the :class:`Client`.
-
-    This happens through, but not limited to, these circumstances:
-
-    - The client got banned.
-    - The client got kicked.
-    - The client left the guild.
-    - The client or the guild owner deleted the guild.
-
-    In order for this event to be invoked then the :class:`Client` must have
-    been part of the guild to begin with. (i.e. it is part of :attr:`Client.guilds`)
-
-    :param guild: The guild that got removed.
-    :type guild: :class:`Guild`
-
-.. function:: on_guild_update(before, after)
-
-    Called when a :class:`Guild` updates, for example:
-
-    - Changed name
-    - Changed AFK channel
-    - Changed AFK timeout
-    - etc
-
-    :param before: The guild prior to being updated.
-    :type before: :class:`Guild`
-    :param after: The guild after being updated.
-    :type after: :class:`Guild`
-
-.. function:: on_guild_role_create(role)
-              on_guild_role_delete(role)
-
-    Called when a :class:`Guild` creates or deletes a new :class:`Role`.
-
-    To get the guild it belongs to, use :attr:`Role.guild`.
-
-    :param role: The role that was created or deleted.
-    :type role: :class:`Role`
-
-.. function:: on_guild_role_update(before, after)
-
-    Called when a :class:`Role` is changed guild-wide.
-
-    :param before: The updated role's old info.
-    :type before: :class:`Role`
-    :param after: The updated role's updated info.
-    :type after: :class:`Role`
-
-.. function:: on_guild_emojis_update(guild, before, after)
-
-    Called when a :class:`Guild` adds or removes :class:`Emoji`.
-
-    :param guild: The guild who got their emojis updated.
-    :type guild: :class:`Guild`
-    :param before: A list of emojis before the update.
-    :type before: Sequence[:class:`Emoji`]
-    :param after: A list of emojis after the update.
-    :type after: Sequence[:class:`Emoji`]
-
-.. function:: on_guild_available(guild)
-              on_guild_unavailable(guild)
-
-    Called when a guild becomes available or unavailable. The guild must have
-    existed in the :attr:`Client.guilds` cache.
-
-    :param guild: The :class:`Guild` that has changed availability.
-
-.. function:: on_voice_state_update(member, before, after)
-
-    Called when a :class:`Member` changes their :class:`VoiceState`.
-
-    The following, but not limited to, examples illustrate when this event is called:
-
-    - A member joins a voice channel.
-    - A member leaves a voice channel.
-    - A member is muted or deafened by their own accord.
-    - A member is muted or deafened by a guild administrator.
-
-    :param member: The member whose voice states changed.
-    :type member: :class:`Member`
-    :param before: The voice state prior to the changes.
-    :type before: :class:`VoiceState`
-    :param after: The voice state after to the changes.
-    :type after: :class:`VoiceState`
-
-.. function:: on_member_ban(guild, user)
-
-    Called when user gets banned from a :class:`Guild`.
-
-    :param guild: The guild the user got banned from.
-    :type guild: :class:`Guild`
-    :param user: The user that got banned.
-                 Can be either :class:`User` or :class:`Member` depending if
-                 the user was in the guild or not at the time of removal.
-    :type user: Union[:class:`User`, :class:`Member`]
-
-.. function:: on_member_unban(guild, user)
-
-    Called when a :class:`User` gets unbanned from a :class:`Guild`.
-
-    :param guild: The guild the user got unbanned from.
-    :type guild: :class:`Guild`
-    :param user: The user that got unbanned.
-    :type user: :class:`User`
-
-.. function:: on_invite_create(invite)
-
-    Called when an :class:`Invite` is created.
-    You must have the :attr:`~Permissions.manage_channels` permission to receive this.
-
-    .. versionadded:: 1.3
-
-    .. note::
-
-        There is a rare possibility that the :attr:`Invite.guild` and :attr:`Invite.channel`
-        attributes will be of :class:`Object` rather than the respective models.
-
-    :param invite: The invite that was created.
-    :type invite: :class:`Invite`
-
-.. function:: on_invite_delete(invite)
-
-    Called when an :class:`Invite` is deleted.
-    You must have the :attr:`~Permissions.manage_channels` permission to receive this.
-
-    .. versionadded:: 1.3
-
-    .. note::
-
-        There is a rare possibility that the :attr:`Invite.guild` and :attr:`Invite.channel`
-        attributes will be of :class:`Object` rather than the respective models.
-
-        Outside of those two attributes, the only other attribute guaranteed to be
-        filled by the Discord gateway for this event is :attr:`Invite.code`.
-
-    :param invite: The invite that was deleted.
-    :type invite: :class:`Invite`
-
-.. function:: on_group_join(channel, user)
-              on_group_remove(channel, user)
-
-    Called when someone joins or leaves a :class:`GroupChannel`.
-
-    :param channel: The group that the user joined or left.
-    :type channel: :class:`GroupChannel`
-    :param user: The user that joined or left.
-    :type user: :class:`User`
-
-.. function:: on_relationship_add(relationship)
-              on_relationship_remove(relationship)
-
-    Called when a :class:`Relationship` is added or removed from the
-    :class:`ClientUser`.
-
-    :param relationship: The relationship that was added or removed.
-    :type relationship: :class:`Relationship`
-
-.. function:: on_relationship_update(before, after)
-
-    Called when a :class:`Relationship` is updated, e.g. when you
-    block a friend or a friendship is accepted.
-
-    :param before: The previous relationship status.
-    :type before: :class:`Relationship`
-    :param after: The updated relationship status.
-    :type after: :class:`Relationship`
 
 .. _discord-api-utils:
 


### PR DESCRIPTION
### Summary

This code change makes the documentation show dispatched events as methods of `discord.Client`, turning `discord.on_ready`, which isn't in line with the way the events are registered, into `discord.Client.on_ready`, which will also show that the methods can be registered on a subclass of `discord.Client`. 

This is achieved by documenting the events in `Client` and not that it's very important, reduces the chances of people mistyping event names in `Client` subclasses, which I have seen a fair few times.

A live version of the docs which I used for debugging with the changes can be viewed here https://notdiscordpy.readthedocs.io/en/latest/api.html#event-reference.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)