### PR TITLE
Fix call close only once

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -657,7 +657,8 @@ class Client:
             try:
                 await self.start(*args, **kwargs)
             finally:
-                await self.close()
+                if not self.is_closed():
+                    await self.close()
 
         def stop_loop_on_completion(f):
             loop.stop()


### PR DESCRIPTION
### Summary

This request is the result of a conversation in Discord #bikeshedding some days/weeks ago.

`Client.run().runner()` calls  `Client.close()` a second time, if `Client.logout()` is called from the bot.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
