### PR TITLE
Typo with voice_client

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -372,7 +372,7 @@ class Guild(Hashable):
 
     @property
     def voice_client(self):
-        """Optional[:class:`VoiceClient`:] Returns the :class:`VoiceClient` associated with this guild, if any."""
+        """Optional[:class:`VoiceClient`]: Returns the :class:`VoiceClient` associated with this guild, if any."""
         return self._state._get_voice_client(self.id)
 
     @property


### PR DESCRIPTION
Optional[:class:`VoiceClient`:] -> Optional[:class:`VoiceClient`]:

### Summary

<!-- What is this pull request for? Does it fix any issues? -->

Small typo in the docs, simple one char switch

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
