### PR TITLE
[matrix] rely on prefers-color-scheme

### DIFF
--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -58,6 +58,13 @@ Object.entries(settings).forEach(([name, setter]) => {
   }
 });
 
+if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+  updateSetting({checked: e.matches, name: 'theme'})
+}
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+  updateSetting({checked: e.matches, name: 'theme'})
+});
+
 document.addEventListener('DOMContentLoaded', () => {
 
   bottomHeightThreshold = document.documentElement.scrollHeight - 30;

--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -25,8 +25,11 @@ function changeDocumentation(element) {
   window.location = element.value;
 }
 
-function updateSetting(element) {
+function updateSetting(element, userOverrided=true) {
   localStorage.setItem(element.name, element.checked);
+  if (userOverrided) {
+    localStorage.setItem('userOverridedSettings', userOverrided);
+  }
   if (element.name in settings) {
     settings[element.name](element.checked);
   }
@@ -58,12 +61,18 @@ Object.entries(settings).forEach(([name, setter]) => {
   }
 });
 
-if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-  updateSetting({checked: e.matches, name: 'theme'})
+function checkColorScheme(matchedMedia, first=false) {
+  let userOverrided = localStorage.getItem('userOverridedSettings')
+  if (!userOverrided) {
+    updateSetting({checked: matchedMedia.matches, name: 'useDarkTheme'}, false)
+    if (first) {
+      matchedMedia.addEventListener('change', checkColorScheme);
+    }
+  }
 }
-window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-  updateSetting({checked: e.matches, name: 'theme'})
-});
+
+let matchedMedia = window.matchMedia('(prefers-color-scheme: dark)')
+checkColorScheme(matchedMedia, true)
 
 document.addEventListener('DOMContentLoaded', () => {
 


### PR DESCRIPTION
### Summary

default onto media match `(prefers-color-scheme: dark)` when it hasn't been chosen yet.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
