### PR TITLE
Prevent `get_command()` from raising errors for whitespace-only names

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1180,6 +1180,8 @@ class GroupMixin:
             return self.all_commands.get(name)
 
         names = name.split()
+        if not names:
+            return None
         obj = self.all_commands.get(names[0])
         if not isinstance(obj, GroupMixin):
             return obj


### PR DESCRIPTION
### Summary

This PR prevents `GroupMixin.get_command()` from raising `IndexError` when whitespace-only name is passed.
Minimal reproduction:
```py
bot.get_command(" ")
```
Error:
```py
  File "/home/ubuntu/bot-venv/lib/python3.8/site-packages/testbot/__main__.py", line 1
    bot.get_command(" ")
  File "/home/ubuntu/bot-venv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 1183, in get_command
    obj = self.all_commands.get(names[0])
IndexError: list index out of range
```

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
