### PR TITLE
Changed command not found error

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -908,7 +908,7 @@ class BotBase(GroupMixin):
             else:
                 self.dispatch('command_completion', ctx)
         elif ctx.invoked_with:
-            exc = errors.CommandNotFound('Command "{}" is not found'.format(ctx.invoked_with))
+            exc = errors.CommandNotFound('Command "{}" was not found'.format(ctx.invoked_with))
             self.dispatch('command_error', ctx, exc)
 
     async def process_commands(self, message):


### PR DESCRIPTION
## Summary

As mentioned ![here](https://canary.discord.com/channels/336642139381301249/603069307286454290/762194141576036353), 'Command "{}" not found' should be changed to 'Command "{}" was not found'. This isn't a hacktoberfest pr, I was just annoyed at seeing that grammar error in my logs.

`it is unfindable/missing/unavailable, but was not found`
`we tried to find it, but after searching through all commands, it was not found`
`command x was not found`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
