### PR TITLE
Raise TypeError when Optional is used with Greedy converter

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -26,6 +26,7 @@ DEALINGS IN THE SOFTWARE.
 
 import re
 import inspect
+import typing
 
 import discord
 
@@ -554,6 +555,9 @@ class _Greedy:
 
         if converter is str or converter is type(None) or converter is _Greedy:
             raise TypeError('Greedy[%s] is invalid.' % converter.__name__)
+
+        if getattr(converter, '__origin__', None) is typing.Union and type(None) in converter.__args__:
+            raise TypeError('Greedy[Optional] is invalid.')
 
         return self.__class__(converter=converter)
 

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -557,7 +557,7 @@ class _Greedy:
             raise TypeError('Greedy[%s] is invalid.' % converter.__name__)
 
         if getattr(converter, '__origin__', None) is typing.Union and type(None) in converter.__args__:
-            raise TypeError('Greedy[Optional] is invalid.')
+            raise TypeError('Greedy[%r] is invalid.' % converter)
 
         return self.__class__(converter=converter)
 

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -552,8 +552,8 @@ This command can be invoked any of the following ways:
     unintended parsing ambiguities in your code. One technique would be to clamp down the expected syntaxes
     allowed through custom converters or reordering the parameters to minimise clashes.
 
-    To help aid with some parsing ambiguities, :class:`str`, ``None`` and :data:`~ext.commands.Greedy` are
-    forbidden as parameters for the :data:`~ext.commands.Greedy` converter.
+    To help aid with some parsing ambiguities, :class:`str`, ``None``, :data:`typing.Optional` and
+    :data:`~ext.commands.Greedy` are forbidden as parameters for the :data:`~ext.commands.Greedy` converter.
 
 .. _ext_commands_error_handler:
 


### PR DESCRIPTION
### Summary

This closes #2253. Having Union[..., `None`] makes no sense in Greedy, and should throw an error.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
