### PR TITLE
[docs] Update AuditLogDiff.type to be accurate

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2170,8 +2170,23 @@ this goal, it must make use of a couple of data classes that aid in this goal.
 
         The type of channel or channel permission overwrite.
 
-        If the type is an :class:`int`, then it is a type of channel which can be either
-        ``0`` to indicate a text channel or ``1`` to indicate a voice channel.
+        If the type is an :class:`int`, then it is one of the following:
+
+        +---+---------------------------------+
+        | 0 | A guild text channel.           |
+        +===+=================================+
+        | 1 | A direct message channel.       |
+        +---+---------------------------------+
+        | 2 | A guild voice channel.          |
+        +---+---------------------------------+
+        | 3 | A group direct message channel. |
+        +---+---------------------------------+
+        | 4 | A guild category channel.       |
+        +---+---------------------------------+
+        | 5 | A guild news channel.           |
+        +---+---------------------------------+
+        | 6 | A guild store channel.          |
+        +---+---------------------------------+
 
         If the type is a :class:`str`, then it is a type of permission overwrite which
         can be either ``'role'`` or ``'member'``.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2172,21 +2172,23 @@ this goal, it must make use of a couple of data classes that aid in this goal.
 
         If the type is an :class:`int`, then it is one of the following:
 
-        +-----+---------------------------------+
-        | `0` | A guild text channel.           |
-        +-----+---------------------------------+
-        | `1` | A direct message channel.       |
-        +-----+---------------------------------+
-        | `2` | A guild voice channel.          |
-        +-----+---------------------------------+
-        | `3` | A group direct message channel. |
-        +-----+---------------------------------+
-        | `4` | A guild category channel.       |
-        +-----+---------------------------------+
-        | `5` | A guild news channel.           |
-        +-----+---------------------------------+
-        | `6` | A guild store channel.          |
-        +-----+---------------------------------+
+        +-------+---------------------------------+
+        | value | meaning                         + 
+        +=======+=================================+
+        |  `0`  | A guild text channel.           |
+        +-------+---------------------------------+
+        |  `1`  | A direct message channel.       |
+        +-------+---------------------------------+
+        |  `2`  | A guild voice channel.          |
+        +-------+---------------------------------+
+        |  `3`  | A group direct message channel. |
+        +-------+---------------------------------+
+        |  `4`  | A guild category channel.       |
+        +-------+---------------------------------+
+        |  `5`  | A guild news channel.           |
+        +-------+---------------------------------+
+        |  `6`  | A guild store channel.          |
+        +-------+---------------------------------+
 
         If the type is a :class:`str`, then it is a type of permission overwrite which
         can be either ``'role'`` or ``'member'``.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2174,7 +2174,7 @@ this goal, it must make use of a couple of data classes that aid in this goal.
 
         +---+---------------------------------+
         | 0 | A guild text channel.           |
-        +===+=================================+
+        +---+---------------------------------+
         | 1 | A direct message channel.       |
         +---+---------------------------------+
         | 2 | A guild voice channel.          |

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2172,21 +2172,21 @@ this goal, it must make use of a couple of data classes that aid in this goal.
 
         If the type is an :class:`int`, then it is one of the following:
 
-        +---+---------------------------------+
-        | 0 | A guild text channel.           |
-        +---+---------------------------------+
-        | 1 | A direct message channel.       |
-        +---+---------------------------------+
-        | 2 | A guild voice channel.          |
-        +---+---------------------------------+
-        | 3 | A group direct message channel. |
-        +---+---------------------------------+
-        | 4 | A guild category channel.       |
-        +---+---------------------------------+
-        | 5 | A guild news channel.           |
-        +---+---------------------------------+
-        | 6 | A guild store channel.          |
-        +---+---------------------------------+
+        +-----+---------------------------------+
+        | `0` | A guild text channel.           |
+        +-----+---------------------------------+
+        | `1` | A direct message channel.       |
+        +-----+---------------------------------+
+        | `2` | A guild voice channel.          |
+        +-----+---------------------------------+
+        | `3` | A group direct message channel. |
+        +-----+---------------------------------+
+        | `4` | A guild category channel.       |
+        +-----+---------------------------------+
+        | `5` | A guild news channel.           |
+        +-----+---------------------------------+
+        | `6` | A guild store channel.          |
+        +-----+---------------------------------+
 
         If the type is a :class:`str`, then it is a type of permission overwrite which
         can be either ``'role'`` or ``'member'``.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2175,19 +2175,19 @@ this goal, it must make use of a couple of data classes that aid in this goal.
         +-------+---------------------------------+
         | value | meaning                         + 
         +=======+=================================+
-        |  `0`  | A guild text channel.           |
+        | ``0`` | A guild text channel.           |
         +-------+---------------------------------+
-        |  `1`  | A direct message channel.       |
+        | ``1`` | A direct message channel.       |
         +-------+---------------------------------+
-        |  `2`  | A guild voice channel.          |
+        | ``2`` | A guild voice channel.          |
         +-------+---------------------------------+
-        |  `3`  | A group direct message channel. |
+        | ``3`` | A group direct message channel. |
         +-------+---------------------------------+
-        |  `4`  | A guild category channel.       |
+        | ``4`` | A guild category channel.       |
         +-------+---------------------------------+
-        |  `5`  | A guild news channel.           |
+        | ``5`` | A guild news channel.           |
         +-------+---------------------------------+
-        |  `6`  | A guild store channel.          |
+        | ``6`` | A guild store channel.          |
         +-------+---------------------------------+
 
         If the type is a :class:`str`, then it is a type of permission overwrite which


### PR DESCRIPTION
### Summary

The documentation for `AuditLogDiff.type` is currently inaccurate and incomplete. This pull request fixes that, using data from [the Discord Developer Docs](https://discord.com/developers/docs/resources/channel#channel-object-channel-types).

### Checklist

- [x] If code changes were made then they have been tested (none have been made).
    - [N/A] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
