### PR TITLE
Mixins is refractored

### DIFF
--- a/discord/mixins.py
+++ b/discord/mixins.py
@@ -24,19 +24,12 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-class EqualityComparable:
-    __slots__ = ()
 
+class Hashable:
+    __slots__ = ()
+    
     def __eq__(self, other):
         return isinstance(other, self.__class__) and other.id == self.id
-
-    def __ne__(self, other):
-        if isinstance(other, self.__class__):
-            return other.id != self.id
-        return True
-
-class Hashable(EqualityComparable):
-    __slots__ = ()
-
+    
     def __hash__(self):
         return self.id >> 22


### PR DESCRIPTION
From what I could see __nq__ was just the inverse of __eq__ so I removed it. EqualityComparable wasn't used anywhere except for Hashable, and I can't imagine anything else, since they both rely on the same thing, object having an id. So I merged them.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
