### PR TITLE
Added GuildConverter converter

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -46,6 +46,7 @@ __all__ = (
     'EmojiConverter',
     'PartialEmojiConverter',
     'CategoryChannelConverter',
+    'GuildConverter',
     'IDConverter',
     'clean_content',
     'Greedy',
@@ -395,6 +396,31 @@ class RoleConverter(IDConverter):
 
         if result is None:
             raise BadArgument('Role "{}" not found.'.format(argument))
+        return result
+
+class GuildConverter(IDConverter):
+    """Converts to a :class:`~discord.Guild`.
+
+    All lookups are done via the global cache.
+
+    The lookup strategy is as follows (in order):
+
+    1. Lookup by ID.
+    2. Lookup by name
+    """
+    async def convert(self, ctx, argument):
+        bot = ctx.bot
+        match = self._get_id_match(argument)
+
+        if match is not None:
+            guild_id = int(match.group(1))
+            result = bot.get_guild(guild_id)
+
+        else:
+            result = discord.utils.get(bot.guilds, name=argument)
+
+        if result is None:
+            raise BadArgument('Guild "{}" not found.'.format(argument))
         return result
 
 class GameConverter(Converter):


### PR DESCRIPTION
### Summary

`GuildConverter` converter has been added in [**commands/converter.py**](https://github.com/Rapptz/discord.py/blob/master/discord/ext/commands/converter.py). This method converts a string to a [`Guild`](https://discordpy.readthedocs.io/en/latest/api.html#guild), if possible.

All lookups are done via the global cache. The lookup strategy is as follows (in order):

 1. Lookup by ID.
 2. Lookup by name

#### Parameters
- **ctx** ([Context](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#context)) – The invocation context that the argument is being used in.
- **argument** ([str](https://docs.python.org/3/library/stdtypes.html#str)) – The argument that is being converted.

#### Raises
- [CommandError](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#discord.ext.commands.CommandError) – A generic exception occurred when converting the argument.
- [BadArgument](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#discord.ext.commands.BadArgument) – The converter failed to convert the argument.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
