### PR TITLE
Fix Member.joined_at documentation

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -149,7 +149,7 @@ class Member(discord.abc.Messageable, _BaseUser):
     ----------
     joined_at: Optional[:class:`datetime.datetime`]
         A datetime object that specifies the date and time in UTC that the member joined the guild for
-        the first time. In certain cases, this can be ``None``.
+        the first time. If the member left and rejoined the guild, will be the latest date. In certain cases, this can be ``None``.
     activities: Tuple[Union[:class:`BaseActivity`, :class:`Spotify`]]
         The activities that the user is currently doing.
     guild: :class:`Guild`

--- a/discord/member.py
+++ b/discord/member.py
@@ -148,8 +148,8 @@ class Member(discord.abc.Messageable, _BaseUser):
     Attributes
     ----------
     joined_at: Optional[:class:`datetime.datetime`]
-        A datetime object that specifies the date and time in UTC that the member joined the guild for
-        the first time. If the member left and rejoined the guild, will be the latest date. In certain cases, this can be ``None``.
+        A datetime object that specifies the date and time in UTC that the member joined the guild.
+        If the member left and rejoined the guild, this will be the latest date. In certain cases, this can be ``None``.
     activities: Tuple[Union[:class:`BaseActivity`, :class:`Spotify`]]
         The activities that the user is currently doing.
     guild: :class:`Guild`


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes the [Member.joined_at](https://discordpy.readthedocs.io/en/latest/api.html#discord.Member.joined_at) documentation.

Also, This PR closes #5183, and this is a potential duplicate of #882.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
