### PR TITLE
[tasks] Remove HTTPException as an exception to silently continue for

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -52,7 +52,6 @@ class Loop:
         self._injected = None
         self._valid_exception = (
             OSError,
-            discord.HTTPException,
             discord.GatewayNotFound,
             discord.ConnectionClosed,
             aiohttp.ClientError,


### PR DESCRIPTION
### Summary

Tasks attempt to catch errors that it may want to just continue on, but this includes `discord.HTTPException` exceptions. This means `discord.Forbidden` and `discord.NotFound` exceptions are also caught, as they subclass `discord.HTTPException`.

This was briefly discussed here, and simply removing this exception was mentioned as fine there:
https://discordapp.com/channels/336642139381301249/603069307286454290/728364450289287309

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
