### PR TITLE
Add missing comma in template.py

### DIFF
--- a/discord/template.py
+++ b/discord/template.py
@@ -29,7 +29,7 @@ from .enums import VoiceRegion
 from .guild import Guild
 
 __all__ = (
-    'Template'
+    'Template',
 )
 
 class _FriendlyHttpAttributeErrorHelper:


### PR DESCRIPTION
### Summary
This fixes issues with `__all__` being str, rather than `tuple`.

According to [Python specs](https://docs.python.org/3/reference/simple_stmts.html#index-38), `__all__`, if defined, must be a sequence of strings.

### Checklist
- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
