### PR TITLE
API calls in default converters and more emphasis on what get does in documentation

### DIFF
--- a/docs/locale/ja/LC_MESSAGES/ext/commands/api.po
+++ b/docs/locale/ja/LC_MESSAGES/ext/commands/api.po
@@ -1257,7 +1257,7 @@ msgstr ""
 
 #: discord.ext.commands.Bot.get_channel:4 discord.ext.commands.Bot.get_emoji:3
 #: discord.ext.commands.Bot.get_guild:3 discord.ext.commands.Bot.get_user:3 of
-msgid "If not found, returns ``None``."
+msgid "If not found, returns ``None``. This method uses cache meaning a mutual guild is required see :meth:`fetch_user`"
 msgstr ""
 
 #: discord.ext.commands.Bot.get_cog:1 of


### PR DESCRIPTION
### Summary

(reopening accidentally overwrote other branch don't ask)
I'm creating this PR on issue #5174 in hopes to give the default converters more ease of use (i've added an API call as a last resort for the discord.ext.commands converters because it doesn't make sense not to have them in my opinion although i'm not sure how others feel about it) I've also added a note next to get_user that states the following "This method uses cache meaning a mutual guild is required see fetch_user" to try to remain consistent with the fetch_user documentation... i'd hope to see this throughout the documentation for all get methods... didn't add it myself because i'm not too familiar with the formatting.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
