### PR TITLE
Added ColorConverter alias

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -42,6 +42,7 @@ __all__ = (
     'RoleConverter',
     'GameConverter',
     'ColourConverter',
+    'ColorConverter',
     'VoiceChannelConverter',
     'EmojiConverter',
     'PartialEmojiConverter',
@@ -344,6 +345,8 @@ class CategoryChannelConverter(IDConverter):
 class ColourConverter(Converter):
     """Converts to a :class:`~discord.Colour`.
 
+    There is an alias for this called ColorConverter.
+
     The following formats are accepted:
 
     - ``0x<hex>``
@@ -369,6 +372,8 @@ class ColourConverter(Converter):
             if arg.startswith('from_') or method is None or not inspect.ismethod(method):
                 raise BadArgument('Colour "{}" is invalid.'.format(arg))
             return method()
+
+ColorConverter = ColourConverter
 
 class RoleConverter(IDConverter):
     """Converts to a :class:`~discord.Role`.

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -344,8 +344,8 @@ class CategoryChannelConverter(IDConverter):
 
 class ColourConverter(Converter):
     """Converts to a :class:`~discord.Colour`.
-
-    There is an alias for this called ColorConverter.
+    .. versionchanged:: 1.5
+        Add an alias named ColorConverter
 
     The following formats are accepted:
 


### PR DESCRIPTION
### Summary

Adds a `ColorConverter` alias. Aliasing `Colour` with `Color` is a standard throughout the library, but no such alias currently exists for converters.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
