### PR TITLE
[RFC] Run on_ready on module load if bot is ready

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -625,6 +625,12 @@ class BotBase(GroupMixin):
         else:
             self.__extensions[key] = lib
 
+        # Call on_ready if module has been loaded after the bot is ready
+        if self.is_ready():
+            for event in self.extra_events.get('on_ready', []):
+                if event.__module__ is not None and _is_submodule(key, event.__module__):
+                    self._schedule_event(event, 'on_ready')
+
     def load_extension(self, name):
         """Loads an extension.
 


### PR DESCRIPTION
### Summary

An `on_ready` might do some specific setup on the extension that is only doable once the bot is ready,
but it isn't being run if the extension is loaded after the Client has finished initializing.

Run all the `on_ready` handlers from that extension once the extension has been loaded
(provided that the bot is in a ready state at that point).

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
