### PR TITLE
Make admonition-title un-selectable. Neo-Docs

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -727,6 +727,10 @@ p.admonition-title {
   margin: 0 -0.8rem;
   padding: 0.4rem 0.6rem 0.4rem 2.5rem;
   position: relative;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 p.admonition-title::before {


### PR DESCRIPTION
All admonition-title's should now be un-selectable.

### Summary
All admonition-title's should now be un-selectable.

### Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
