### PR TITLE
[commands] Add cls parameter to process_commands method.

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -911,7 +911,7 @@ class BotBase(GroupMixin):
             exc = errors.CommandNotFound('Command "{}" is not found'.format(ctx.invoked_with))
             self.dispatch('command_error', ctx, exc)
 
-    async def process_commands(self, message):
+    async def process_commands(self, message, cls=Context):
         """|coro|
 
         This function processes the commands that have been registered
@@ -932,11 +932,16 @@ class BotBase(GroupMixin):
         -----------
         message: :class:`discord.Message`
             The message to process commands for.
+        cls
+            The factory class that will be used to create the context.
+            By default, this is :class:`.Context`. Should a custom
+            class be provided, it must be similar enough to :class:`.Context`\'s
+            interface.
         """
         if message.author.bot:
             return
 
-        ctx = await self.get_context(message)
+        ctx = await self.get_context(message, cls=cls)
         await self.invoke(ctx)
 
     async def on_message(self, message):


### PR DESCRIPTION
### Summary

Adds a cls parameter to the process_commands method in bot.py
So, you don't need to make a custom process_commands to pass in a new context.

Here's an example:
```py
@bot.event
async def on_message(message: discord.Message):
    await bot.process_commands(message, cls=InvitesContext)
```

Before this PR:
```py
class Bot(commands.Bot):
    async def get_context(self, message, *, cls=Context):
        return await super().get_context(message, cls=cls)
```
I feel the Bot subclassing unnecessary as it is very easy just to add a cls parameter to the bot.process_commands

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
