### PR TITLE
Updated ClientUser.edit and PremiumType documentation.

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1690,6 +1690,13 @@ class Guild(Hashable):
         -----------
         name: :class:`str`
             The role name. Defaults to 'new role'.
+
+            .. note ::
+
+                The role name cannot be longer than 100 characters.
+                If you try to create a role with a name longer than that,
+                it will lead to an HTTPException.
+
         permissions: :class:`Permissions`
             The permissions to have. Defaults to no permissions.
         colour: :class:`Colour`

--- a/discord/user.py
+++ b/discord/user.py
@@ -430,6 +430,14 @@ class ClientUser(BaseUser):
             Only applicable to user accounts.
         username: :class:`str`
             The new username you wish to change to.
+
+        .. note::
+
+            The new username cannot be ``discordtag``, ``everyone``, or ``here``.
+
+        .. warning ::
+            There is a strict ratelimit of changing your username of twice per 30 minutes.
+
         avatar: :class:`bytes`
             A :term:`py:bytes-like object` representing the image to upload.
             Could be ``None`` to denote no avatar.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1802,11 +1802,11 @@ of :class:`enum.Enum`.
 
     .. attribute:: nitro
 
-        Represents the Discord Nitro with Nitro-exclusive games.
+        Represents the Discord Nitro that includes 2 "boosts" and more "perks" than the classic version.
 
     .. attribute:: nitro_classic
 
-        Represents the Discord Nitro with no Nitro-exclusive games.
+        Represents the Discord Nitro that does not include 2 "boosts".
 
 
 .. class:: Theme


### PR DESCRIPTION
I edited the documentation for `ClientUser.edit` (to note the rate limit for changing the client's username), the `PremiumType` enum (since discord does not offer games with Nitro anymore), and  `Guild.create_role` (to note the character limit for role names).

### Summary

I edited the `ClientUser.edit` documentation to warn that there is a strict rate limit on changing the client's username, and that the username cannot be `discordtag`, `everyone`, or `here`.

I also edited the `PremiumType` enum documentation since Discord does not offer special for games anymore with Nitro, and noted that in the `create_role` method in a `Guild` the `name` parameter must be less than 100 characters long (and that trying to create a role with a name longer than 100 characters will lead to an HTTPException).
<!-- What is this pull request for? Does it fix any issues? -->

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
