### PR TITLE
Command instead of "on_message" commands (README.rst)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,11 +81,16 @@ Quick Example
             # don't respond to ourselves
             if message.author == self.user:
                 return
-
-            if message.content == 'ping':
-                await message.channel.send('pong')
+                
+            # Process commands
+            await self.process_commands(message)
 
     client = MyClient()
+    
+    @client.command(name='ping')
+    async def ping(ctx):
+        await ctx.send('pong')
+    
     client.run('token')
 
 Bot Example


### PR DESCRIPTION
### Summary

Changes the content of README.rst section `Quick Example` so that it uses the commands format instead of on_message.

My logic behind this is so that people new to this library won't immediately use the `on_message` way as it is a lot more confusing to switch to commands. This will encourage newer users to start with commands instead of parsing the messages manually.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
