### PR TITLE
Extend __path__ with pkgutil to allow editable extensions

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -17,6 +17,8 @@ __license__ = 'MIT'
 __copyright__ = 'Copyright 2015-2020 Rapptz'
 __version__ = '1.4.0'
 
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+
 from collections import namedtuple
 import logging
 


### PR DESCRIPTION
### Summary

When developing third party extensions for discord.py, due to an issue with editable extensions, it will not find the extensions as it will only search the module path and realise that the name does not exist in the ext directory. However, using pkgutil to extend the path seems to resolve the issue:

```python
__path__ = __import__('pkgutil').extend_path(__path__, __name__)
```

Related: https://github.com/pypa/pip/issues/7265#issuecomment-560044170

The way I discovered this was while developing an extension, I installed `discord.py` to a virtual environment and installed the extension as editable to the same virtual environment:

```
python -m venv .venv
source .venv/bin/activate
pip install -U discord.py
pip install -e .
python
>>> import discord.ext.my_extension
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'discord.ext.my_extension'
```

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
