### PR TITLE
Fix typo in fetch_message_fast documentation

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -983,7 +983,7 @@ class Messageable(metaclass=abc.ABCMeta):
         Raises
         --------
         ~discord.NotFound
-            The specified channel was not found.
+            The specified message was not found.
         ~discord.Forbidden
             You do not have permissions to get channel message history.
         ~discord.HTTPException


### PR DESCRIPTION
### Summary

`Messageable.fetch_message_fast`'s documentation says `NotFound` is raised if "The specified **channel** was not found."
Changed this to "The specified **message** was not found."

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
