### PR TITLE
Add support for message_reference on Message object

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -33,7 +33,7 @@ from .guild import Guild
 from .flags import *
 from .relationship import Relationship
 from .member import Member, VoiceState
-from .message import Message, Attachment
+from .message import Message, MessageReference, Attachment
 from .asset import Asset
 from .errors import *
 from .calls import CallMessage, GroupCall

--- a/discord/message.py
+++ b/discord/message.py
@@ -236,10 +236,10 @@ class MessageReference:
     @property
     def cached_message(self):
         """Optional[:class:`Message`]: The cached message, if found in the internal message cache."""
-        return self._state._get_message(self._message_id)
+        return self._state._get_message(self.message_id)
 
     def __repr__(self):
-        return '<MessageReference message_id={0._message_id!r} channel_id={0._channel_id!r} guild_id={0._guild_id!r}>'.format(self)
+        return '<MessageReference message_id={0.message_id!r} channel_id={0.channel_id!r} guild_id={0.guild_id!r}>'.format(self)
 
 def flatten_handlers(cls):
     prefix = len('_handle_')

--- a/discord/message.py
+++ b/discord/message.py
@@ -229,7 +229,7 @@ class MessageReference:
     def __init__(self, **kwargs):
         self.message_id = utils._get_as_snowflake(kwargs, 'message_id')
         self.channel_id = int(kwargs.pop('channel_id'))
-        self.guild_id = int(kwargs.pop('guild_id', 0)) or None
+        self.guild_id = utils._get_as_snowflake(kwargs, 'guild_id')
         self.cached_message = None
 
     def __repr__(self):

--- a/discord/message.py
+++ b/discord/message.py
@@ -212,29 +212,26 @@ class MessageReference:
     """Represents a reference to a :class:`Message`.
 
     .. versionadded:: 1.5
+
+    Attributes
+    -----------
+    message_id: Optional[:class:`int`]
+        The id of the message referenced.
+    channel_id: :class:`int`
+        The channel id of the message referenced.
+    guild_id: Optional[:class:`int`]
+        The guild id of the message referenced.
+    cached_message: Optional[:class:`Message`]
+        The cached message, if found in the internal message cache.
     """
-    __slots__ = ('_message_id', '_channel_id', '_guild_id', '_state')
+
+    __slots__ = ('message_id', 'channel_id', 'guild_id', '_state')
 
     def __init__(self, state, **kwargs):
-        self._message_id = utils._get_as_snowflake(kwargs, 'message_id')
-        self._channel_id = int(kwargs.pop('channel_id'))
-        self._guild_id = utils._get_as_snowflake(kwargs, 'guild_id')
+        self.message_id = utils._get_as_snowflake(kwargs, 'message_id')
+        self.channel_id = int(kwargs.pop('channel_id'))
+        self.guild_id = utils._get_as_snowflake(kwargs, 'guild_id')
         self._state = state
-
-    @property
-    def message_id(self):
-        """Optional[:class:`int`]: The id of the message referenced."""
-        return self._message_id
-    
-    @property
-    def channel_id(self):
-        """:class:`int`: The channel id of the message referenced."""
-        return self._channel_id
-
-    @property
-    def guild_id(self):
-        """Optional[:class:`int`]: The guild id of the message referenced."""
-        return self._guild_id
 
     @property
     def cached_message(self):

--- a/discord/message.py
+++ b/discord/message.py
@@ -353,8 +353,12 @@ class Message:
         ref = data.get('message_reference')
         # For some reason message_id is an optional key, meaning that
         # even if a message_reference exists, the message_id could be None
-        self.reference_id = ref.get('message_id') if ref is not None else None
-        self.referenced_message = state._get_message(int(self.reference_id)) if self.reference_id is not None else None
+        try:
+            self.reference_id = int(ref.get('message_id')) if ref is not None else None
+        except TypeError:
+            self.reference_id = None
+
+        self.referenced_message = state._get_message(self.reference_id) if self.reference_id is not None else None
 
         for handler in ('author', 'member', 'mentions', 'mention_roles', 'call', 'flags'):
             try:

--- a/discord/message.py
+++ b/discord/message.py
@@ -373,9 +373,12 @@ class Message:
         self.nonce = data.get('nonce')
 
         ref = data.get('message_reference')
-        self.reference = msg_ref = MessageReference(**ref) if ref is not None else None
-        if msg_ref is not None and msg_ref.message_id is not None:
-            msg_ref.cached_message = state._get_message(msg_ref.message_id)
+        if ref is not None:
+            self.reference = msg_ref = MessageReference(**ref)
+            if msg_ref.message_id is not None:
+                msg_ref.cached_message = state._get_message(msg_ref.message_id)
+        else:
+            self.reference = None
 
         for handler in ('author', 'member', 'mentions', 'mention_roles', 'call', 'flags'):
             try:

--- a/discord/message.py
+++ b/discord/message.py
@@ -221,8 +221,6 @@ class MessageReference:
         The channel id of the message referenced.
     guild_id: Optional[:class:`int`]
         The guild id of the message referenced.
-    cached_message: Optional[:class:`Message`]
-        The cached message, if found in the internal message cache.
     """
 
     __slots__ = ('message_id', 'channel_id', 'guild_id', '_state')

--- a/discord/message.py
+++ b/discord/message.py
@@ -251,6 +251,18 @@ class Message:
     call: Optional[:class:`CallMessage`]
         The call that the message refers to. This is only applicable to messages of type
         :attr:`MessageType.call`.
+    reference_id: Optional[:class:`int`]
+        The id of the pinned message the message refers to. This is only applicable to
+        messages of type :attr:`MessageType.pins_add`.
+
+        .. versionadded:: 1.5
+
+    referenced_message: Optional[:class:`Message`]
+        The pinned message the message refers to, if found in the internal message cache.
+        This is only applicable to messages of type :attr:`MessageType.pins_add`.
+
+        .. versionadded:: 1.5
+
     mention_everyone: :class:`bool`
         Specifies if the message mentions everyone.
 
@@ -316,8 +328,8 @@ class Message:
                  '_cs_channel_mentions', '_cs_raw_mentions', 'attachments',
                  '_cs_clean_content', '_cs_raw_channel_mentions', 'nonce', 'pinned',
                  'role_mentions', '_cs_raw_role_mentions', 'type', 'call', 'flags',
-                 '_cs_system_content', '_cs_guild', '_state', 'reactions',
-                 'application', 'activity')
+                 '_cs_system_content', '_cs_guild', '_state', 'reactions', 'reference_id',
+                 'referenced_message', 'application', 'activity')
 
     def __init__(self, *, state, channel, data):
         self._state = state
@@ -337,6 +349,12 @@ class Message:
         self.tts = data['tts']
         self.content = data['content']
         self.nonce = data.get('nonce')
+
+        ref = data.get('message_reference')
+        # For some reason message_id is an optional key, meaning that
+        # even if a message_reference exists, the message_id could be None
+        self.reference_id = ref.get('message_id') if ref is not None else None
+        self.referenced_message = state._get_message(int(self.reference_id)) if self.reference_id is not None else None
 
         for handler in ('author', 'member', 'mentions', 'mention_roles', 'call', 'flags'):
             try:

--- a/discord/message.py
+++ b/discord/message.py
@@ -212,28 +212,37 @@ class MessageReference:
     """Represents a reference to a :class:`Message`.
 
     .. versionadded:: 1.5
-
-    Attributes
-    -----------
-    message_id: Optional[:class:`int`]
-        The id of the message referenced.
-    channel_id: :class:`int`
-        The channel id of the message referenced.
-    guild_id: Optional[:class:`int`]
-        The guild id of the message referenced.
-    cached_message: Optional[:class:`Message`]
-        The cached message, if found in the internal message cache.
     """
-    __slots__ = ('message_id', 'channel_id', 'guild_id', 'cached_message')
+    __slots__ = ('_message_id', '_channel_id', '_guild_id', '_state')
 
-    def __init__(self, **kwargs):
-        self.message_id = utils._get_as_snowflake(kwargs, 'message_id')
-        self.channel_id = int(kwargs.pop('channel_id'))
-        self.guild_id = utils._get_as_snowflake(kwargs, 'guild_id')
-        self.cached_message = None
+    def __init__(self, state, **kwargs):
+        self._message_id = utils._get_as_snowflake(kwargs, 'message_id')
+        self._channel_id = int(kwargs.pop('channel_id'))
+        self._guild_id = utils._get_as_snowflake(kwargs, 'guild_id')
+        self._state = state
+
+    @property
+    def message_id(self):
+        """Optional[:class:`int`]: The id of the message referenced."""
+        return self._message_id
+    
+    @property
+    def channel_id(self):
+        """:class:`int`: The channel id of the message referenced."""
+        return self._channel_id
+
+    @property
+    def guild_id(self):
+        """Optional[:class:`int`]: The guild id of the message referenced."""
+        return self._guild_id
+
+    @property
+    def cached_message(self):
+        """Optional[:class:`Message`]: The cached message, if found in the internal message cache."""
+        return self._state._get_message(self._message_id)
 
     def __repr__(self):
-        return '<MessageReference message_id={0.message_id!r} channel_id={0.channel_id!r} guild_id={0.guild_id!r}>'.format(self)
+        return '<MessageReference message_id={0._message_id!r} channel_id={0._channel_id!r} guild_id={0._guild_id!r}>'.format(self)
 
 def flatten_handlers(cls):
     prefix = len('_handle_')
@@ -373,12 +382,7 @@ class Message:
         self.nonce = data.get('nonce')
 
         ref = data.get('message_reference')
-        if ref is not None:
-            self.reference = msg_ref = MessageReference(**ref)
-            if msg_ref.message_id is not None:
-                msg_ref.cached_message = state._get_message(msg_ref.message_id)
-        else:
-            self.reference = None
+        self.reference = MessageReference(state, **ref) if ref is not None else None
 
         for handler in ('author', 'member', 'mentions', 'mention_roles', 'call', 'flags'):
             try:

--- a/discord/message.py
+++ b/discord/message.py
@@ -227,7 +227,7 @@ class MessageReference:
     __slots__ = ('message_id', 'channel_id', 'guild_id', 'cached_message')
 
     def __init__(self, **kwargs):
-        self.message_id = int(kwargs.pop('message_id', 0)) or None
+        self.message_id = utils._get_as_snowflake(kwargs, 'message_id')
         self.channel_id = int(kwargs.pop('channel_id'))
         self.guild_id = int(kwargs.pop('guild_id', 0)) or None
         self.cached_message = None

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2731,6 +2731,11 @@ Widget
 .. autoclass:: Widget()
     :members:
 
+MessageReference
+~~~~~~~~~~~~~~~~~
+.. autoclass:: MessageReference()
+    :members:
+
 RawMessageDeleteEvent
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
### Summary

This PR resolves #5754. Only the `message_id` attribute is exposed since the guild and channel id can be found on the original message object. A `referenced_message` attribute is also added for convenience.

Note: for some reason the [message_id key is optional](https://discord.com/developers/docs/resources/channel#message-object-message-reference-structure).

### Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
