### PR TITLE
Add missing permission on clone

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -679,6 +679,9 @@ class GuildChannel:
         Clones this channel. This creates a channel with the same properties
         as this channel.
 
+        You must have the :attr:`~Permissions.manage_channels` permission to
+        do this.
+
         .. versionadded:: 1.1
 
         Parameters

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -679,7 +679,7 @@ class GuildChannel:
         Clones this channel. This creates a channel with the same properties
         as this channel.
 
-        You must have the :attr:`~Permissions.manage_channels` permission to
+        You must have the :attr:`~discord.Permissions.manage_channels` permission to
         do this.
 
         .. versionadded:: 1.1


### PR DESCRIPTION
### Summary

The clone channel command requires the manage_channels permission, which is not mentioned in the documentation.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
