### PR TITLE
Small feature on permissions checks

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1718,7 +1718,7 @@ def has_permissions(**perms):
         if not missing:
             return True
 
-        raise MissingPermissions(missing)
+        raise MissingPermissions(missing, on_guild=False)
 
     return check(predicate)
 
@@ -1744,7 +1744,7 @@ def bot_has_permissions(**perms):
         if not missing:
             return True
 
-        raise BotMissingPermissions(missing)
+        raise BotMissingPermissions(missing, on_guild=False)
 
     return check(predicate)
 
@@ -1772,7 +1772,7 @@ def has_guild_permissions(**perms):
         if not missing:
             return True
 
-        raise MissingPermissions(missing)
+        raise MissingPermissions(missing, on_guild=True)
 
     return check(predicate)
 
@@ -1797,7 +1797,7 @@ def bot_has_guild_permissions(**perms):
         if not missing:
             return True
 
-        raise BotMissingPermissions(missing)
+        raise BotMissingPermissions(missing, on_guild=True)
 
     return check(predicate)
 

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -383,8 +383,9 @@ class MissingPermissions(CheckFailure):
     missing_perms: :class:`list`
         The required permissions that are missing.
     """
-    def __init__(self, missing_perms, *args):
+    def __init__(self, missing_perms, on_guild, *args):
         self.missing_perms = missing_perms
+        self.on_guild = on_guild
 
         missing = [perm.replace('_', ' ').replace('guild', 'server').title() for perm in missing_perms]
 
@@ -406,8 +407,9 @@ class BotMissingPermissions(CheckFailure):
     missing_perms: :class:`list`
         The required permissions that are missing.
     """
-    def __init__(self, missing_perms, *args):
+    def __init__(self, missing_perms, on_guild, *args):
         self.missing_perms = missing_perms
+        self.on_guild = on_guild
 
         missing = [perm.replace('_', ' ').replace('guild', 'server').title() for perm in missing_perms]
 


### PR DESCRIPTION
### Summary

Added a small and non-breaking change: `MissingPermissions` and `BotMissingPermissions` now have a `on_guild` attribute, to specify if the check was done via a channel permissions lookup or a guild wild permissions lookup. This is something I found missing and is quite useful when using `on_command_error`. Example:

```python
import discord, asyncio
from discord.ext import commands

bot = commands.Bot("!")

@bot.event
async def on_command_error(ctx, error):
    if isinstance(error, commands.MissingPermissions):
        missing = ", ".join(str(m) for m in error.missing_perms)
        if error.on_guild:
            await ctx.send("Missing guild permissions: {}".format(missing)
            return
        await ctx.send("Missing channel permissions: {}. Please check channel overwrites.".format(missing))
```

Another idea could be to have two separate classes for guild permissions lookup (`MissingGuildPermissions` and `BotMissingGuildPermissions`) instead.