### PR TITLE
[commands] Correct command removing during cog injecting

### DIFF
--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -385,7 +385,7 @@ class Cog(metaclass=CogMeta):
                 except Exception as e:
                     # undo our additions
                     for to_undo in self.__cog_commands__[:index]:
-                        bot.remove_command(to_undo)
+                        bot.remove_command(to_undo.name)
                     raise e
 
         # check if we're overriding the default


### PR DESCRIPTION
### Summary

`bot.remove_command` takes a string, however the command object was attempting to be passed during the handling of errors when injecting during `bot.add_cog`.

Since [commands are removed during loading of extensions](https://github.com/Rapptz/discord.py/blob/4b18238ade0137d6a809b065bfc62daccebd408c/discord/ext/commands/bot.py#L568-L572) this doesn't actually cause an issue in most use cases, since extensions and cogs typically go hand in hand. However in the specific use case of using case insensitive commands, [when it tries to pop the name it tries to run casefold](https://github.com/Rapptz/discord.py/blob/4b18238ade0137d6a809b065bfc62daccebd408c/discord/ext/commands/core.py#L126), expecting the key to be a string. This fails on this situation, and you end up with an unhelpful error message of `AttributeError: 'Command' object has no attribute 'casefold'`. This PR fixes that

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
