### PR TITLE
PR template: use h2 instead of h3

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
-### Summary
+## Summary
 
 <!-- What is this pull request for? Does it fix any issues? -->
 
-### Checklist
+## Checklist
 
 <!-- Put an x inside [ ] to check it, like so: [x] -->
 


### PR DESCRIPTION
## Summary

\<h2\> is the semantically correct heading here,
as \<h1\> is for document titles and \<h2\> is for the top level headings within a document.
\<h3\> should be used for subheadings of \<h2\> headings.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
