### PR TITLE
Fixed a typo error in webhook.py documentation

### DIFF
--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -693,7 +693,7 @@ class Webhook(Hashable):
         avatar: Optional[:class:`bytes`]
             A :term:`py:bytes-like object` representing the webhook's new default avatar.
         reason: Optional[:class:`str`]
-            The reason for deleting this webhook. Shows up on the audit log.
+            The reason for editing this webhook. Shows up on the audit log.
 
             .. versionadded:: 1.4
 


### PR DESCRIPTION
Fixed a typo in webhook.py docs relating new v1.4 feature.

### Summary

<!-- What is this pull request for? Does it fix any issues? -->

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
