### PR TITLE
[matrix] Fix methods from superclass showing under "Attributes" table

### DIFF
--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -165,7 +165,7 @@ def process_attributetable(app, doctree, fromdocname):
 
 def get_class_results(lookup, modulename, name, fullname):
     module = importlib.import_module(modulename)
-    cls_dict = getattr(module, name).__dict__
+    cls = getattr(module, name)
 
     groups = OrderedDict([
         (_('Attributes'), []),
@@ -183,7 +183,7 @@ def get_class_results(lookup, modulename, name, fullname):
         badge = None
         label = attr
 
-        value = cls_dict.get(attr)
+        value = getattr(cls, attr, None)
         if value is not None:
             doc = value.__doc__ or ''
             if inspect.iscoroutinefunction(value) or doc.startswith('|coro|'):


### PR DESCRIPTION
### Summary

This should fix methods from superclass to show under "Attributes" section in attribute table.

Before:
![image](https://user-images.githubusercontent.com/6032823/90670923-37d41e80-e254-11ea-9c64-356b095edf10.png)

After:
![image](https://user-images.githubusercontent.com/6032823/90671064-723dbb80-e254-11ea-8fc4-cb8013a680b4.png)


### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
