### PR TITLE
Change PartialInviteGuild.icon_url_as to mimic Guild.icon_url_as

### DIFF
--- a/discord/invite.py
+++ b/discord/invite.py
@@ -162,7 +162,7 @@ class PartialInviteGuild:
     def icon_url_as(self, *, format=None, static_format='webp', size=1024):
         """The same operation as :meth:`Guild.icon_url_as`."""
         return Asset._from_guild_icon(self._state, self, format=format, static_format=static_format, size=size)
-    
+
     @property
     def banner_url(self):
         """:class:`Asset`: Returns the guild's banner asset."""

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -154,11 +154,15 @@ class PartialInviteGuild:
     def icon_url(self):
         """:class:`Asset`: Returns the guild's icon asset."""
         return self.icon_url_as()
+    
+    def is_icon_animated(self):
+        """:class:`Asset`: Returns the guild's icon asset."""
+        return bool(self.icon and self.icon.startswith('a_'))
 
-    def icon_url_as(self, *, format='webp', size=1024):
+    def icon_url_as(self, *, format=None, static_format='webp', size=1024):
         """The same operation as :meth:`Guild.icon_url_as`."""
-        return Asset._from_guild_image(self._state, self.id, self.icon, 'icons', format=format, size=size)
-
+        return Asset._from_guild_icon(self._state, self, format=format, static_format=static_format, size=size)
+    
     @property
     def banner_url(self):
         """:class:`Asset`: Returns the guild's banner asset."""

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -156,7 +156,10 @@ class PartialInviteGuild:
         return self.icon_url_as()
     
     def is_icon_animated(self):
-        """:class:`bool`: Returns True if the guild has an animated icon."""
+        """:class:`bool`: Returns True if the guild has an animated icon.
+
+        .. versionadded:: 1.4
+        """
         return bool(self.icon and self.icon.startswith('a_'))
 
     def icon_url_as(self, *, format=None, static_format='webp', size=1024):

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -156,7 +156,7 @@ class PartialInviteGuild:
         return self.icon_url_as()
     
     def is_icon_animated(self):
-        """:class:`Asset`: Returns the guild's icon asset."""
+        """:class:`bool`: Returns True if the guild has an animated icon."""
         return bool(self.icon and self.icon.startswith('a_'))
 
     def icon_url_as(self, *, format=None, static_format='webp', size=1024):


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR Implements `is_icon_animated` for `PartialInviteGuild` and changes `PartialInviteGuild.icon_url_as` to be consistent with `Guild.icon_url_as` . Fixes #4180 .
### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
