### PR TITLE
[commands] Change exception raising behaviour of Command before / after invoke hooks.

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -716,7 +716,7 @@ class Command(_BaseCommand):
         cog = self.cog
         if self._before_invoke is not None:
             # should be cog if @commands.before_invoke is used
-            instance = getattr(self.before_invoke, '__self__', self.cog)
+            instance = getattr(self._before_invoke, '__self__', self.cog)
             # __self__ only exists for methods, not functions
             # however, if @command.before_invoke is used, it will be a function
             if instance:

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -715,18 +715,14 @@ class Command(_BaseCommand):
         # first, call the command local hook:
         cog = self.cog
         if self._before_invoke is not None:
-            try:
-                instance = self._before_invoke.__self__
-                # should be cog if @commands.before_invoke is used
-            except AttributeError:
-                # __self__ only exists for methods, not functions
-                # however, if @command.before_invoke is used, it will be a function
-                if self.cog:
-                    await self._before_invoke(cog, ctx)
-                else:
-                    await self._before_invoke(ctx)
-            else:
+            # should be cog if @commands.before_invoke is used
+            instance = getattr(self.before_invoke, '__self__', self.cog)
+            # __self__ only exists for methods, not functions
+            # however, if @command.before_invoke is used, it will be a function
+            if instance:
                 await self._before_invoke(instance, ctx)
+            else:
+                await self._before_invoke(ctx)
 
         # call the cog local hook if applicable:
         if cog is not None:

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -716,7 +716,7 @@ class Command(_BaseCommand):
         cog = self.cog
         if self._before_invoke is not None:
             # should be cog if @commands.before_invoke is used
-            instance = getattr(self._before_invoke, '__self__', self.cog)
+            instance = getattr(self._before_invoke, '__self__', cog)
             # __self__ only exists for methods, not functions
             # however, if @command.before_invoke is used, it will be a function
             if instance:

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -738,15 +738,11 @@ class Command(_BaseCommand):
     async def call_after_hooks(self, ctx):
         cog = self.cog
         if self._after_invoke is not None:
-            try:
-                instance = self._after_invoke.__self__
-            except AttributeError:
-                if self.cog:
-                    await self._after_invoke(cog, ctx)
-                else:
-                    await self._after_invoke(ctx)
+            instance = getattr(self._after_invoke, '__self__', cog)
+            if instance:
+                    await self._after_invoke(instance, ctx)
             else:
-                await self._after_invoke(instance, ctx)
+                await self._after_invoke(ctx)
 
         # call the cog local hook if applicable:
         if cog is not None:


### PR DESCRIPTION
### Summary

Before if an exception was raised in a `Command.before_invoke` or `Command.after_invoke` callable in a `Cog` it would be raised as

`AttributeError: 'function' object has no attribute '__self__'`

This is due to the way python exception handling is done, and the use of a `try: except:` block to determine whether the `Command` was part of a `Cog` or not.

This PR changes this behaviour by instead raising the original exception in the `Command.before_invoke` / `Command.after_invoke` callable.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed) 
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
