### PR TITLE
Added before_cached_message and after_cached_message attributes to RawMessageUpdateEvent

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -96,17 +96,20 @@ class RawMessageUpdateEvent(_RawReprMixin):
 
     data: :class:`dict`
         The raw data given by the `gateway <https://discord.com/developers/docs/topics/gateway#message-update>`_
-    cached_message: Optional[:class:`Message`]
-        The cached message, if found in the internal message cache.
+    before_cached_message: Optional[:class:`Message`]
+        The cached message before it was updated, if found in the internal message cache.
+    after_cached_message: Optional[:class:`Message`]
+        The cached message after it was updated, if found in the internal message cache.
     """
 
-    __slots__ = ('message_id', 'channel_id', 'data', 'cached_message')
+    __slots__ = ('message_id', 'channel_id', 'data', 'before_cached_message', 'after_cached_message')
 
     def __init__(self, data):
         self.message_id = int(data['id'])
         self.channel_id = int(data['channel_id'])
         self.data = data
-        self.cached_message = None
+        self.before_cached_message = None
+        self.after_cached_message = None
 
 class RawReactionActionEvent(_RawReprMixin):
     """Represents the payload for a :func:`on_raw_reaction_add` or

--- a/discord/state.py
+++ b/discord/state.py
@@ -507,9 +507,10 @@ class ConnectionState:
         message = self._get_message(raw.message_id)
         if message is not None:
             older_message = copy.copy(message)
-            raw.cached_message = older_message
-            self.dispatch('raw_message_edit', raw)
+            raw.before_cached_message = older_message
+            raw.after_cached_message = message
             message._update(data)
+            self.dispatch('raw_message_edit', raw)
             self.dispatch('message_edit', older_message, message)
         else:
             self.dispatch('raw_message_edit', raw)


### PR DESCRIPTION
## Summary

So we can access both the old and new versions of the message from RawMessageUpdateEvent's if it was cached
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
