### PR TITLE
issue/PR templates: use h2 instead of h3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,24 +4,24 @@ about: Report broken or incorrect behaviour
 labels: bug
 ---
 
-### Summary
+## Summary
 
 <!-- A summary of your bug report -->
 
-### Reproduction Steps
+## Reproduction Steps
 
 <!-- What you did to make it happen. Ideally there should be a short code snippet in this section to help reproduce the bug. -->
 
-### Expected Results
+## Expected Results
 
 <!-- What you expected to happen -->
 
-### Actual Results
+## Actual Results
 
 <!-- What actually happened. If there is a traceback, please show the entire thing. -->
 
 
-### Checklist
+## Checklist
 
 <!-- Put an x inside [ ] to check it, like so: [x] -->
 
@@ -29,7 +29,7 @@ labels: bug
 - [ ] I have shown the entire traceback, if possible.
 - [ ] I have removed my token from display, if visible.
 
-### System Information
+## System Information
 
 <!-- Run `python -m discord -v` and paste this information below. -->
 <!-- This command is available in v1.1.0 or higher. If you are unable to run this command, paste basic info (ie. Python version, library version, and your operating system -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,24 +4,24 @@ about: Suggest a feature for this library
 labels: feature request
 ---
 
-### The Problem
+## The Problem
 
 <!--
 What problem is your feature trying to solve? What becomes easier or possible when this feature is implemented?
 -->
 
-### The Ideal Solution
+## The Ideal Solution
 
 <!--
 What is your ideal solution to the problem? What would you like this feature to do?
 -->
 
-### The Current Solution
+## The Current Solution
 
 <!--
 What is the current solution to the problem, if any?
 -->
 
-### Summary
+## Summary
 
 <!-- A short summary of your feature request. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
-### Summary
+## Summary
 
 <!-- What is this pull request for? Does it fix any issues? -->
 
-### Checklist
+## Checklist
 
 <!-- Put an x inside [ ] to check it, like so: [x] -->
 


### PR DESCRIPTION
## Summary

\<h2\> is the semantically correct heading here,
as \<h1\> is for document titles and \<h2\> is for the top level headings within a document.
\<h3\> should be used for subheadings of \<h2\> headings.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
