### PR TITLE
Remove the caching behavior of Member.roles

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -161,7 +161,7 @@ class Member(discord.abc.Messageable, _BaseUser):
         Nitro boost on the guild, if available. This could be ``None``.
     """
 
-    __slots__ = ('_roles', '_cs_roles', 'joined_at', 'premium_since', '_client_status',
+    __slots__ = ('_roles', 'joined_at', 'premium_since', '_client_status',
                  'activities', 'guild', 'nick', '_user', '_state')
 
     def __init__(self, *, data, guild, state):
@@ -234,11 +234,6 @@ class Member(discord.abc.Messageable, _BaseUser):
         self.activities = member.activities
         self._state = member._state
 
-        try:
-            del self._cs_roles
-        except AttributeError:
-            pass
-
         # Reference will not be copied unless necessary by PRESENCE_UPDATE
         # See below
         self._user = member._user
@@ -250,10 +245,6 @@ class Member(discord.abc.Messageable, _BaseUser):
 
     def _update_roles(self, data):
         self._roles = utils.SnowflakeList(map(int, data['roles']))
-        try:
-            del self._cs_roles
-        except AttributeError:
-            pass
 
     def _update(self, data):
         # the nickname change is optional,
@@ -344,7 +335,7 @@ class Member(discord.abc.Messageable, _BaseUser):
         """
         return self.colour
 
-    @utils.cached_slot_property('_cs_roles')
+    @property
     def roles(self):
         """List[:class:`Role`]: A :class:`list` of :class:`Role` that the member belongs to. Note
         that the first element of this list is always the default '@everyone'
@@ -434,7 +425,11 @@ class Member(discord.abc.Messageable, _BaseUser):
         This is useful for figuring where a member stands in the role
         hierarchy chain.
         """
-        return self.roles[-1]
+        guild = self.guild
+        if len(self._roles) == 0:
+            return guild.default_role
+        
+        return max(guild.get_role(rid) or guild.default_role for rid in self._roles)
 
     @property
     def guild_permissions(self):


### PR DESCRIPTION

### Summary

- fixes #4087

- This intentionally uses some internals in both Member.roles and Member.top_role to
retain as much performance as possible while removing the cache due to potential expense in cache invalidation

I've not tested this yet but there's every expectation that these changes work. Changes are here prior to testing for discussion in bikeshedding in case even the design needs reconsidering.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
