### PR TITLE
Check if self.guild is object as well as not None

### DIFF
--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -157,7 +157,7 @@ class ReactionIterator(_AsyncIterator):
                 self.limit -= retrieve
                 self.after = Object(id=int(data[-1]['id']))
 
-            if self.guild is None:
+            if self.guild is None or isinstance(self.guild, Object):
                 for element in reversed(data):
                     await self.users.put(User(state=self.state, data=element))
             else:


### PR DESCRIPTION
### Summary

Catch AttributeError exception on user reactions iterator

It seems that sometimes the guild is a simple object file, and doesnt have get_member

File "/home/user/.envs/discord/lib/python3.6/site-packages/discord/iterators.py", line 166, in fill_users
    member = self.guild.get_member(member_id)
AttributeError: 'Object' object has no attribute 'get_member'

Add generic try/except to catch this case, and set member to zero.

Tested in my app and fixes issue

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
