### PR TITLE
Add support for flag alias

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -50,6 +50,9 @@ class flag_value:
     def __repr__(self):
         return '<flag_value flag={.flag!r}>'.format(self)
 
+class alias_flag_value(flag_value):
+    pass
+
 def fill_with_flags(*, inverted=False):
     def decorator(cls):
         cls.VALID_FLAGS = {
@@ -98,6 +101,9 @@ class BaseFlags:
 
     def __iter__(self):
         for name, value in self.__class__.__dict__.items():
+            if isinstance(value, alias_flag_value):
+                continue
+            
             if isinstance(value, flag_value):
                 yield (name, self._has_flag(value.flag))
 
@@ -248,6 +254,14 @@ class PublicUserFlags(BaseFlags):
         .. describe:: x != y
 
             Checks if two PublicUserFlags are not equal.
+        .. describe:: hash(x)
+
+            Return the flag's hash.
+        .. describe:: iter(x)
+
+            Returns an iterator of ``(name, value)`` pairs. This allows it
+            to be, for example, constructed as a dict or a list of pairs.
+            Note that aliases are not shown.
 
     .. versionadded:: 1.4
 
@@ -323,7 +337,15 @@ class PublicUserFlags(BaseFlags):
 
     @flag_value
     def verified_bot_developer(self):
-        """:class:`bool`: Returns ``True`` if the user is a Verified Bot Developer."""
+        """:class:`bool`: Returns ``True`` if the user is an Early Verified Bot Developer."""
+        return UserFlags.verified_bot_developer.value
+    
+    @alias_flag_value
+    def early_verified_bot_developer(self):
+        """:class:`bool`: An alias for :attr:`verified_bot_developer`.
+
+        .. versionadded:: 1.5
+        """
         return UserFlags.verified_bot_developer.value
 
     def all(self):

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -24,7 +24,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-from .flags import BaseFlags, flag_value, fill_with_flags
+from .flags import BaseFlags, flag_value, fill_with_flags, alias_flag_value
 
 __all__ = (
     'Permissions',
@@ -33,7 +33,7 @@ __all__ = (
 
 # A permission alias works like a regular flag but is marked
 # So the PermissionOverwrite knows to work with it
-class permission_alias(flag_value):
+class permission_alias(alias_flag_value):
     pass
 
 def make_permission_alias(alias):
@@ -130,14 +130,6 @@ class Permissions(BaseFlags):
     __ge__ = is_superset
     __lt__ = is_strict_subset
     __gt__ = is_strict_superset
-
-    def __iter__(self):
-        for name, value in self.__class__.__dict__.items():
-            if isinstance(value, permission_alias):
-                continue
-
-            if isinstance(value, flag_value):
-                yield (name, self._has_flag(value.flag))
 
     @classmethod
     def none(cls):


### PR DESCRIPTION
## Summary
Adds support for flag alias. There were previously Permissions exclusive feature, now ported to flags.py. This also adds `PublicUserFlags.early_verified_bot_developer`.

## Checklist
- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
