### PR TITLE
Change in checks involving permissions

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -60,8 +60,8 @@ __all__ = (
     'guild_only',
     'is_owner',
     'is_nsfw',
-    'has_guild_permissions',
-    'bot_has_guild_permissions'
+    'has_any_permissions',
+    'bot_has_any_permissions'
 )
 
 def wrap_callback(coro):

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -49,6 +49,8 @@ __all__ = (
     'BotMissingAnyRole',
     'MissingPermissions',
     'BotMissingPermissions',
+    'MissingAnyPermissions',
+    'BotMissingAnyPermissions',
     'NSFWChannelRequired',
     'ConversionError',
     'BadUnionArgument',

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -380,10 +380,13 @@ class MissingPermissions(CheckFailure):
 
     Attributes
     -----------
+    on_guild: :class:`bool`
+        If the lookup was done using guild permissions.
     missing_perms: :class:`list`
         The required permissions that are missing.
     """
-    def __init__(self, missing_perms, *args):
+    def __init__(self, on_guild, missing_perms, *args):
+        self.on_guild = on_guild
         self.missing_perms = missing_perms
 
         missing = [perm.replace('_', ' ').replace('guild', 'server').title() for perm in missing_perms]
@@ -403,10 +406,13 @@ class BotMissingPermissions(CheckFailure):
 
     Attributes
     -----------
+    on_guild: :class:`bool`
+        If the lookup was done using guild permissions.
     missing_perms: :class:`list`
         The required permissions that are missing.
     """
-    def __init__(self, missing_perms, *args):
+    def __init__(self, on_guild, missing_perms, *args):
+        self.on_guild = on_guild
         self.missing_perms = missing_perms
 
         missing = [perm.replace('_', ' ').replace('guild', 'server').title() for perm in missing_perms]
@@ -416,6 +422,58 @@ class BotMissingPermissions(CheckFailure):
         else:
             fmt = ' and '.join(missing)
         message = 'Bot requires {} permission(s) to run this command.'.format(fmt)
+        super().__init__(message, *args)
+
+class MissingAnyPermissions(CheckFailure):
+    """Exception raised when the command invoker doesn't have any of the permissions specified
+    to run a command.
+
+    This inherits from :exc:`CheckFailure`
+
+    Attributes
+    -----------
+    on_guild: :class:`bool`
+        If the lookup was done using guild permissions.
+    missing_perms: :class:`list`
+        The required permissions that are missing.
+    """
+    def __init__(self, on_guild, missing_perms, *args):
+        self.on_guild = on_guild
+        self.missing_perms = missing_perms
+
+        missing = [perm.replace('_', ' ').replace('guild', 'server').title() for perm in missing_perms]
+
+        if len(missing) > 2:
+            fmt = '{}, and {}'.format(", ".join(missing[:-1]), missing[-1])
+        else:
+            fmt = ' and '.join(missing)
+        message = 'You are missing at least one of the required permissions to run this command: {}'.format(fmt)
+        super().__init__(message, *args)
+
+class BotMissingAnyPermissions(CheckFailure):
+    """Exception raised when the bot's member doesn't have any of the permissions specified
+    to run a command.
+
+    This inherits from :exc:`CheckFailure`
+
+    Attributes
+    -----------
+    on_guild: :class:`bool`
+        If the lookup was done using guild permissions.
+    missing_perms: :class:`list`
+        The required permissions that are missing.
+    """
+    def __init__(self, on_guild, missing_perms, *args):
+        self.on_guild = on_guild
+        self.missing_perms = missing_perms
+
+        missing = [perm.replace('_', ' ').replace('guild', 'server').title() for perm in missing_perms]
+
+        if len(missing) > 2:
+            fmt = '{}, and {}'.format(", ".join(missing[:-1]), missing[-1])
+        else:
+            fmt = ' and '.join(missing)
+        message = 'Bot requires at lease one of the required permissions to run this command: {}'.format(fmt)
         super().__init__(message, *args)
 
 class BadUnionArgument(UserInputError):


### PR DESCRIPTION
### Summary

- Added the `has_any_permissions` and `bot_has_any_permissions` checks, to check if the user or the bot has at least one of the permissions listed.

- Deleted `has_guild_permissions` and `bot_has_guild_permissions`.

- The `on_guild` attribute can now be used on the `has_permissions`, `bot_has_permissions`, `has_any_permissions` and `bot_has_any_permissions` checks to indicate a guild wide permissions lookup (if `False`, use current channel permissions). We now have four permissions checks instead of eight.

### Checklist

#### In [`commands/core.py`](https://github.com/Rapptz/discord.py/blob/master/discord/ext/commands/core.py):
- Added the `has_any_permissions` and `bot_has_any_permissions`.
- Added the `on_guild` attribute for these functions, as well as for `has_permissions` and `bot_has_permissions`.
- Deleted the `has_guild_permissions` and `bot_has_guild_permissions`.
- Replaced `'has_guild_permissions'` and `'bot_has_guild_permissions'` by `'has_any_permissions'` and `'bot_has_any_permissions'` in the `__all__` tuple.

#### In [`commands/errors.py`](https://github.com/Rapptz/discord.py/blob/master/discord/ext/commands/errors.py):
- Added `MissingAnyPermissions` and `BotMissingAnyPermissions` errors.
- Added `on_guild` attribute to `MissingPermissions` and `BotMissingPermissions`, `MissingAnyPermissions` and `BotMissingAnyPermissions` errors.
- Added `'MissingAnyPermissions'` and `'BotMissingAnyPermissions'` in the `__all__` tuple.