### PR TITLE
[matrix] Use default scrollbar for page body

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -140,21 +140,19 @@ body {
 
 /* Scrollbar related */
 
-body::-webkit-scrollbar,
 #sidebar::-webkit-scrollbar {
-  width: 1em;
+  width: 0.5em;
 }
  
-body::-webkit-scrollbar-thumb,
 #sidebar::-webkit-scrollbar-thumb {
   background-color: var(--scrollbar);
-  border-radius: 0.5em;
+  border-radius: 0.25em;
 }
 
-body::-webkit-scrollbar-thumb:hover,
 #sidebar::-webkit-scrollbar-thumb:hover {
   background-color: var(--scrollbar-hover);
 }
+
 
 /* grid related */
 


### PR DESCRIPTION
### Summary

Uses the default scrollbar for the body of the page instead of a customised one.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
