### PR TITLE
Add gray alias for discord.Colour

### DIFF
--- a/discord/colour.py
+++ b/discord/colour.py
@@ -202,20 +202,28 @@ class Colour:
         """A factory method that returns a :class:`Colour` with a value of ``0x95a5a6``."""
         return cls(0x95a5a6)
 
+    lighter_gray = lighter_grey
+
     @classmethod
     def dark_grey(cls):
         """A factory method that returns a :class:`Colour` with a value of ``0x607d8b``."""
         return cls(0x607d8b)
+
+    dark_gray = dark_grey
 
     @classmethod
     def light_grey(cls):
         """A factory method that returns a :class:`Colour` with a value of ``0x979c9f``."""
         return cls(0x979c9f)
 
+    light_gray = light_grey
+
     @classmethod
     def darker_grey(cls):
         """A factory method that returns a :class:`Colour` with a value of ``0x546e7a``."""
         return cls(0x546e7a)
+
+    darker_gray = darker_grey
 
     @classmethod
     def blurple(cls):


### PR DESCRIPTION
### Summary

Currently, the factory methods for grey colors in discord.Colour do not have aliases for "gray".

The `DefaultAvatar` enum has a `gray` alias to `grey`, so there is no reason Colour shouldn't as well.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
