### PR TITLE
Fix by_category in guild.py overwriting channels

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -416,7 +416,8 @@ class Guild(Hashable):
         grouped = {}
         for channel in self._channels.values():
             if isinstance(channel, CategoryChannel):
-                grouped.setdefault(channel.id, [])
+                # As dictionary keys are defined below (On KeyError),
+                # we can safely skip category channels.
                 continue
 
             try:


### PR DESCRIPTION
### Summary

Fixes by_category. Currently, by_category will almost always not return all of the channels, as they're overwritten due to a needless line of code.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
