### PR TITLE
Escape masked URLs; Support quotes for as_needed

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -440,7 +440,9 @@ def resolve_invite(invite):
 _MARKDOWN_ESCAPE_SUBREGEX = '|'.join(r'\{0}(?=([\s\S]*((?<!\{0})\{0})))'.format(c)
                                      for c in ('*', '`', '_', '~', '|'))
 
-_MARKDOWN_ESCAPE_REGEX = re.compile(r'(?P<markdown>%s)' % _MARKDOWN_ESCAPE_SUBREGEX)
+_MARKDOWN_ESCAPE_COMMON = r'^>(?:>>)?\s|\[.+\]\(.+\)'
+
+_MARKDOWN_ESCAPE_REGEX = re.compile(r'(?P<markdown>%s|%s)' % (_MARKDOWN_ESCAPE_SUBREGEX, _MARKDOWN_ESCAPE_COMMON))
 
 def escape_markdown(text, *, as_needed=False, ignore_links=True):
     r"""A helper function that escapes Discord's markdown.
@@ -476,7 +478,7 @@ def escape_markdown(text, *, as_needed=False, ignore_links=True):
                 return is_url
             return '\\' + groupdict['markdown']
 
-        regex = r'(?P<markdown>[_\\~|\*`]|>(?:>>)?\s)'
+        regex = r'(?P<markdown>[_\\~|\*`]|%s)' % _MARKDOWN_ESCAPE_COMMON
         if ignore_links:
             regex = '(?:%s|%s)' % (url_regex, regex)
         return re.sub(regex, replacement, text)


### PR DESCRIPTION
### Summary

This adds support for escaping masked URLs (closes #4206) and adds support for escaping quote blocks (`>` / `>>>`) when using the `as_needed` parameter. 

```py
>>> escape_markdown('> Hello World\n>>> Example', as_needed=True)
'\\> Hello World\n\\>>> Example'
>>> escape_markdown('> Hello World\n>>> Example')
'\\> Hello World\n\\>>> Example'
>>> escape_markdown('[Hello World](https://example.com)')
'\\[Hello World](https://example.com)'
>>> escape_markdown('[Hello World](https://example.com)', as_needed=True)
'\\[Hello World](https://example.com)'
```

### Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
