### PR TITLE
Update command_callback to make it prefix immune

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -798,6 +798,11 @@ class HelpCommand:
         if cmd is None:
             string = await maybe_coro(self.command_not_found, self.remove_mentions(keys[0]))
             return await self.send_error_message(string)
+        
+        # maybe it has a prefix at the beginning
+        prefix_length = len(self.context.prefix)
+        if keys[0][:prefix_length] == self.context.prefix:
+            keys[0] = keys[0][prefix_length:]
 
         for key in keys[1:]:
             try:

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -800,8 +800,8 @@ class HelpCommand:
             return await self.send_error_message(string)
         
         # maybe it has a prefix at the beginning
-        prefix_length = len(self.context.prefix)
-        if keys[0][:prefix_length] == self.context.prefix:
+        prefix_length = len(ctx.prefix)
+        if keys[0][:prefix_length] == ctx.prefix:
             keys[0] = keys[0][prefix_length:]
 
         for key in keys[1:]:


### PR DESCRIPTION
### Summary

With this pull request, `command_callback()` removes the prefix from the beginning so that the help command can be used like this (assuming the prefix is `!`):

`!help !ping`

### Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
