### PR TITLE
Fix TypeError on missing shard_id kwarg

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -747,11 +747,7 @@ class ConnectionState:
 
     async def _chunk_and_dispatch(self, guild, unavailable):
         chunks = list(self.chunks_needed(guild))
-        if guild.shard_id is None:
-            await self.chunker(guild.id)
-        else:
-            await self.chunker(guild.id, shard_id=guild.shard_id)
-  
+        await self.chunker(guild.id)
         if chunks:
             try:
                 await utils.sane_wait_for(chunks, timeout=len(chunks))
@@ -1052,8 +1048,8 @@ class AutoShardedConnectionState(ConnectionState):
         self._ready_task = None
         self.shard_ids = ()
 
-    async def chunker(self, guild_id, query='', limit=0, *, shard_id, nonce=None):
-        ws = self._get_websocket(shard_id=shard_id)
+    async def chunker(self, guild_id, query='', limit=0, *, shard_id=None, nonce=None):
+        ws = self._get_websocket(guild_id, shard_id=shard_id)
         await ws.request_chunks(guild_id, query=query, limit=limit, nonce=nonce)
 
     async def request_offline_members(self, guilds, *, shard_id):

--- a/discord/state.py
+++ b/discord/state.py
@@ -747,7 +747,11 @@ class ConnectionState:
 
     async def _chunk_and_dispatch(self, guild, unavailable):
         chunks = list(self.chunks_needed(guild))
-        await self.chunker(guild.id)
+        if guild.shard_id is None:
+            await self.chunker(guild.id)
+        else:
+            await self.chunker(guild.id, shard_id=guild.shard_id)
+  
         if chunks:
             try:
                 await utils.sane_wait_for(chunks, timeout=len(chunks))


### PR DESCRIPTION
### Summary

This PR fixes TypeError raised when `chunker` method is missing `shard_id` keyword-only argument in `_chunk_and_dispatch` for `AutoShardedConnectionState`.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
