### PR TITLE
Add new Message.quote property

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -637,7 +637,13 @@ class Message:
     @property
     def quote(self):
         """:class:`str`: Returns a string formatted as a quote, without the author mention."""
-        return "\n".join(["> {line}".format(line) for line in self.content.splitlines()])
+        if self.type is MessageType.default:
+            text = self.clean_content
+        else:
+            text = self.system_content
+
+        return "\n".join(["> {line}".format(line) for line in text.splitlines()])
+
 
     def is_system(self):
         """:class:`bool`: Whether the message is a system message.

--- a/discord/message.py
+++ b/discord/message.py
@@ -634,6 +634,11 @@ class Message:
         guild_id = getattr(self.guild, 'id', '@me')
         return 'https://discord.com/channels/{0}/{1.channel.id}/{1.id}'.format(guild_id, self)
 
+    @property
+    def quote(self):
+        """:class:`str`: Returns a string formatted as a quote, without the author mention."""
+        return "\n".join(["> {line}".format(line) for line in self.content.splitlines()])
+
     def is_system(self):
         """:class:`bool`: Whether the message is a system message.
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -28,6 +28,7 @@ import asyncio
 import datetime
 import re
 import io
+import textwrap
 
 from . import utils
 from .reaction import Reaction
@@ -642,7 +643,7 @@ class Message:
         else:
             text = self.system_content
 
-        return "\n".join(["> {line}".format(line) for line in text.splitlines()])
+        return textwrap.indent(text, "> ", lambda line: True)
 
 
     def is_system(self):


### PR DESCRIPTION
### Summary

Adds a `quote` parameter to the `Message` object which can be used like so

```python
# Example with ctx
ctx.send(f"{ctx.message.quote}\n Ha, no!")

# Example without ctx
message.channel.send(f"{message.quote}\n Ha, no!")
```

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
