### PR TITLE
[docs] remove unresolved doc refs, fix attribute ref

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1023,7 +1023,7 @@ class Command(_BaseCommand):
         """|coro|
 
         Checks if the command can be executed by checking all the predicates
-        inside the :attr:`.checks` attribute. This also checks whether the
+        inside the :attr:`checks` attribute. This also checks whether the
         command is disabled.
 
         .. versionchanged:: 1.3

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -353,13 +353,7 @@ Exceptions
 .. autoexception:: discord.ext.commands.ChannelNotReadable
     :members:
 
-.. autoexception:: discord.ext.commands.InvalidColour
-    :members:
-
 .. autoexception:: discord.ext.commands.RoleNotFound
-    :members:
-
-.. autoexception:: discord.ext.commands.InvalidInvite
     :members:
 
 .. autoexception:: discord.ext.commands.EmojiNotFound


### PR DESCRIPTION
### Summary

Two exceptions were left documented from a regression in 6ebd2e1, `InvalidColour` and `InvalidInvite`, and are removed in this PR. Also fixes a cross-reference issue for `Group.can_run`.

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
