### PR TITLE
fix incorrect class reference in documentation

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -134,7 +134,7 @@ class BaseUser(_BaseUser):
 
     @property
     def public_flags(self):
-        """:class:`PublicFlags`: The publicly available flags the user has."""
+        """:class:`PublicUserFlags`: The publicly available flags the user has."""
         return PublicUserFlags._from_value(self._public_flags)
 
     @property


### PR DESCRIPTION
### Summary

This PR fixes an incorrect reference to PublicFlags, which is the old name of PublicUserFlags.
Sorry, this one's my fault. I'm pretty new to PRing stuff. At least I fixed my mistake I suppose.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
