### PR TITLE
update the docs on RawReactionActionEvent.member

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -125,7 +125,7 @@ class RawReactionActionEvent(_RawReprMixin):
     emoji: :class:`PartialEmoji`
         The custom or unicode emoji being used.
     member: Optional[:class:`Member`]
-        The member who added the reaction. Only available if `event_type` is `REACTION_ADD`.
+        The member who added the reaction. Only available if `event_type` is `REACTION_ADD` or the reaction is inside a guild.
 
         .. versionadded:: 1.3
 


### PR DESCRIPTION
### Summary

this fixes the docs for RawReactionActionEvent.member to say that it is also none when inside dms
### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ x ] This PR is **not** a code change (e.g. documentation, README, ...)
