### PR TITLE
Support discord.com/invite URL in resolve_invite

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -431,7 +431,7 @@ def resolve_invite(invite):
     if isinstance(invite, (Invite, Object)):
         return invite.id
     else:
-        rx = r'(?:https?\:\/\/)?discord(?:\.gg|app\.com\/invite)\/(.+)'
+        rx = r'(?:https?\:\/\/)?discord(?:\.gg|(?:app)?\.com\/invite)\/(.+)'
         m = re.match(rx, invite)
         if m:
             return m.group(1)


### PR DESCRIPTION
### Summary
`resolve_invite` now supports discord.com/invite URLs (such as `https://discord.com/invite/dpy`). No docs change needed.

### Checklist
- [x] If code changes were made then they have been tested.
    - [] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
