### PR TITLE
Feature: Enable overriding default converters

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -95,7 +95,8 @@ class _DefaultRepr:
 _default = _DefaultRepr()
 
 class BotBase(GroupMixin):
-    def __init__(self, command_prefix, help_command=_default, description=None, **options):
+    def __init__(self, command_prefix, help_command=_default, description=None,
+                 default_converters={}, **options):
         super().__init__(**options)
         self.command_prefix = command_prefix
         self.extra_events = {}
@@ -106,7 +107,9 @@ class BotBase(GroupMixin):
         self._before_invoke = None
         self._after_invoke = None
         self._help_command = None
-        self.default_converters = converters.DEFAULT_DISCORD_CONVERTERS.copy()
+        self._default_converters = {
+            **converters.DEFAULT_DISCORD_CONVERTERS.copy(), **default_converters
+        }
         self.description = inspect.cleandoc(description) if description else ''
         self.owner_id = options.get('owner_id')
         self.owner_ids = options.get('owner_ids', set())
@@ -982,6 +985,9 @@ class Bot(BotBase, discord.Client):
         Whether the commands should be case insensitive. Defaults to ``False``. This
         attribute does not carry over to groups. You must set it to every group if
         you require group commands to be case insensitive as well.
+    default_converters: :class:`dict`
+        A mapping from type to converter. These globally override the default
+        converters.
     description: :class:`str`
         The content prefixed into the default help message.
     self_bot: :class:`bool`

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -38,7 +38,7 @@ import discord
 from .core import GroupMixin, Command
 from .view import StringView
 from .context import Context
-from . import errors
+from . import errors, converters
 from .help import HelpCommand, DefaultHelpCommand
 from .cog import Cog
 
@@ -106,6 +106,7 @@ class BotBase(GroupMixin):
         self._before_invoke = None
         self._after_invoke = None
         self._help_command = None
+        self.default_converters = converters.DEFAULT_DISCORD_CONVERTERS.copy()
         self.description = inspect.cleandoc(description) if description else ''
         self.owner_id = options.get('owner_id')
         self.owner_ids = options.get('owner_ids', set())

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -33,6 +33,7 @@ import discord
 from .errors import BadArgument, NoPrivateMessage
 
 __all__ = (
+    'DEFAULT_DISCORD_CONVERTERS',
     'Converter',
     'MemberConverter',
     'UserConverter',
@@ -50,6 +51,21 @@ __all__ = (
     'clean_content',
     'Greedy',
 )
+
+DEFAULT_DISCORD_CONVERTERS = {
+    discord.Member: MemberConverter,
+    discord.User: UserConverter,
+    discord.Message: MessageConverter,
+    discord.TextChannel: TextChannelConverter,
+    discord.Invite: InviteConverter,
+    discord.Role: RoleConverter,
+    discord.Game: GameConverter,
+    discord.Colour: ColourConverter,
+    discord.VoiceChannel: VoiceChannelConverter,
+    discord.Emoji: EmojiConverter,
+    discord.PartialEmoji: PartialEmojiConverter,
+    discord.CategoryChannel: CategoryChannelConverter,
+}
 
 def _get_from_guilds(bot, getter, argument):
     result = None

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -426,7 +426,7 @@ class Command(_BaseCommand):
             ctx.bot.dispatch('command_error', ctx, error)
 
     async def _actual_conversion(self, ctx, converter, argument, param):
-        converter = ctx.bot.default_converters.get(converter, converter)
+        converter = ctx.bot._default_converters.get(converter, converter)
 
         if converter is bool:
             return _convert_to_bool(argument)

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -426,16 +426,10 @@ class Command(_BaseCommand):
             ctx.bot.dispatch('command_error', ctx, error)
 
     async def _actual_conversion(self, ctx, converter, argument, param):
+        converter = ctx.bot.default_converters.get(converter, converter)
+
         if converter is bool:
             return _convert_to_bool(argument)
-
-        try:
-            module = converter.__module__
-        except AttributeError:
-            pass
-        else:
-            if module is not None and (module.startswith('discord.') and not module.endswith('converter')):
-                converter = getattr(converters, converter.__name__ + 'Converter', converter)
 
         try:
             if inspect.isclass(converter):

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -560,9 +560,10 @@ This command can be invoked any of the following ways:
 Globally Overriding Default Converters
 ++++++++++++++++++++++++++++++++++++++
 
-The default converters used by the bot can be globally overriden by using the `.Bot.default_converters` dict. This may
-be useful if there needs to be a globally consistent change to how arguments are parsed. This includes Discord model
-converters. For example, to alter how `time.deltatime` is parsed globally using `pytimeparse.parse`:
+The default converters used by the bot can be globally overriden by using the `default_converters` keyword parameter
+when constructing the client. This may be useful if there needs to be a globally consistent change to how arguments
+are parsed. This includes Discord model converters. For example, to alter how `time.deltatime` is parsed globally
+using `pytimeparse.parse`:
 
 .. code-block:: python3
 
@@ -572,7 +573,9 @@ converters. For example, to alter how `time.deltatime` is parsed globally using 
         async def convert(self, ctx, argument):
             return time.timedelta(pytimeparse.parse(argument))
 
-    bot.default_converters[time.deltatime] = CustomDeltaTimeConverter
+    bot = Bot(default_converters={
+      time.deltatime: CustomDeltaTimeConverter
+    })
 
     @bot.command()
     async def remind(ctx, time: time.deltatime, *, reminder: str):

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -557,6 +557,28 @@ This command can be invoked any of the following ways:
 
 .. _ext_commands_error_handler:
 
+Globally Overriding Default Converters
+++++++++++++++++++++++++++++++++++++++
+
+The default converters used by the bot can be globally overriden by using the `.Bot.default_converters` dict. This may
+be useful if there needs to be a globally consistent change to how arguments are parsed. This includes Discord model
+converters. For example, to alter how `time.deltatime` is parsed globally using `pytimeparse.parse`:
+
+.. code-block:: python3
+
+    import pytimeparse
+
+    class CustomDeltaTimeConverter(commands.Converter):
+        async def convert(self, ctx, argument):
+            return time.timedelta(pytimeparse.parse(argument))
+
+    bot.default_converters[time.deltatime] = CustomDeltaTimeConverter
+
+    @bot.command()
+    async def remind(ctx, time: time.deltatime, *, reminder: str):
+        ...
+
+
 Error Handling
 ----------------
 


### PR DESCRIPTION
### Summary

Allows developers to globally alter default conversion behavior instead of hard-coding references to specific converters as the defaults. This is useful for making globally consistent conversion behavior that doesn't require importing a converter into every instance where the converter is required. An simple use case might be as parsing timedeltas using `pytimeparse` globally. A more a advanced use case might be changing the `discord.Member` converter to use a custom converter that uses `guild.query_members`  when the user is not in the immediate member cache, a potentially common use case for large bots with `guild_subscriptions` disabled.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

I haven't directly tested these changes yet, but will soon. I might have missed a few points in the documentation. 
