### PR TITLE
[bug] Fix NameError with resolving codes with Template

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -469,7 +469,7 @@ def resolve_template(code):
     """
     from .template import Template # circular import
     if isinstance(code, Template):
-        return template.code
+        return code.code
     else:
         rx = r'(?:https?\:\/\/)?discord(?:\.new|(?:app)?\.com\/template)\/(.+)'
         m = re.match(rx, code)


### PR DESCRIPTION
### Summary

This fixes a `NameError` raised when using `utils.resolve_template` with a `discord.Template` instance.

### Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
