### PR TITLE
Fix hyperlink reference to PartialInviteChannel

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -1189,7 +1189,7 @@ class Client:
 
             If the invite is for a guild you have not joined, the guild and channel
             attributes of the returned :class:`.Invite` will be :class:`.PartialInviteGuild` and
-            :class:`PartialInviteChannel` respectively.
+            :class:`.PartialInviteChannel` respectively.
 
         Parameters
         -----------


### PR DESCRIPTION
### Summary

Prepend a period to fix the hyperlink reference for `fetch_invite`

`commands.Bot` inheriting `discord.Client` caused the hyperlink reference to not function properly.

This change fixes that hyperlink issue, so now both are referencing & hyperlinking `PartialInviteChannel` correctly.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
