### PR TITLE
Fix typo in ValueError message

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -151,7 +151,7 @@ class ConnectionState:
 
         # Ensure these two are set properly
         if not intents.members and self._chunk_guilds:
-            raise ValueError('Intents.members has be enabled to chunk guilds at startup.')
+            raise ValueError('Intents.members must be enabled to chunk guilds at startup.')
 
         cache_flags = options.get('member_cache_flags', None)
         if cache_flags is None:


### PR DESCRIPTION
## Summary
Fixes typo at `has be enabled` (-> `must be enabled`)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
