### PR TITLE
Fix reconnecting loop due to failed handshake on region change

### DIFF
--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -202,6 +202,7 @@ class VoiceClient:
         if self._handshake_complete.is_set():
             # terminate the websocket and handle the reconnect loop if necessary.
             self._handshake_complete.clear()
+            self._handshaking = False
             await self.ws.close(4000)
             return
 


### PR DESCRIPTION
### Summary

Fix for reconnecting loop issue that arises due to failure of handshake upon Voice server region changing, when the bot is in a voice channel. See issue #3996 

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
