### PR TITLE
[matrix] Another take at fixing methods showing up under "Attributes" table

### DIFF
--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -183,7 +183,11 @@ def get_class_results(lookup, modulename, name, fullname):
         badge = None
         label = attr
 
-        value = getattr(cls, attr, None)
+        for base in cls.__mro__:
+            value = base.__dict__.get(attr)
+            if value is not None:
+                break
+
         if value is not None:
             doc = value.__doc__ or ''
             if inspect.iscoroutinefunction(value) or doc.startswith('|coro|'):


### PR DESCRIPTION
### Summary

Should fix class methods showing in wrong place due to how descriptor protocol works.

Before (notice the placing of `from_dict()` method):
![image](https://user-images.githubusercontent.com/6032823/91649707-cfb4e200-ea76-11ea-9ba3-a2300d599885.png)

After:
![image](https://user-images.githubusercontent.com/6032823/91649690-ba3fb800-ea76-11ea-9064-43f86bf8c15b.png)


### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
