### PR TITLE
Add a new exception class for command registration errors

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1075,6 +1075,9 @@ class GroupMixin:
         This is usually not called, instead the :meth:`~.GroupMixin.command` or
         :meth:`~.GroupMixin.group` shortcut decorators are used instead.
 
+        .. versionchanged:: 1.4
+             Raise :exc:`.CommandRegistrationError` instead of generic :exc:`.ClientException`
+
         Parameters
         -----------
         command: :class:`Command`
@@ -1082,8 +1085,8 @@ class GroupMixin:
 
         Raises
         -------
-        :exc:`.ClientException`
-            If the command is already registered.
+        :exc:`.CommandRegistrationError`
+            If the command or its alias is already registered by different command.
         TypeError
             If the command passed is not a subclass of :class:`.Command`.
         """

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1095,12 +1095,12 @@ class GroupMixin:
             command.parent = self
 
         if command.name in self.all_commands:
-            raise discord.ClientException('Command {0.name} is already registered.'.format(command))
+            raise CommandRegistrationError(command.name)
 
         self.all_commands[command.name] = command
         for alias in command.aliases:
             if alias in self.all_commands:
-                raise discord.ClientException('The alias {} is already an existing command or alias.'.format(alias))
+                raise CommandRegistrationError(alias, alias_conflict=True)
             self.all_commands[alias] = command
 
     def remove_command(self, name):

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -601,7 +601,5 @@ class CommandRegistrationError(ClientException):
     def __init__(self, name, *, alias_conflict=False):
         self.name = name
         self.alias_conflict = alias_conflict
-        if alias_conflict:
-            super().__init__('The alias {} is already an existing command or alias.'.format(name))
-        else:
-            super().__init__('Command {} is already registered.'.format(name))
+        type_ = 'alias' if alias_conflict else 'command'
+        super().__init__('The {} {} is already an existing command or alias.'.format(type_, name))

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -591,6 +591,8 @@ class CommandRegistrationError(ClientException):
 
     This inherits from :exc:`ClientException`
 
+    .. versionadded:: 1.4
+
     Attributes
     ----------
     name: :class:`str`

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -24,7 +24,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-from discord.errors import DiscordException
+from discord.errors import ClientException, DiscordException
 
 
 __all__ = (
@@ -62,6 +62,7 @@ __all__ = (
     'NoEntryPointError',
     'ExtensionFailed',
     'ExtensionNotFound',
+    'CommandRegistrationError',
 )
 
 class CommandError(DiscordException):
@@ -583,3 +584,24 @@ class ExtensionNotFound(ExtensionError):
         self.original = None
         fmt = 'Extension {0!r} could not be loaded.'
         super().__init__(fmt.format(name), name=name)
+
+class CommandRegistrationError(ClientException):
+    """An exception raised when the command can't be added
+    because the name is already taken by a different command.
+
+    This inherits from :exc:`ClientException`
+
+    Attributes
+    ----------
+    name: :class:`str`
+        The command name that had the error.
+    alias_conflict: :class:`bool`
+        Whether the name that conflicts is an alias of the command we try to add.
+    """
+    def __init__(self, name, *, alias_conflict=False):
+        self.name = name
+        self.alias_conflict = alias_conflict
+        if alias_conflict:
+            super().__init__('The alias {} is already an existing command or alias.'.format(name))
+        else:
+            super().__init__('Command {} is already registered.'.format(name))

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -589,7 +589,7 @@ class CommandRegistrationError(ClientException):
     """An exception raised when the command can't be added
     because the name is already taken by a different command.
 
-    This inherits from :exc:`ClientException`
+    This inherits from :exc:`discord.ClientException`
 
     .. versionadded:: 1.4
 

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -377,6 +377,9 @@ Exceptions
 .. autoexception:: discord.ext.commands.ExtensionNotFound
     :members:
 
+.. autoexception:: discord.ext.commands.CommandRegistrationError
+    :members:
+
 
 Exception Hierarchy
 +++++++++++++++++++++
@@ -418,3 +421,5 @@ Exception Hierarchy
             - :exc:`~.commands.NoEntryPointError`
             - :exc:`~.commands.ExtensionFailed`
             - :exc:`~.commands.ExtensionNotFound`
+    - :exc:`~.ClientException`
+        - :exc:`~.commands.CommandRegistrationError`


### PR DESCRIPTION
### Summary

This adds a new exception class for command registration errors so that developers could add some special error handling when command registration fails.
~~I'll test this code change in a few.~~ Tested and it works™

### Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
