### PR TITLE
[commands] Remove deprecation warning by using fetch_message_fast in MessageConverter

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -229,7 +229,7 @@ class MessageConverter(Converter):
         if not channel:
             raise ChannelNotFound(channel_id)
         try:
-            return await channel.fetch_message(message_id)
+            return await channel.fetch_message_fast(message_id)
         except discord.NotFound:
             raise MessageNotFound(argument)
         except discord.Forbidden:


### PR DESCRIPTION
### Summary

Fixes deprecation warning when using the MessageConverter, since apparently fetch_message is deprecated now

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
