### PR TITLE
Fix letter to be consistent with the rest of the docs

### DIFF
--- a/discord/mentions.py
+++ b/discord/mentions.py
@@ -39,7 +39,7 @@ default = _FakeBool()
 class AllowedMentions:
     """A class that represents what mentions are allowed in a message.
 
-    This class can be set during :class:`Client` initialization to apply
+    This class can be set during :class:`Client` initialisation to apply
     to every message sent. It can also be applied on a per message basis
     via :meth:`abc.Messageable.send` for more fine-grained control.
 


### PR DESCRIPTION
### Summary

This PR resolves issue #5208.

Class description for AllowedMentions uses the word **initialization**, but the the docs use **initialisation**. I've switched the **z** for **s** for consistency.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
