### PR TITLE
Fixed incorrectly named 'Intent' class in doc.

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -711,7 +711,7 @@ class Guild(Hashable):
         .. warning::
 
             Due to a Discord limitation, in order for this attribute to remain up-to-date and
-            accurate, it requires :attr:`Intent.members` to be specified.
+            accurate, it requires :attr:`Intents.members` to be specified.
 
         """
         return self._member_count


### PR DESCRIPTION
`Intent.members` -> `Intents.members`.

- [x] This PR is **not** a code change (e.g. documentation, README, ...)
