### PR TITLE
Document that sleep until expects datetimes to be in UTC

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -368,7 +368,7 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
                 return
 
         self._dispatch('socket_response', msg)
-        
+
         msg = json.loads(msg)
 
         log.debug('For Shard ID %s: WebSocket Event: %s', self.shard_id, msg)

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -367,10 +367,11 @@ class DiscordWebSocket(websockets.client.WebSocketClientProtocol):
             else:
                 return
 
+        self._dispatch('socket_response', msg)
+        
         msg = json.loads(msg)
 
         log.debug('For Shard ID %s: WebSocket Event: %s', self.shard_id, msg)
-        self._dispatch('socket_response', msg)
 
         op = msg.get('op')
         data = msg.get('d')

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -342,7 +342,7 @@ async def sane_wait_for(futures, *, timeout):
 async def sleep_until(when, result=None):
     """|coro|
 
-    Sleep until a specified time.
+    Sleep until a specified time in UTC.
 
     If the time supplied is in the past this function will yield instantly.
 
@@ -351,7 +351,7 @@ async def sleep_until(when, result=None):
     Parameters
     -----------
     when: :class:`datetime.datetime`
-        The timestamp in which to sleep until.
+        The timestamp in UTC to sleep until.
     result: Any
         If provided is returned to the caller when the coroutine completes.
     """

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -187,10 +187,41 @@ to handle it, which defaults to print a traceback and ignoring the exception.
         This is only for the messages received from the client
         WebSocket. The voice WebSocket will not trigger this event.
 
+    .. note::
+
+        Similar to :func:`on_socket_response` but the message will generally
+        be compressed.
+
+
     :param msg: The message passed in from the WebSocket library.
                 Could be :class:`bytes` for a binary message or :class:`str`
                 for a regular message.
     :type msg: Union[:class:`bytes`, :class:`str`]
+
+.. function:: on_socket_response(msg)
+
+    Called whenever a message is received from the WebSocket, after
+    being decompressed but before being parsed.
+    This event is always dispatched when a message is
+    received and the passed data is not processed in any way.
+
+    This is only really useful for grabbing the WebSocket stream and
+    debugging purposes.
+
+    .. note::
+
+        This is only for the messages received from the client
+        WebSocket. The voice WebSocket will not trigger this event.
+
+    .. note::
+
+        Similar to :func:`on_socket_raw_receive` but the message will be decompressed.
+
+    .. versionchanged:: 2.0
+        This event receives a json-encoded :class:`str` of the message instead of a :class:`dict`
+
+    :param msg: The decompressed message passed in from the WebSocket library.
+    :type msg: :class:`str`
 
 .. function:: on_socket_raw_send(payload)
 


### PR DESCRIPTION
### Summary

Improves documentation of sleep_until to note that it requires timestamps to be in UTC to function properly. 

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
