### PR TITLE
Add South Korea VoiceRegion

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -193,6 +193,7 @@ class VoiceRegion(Enum):
     russia        = 'russia'
     japan         = 'japan'
     southafrica   = 'southafrica'
+    south_korea   = 'south-korea'
     india         = 'india'
     europe        = 'europe'
     dubai         = 'dubai'

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1045,6 +1045,9 @@ of :class:`enum.Enum`.
     .. attribute:: southafrica
 
         The South Africa region.
+    .. attribute:: south_korea
+
+        The South Korea region.
     .. attribute:: sydney
 
         The Sydney region.


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->
This adds `South Korea` VoiceRegion into Discord.py enums

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
