### PR TITLE
Add convenience methods run_from_file and run_from_env

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -27,6 +27,7 @@ DEALINGS IN THE SOFTWARE.
 import asyncio
 from collections import namedtuple
 import logging
+import os
 import signal
 import sys
 import traceback
@@ -679,6 +680,50 @@ class Client:
             except KeyboardInterrupt:
                 # I am unsure why this gets raised here but suppress it anyway
                 return None
+
+    def run_from_file(self, filename, *args, **kwargs):
+        """Wrapper around :meth:`run` method. Specfiy filename to load the token from.
+        The file should be a regular textfile with a single line containing only the token.
+
+        .. warning::
+
+            This function must be the last function to call due to the fact that it
+            is blocking. That means that registration of events or anything being
+            called after this function call will not execute until it returns.
+
+        Parameters
+        -----------
+        filename: :class:`str`
+            The filename to load the token from.
+
+        Raises
+        ------
+        :exc:`FileNotFoundError`
+            Token file does not exist.
+        """
+        with open(filename, 'r') as f:
+            self.run(f.read().strip(), *args, **kwargs)
+
+    def run_from_env(self, envvar='DISCORDPY_TOKEN', *args, **kwargs):
+        """Wrapper around :meth:`run` method. Loads the token from the environment variable named by envvar.
+
+        .. warning::
+
+            This function must be the last function to call due to the fact that it
+            is blocking. That means that registration of events or anything being
+            called after this function call will not execute until it returns.
+
+        Parameters
+        -----------
+        envvar: :class:`str`
+            The name of the environment variable to fetch the token from.
+
+        Raises
+        ------
+        :exc:`KeyError`
+            Environment variable does not exist.
+        """
+        self.run(os.environ[envvar], *args, **kwargs)
 
     # properties
 


### PR DESCRIPTION
### Summary

Fetching the token from alternative sources is an obvious thing to do, that I decided to add those two convenience methods. But the primary reason I made this change is because beginners new to python (or programming in general) tend to accidentally disclose their token when sharing/showing their code to get help.

So it doesn't really address any issue with the bot itself, but I thought it would be a nice thing to have.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
