### PR TITLE
[bugs] stop resolving Object for template/invite; remove dupe methods

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -1027,7 +1027,7 @@ class Client:
 
         Parameters
         -----------
-        code: :class:`str`
+        code: Union[:class:`.Template`, :class:`str`]
             The Discord Template Code or URL (must be a discord.new URL).
 
         Raises
@@ -1144,7 +1144,7 @@ class Client:
 
         Parameters
         -----------
-        url: :class:`str`
+        url: Union[:class:`.Invite`, :class:`str`]
             The Discord invite ID or URL (must be a discord.gg URL).
         with_counts: :class:`bool`
             Whether to include count information in the invite. This fills the

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1485,58 +1485,6 @@ class Guild(Hashable):
 
         return result
 
-    async def fetch_emojis(self):
-        r"""|coro|
-
-        Retrieves all custom :class:`Emoji`\s from the guild.
-
-        .. note::
-
-            This method is an API call. For general usage, consider :attr:`emojis` instead.
-
-        Raises
-        ---------
-        HTTPException
-            An error occurred fetching the emojis.
-
-        Returns
-        --------
-        List[:class:`Emoji`]
-            The retrieved emojis.
-        """
-        data = await self._state.http.get_all_custom_emojis(self.id)
-        return [Emoji(guild=self, state=self._state, data=d) for d in data]
-
-    async def fetch_emoji(self, emoji_id):
-        """|coro|
-
-        Retrieves a custom :class:`Emoji` from the guild.
-
-        .. note::
-
-            This method is an API call.
-            For general usage, consider iterating over :attr:`emojis` instead.
-
-        Parameters
-        -------------
-        emoji_id: :class:`int`
-            The emoji's ID.
-
-        Raises
-        ---------
-        NotFound
-            The emoji requested could not be found.
-        HTTPException
-            An error occurred fetching the emoji.
-
-        Returns
-        --------
-        :class:`Emoji`
-            The retrieved emoji.
-        """
-        data = await self._state.http.get_custom_emoji(self.id, emoji_id)
-        return Emoji(guild=self, state=self._state, data=data)
-
     async def create_integration(self, *, type, id):
         """|coro|
 
@@ -1589,9 +1537,13 @@ class Guild(Hashable):
         return [Integration(guild=self, data=d) for d in data]
 
     async def fetch_emojis(self):
-        """|coro|
+        r"""|coro|
 
-        Retrieves all custom :class:`Emoji`s from the guild.
+        Retrieves all custom :class:`Emoji`\s from the guild.
+
+        .. note::
+
+            This method is an API call. For general usage, consider :attr:`emojis` instead.
 
         Raises
         ---------
@@ -1610,6 +1562,11 @@ class Guild(Hashable):
         """|coro|
 
         Retrieves a custom :class:`Emoji` from the guild.
+
+        .. note::
+
+            This method is an API call.
+            For general usage, consider iterating over :attr:`emojis` instead.
 
         Parameters
         -------------

--- a/discord/integrations.py
+++ b/discord/integrations.py
@@ -70,7 +70,7 @@ class Integration:
         Where the integration is currently syncing.
     role: :class:`Role`
         The role which the integration uses for subscribers.
-    enable_emoticons: :class:`bool`
+    enable_emoticons: Optional[:class:`bool`]
         Whether emoticons should be synced for this integration (currently twitch only).
     expire_behaviour: :class:`ExpireBehaviour`
         The behaviour of expiring subscribers. Aliased to ``expire_behavior`` as well.

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -442,8 +442,8 @@ def resolve_invite(invite):
         The invite code.
     """
     from .invite import Invite  # circular import
-    if isinstance(invite, (Invite, Object)):
-        return invite.id
+    if isinstance(invite, Invite):
+        return invite.code
     else:
         rx = r'(?:https?\:\/\/)?discord(?:\.gg|(?:app)?\.com\/invite)\/(.+)'
         m = re.match(rx, invite)
@@ -453,8 +453,8 @@ def resolve_invite(invite):
 
 def resolve_template(code):
     from .template import Template # circular import
-    if isinstance(code, (Template, Object)):
-        return template.id
+    if isinstance(code, Template):
+        return template.code
     else:
         rx = r'(?:https?\:\/\/)?discord(?:\.new|(?:app)?\.com\/template)\/(.+)'
         m = re.match(rx, code)


### PR DESCRIPTION
### Summary

Fixes:
- Passing `discord.Object` for `utils.resolve_invite` originally introduced in dd2e08e, contrary to 80eb567
    - Fixed for `utils.resolve_template` as well.
- Removed duplicate methods for `Guild.fetch_emoji(s)` caused by a faulty merge with 1d701f3
- Also changes some docstrings to match the types properly.

*Courtesy of @bryanforbes.*

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
