### PR TITLE
Add subclasses of BadArgument for converters

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -372,7 +372,7 @@ class ColourConverter(Converter):
         - The ``_`` in the name can be optionally replaced with spaces.
 
     .. versionchanged:: 1.5
-         Raise :exc:`.InvalidColour` instead of generic :exc:`.BadArgument`
+         Raise :exc:`.BadColourArgument` instead of generic :exc:`.BadArgument`
     """
     async def convert(self, ctx, argument):
         arg = argument.replace('0x', '').lower()
@@ -382,13 +382,13 @@ class ColourConverter(Converter):
         try:
             value = int(arg, base=16)
             if not (0 <= value <= 0xFFFFFF):
-                raise InvalidColour(arg)
+                raise BadColourArgument(arg)
             return discord.Colour(value=value)
         except ValueError:
             arg = arg.replace(' ', '_')
             method = getattr(discord.Colour, arg, None)
             if arg.startswith('from_') or method is None or not inspect.ismethod(method):
-                raise InvalidColour(arg)
+                raise BadColourArgument(arg)
             return method()
 
 class RoleConverter(IDConverter):
@@ -432,14 +432,14 @@ class InviteConverter(Converter):
     This is done via an HTTP request using :meth:`.Bot.fetch_invite`.
 
     .. versionchanged:: 1.5
-         Raise :exc:`.InvalidInvite` instead of generic :exc:`.BadArgument`
+         Raise :exc:`.BadInviteArgument` instead of generic :exc:`.BadArgument`
     """
     async def convert(self, ctx, argument):
         try:
             invite = await ctx.bot.fetch_invite(argument)
             return invite
         except Exception as exc:
-            raise InvalidInvite() from exc
+            raise BadInviteArgument() from exc
 
 class EmojiConverter(IDConverter):
     """Converts to a :class:`~discord.Emoji`.

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -118,6 +118,9 @@ class MemberConverter(IDConverter):
     3. Lookup by name#discrim
     4. Lookup by name
     5. Lookup by nickname
+
+    .. versionchanged:: 1.5
+         Raise :exc:`.MemberNotFound` instead of generic :exc:`.BadArgument`
     """
 
     async def convert(self, ctx, argument):
@@ -154,6 +157,9 @@ class UserConverter(IDConverter):
     2. Lookup by mention.
     3. Lookup by name#discrim
     4. Lookup by name
+
+    .. versionchanged:: 1.5
+         Raise :exc:`.UserNotFound` instead of generic :exc:`.BadArgument`
     """
     async def convert(self, ctx, argument):
         match = self._get_id_match(argument) or re.match(r'<@!?([0-9]+)>$', argument)
@@ -198,6 +204,9 @@ class MessageConverter(Converter):
     1. Lookup by "{channel ID}-{message ID}" (retrieved by shift-clicking on "Copy ID")
     2. Lookup by message ID (the message **must** be in the context channel)
     3. Lookup by message URL
+
+    .. versionchanged:: 1.5
+         Raise :exc:`.ChannelNotFound`, `MessageNotFound` or `ChannelNotReadable` instead of generic :exc:`.BadArgument`
     """
 
     async def convert(self, ctx, argument):
@@ -236,6 +245,9 @@ class TextChannelConverter(IDConverter):
     1. Lookup by ID.
     2. Lookup by mention.
     3. Lookup by name
+
+    .. versionchanged:: 1.5
+         Raise :exc:`.ChannelNotFound` instead of generic :exc:`.BadArgument`
     """
     async def convert(self, ctx, argument):
         bot = ctx.bot
@@ -275,6 +287,9 @@ class VoiceChannelConverter(IDConverter):
     1. Lookup by ID.
     2. Lookup by mention.
     3. Lookup by name
+
+    .. versionchanged:: 1.5
+         Raise :exc:`.ChannelNotFound` instead of generic :exc:`.BadArgument`
     """
     async def convert(self, ctx, argument):
         bot = ctx.bot
@@ -313,6 +328,9 @@ class CategoryChannelConverter(IDConverter):
     1. Lookup by ID.
     2. Lookup by mention.
     3. Lookup by name
+
+    .. versionchanged:: 1.5
+         Raise :exc:`.ChannelNotFound` instead of generic :exc:`.BadArgument`
     """
     async def convert(self, ctx, argument):
         bot = ctx.bot
@@ -352,6 +370,9 @@ class ColourConverter(Converter):
     - Any of the ``classmethod`` in :class:`Colour`
 
         - The ``_`` in the name can be optionally replaced with spaces.
+
+    .. versionchanged:: 1.5
+         Raise :exc:`.InvalidColour` instead of generic :exc:`.BadArgument`
     """
     async def convert(self, ctx, argument):
         arg = argument.replace('0x', '').lower()
@@ -381,6 +402,9 @@ class RoleConverter(IDConverter):
     1. Lookup by ID.
     2. Lookup by mention.
     3. Lookup by name
+
+    .. versionchanged:: 1.5
+         Raise :exc:`.RoleNotFound` instead of generic :exc:`.BadArgument`
     """
     async def convert(self, ctx, argument):
         guild = ctx.guild
@@ -406,6 +430,9 @@ class InviteConverter(Converter):
     """Converts to a :class:`~discord.Invite`.
 
     This is done via an HTTP request using :meth:`.Bot.fetch_invite`.
+
+    .. versionchanged:: 1.5
+         Raise :exc:`.InvalidInvite` instead of generic :exc:`.BadArgument`
     """
     async def convert(self, ctx, argument):
         try:
@@ -425,6 +452,9 @@ class EmojiConverter(IDConverter):
     1. Lookup by ID.
     2. Lookup by extracting ID from the emoji.
     3. Lookup by name
+
+    .. versionchanged:: 1.5
+         Raise :exc:`.EmojiNotFound` instead of generic :exc:`.BadArgument`
     """
     async def convert(self, ctx, argument):
         match = self._get_id_match(argument) or re.match(r'<a?:[a-zA-Z0-9\_]+:([0-9]+)>$', argument)
@@ -458,6 +488,9 @@ class PartialEmojiConverter(Converter):
     """Converts to a :class:`~discord.PartialEmoji`.
 
     This is done by extracting the animated flag, name and ID from the emoji.
+
+    .. versionchanged:: 1.5
+         Raise :exc:`.PartialEmojiNotFound` instead of generic :exc:`.BadArgument`
     """
     async def convert(self, ctx, argument):
         match = re.match(r'<(a?):([a-zA-Z0-9\_]+):([0-9]+)>$', argument)

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -361,13 +361,13 @@ class ColourConverter(Converter):
         try:
             value = int(arg, base=16)
             if not (0 <= value <= 0xFFFFFF):
-                raise ColourInvalid(arg)
+                raise InvalidColour(arg)
             return discord.Colour(value=value)
         except ValueError:
             arg = arg.replace(' ', '_')
             method = getattr(discord.Colour, arg, None)
             if arg.startswith('from_') or method is None or not inspect.ismethod(method):
-                raise ColourInvalid(arg)
+                raise InvalidColour(arg)
             return method()
 
 class RoleConverter(IDConverter):
@@ -412,7 +412,7 @@ class InviteConverter(Converter):
             invite = await ctx.bot.fetch_invite(argument)
             return invite
         except Exception as exc:
-            raise InviteInvalid() from exc
+            raise InvalidInvite() from exc
 
 class EmojiConverter(IDConverter):
     """Converts to a :class:`~discord.Emoji`.

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -490,7 +490,7 @@ class PartialEmojiConverter(Converter):
     This is done by extracting the animated flag, name and ID from the emoji.
 
     .. versionchanged:: 1.5
-         Raise :exc:`.PartialEmojiNotFound` instead of generic :exc:`.BadArgument`
+         Raise :exc:`.PartialEmojiConversionFailure` instead of generic :exc:`.BadArgument`
     """
     async def convert(self, ctx, argument):
         match = re.match(r'<(a?):([a-zA-Z0-9\_]+):([0-9]+)>$', argument)
@@ -503,7 +503,7 @@ class PartialEmojiConverter(Converter):
             return discord.PartialEmoji.with_state(ctx.bot._connection, animated=emoji_animated, name=emoji_name,
                                                    id=emoji_id)
 
-        raise PartialEmojiNotFound(argument)
+        raise PartialEmojiConversionFailure(argument)
 
 class clean_content(Converter):
     """Converts the argument to mention scrubbed version of

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -107,7 +107,7 @@ def _convert_to_bool(argument):
     elif lowered in ('no', 'n', 'false', 'f', '0', 'disable', 'off'):
         return False
     else:
-        raise InvalidBoolean(lowered)
+        raise BadBooleanArgument(lowered)
 
 class _CaseInsensitiveDict(dict):
     def __contains__(self, k):

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -107,7 +107,7 @@ def _convert_to_bool(argument):
     elif lowered in ('no', 'n', 'false', 'f', '0', 'disable', 'off'):
         return False
     else:
-        raise BadArgument(lowered + ' is not a recognised boolean option')
+        raise InvalidBoolean(lowered)
 
 class _CaseInsensitiveDict(dict):
     def __contains__(self, k):

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -223,12 +223,12 @@ class MemberNotFound(BadArgument):
 
     Attributes
     -----------
-    member: :class:`str`
+    arg: :class:`str`
         The member supplied by the caller that was not found
     """
-    def __init__(self, member):
-        self.member = member
-        super().__init__('Member "{}" not found.'.format(member))
+    def __init__(self, arg):
+        self.arg = arg
+        super().__init__('Member "{}" not found.'.format(arg))
 
 class UserNotFound(BadArgument):
     """Exception raised when the user provided was not found in the bot's
@@ -240,12 +240,12 @@ class UserNotFound(BadArgument):
 
     Attributes
     -----------
-    user: :class:`str`
+    arg: :class:`str`
         The user supplied by the caller that was not found
     """
-    def __init__(self, user):
-        self.user = user
-        super().__init__('User "{}" not found.'.format(user))
+    def __init__(self, arg):
+        self.arg = arg
+        super().__init__('User "{}" not found.'.format(arg))
 
 class MessageNotFound(BadArgument):
     """Exception raised when the message provided was not found in the channel.
@@ -256,12 +256,12 @@ class MessageNotFound(BadArgument):
 
     Attributes
     -----------
-    message: :class:`str`
+    arg: :class:`str`
         The message supplied by the caller that was not found
     """
-    def __init__(self, msg):
-        self.msg = msg
-        super().__init__('Message "{}" not found.'.format(msg))
+    def __init__(self, arg):
+        self.arg = arg
+        super().__init__('Message "{}" not found.'.format(arg))
 
 class ChannelNotReadable(BadArgument):
     """Exception raised when the bot does not have permission to read messages
@@ -273,12 +273,12 @@ class ChannelNotReadable(BadArgument):
 
     Attributes
     -----------
-    channel: :class:`Channel`
+    arg: :class:`Channel`
         The channel supplied by the caller that was not readable
     """
-    def __init__(self, channel):
-        self.channel = channel
-        super().__init__("Can't read messages in {}.".format(channel.mention))
+    def __init__(self, arg):
+        self.arg = arg
+        super().__init__("Can't read messages in {}.".format(arg.mention))
 
 class ChannelNotFound(BadArgument):
     """Exception raised when the bot can not find the channel.
@@ -292,9 +292,9 @@ class ChannelNotFound(BadArgument):
     channel: :class:`str`
         The channel supplied by the caller that was not found
     """
-    def __init__(self, channel):
-        self.channel = channel
-        super().__init__('Channel "{}" not found.'.format(channel))
+    def __init__(self, arg):
+        self.arg = arg
+        super().__init__('Channel "{}" not found.'.format(arg))
 
 class BadColourArgument(BadArgument):
     """Exception raised when the colour is not valid.
@@ -305,16 +305,12 @@ class BadColourArgument(BadArgument):
 
     Attributes
     -----------
-    colour: :class:`str`
+    arg: :class:`str`
         The colour supplied by the caller that was not valid
     """
-    def __init__(self, colour):
-        self.colour = colour
-        super().__init__('Colour "{}" is invalid.'.format(colour))
-
-    @property
-    def color(self):
-        return self.colour
+    def __init__(self, arg):
+        self.arg = arg
+        super().__init__('Colour "{}" is invalid.'.format(arg))
 
 BadColorArgument = BadColourArgument
 
@@ -327,12 +323,12 @@ class RoleNotFound(BadArgument):
 
     Attributes
     -----------
-    role: :class:`str`
+    arg: :class:`str`
         The role supplied by the caller that was not found
     """
-    def __init__(self, role):
-        self.role = role
-        super().__init__('Role "{}" not found.'.format(role))
+    def __init__(self, arg):
+        self.arg = arg
+        super().__init__('Role "{}" not found.'.format(arg))
 
 class BadInviteArgument(BadArgument):
     """Exception raised when the invite is invalid or expired.
@@ -353,12 +349,12 @@ class EmojiNotFound(BadArgument):
 
     Attributes
     -----------
-    emoji: :class:`str`
+    arg: :class:`str`
         The emoji supplied by the caller that was not found
     """
-    def __init__(self, emoji):
-        self.emoji = emoji
-        super().__init__('Emoji "{}" not found.'.format(emoji))
+    def __init__(self, arg):
+        self.arg = arg
+        super().__init__('Emoji "{}" not found.'.format(arg))
 
 class PartialEmojiConversionFailure(BadArgument):
     """Exception raised when the emoji provided does not match the correct
@@ -370,12 +366,12 @@ class PartialEmojiConversionFailure(BadArgument):
 
     Attributes
     -----------
-    emoji: :class:`str`
+    arg: :class:`str`
         The emoji supplied by the caller that did not match the regex
     """
-    def __init__(self, emoji):
-        self.emoji = emoji
-        super().__init__('Couldn\'t convert "{}" to PartialEmoji.'.format(emoji))
+    def __init__(self, arg):
+        self.arg = arg
+        super().__init__('Couldn\'t convert "{}" to PartialEmoji.'.format(arg))
 
 class InvalidBoolean(BadArgument):
     """Exception raised when a boolean argument was not convertable.

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -223,12 +223,12 @@ class MemberNotFound(BadArgument):
 
     Attributes
     -----------
-    arg: :class:`str`
+    argument: :class:`str`
         The member supplied by the caller that was not found
     """
-    def __init__(self, arg):
-        self.arg = arg
-        super().__init__('Member "{}" not found.'.format(arg))
+    def __init__(self, argument):
+        self.argument = argument
+        super().__init__('Member "{}" not found.'.format(argument))
 
 class UserNotFound(BadArgument):
     """Exception raised when the user provided was not found in the bot's
@@ -240,12 +240,12 @@ class UserNotFound(BadArgument):
 
     Attributes
     -----------
-    arg: :class:`str`
+    argument: :class:`str`
         The user supplied by the caller that was not found
     """
-    def __init__(self, arg):
-        self.arg = arg
-        super().__init__('User "{}" not found.'.format(arg))
+    def __init__(self, argument):
+        self.argument = argument
+        super().__init__('User "{}" not found.'.format(argument))
 
 class MessageNotFound(BadArgument):
     """Exception raised when the message provided was not found in the channel.
@@ -256,12 +256,12 @@ class MessageNotFound(BadArgument):
 
     Attributes
     -----------
-    arg: :class:`str`
+    argument: :class:`str`
         The message supplied by the caller that was not found
     """
-    def __init__(self, arg):
-        self.arg = arg
-        super().__init__('Message "{}" not found.'.format(arg))
+    def __init__(self, argument):
+        self.argument = argument
+        super().__init__('Message "{}" not found.'.format(argument))
 
 class ChannelNotReadable(BadArgument):
     """Exception raised when the bot does not have permission to read messages
@@ -273,12 +273,12 @@ class ChannelNotReadable(BadArgument):
 
     Attributes
     -----------
-    arg: :class:`Channel`
+    argument: :class:`Channel`
         The channel supplied by the caller that was not readable
     """
-    def __init__(self, arg):
-        self.arg = arg
-        super().__init__("Can't read messages in {}.".format(arg.mention))
+    def __init__(self, argument):
+        self.argument = argument
+        super().__init__("Can't read messages in {}.".format(argument.mention))
 
 class ChannelNotFound(BadArgument):
     """Exception raised when the bot can not find the channel.
@@ -292,9 +292,9 @@ class ChannelNotFound(BadArgument):
     channel: :class:`str`
         The channel supplied by the caller that was not found
     """
-    def __init__(self, arg):
-        self.arg = arg
-        super().__init__('Channel "{}" not found.'.format(arg))
+    def __init__(self, argument):
+        self.argument = argument
+        super().__init__('Channel "{}" not found.'.format(argument))
 
 class BadColourArgument(BadArgument):
     """Exception raised when the colour is not valid.
@@ -305,12 +305,12 @@ class BadColourArgument(BadArgument):
 
     Attributes
     -----------
-    arg: :class:`str`
+    argument: :class:`str`
         The colour supplied by the caller that was not valid
     """
-    def __init__(self, arg):
-        self.arg = arg
-        super().__init__('Colour "{}" is invalid.'.format(arg))
+    def __init__(self, argument):
+        self.argument = argument
+        super().__init__('Colour "{}" is invalid.'.format(argument))
 
 BadColorArgument = BadColourArgument
 
@@ -323,12 +323,12 @@ class RoleNotFound(BadArgument):
 
     Attributes
     -----------
-    arg: :class:`str`
+    argument: :class:`str`
         The role supplied by the caller that was not found
     """
-    def __init__(self, arg):
-        self.arg = arg
-        super().__init__('Role "{}" not found.'.format(arg))
+    def __init__(self, argument):
+        self.argument = argument
+        super().__init__('Role "{}" not found.'.format(argument))
 
 class BadInviteArgument(BadArgument):
     """Exception raised when the invite is invalid or expired.
@@ -349,12 +349,12 @@ class EmojiNotFound(BadArgument):
 
     Attributes
     -----------
-    arg: :class:`str`
+    argument: :class:`str`
         The emoji supplied by the caller that was not found
     """
-    def __init__(self, arg):
-        self.arg = arg
-        super().__init__('Emoji "{}" not found.'.format(arg))
+    def __init__(self, argument):
+        self.argument = argument
+        super().__init__('Emoji "{}" not found.'.format(argument))
 
 class PartialEmojiConversionFailure(BadArgument):
     """Exception raised when the emoji provided does not match the correct
@@ -366,12 +366,12 @@ class PartialEmojiConversionFailure(BadArgument):
 
     Attributes
     -----------
-    arg: :class:`str`
+    argument: :class:`str`
         The emoji supplied by the caller that did not match the regex
     """
-    def __init__(self, arg):
-        self.arg = arg
-        super().__init__('Couldn\'t convert "{}" to PartialEmoji.'.format(arg))
+    def __init__(self, argument):
+        self.argument = argument
+        super().__init__('Couldn\'t convert "{}" to PartialEmoji.'.format(argument))
 
 class BadBooleanArgument(BadArgument):
     """Exception raised when a boolean argument was not convertable.
@@ -382,12 +382,12 @@ class BadBooleanArgument(BadArgument):
 
     Attributes
     -----------
-    arg: :class:`str`
+    argument: :class:`str`
         The boolean argument supplied by the caller that is not in the predefined list
     """
-    def __init__(self, arg):
-        self.arg = arg
-        super().__init__('{} is not a recognised boolean option'.format(arg))
+    def __init__(self, argument):
+        self.argument = argument
+        super().__init__('{} is not a recognised boolean option'.format(argument))
 
 class DisabledCommand(CommandError):
     """Exception raised when the command being invoked is disabled.

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -53,7 +53,7 @@ __all__ = (
     'BadInviteArgument',
     'EmojiNotFound',
     'PartialEmojiConversionFailure',
-    'InvalidBoolean',
+    'BadBooleanArgument',
     'MissingRole',
     'BotMissingRole',
     'MissingAnyRole',

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -48,9 +48,9 @@ __all__ = (
     'UserNotFound',
     'ChannelNotFound',
     'ChannelNotReadable',
-    'InvalidColour',
+    'BadColourArgument',
     'RoleNotFound',
-    'InvalidInvite',
+    'BadInviteArgument',
     'EmojiNotFound',
     'PartialEmojiConversionFailure',
     'InvalidBoolean',
@@ -296,7 +296,7 @@ class ChannelNotFound(BadArgument):
         self.channel = channel
         super().__init__('Channel "{}" not found.'.format(channel))
 
-class InvalidColour(BadArgument):
+class BadColourArgument(BadArgument):
     """Exception raised when the colour is not valid.
 
     This inherits from :exc:`BadArgument`
@@ -316,7 +316,7 @@ class InvalidColour(BadArgument):
     def color(self):
         return self.colour
 
-InvalidColor = InvalidColour
+BadColorArgument = BadColourArgument
 
 class RoleNotFound(BadArgument):
     """Exception raised when the bot can not find the role.
@@ -334,7 +334,7 @@ class RoleNotFound(BadArgument):
         self.role = role
         super().__init__('Role "{}" not found.'.format(role))
 
-class InvalidInvite(BadArgument):
+class BadInviteArgument(BadArgument):
     """Exception raised when the invite is invalid or expired.
 
     This inherits from :exc:`BadArgument`

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -48,9 +48,9 @@ __all__ = (
     'UserNotFound',
     'ChannelNotFound',
     'ChannelNotReadable',
-    'ColourInvalid',
+    'InvalidColour',
     'RoleNotFound',
-    'InviteInvalid',
+    'InvalidInvite',
     'EmojiNotFound',
     'PartialEmojiNotFound',
     'MissingRole',
@@ -260,7 +260,7 @@ class ChannelNotFound(BadArgument):
         self.channel = channel
         super().__init__('Channel "{}" not found.'.format(channel))
 
-class ColourInvalid(BadArgument):
+class InvalidColour(BadArgument):
     """Exception raised when the colour is not valid.
 
     This inherits from :exc:`BadArgument`
@@ -268,6 +268,12 @@ class ColourInvalid(BadArgument):
     def __init__(self, colour):
         self.colour = colour
         super().__init__('Colour "{}" is invalid.'.format(colour))
+
+    @property
+    def color(self):
+        return self.colour
+
+InvalidColor = InvalidColour
 
 class RoleNotFound(BadArgument):
     """Exception raised when the bot can not find the role.
@@ -278,7 +284,7 @@ class RoleNotFound(BadArgument):
         self.role = role
         super().__init__('Role "{}" not found.'.format(role))
 
-class InviteInvalid(BadArgument):
+class InvalidInvite(BadArgument):
     """Exception raised when the invite is invalid or expired.
 
     This inherits from :exc:`BadArgument`

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -53,6 +53,7 @@ __all__ = (
     'InvalidInvite',
     'EmojiNotFound',
     'PartialEmojiNotFound',
+    'InvalidBoolean',
     'MissingRole',
     'BotMissingRole',
     'MissingAnyRole',
@@ -375,6 +376,22 @@ class PartialEmojiNotFound(BadArgument):
     def __init__(self, emoji):
         self.emoji = emoji
         super().__init__('Couldn\'t convert "{}" to PartialEmoji.'.format(emoji))
+
+class InvalidBoolean(BadArgument):
+    """Exception raised when a boolean argument was not convertable.
+
+    This inherits from :exc:`BadArgument`
+
+    .. versionadded:: 1.5
+
+    Attributes
+    -----------
+    arg: :class:`str`
+        The boolean argument supplied by the caller that is not in the predefined list
+    """
+    def __init__(self, arg):
+        self.arg = arg
+        super().__init__('{} is not a recognised boolean option'.format(arg))
 
 class DisabledCommand(CommandError):
     """Exception raised when the command being invoked is disabled.

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -43,6 +43,16 @@ __all__ = (
     'CommandOnCooldown',
     'MaxConcurrencyReached',
     'NotOwner',
+    'MessageNotFound',
+    'MemberNotFound',
+    'UserNotFound',
+    'ChannelNotFound',
+    'ChannelNotReadable',
+    'ColourInvalid',
+    'RoleNotFound',
+    'InviteInvalid',
+    'EmojiNotFound',
+    'PartialEmojiNotFound',
     'MissingRole',
     'BotMissingRole',
     'MissingAnyRole',
@@ -201,6 +211,98 @@ class NotOwner(CheckFailure):
     This inherits from :exc:`CheckFailure`
     """
     pass
+
+class MemberNotFound(BadArgument):
+    """Exception raised when the member provided was not found in the bot's
+    cache.
+
+    This inherits from :exc:`BadArgument`
+    """
+    def __init__(self, member):
+        self.member = member
+        super().__init__('Member "{}" not found.'.format(member))
+
+class UserNotFound(BadArgument):
+    """Exception raised when the user provided was not found in the bot's
+    cache.
+
+    This inherits from :exc:`BadArgument`
+    """
+    def __init__(self, user):
+        self.user = user
+        super().__init__('User "{}" not found.'.format(user))
+
+class MessageNotFound(BadArgument):
+    """Exception raised when the message provided was not found in the channel.
+
+    This inherits from :exc:`BadArgument`
+    """
+    def __init__(self, msg):
+        self.msg = msg
+        super().__init__('Message "{}" not found.'.format(msg))
+
+class ChannelNotReadable(BadArgument):
+    """Exception raised when the bot does not have permission to read messages
+    in the channel.
+
+    This inherits from :exc:`BadArgument`
+    """
+    def __init__(self, channel):
+        self.channel = channel
+        super().__init__("Can't read messages in {}.".format(channel.mention))
+
+class ChannelNotFound(BadArgument):
+    """Exception raised when the bot can not find the channel.
+
+    This inherits from :exc:`BadArgument`
+    """
+    def __init__(self, channel):
+        self.channel = channel
+        super().__init__('Channel "{}" not found.'.format(channel))
+
+class ColourInvalid(BadArgument):
+    """Exception raised when the colour is not valid.
+
+    This inherits from :exc:`BadArgument`
+    """
+    def __init__(self, colour):
+        self.colour = colour
+        super().__init__('Colour "{}" is invalid.'.format(colour))
+
+class RoleNotFound(BadArgument):
+    """Exception raised when the bot can not find the role.
+
+    This inherits from :exc:`BadArgument`
+    """
+    def __init__(self, role):
+        self.role = role
+        super().__init__('Role "{}" not found.'.format(role))
+
+class InviteInvalid(BadArgument):
+    """Exception raised when the invite is invalid or expired.
+
+    This inherits from :exc:`BadArgument`
+    """
+    def __init__(self):
+        super().__init__('Invite is invalid or expired.')
+
+class EmojiNotFound(BadArgument):
+    """Exception raised when the bot can not find the emoji.
+
+    This inherits from :exc:`BadArgument`
+    """
+    def __init__(self, emoji):
+        self.emoji = emoji
+        super().__init__('Emoji "{}" not found.'.format(emoji))
+
+class PartialEmojiNotFound(BadArgument):
+    """Exception raised when the emoji provided does not match the correct format.
+
+    This inherits from :exc:`BadArgument`
+    """
+    def __init__(self, emoji):
+        self.emoji = emoji
+        super().__init__('Couldn\'t convert "{}" to PartialEmoji.'.format(emoji))
 
 class DisabledCommand(CommandError):
     """Exception raised when the command being invoked is disabled.

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -373,7 +373,7 @@ class PartialEmojiConversionFailure(BadArgument):
         self.arg = arg
         super().__init__('Couldn\'t convert "{}" to PartialEmoji.'.format(arg))
 
-class InvalidBoolean(BadArgument):
+class BadBooleanArgument(BadArgument):
     """Exception raised when a boolean argument was not convertable.
 
     This inherits from :exc:`BadArgument`

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -52,7 +52,7 @@ __all__ = (
     'RoleNotFound',
     'InvalidInvite',
     'EmojiNotFound',
-    'PartialEmojiNotFound',
+    'PartialEmojiConversionFailure',
     'InvalidBoolean',
     'MissingRole',
     'BotMissingRole',
@@ -360,7 +360,7 @@ class EmojiNotFound(BadArgument):
         self.emoji = emoji
         super().__init__('Emoji "{}" not found.'.format(emoji))
 
-class PartialEmojiNotFound(BadArgument):
+class PartialEmojiConversionFailure(BadArgument):
     """Exception raised when the emoji provided does not match the correct
     format.
 

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -296,7 +296,8 @@ class EmojiNotFound(BadArgument):
         super().__init__('Emoji "{}" not found.'.format(emoji))
 
 class PartialEmojiNotFound(BadArgument):
-    """Exception raised when the emoji provided does not match the correct format.
+    """Exception raised when the emoji provided does not match the correct
+    format.
 
     This inherits from :exc:`BadArgument`
     """

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -217,6 +217,13 @@ class MemberNotFound(BadArgument):
     cache.
 
     This inherits from :exc:`BadArgument`
+
+    .. versionadded:: 1.5
+
+    Attributes
+    -----------
+    member: :class:`str`
+        The member supplied by the caller that was not found
     """
     def __init__(self, member):
         self.member = member
@@ -227,6 +234,13 @@ class UserNotFound(BadArgument):
     cache.
 
     This inherits from :exc:`BadArgument`
+
+    .. versionadded:: 1.5
+
+    Attributes
+    -----------
+    user: :class:`str`
+        The user supplied by the caller that was not found
     """
     def __init__(self, user):
         self.user = user
@@ -236,6 +250,13 @@ class MessageNotFound(BadArgument):
     """Exception raised when the message provided was not found in the channel.
 
     This inherits from :exc:`BadArgument`
+
+    .. versionadded:: 1.5
+
+    Attributes
+    -----------
+    message: :class:`str`
+        The message supplied by the caller that was not found
     """
     def __init__(self, msg):
         self.msg = msg
@@ -246,6 +267,13 @@ class ChannelNotReadable(BadArgument):
     in the channel.
 
     This inherits from :exc:`BadArgument`
+
+    .. versionadded:: 1.5
+
+    Attributes
+    -----------
+    channel: :class:`Channel`
+        The channel supplied by the caller that was not readable
     """
     def __init__(self, channel):
         self.channel = channel
@@ -255,6 +283,13 @@ class ChannelNotFound(BadArgument):
     """Exception raised when the bot can not find the channel.
 
     This inherits from :exc:`BadArgument`
+
+    .. versionadded:: 1.5
+
+    Attributes
+    -----------
+    channel: :class:`str`
+        The channel supplied by the caller that was not found
     """
     def __init__(self, channel):
         self.channel = channel
@@ -264,6 +299,13 @@ class InvalidColour(BadArgument):
     """Exception raised when the colour is not valid.
 
     This inherits from :exc:`BadArgument`
+
+    .. versionadded:: 1.5
+
+    Attributes
+    -----------
+    colour: :class:`str`
+        The colour supplied by the caller that was not valid
     """
     def __init__(self, colour):
         self.colour = colour
@@ -279,6 +321,13 @@ class RoleNotFound(BadArgument):
     """Exception raised when the bot can not find the role.
 
     This inherits from :exc:`BadArgument`
+
+    .. versionadded:: 1.5
+
+    Attributes
+    -----------
+    role: :class:`str`
+        The role supplied by the caller that was not found
     """
     def __init__(self, role):
         self.role = role
@@ -288,6 +337,8 @@ class InvalidInvite(BadArgument):
     """Exception raised when the invite is invalid or expired.
 
     This inherits from :exc:`BadArgument`
+
+    .. versionadded:: 1.5
     """
     def __init__(self):
         super().__init__('Invite is invalid or expired.')
@@ -296,6 +347,13 @@ class EmojiNotFound(BadArgument):
     """Exception raised when the bot can not find the emoji.
 
     This inherits from :exc:`BadArgument`
+
+    .. versionadded:: 1.5
+
+    Attributes
+    -----------
+    emoji: :class:`str`
+        The emoji supplied by the caller that was not found
     """
     def __init__(self, emoji):
         self.emoji = emoji
@@ -306,6 +364,13 @@ class PartialEmojiNotFound(BadArgument):
     format.
 
     This inherits from :exc:`BadArgument`
+
+    .. versionadded:: 1.5
+
+    Attributes
+    -----------
+    emoji: :class:`str`
+        The emoji supplied by the caller that did not match the regex
     """
     def __init__(self, emoji):
         self.emoji = emoji

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -368,6 +368,9 @@ Exceptions
 .. autoexception:: discord.ext.commands.PartialEmojiConversionFailure
     :members:
 
+.. autoexception:: discord.ext.commands.InvalidBoolean
+    :members:
+
 .. autoexception:: discord.ext.commands.MissingPermissions
     :members:
 
@@ -433,6 +436,7 @@ Exception Hierarchy
                     - :exc:`~.commands.InvalidInvite`
                     - :exc:`~.commands.EmojiNotFound`
                     - :exc:`~.commands.PartialEmojiConversionFailure`
+                    - :exc:`~.commands.InvalidBoolean`
                 - :exc:`~.commands.BadUnionArgument`
                 - :exc:`~.commands.ArgumentParsingError`
                     - :exc:`~.commands.UnexpectedQuoteError`

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -338,6 +338,36 @@ Exceptions
 .. autoexception:: discord.ext.commands.NotOwner
     :members:
 
+.. autoexception:: discord.ext.commands.MessageNotFound
+    :members:
+
+.. autoexception:: discord.ext.commands.MemberNotFound
+    :members:
+
+.. autoexception:: discord.ext.commands.UserNotFound
+    :members:
+
+.. autoexception:: discord.ext.commands.ChannelNotFound
+    :members:
+
+.. autoexception:: discord.ext.commands.ChannelNotReadable
+    :members:
+
+.. autoexception:: discord.ext.commands.ColourInvalid
+    :members:
+
+.. autoexception:: discord.ext.commands.RoleNotFound
+    :members:
+
+.. autoexception:: discord.ext.commands.InviteInvalid
+    :members:
+
+.. autoexception:: discord.ext.commands.EmojiNotFound
+    :members:
+
+.. autoexception:: discord.ext.commands.PartialEmojiNotFound
+    :members:
+
 .. autoexception:: discord.ext.commands.MissingPermissions
     :members:
 
@@ -404,6 +434,16 @@ Exception Hierarchy
                 - :exc:`~.commands.PrivateMessageOnly`
                 - :exc:`~.commands.NoPrivateMessage`
                 - :exc:`~.commands.NotOwner`
+                - :exc:`~.commands.MessageNotFound`
+                - :exc:`~.commands.MemberNotFound`
+                - :exc:`~.commands.UserNotFound`
+                - :exc:`~.commands.ChannelNotFound`
+                - :exc:`~.commands.ChannelNotReadable`
+                - :exc:`~.commands.ColourInvalid`
+                - :exc:`~.commands.RoleNotFound`
+                - :exc:`~.commands.InviteInvalid`
+                - :exc:`~.commands.EmojiNotFound`
+                - :exc:`~.commands.PartialEmojiNotFound`
                 - :exc:`~.commands.MissingPermissions`
                 - :exc:`~.commands.BotMissingPermissions`
                 - :exc:`~.commands.MissingRole`

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -368,7 +368,7 @@ Exceptions
 .. autoexception:: discord.ext.commands.PartialEmojiConversionFailure
     :members:
 
-.. autoexception:: discord.ext.commands.InvalidBoolean
+.. autoexception:: discord.ext.commands.BadBooleanArgument
     :members:
 
 .. autoexception:: discord.ext.commands.MissingPermissions

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -353,13 +353,13 @@ Exceptions
 .. autoexception:: discord.ext.commands.ChannelNotReadable
     :members:
 
-.. autoexception:: discord.ext.commands.ColourInvalid
+.. autoexception:: discord.ext.commands.InvalidColour
     :members:
 
 .. autoexception:: discord.ext.commands.RoleNotFound
     :members:
 
-.. autoexception:: discord.ext.commands.InviteInvalid
+.. autoexception:: discord.ext.commands.InvalidInvite
     :members:
 
 .. autoexception:: discord.ext.commands.EmojiNotFound
@@ -423,6 +423,16 @@ Exception Hierarchy
                 - :exc:`~.commands.MissingRequiredArgument`
                 - :exc:`~.commands.TooManyArguments`
                 - :exc:`~.commands.BadArgument`
+                    - :exc:`~.commands.MessageNotFound`
+                    - :exc:`~.commands.MemberNotFound`
+                    - :exc:`~.commands.UserNotFound`
+                    - :exc:`~.commands.ChannelNotFound`
+                    - :exc:`~.commands.ChannelNotReadable`
+                    - :exc:`~.commands.InvalidColour`
+                    - :exc:`~.commands.RoleNotFound`
+                    - :exc:`~.commands.InvalidInvite`
+                    - :exc:`~.commands.EmojiNotFound`
+                    - :exc:`~.commands.PartialEmojiNotFound`
                 - :exc:`~.commands.BadUnionArgument`
                 - :exc:`~.commands.ArgumentParsingError`
                     - :exc:`~.commands.UnexpectedQuoteError`
@@ -434,16 +444,6 @@ Exception Hierarchy
                 - :exc:`~.commands.PrivateMessageOnly`
                 - :exc:`~.commands.NoPrivateMessage`
                 - :exc:`~.commands.NotOwner`
-                - :exc:`~.commands.MessageNotFound`
-                - :exc:`~.commands.MemberNotFound`
-                - :exc:`~.commands.UserNotFound`
-                - :exc:`~.commands.ChannelNotFound`
-                - :exc:`~.commands.ChannelNotReadable`
-                - :exc:`~.commands.ColourInvalid`
-                - :exc:`~.commands.RoleNotFound`
-                - :exc:`~.commands.InviteInvalid`
-                - :exc:`~.commands.EmojiNotFound`
-                - :exc:`~.commands.PartialEmojiNotFound`
                 - :exc:`~.commands.MissingPermissions`
                 - :exc:`~.commands.BotMissingPermissions`
                 - :exc:`~.commands.MissingRole`

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -431,12 +431,12 @@ Exception Hierarchy
                     - :exc:`~.commands.UserNotFound`
                     - :exc:`~.commands.ChannelNotFound`
                     - :exc:`~.commands.ChannelNotReadable`
-                    - :exc:`~.commands.InvalidColour`
+                    - :exc:`~.commands.BadColourArgument`
                     - :exc:`~.commands.RoleNotFound`
-                    - :exc:`~.commands.InvalidInvite`
+                    - :exc:`~.commands.BadInviteArgument`
                     - :exc:`~.commands.EmojiNotFound`
                     - :exc:`~.commands.PartialEmojiConversionFailure`
-                    - :exc:`~.commands.InvalidBoolean`
+                    - :exc:`~.commands.BadBooleanArgument`
                 - :exc:`~.commands.BadUnionArgument`
                 - :exc:`~.commands.ArgumentParsingError`
                     - :exc:`~.commands.UnexpectedQuoteError`

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -365,7 +365,7 @@ Exceptions
 .. autoexception:: discord.ext.commands.EmojiNotFound
     :members:
 
-.. autoexception:: discord.ext.commands.PartialEmojiNotFound
+.. autoexception:: discord.ext.commands.PartialEmojiConversionFailure
     :members:
 
 .. autoexception:: discord.ext.commands.MissingPermissions
@@ -432,7 +432,7 @@ Exception Hierarchy
                     - :exc:`~.commands.RoleNotFound`
                     - :exc:`~.commands.InvalidInvite`
                     - :exc:`~.commands.EmojiNotFound`
-                    - :exc:`~.commands.PartialEmojiNotFound`
+                    - :exc:`~.commands.PartialEmojiConversionFailure`
                 - :exc:`~.commands.BadUnionArgument`
                 - :exc:`~.commands.ArgumentParsingError`
                     - :exc:`~.commands.UnexpectedQuoteError`


### PR DESCRIPTION
### Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR adds custom exception classes for converters. This enables the possibility for translation  of these messages, and easier debugging.

Exceptions added for each converter:
 - MemberConverter:
   - MemberNotFound
 - UserConverter:
   - UserNotFound
 - MessageConverter:
   - MessageNotFound
   - ChannelNotFound
   - ChannelNotReadable
 - TextChannelConverter:
   - ChannelNotFound
 - VoiceChannelConverter:
   - ChannelNotFound
 - CategoryChannelConverter:
   - ChannelNotFound
 - ColourConverter:
   - ColourInvalid
 - RoleConverter:
   - RoleNotFound
 - InviteConverter:
   - InviteInvalid
 - EmojiConverter:
   - EmojiNotFound
 - PartialEmojiConverter:
   - PartialEmojiNotFound


### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
