### PR TITLE
Raise error when a cog with the same name is already registered

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -489,7 +489,7 @@ class BotBase(GroupMixin):
 
         A cog is a class that has its own event listeners and commands.
 
-        .. versionchanged:: 1.5
+        .. versionchanged:: 2.0
 
             :exc:`.ClientException` is raised when a cog with the same name
             is already loaded.
@@ -502,7 +502,7 @@ class BotBase(GroupMixin):
             If a previously loaded cog with the same name should be ejected
             instead of raising an error.
 
-            .. versionadded:: 1.5
+            .. versionadded:: 2.0
 
         Raises
         -------

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -489,6 +489,11 @@ class BotBase(GroupMixin):
 
         A cog is a class that has its own event listeners and commands.
 
+        .. versionchanged:: 1.4
+
+            :exc:`.ClientException` is raised when a cog with the same name
+            is already loaded.
+
         Parameters
         -----------
         cog: :class:`.Cog`
@@ -500,13 +505,21 @@ class BotBase(GroupMixin):
             The cog does not inherit from :class:`.Cog`.
         CommandError
             An error happened during loading.
+        .ClientException
+            A cog with the same name is already loaded.
         """
 
         if not isinstance(cog, Cog):
             raise TypeError('cogs must derive from Cog')
 
+        cog_name = cog.__cog_name__
+        existing = self.__cogs.get(cog_name)
+
+        if existing:
+            raise discord.ClientException('The cog {0.__cog_name__} is already loaded.'.format(existing))
+
         cog = cog._inject(self)
-        self.__cogs[cog.__cog_name__] = cog
+        self.__cogs[cog_name] = cog
 
     def get_cog(self, name):
         """Gets the cog instance requested.

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -522,7 +522,7 @@ class BotBase(GroupMixin):
 
         if existing is not None:
             if not override:
-                raise discord.ClientException('a cog with name %s is already loaded' % cog_name)
+                raise discord.ClientException('Cog named %r already loaded' % cog_name)
             self.remove_cog(cog_name)
 
         cog = cog._inject(self)

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -484,7 +484,7 @@ class BotBase(GroupMixin):
 
     # cogs
 
-    def add_cog(self, cog, *, override=False):
+    def add_cog(self, cog: Cog, *, override: bool = False) -> None:
         """Adds a "cog" to the bot.
 
         A cog is a class that has its own event listeners and commands.

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -522,7 +522,7 @@ class BotBase(GroupMixin):
 
         if existing is not None:
             if not override:
-                raise discord.ClientException('Cog named %r already loaded' % cog_name)
+                raise discord.ClientException(f'Cog named {cog_name!r} already loaded')
             self.remove_cog(cog_name)
 
         cog = cog._inject(self)

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -484,12 +484,12 @@ class BotBase(GroupMixin):
 
     # cogs
 
-    def add_cog(self, cog):
+    def add_cog(self, cog, *, override=False):
         """Adds a "cog" to the bot.
 
         A cog is a class that has its own event listeners and commands.
 
-        .. versionchanged:: 1.4
+        .. versionchanged:: 1.5
 
             :exc:`.ClientException` is raised when a cog with the same name
             is already loaded.
@@ -498,6 +498,11 @@ class BotBase(GroupMixin):
         -----------
         cog: :class:`.Cog`
             The cog to register to the bot.
+        override: :class:`bool`
+            If a previously loaded cog with the same name should be ejected
+            instead of raising an error.
+
+            .. versionadded:: 1.5
 
         Raises
         -------
@@ -515,8 +520,10 @@ class BotBase(GroupMixin):
         cog_name = cog.__cog_name__
         existing = self.__cogs.get(cog_name)
 
-        if existing:
-            raise discord.ClientException('a cog with name {0.__cog_name__} is already loaded'.format(existing))
+        if existing is not None:
+            if not override:
+                raise discord.ClientException('a cog with name %s is already loaded' % cog_name)
+            self.remove_cog(cog_name)
 
         cog = cog._inject(self)
         self.__cogs[cog_name] = cog

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -516,7 +516,7 @@ class BotBase(GroupMixin):
         existing = self.__cogs.get(cog_name)
 
         if existing:
-            raise discord.ClientException('The cog {0.__cog_name__} is already loaded.'.format(existing))
+            raise discord.ClientException('a cog with name {0.__cog_name__} is already loaded'.format(existing))
 
         cog = cog._inject(self)
         self.__cogs[cog_name] = cog


### PR DESCRIPTION
# Summary

Currently, `Bot.add_cog` overwrites any existing cog in the internal cogs dictionary. The previously loaded cog is *not* ejected, and the listeners/commands added will indefinitely be registered to the bot. This change raises an error when a user tries to load a cog with the same name.

Alternative idea: Instead of always raising an error, add a kwarg (`override`? `force`?) that allows an already loaded cog to be overwritten in the internal dictionary and ejected from the bot properly.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
