### PR TITLE
Fixing zombie voice client

### DIFF
--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -152,7 +152,7 @@ class VoiceClient:
         try:
             await asyncio.wait_for(self._handshake_complete.wait(), timeout=self.timeout)
         except asyncio.TimeoutError:
-            await self.terminate_handshake(remove=True)
+            await self.terminate_handshake()
             raise
 
         log.info('Voice handshake complete. Endpoint found %s (IP: %s)', self.endpoint, self.endpoint_ip)


### PR DESCRIPTION
### Summary

Fixes #3994
This fixes a scenario where a bad disconnect code on a websocket can cause us to end up with a zombie voice client that never goes away. After thorough investigation, it appears the problem was that we were at some point losing our reference to the voice client, as it was getting removed from the list of connected voice clients. this would be fine, except that the `poll_voice_ws` was still looping, often forever. I realized the only place that we remove the voice client from the list is when calling `terminate_handshake()` and passing in `remove=True`. We were only doing this in 2 places. One when we disconnect with a normal close code (which makes sense, thats the happy path of an actual closed connection), and one in `start_handshake()`. The problem was that when `poll_voice_ws` gets caught in a loop with a bad close code (see #3994), it would continuously fail the `start_handshake()` call before (sometimes) succeeding. Failing the call even once meant the voice client got removed from the list, which meant we had no way to actually close it, as the reference to it was essentially lost. This meant it kept coming back and interfering with things even if you created a new voice client and connected to the channel with it. Removing the argument as I did in this pull request solves the problem, and lets us close the client if its misbehaving.

Let me know if this is the wrong way to do this or if something else needs to be tweaked here.