### PR TITLE
[commands] Added optional arguments to load_extension

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -599,7 +599,7 @@ class BotBase(GroupMixin):
                 if _is_submodule(name, module):
                     del sys.modules[module]
 
-    def _load_from_module_spec(self, spec, key):
+    def _load_from_module_spec(self, spec, key, *args, **kwargs):
         # precondition: key not in self.__extensions
         lib = importlib.util.module_from_spec(spec)
         sys.modules[key] = lib
@@ -616,7 +616,7 @@ class BotBase(GroupMixin):
             raise errors.NoEntryPointError(key)
 
         try:
-            setup(self)
+            setup(self, *args, **kwargs)
         except Exception as e:
             del sys.modules[key]
             self._remove_module_references(lib.__name__)
@@ -625,7 +625,7 @@ class BotBase(GroupMixin):
         else:
             self.__extensions[key] = lib
 
-    def load_extension(self, name):
+    def load_extension(self, name, *args, **kwargs):
         """Loads an extension.
 
         An extension is a python module that contains commands, cogs, or
@@ -633,7 +633,9 @@ class BotBase(GroupMixin):
 
         An extension must have a global function, ``setup`` defined as
         the entry point on what to do when the extension is loaded. This entry
-        point must have a single argument, the ``bot``.
+        point must have the ``bot`` as its first argument. Optionally, it may
+        accept extra positional and keyword arguments that will be forwarded
+        to the extension's ``setup`` method.
 
         Parameters
         ------------
@@ -661,7 +663,7 @@ class BotBase(GroupMixin):
         if spec is None:
             raise errors.ExtensionNotFound(name)
 
-        self._load_from_module_spec(spec, name)
+        self._load_from_module_spec(spec, name, *args, **kwargs)
 
     def unload_extension(self, name):
         """Unloads an extension.

--- a/docs/ext/commands/extensions.rst
+++ b/docs/ext/commands/extensions.rst
@@ -10,7 +10,7 @@ There comes a time in the bot development when you want to extend the bot functi
 Primer
 --------
 
-An extension at its core is a python file with an entry point called ``setup``. This setup must be a plain Python function (not a coroutine). It takes a single parameter -- the :class:`~.commands.Bot` that loads the extension.
+An extension at its core is a python file with an entry point called ``setup``. This setup must be a plain Python function (not a coroutine). Its first parameter must be the :class:`~.commands.Bot` that loads the extension. Optionally, you may also add extra positional and keyword arguments to provide any extra data your extension will need to setup.
 
 An example extension looks like this:
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
I have added the ability to pass extra positional and keyword arguments to an extension's setup method to provide a nice way to share data with an extension and the main bot code. I have tested this and code that doesn't pass extra arguments works the same as before, and passing positional and keyword arguments to the setup function also works.
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
