### PR TITLE
Expose a way to call `Update Voice State` gateway command

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2065,7 +2065,7 @@ class Guild(Hashable):
         limit = limit or 5
         return await self._state.query_members(self, query=query, limit=limit, user_ids=user_ids, cache=cache)
 
-    async def change_voice_state(self, *, self_mute, self_deaf):
+    async def change_voice_state(self, channel, *, self_mute, self_deaf):
         """|coro|
 
         Changes client's voice state in the guild.
@@ -2074,13 +2074,13 @@ class Guild(Hashable):
 
         Parameters
         -----------
+        channel: Optional[:class:`VoiceChannel`]
+            Channel the client wants to join. Use ``None`` to disconnect.
         self_mute: :class:`bool`
             Indicates if the client should be self-muted.
         self_deaf: :class:`bool`
             Indicates if the client should be self-deafened.
         """
         ws = self._state._get_websocket(self.id)
-        current_state = self._voice_state_for(self._state.self_id)
-        channel = current_state.channel if current_state else None
         channel_id = channel.id if channel else None
         await ws.voice_state(self.id, channel_id, self_mute, self_deaf)

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2065,7 +2065,7 @@ class Guild(Hashable):
         limit = limit or 5
         return await self._state.query_members(self, query=query, limit=limit, user_ids=user_ids, cache=cache)
 
-    async def change_voice_state(self, channel, *, self_mute, self_deaf):
+    async def change_voice_state(self, channel, *, self_mute=False, self_deaf=False):
         """|coro|
 
         Changes client's voice state in the guild.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2065,7 +2065,7 @@ class Guild(Hashable):
         limit = limit or 5
         return await self._state.query_members(self, query=query, limit=limit, user_ids=user_ids, cache=cache)
 
-    async def change_voice_state(self, channel, *, self_mute=False, self_deaf=False):
+    async def change_voice_state(self, *, channel, self_mute=False, self_deaf=False):
         """|coro|
 
         Changes client's voice state in the guild.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2064,3 +2064,23 @@ class Guild(Hashable):
 
         limit = limit or 5
         return await self._state.query_members(self, query=query, limit=limit, user_ids=user_ids, cache=cache)
+
+    async def change_voice_state(self, *, self_mute, self_deaf):
+        """|coro|
+
+        Changes client's voice state in the guild.
+
+        .. versionadded:: 1.4
+
+        Parameters
+        -----------
+        self_mute: :class:`bool`
+            Indicates if the client should be self-muted.
+        self_deaf: :class:`bool`
+            Indicates if the client should be self-deafened.
+        """
+        ws = self._state._get_websocket(self.id)
+        current_state = self._voice_state_for(self._state.self_id)
+        channel = current_state.channel if current_state else None
+        channel_id = channel.id if channel else None
+        await ws.voice_state(self.id, channel_id, self_mute, self_deaf)


### PR DESCRIPTION
### Summary

This PR adds a `Guild.change_voice_state()` method which exposes [Update Voice State](https://discord.com/developers/docs/topics/gateway#update-voice-state) command in the main gateway.

I decided to just make the PR and people can bikeshed it now with at least having *some* implementation.

1. Although I *can* get the `channel` from `guild.me.voice`, I figured that it can also be useful to connect the bot without using the `VoiceChannel.connect()` method which also creates a `VoiceClient` and establishes the connection with voice server. If you want to, I can add some sentinel as default value for `channel` parameter, so that d.py users could also use this method without passing the channel. (example for that [here](https://github.com/jack1142/discord.py/commit/96dfe1f87dde48bc1bcead24cda2739126429f5a))
2. I called this method `change_voice_state()` to make it consistent with `change_presence()` but other names could be used as well.
3. This method could possibly be put on a different object too, but I think this suits it rather well considering the data that this gateway command needs.


Fixes #4215 

### Checklist

- [X] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
