### PR TITLE
Added proper hex support for Colour objects

### DIFF
--- a/discord/colour.py
+++ b/discord/colour.py
@@ -253,4 +253,18 @@ class Colour:
 
     grayple = greyple
 
+    @classmethod
+    def black(cls):
+        """A factory method that returns a :class:`Colour` with a value of ``0x000001``.
+        .. versionadded:: 1.5
+        """
+        return cls(1)
+
+    @classmethod
+    def white(cls):
+        """A factory method that returns a :class:`Colour` with a value of ``0xffffff``.
+        .. versionadded:: 1.5
+        """
+        return cls(0xffffff)
+
 Color = Colour

--- a/discord/colour.py
+++ b/discord/colour.py
@@ -263,6 +263,7 @@ class Colour:
     @classmethod
     def white(cls):
         """A factory method that returns a :class:`Colour` with a value of ``0xffffff``.
+
         .. versionadded:: 1.5
         """
         return cls(0xffffff)

--- a/discord/colour.py
+++ b/discord/colour.py
@@ -245,7 +245,12 @@ class Colour:
 
     @classmethod
     def greyple(cls):
-        """A factory method that returns a :class:`Colour` with a value of ``0x99aab5``."""
+        """A factory method that returns a :class:`Colour` with a value of ``0x99aab5``.
+        .. versionchanged:: 1.5
+            Added grayple alias.
+        """
         return cls(0x99aab5)
+
+    grayple = greyple
 
 Color = Colour

--- a/discord/colour.py
+++ b/discord/colour.py
@@ -101,6 +101,12 @@ class Colour:
         """Tuple[:class:`int`, :class:`int`, :class:`int`]: Returns an (r, g, b) tuple representing the colour."""
         return (self.r, self.g, self.b)
 
+    def to_hex(self):
+        """:class:`str`: Returns the hex format for the colour.
+        .. versionadded:: 1.5
+        """
+        return '#{:0>6x}'.format(self.value)
+
     @classmethod
     def from_rgb(cls, r, g, b):
         """Constructs a :class:`Colour` from an RGB tuple."""
@@ -111,6 +117,13 @@ class Colour:
         """Constructs a :class:`Colour` from an HSV tuple."""
         rgb = colorsys.hsv_to_rgb(h, s, v)
         return cls.from_rgb(*(int(x * 255) for x in rgb))
+
+    @classmethod
+    def from_hex(cls, hexa):
+        """Constructs a :class:`Colour` from hex format.
+        .. versionadded:: 1.5
+        """
+        return cls(int(hexa.strip("#"), base=16))
 
     @classmethod
     def default(cls):


### PR DESCRIPTION
### Summary

Adds convenience methods to add better hexadecimal support, as well as an alias for one colour, and two factory methods.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
