### PR TITLE
Implement icon_url_as and cover_image_url_as methods

### DIFF
--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -147,7 +147,7 @@ class AppInfo:
         -----------
         format: Optional[:class:`str`]
             The format to attempt to convert the icon to.
-            If the format is ``None``, then it is automatically detected into either 'jpg'.
+            If the format is ``None``, then it automatically uses 'webp'.
         size: :class:`int`
             The size of the image to display.
 
@@ -185,7 +185,7 @@ class AppInfo:
         -----------
         format: Optional[:class:`str`]
             The format to attempt to convert the image to.
-            If the format is ``None``, then it is automatically detected into either 'jpg'.
+            If the format is ``None``, then it automatically uses 'webp'.
         size: :class:`int`
             The size of the image to display.
 

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -146,7 +146,7 @@ class AppInfo:
         Parameters
         -----------
         format: Optional[:class:`str`]
-            The format to attempt to convert the avatar to.
+            The format to attempt to convert the icon to.
             If the format is ``None``, then it is automatically detected into either 'jpg'.
         size: :class:`int`
             The size of the image to display.
@@ -184,7 +184,7 @@ class AppInfo:
         Parameters
         -----------
         format: Optional[:class:`str`]
-            The format to attempt to convert the avatar to.
+            The format to attempt to convert the image to.
             If the format is ``None``, then it is automatically detected into either 'jpg'.
         size: :class:`int`
             The size of the image to display.

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -138,7 +138,7 @@ class AppInfo:
         """
         return self.icon_url_as()
 
-    def icon_url_as(self, *, format=None, size=1024):
+    def icon_url_as(self, *, format='webp', size=1024):
         """Returns an :class:`Asset` for the icon the application has.
 
         The format must be one of 'webp', 'jpeg', 'jpg' or 'png'.
@@ -148,9 +148,8 @@ class AppInfo:
 
         Parameters
         -----------
-        format: Optional[:class:`str`]
-            The format to attempt to convert the icon to.
-            If the format is ``None``, then it automatically uses 'webp'.
+        format: :class:`str`
+            The format to attempt to convert the icon to. Defaults to 'webp'.
         size: :class:`int`
             The size of the image to display.
 
@@ -178,7 +177,7 @@ class AppInfo:
         """
         return self.cover_image_url_as()
 
-    def cover_image_url_as(self, *, format=None, size=1024):
+    def cover_image_url_as(self, *, format='webp', size=1024):
         """Returns an :class:`Asset` for the image on store embeds
         if this application is a game sold on Discord.
 
@@ -189,9 +188,8 @@ class AppInfo:
 
         Parameters
         -----------
-        format: Optional[:class:`str`]
-            The format to attempt to convert the image to.
-            If the format is ``None``, then it automatically uses 'webp'.
+        format: :class:`str`
+            The format to attempt to convert the image to. Defaults to 'webp'.
         size: :class:`int`
             The size of the image to display.
 

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -131,6 +131,9 @@ class AppInfo:
     def icon_url(self):
         """:class:`.Asset`: Retrieves the application's icon asset.
 
+        This is equivalent to calling :meth:`icon_url_as` with
+        the default parameters ('webp' format and a size of 1024).
+
         .. versionadded:: 1.3
         """
         return self.icon_url_as()
@@ -167,6 +170,9 @@ class AppInfo:
     @property
     def cover_image_url(self):
         """:class:`.Asset`: Retrieves the cover image on a store embed.
+
+        This is equivalent to calling :meth:`cover_image_url_as` with
+        the default parameters ('webp' format and a size of 1024).
 
         .. versionadded:: 1.3
         """

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -133,7 +133,36 @@ class AppInfo:
 
         .. versionadded:: 1.3
         """
-        return Asset._from_icon(self._state, self, 'app')
+        return self.icon_url_as()
+
+    def icon_url_as(self, *, format=None, size=1024):
+        """Returns an :class:`Asset` for the icon the application has.
+
+        The format must be one of 'webp', 'jpeg', 'jpg' or 'png'.
+        The size must be a power of 2 between 16 and 4096.
+
+        .. versionadded:: 2.0
+
+        Parameters
+        -----------
+        format: Optional[:class:`str`]
+            The format to attempt to convert the avatar to.
+            If the format is ``None``, then it is automatically detected into either 'jpg'.
+        size: :class:`int`
+            The size of the image to display.
+
+        Raises
+        ------
+        InvalidArgument
+            Bad image format passed to ``format`` or invalid ``size``.
+
+        Returns
+        --------
+        :class:`Asset`
+            The resulting CDN asset.
+        """
+        return Asset._from_icon(self._state, self, 'app', format=format, size=size)
+    
 
     @property
     def cover_image_url(self):
@@ -141,7 +170,36 @@ class AppInfo:
 
         .. versionadded:: 1.3
         """
-        return Asset._from_cover_image(self._state, self)
+        return self.cover_image_url_as()
+
+    def cover_image_url_as(self, *, format=None, size=1024):
+        """Returns an :class:`Asset` for the image on store embeds
+        if this application is a game sold on Discord.
+
+        The format must be one of 'webp', 'jpeg', 'jpg' or 'png'.
+        The size must be a power of 2 between 16 and 4096.
+
+        .. versionadded:: 2.0
+
+        Parameters
+        -----------
+        format: Optional[:class:`str`]
+            The format to attempt to convert the avatar to.
+            If the format is ``None``, then it is automatically detected into either 'jpg'.
+        size: :class:`int`
+            The size of the image to display.
+
+        Raises
+        ------
+        InvalidArgument
+            Bad image format passed to ``format`` or invalid ``size``.
+
+        Returns
+        --------
+        :class:`Asset`
+            The resulting CDN asset.
+        """
+        return Asset._from_cover_image(self._state, self, format=format, size=size)
 
     @property
     def guild(self):

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -98,7 +98,7 @@ class Asset:
         if format is not None and format not in VALID_STATIC_FORMATS:
             raise InvalidArgument("format must be None or one of {}".format(VALID_STATIC_FORMATS))
         else:
-            format = 'jpg'
+            format = 'webp'
 
         url = '/{0}-icons/{1.id}/{1.icon}.{2}?size={3}'.format(path, object, format, size)
         return cls(state, url)
@@ -113,7 +113,7 @@ class Asset:
         if format is not None and format not in VALID_STATIC_FORMATS:
             raise InvalidArgument("format must be None or one of {}".format(VALID_STATIC_FORMATS))
         else:
-            format = 'jpg'
+            format = 'webp'
 
         url = '/app-assets/{0.id}/store/{0.cover_image}.{1}?size={2}'.format(obj, format, size)
         return cls(state, url)

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -89,31 +89,27 @@ class Asset:
         return cls(state, '/avatars/{0.id}/{0.avatar}.{1}?size={2}'.format(user, format, size))
 
     @classmethod
-    def _from_icon(cls, state, object, path, *, format=None, size=1024):
+    def _from_icon(cls, state, object, path, *, format='webp', size=1024):
         if object.icon is None:
             return cls(state)
 
         if not utils.valid_icon_size(size):
             raise InvalidArgument("size must be a power of 2 between 16 and 4096")
-        if format is not None and format not in VALID_STATIC_FORMATS:
+        if format not in VALID_STATIC_FORMATS:
             raise InvalidArgument("format must be None or one of {}".format(VALID_STATIC_FORMATS))
-        else:
-            format = 'webp'
 
         url = '/{0}-icons/{1.id}/{1.icon}.{2}?size={3}'.format(path, object, format, size)
         return cls(state, url)
 
     @classmethod
-    def _from_cover_image(cls, state, obj, *, format=None, size=1024):
+    def _from_cover_image(cls, state, obj, *, format='webp', size=1024):
         if obj.cover_image is None:
             return cls(state)
 
         if not utils.valid_icon_size(size):
             raise InvalidArgument("size must be a power of 2 between 16 and 4096")
-        if format is not None and format not in VALID_STATIC_FORMATS:
+        if format not in VALID_STATIC_FORMATS:
             raise InvalidArgument("format must be None or one of {}".format(VALID_STATIC_FORMATS))
-        else:
-            format = 'webp'
 
         url = '/app-assets/{0.id}/store/{0.cover_image}.{1}?size={2}'.format(obj, format, size)
         return cls(state, url)

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -89,19 +89,33 @@ class Asset:
         return cls(state, '/avatars/{0.id}/{0.avatar}.{1}?size={2}'.format(user, format, size))
 
     @classmethod
-    def _from_icon(cls, state, object, path):
+    def _from_icon(cls, state, object, path, *, format=None, size=1024):
         if object.icon is None:
             return cls(state)
 
-        url = '/{0}-icons/{1.id}/{1.icon}.jpg'.format(path, object)
+        if not utils.valid_icon_size(size):
+            raise InvalidArgument("size must be a power of 2 between 16 and 4096")
+        if format is not None and format not in VALID_STATIC_FORMATS:
+            raise InvalidArgument("format must be None or one of {}".format(VALID_STATIC_FORMATS))
+        else:
+            format = 'jpg'
+
+        url = '/{0}-icons/{1.id}/{1.icon}.{2}?size={3}'.format(path, object, format, size)
         return cls(state, url)
 
     @classmethod
-    def _from_cover_image(cls, state, obj):
+    def _from_cover_image(cls, state, obj, *, format=None, size=1024):
         if obj.cover_image is None:
             return cls(state)
 
-        url = '/app-assets/{0.id}/store/{0.cover_image}.jpg'.format(obj)
+        if not utils.valid_icon_size(size):
+            raise InvalidArgument("size must be a power of 2 between 16 and 4096")
+        if format is not None and format not in VALID_STATIC_FORMATS:
+            raise InvalidArgument("format must be None or one of {}".format(VALID_STATIC_FORMATS))
+        else:
+            format = 'jpg'
+
+        url = '/app-assets/{0.id}/store/{0.cover_image}.{1}?size={2}'.format(obj, format, size)
         return cls(state, url)
 
     @classmethod

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1155,7 +1155,35 @@ class GroupChannel(discord.abc.Messageable, Hashable):
     @property
     def icon_url(self):
         """:class:`Asset`: Returns the channel's icon asset if available."""
-        return Asset._from_icon(self._state, self, 'channel')
+        return self.icon_url_as()
+
+    def icon_url_as(self, *, format=None, size=1024):
+        """Returns an :class:`Asset` for the icon the application has.
+
+        The format must be one of 'webp', 'jpeg', 'jpg' or 'png'.
+        The size must be a power of 2 between 16 and 4096.
+
+        .. versionadded:: 2.0
+
+        Parameters
+        -----------
+        format: Optional[:class:`str`]
+            The format to attempt to convert the avatar to.
+            If the format is ``None``, then it is automatically detected into either 'jpg'.
+        size: :class:`int`
+            The size of the image to display.
+
+        Raises
+        ------
+        InvalidArgument
+            Bad image format passed to ``format`` or invalid ``size``.
+
+        Returns
+        --------
+        :class:`Asset`
+            The resulting CDN asset.
+        """
+        return Asset._from_icon(self._state, self, 'channel', format=format, size=size)
 
     @property
     def created_at(self):

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1158,7 +1158,7 @@ class GroupChannel(discord.abc.Messageable, Hashable):
         return self.icon_url_as()
 
     def icon_url_as(self, *, format=None, size=1024):
-        """Returns an :class:`Asset` for the icon the application has.
+        """Returns an :class:`Asset` for the icon the channel has.
 
         The format must be one of 'webp', 'jpeg', 'jpg' or 'png'.
         The size must be a power of 2 between 16 and 4096.
@@ -1168,7 +1168,7 @@ class GroupChannel(discord.abc.Messageable, Hashable):
         Parameters
         -----------
         format: Optional[:class:`str`]
-            The format to attempt to convert the avatar to.
+            The format to attempt to convert the icon to.
             If the format is ``None``, then it is automatically detected into either 'jpg'.
         size: :class:`int`
             The size of the image to display.

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1169,7 +1169,7 @@ class GroupChannel(discord.abc.Messageable, Hashable):
         -----------
         format: Optional[:class:`str`]
             The format to attempt to convert the icon to.
-            If the format is ``None``, then it is automatically detected into either 'jpg'.
+            If the format is ``None``, then it automatically uses 'webp'.
         size: :class:`int`
             The size of the image to display.
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1154,7 +1154,11 @@ class GroupChannel(discord.abc.Messageable, Hashable):
 
     @property
     def icon_url(self):
-        """:class:`Asset`: Returns the channel's icon asset if available."""
+        """:class:`Asset`: Returns the channel's icon asset if available.
+
+        This is equivalent to calling :meth:`icon_url_as` with
+        the default parameters ('webp' format and a size of 1024).
+        """
         return self.icon_url_as()
 
     def icon_url_as(self, *, format=None, size=1024):

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1161,7 +1161,7 @@ class GroupChannel(discord.abc.Messageable, Hashable):
         """
         return self.icon_url_as()
 
-    def icon_url_as(self, *, format=None, size=1024):
+    def icon_url_as(self, *, format='webp', size=1024):
         """Returns an :class:`Asset` for the icon the channel has.
 
         The format must be one of 'webp', 'jpeg', 'jpg' or 'png'.
@@ -1171,9 +1171,8 @@ class GroupChannel(discord.abc.Messageable, Hashable):
 
         Parameters
         -----------
-        format: Optional[:class:`str`]
-            The format to attempt to convert the icon to.
-            If the format is ``None``, then it automatically uses 'webp'.
+        format: :class:`str`
+            The format to attempt to convert the icon to. Defaults to 'webp'.
         size: :class:`int`
             The size of the image to display.
 

--- a/discord/team.py
+++ b/discord/team.py
@@ -69,7 +69,35 @@ class Team:
     @property
     def icon_url(self):
         """:class:`.Asset`: Retrieves the team's icon asset."""
-        return Asset._from_icon(self._state, self, 'team')
+        return self.icon_url_as()
+
+    def icon_url_as(self, *, format=None, size=1024):
+        """Returns an :class:`Asset` for the icon the application has.
+
+        The format must be one of 'webp', 'jpeg', 'jpg' or 'png'.
+        The size must be a power of 2 between 16 and 4096.
+
+        .. versionadded:: 2.0
+
+        Parameters
+        -----------
+        format: Optional[:class:`str`]
+            The format to attempt to convert the avatar to.
+            If the format is ``None``, then it is automatically detected into either 'jpg'.
+        size: :class:`int`
+            The size of the image to display.
+
+        Raises
+        ------
+        InvalidArgument
+            Bad image format passed to ``format`` or invalid ``size``.
+
+        Returns
+        --------
+        :class:`Asset`
+            The resulting CDN asset.
+        """
+        return Asset._from_icon(self._state, self, 'team', format=format, size=size)
 
     @property
     def owner(self):

--- a/discord/team.py
+++ b/discord/team.py
@@ -72,7 +72,7 @@ class Team:
         return self.icon_url_as()
 
     def icon_url_as(self, *, format=None, size=1024):
-        """Returns an :class:`Asset` for the icon the application has.
+        """Returns an :class:`Asset` for the icon the team has.
 
         The format must be one of 'webp', 'jpeg', 'jpg' or 'png'.
         The size must be a power of 2 between 16 and 4096.
@@ -82,7 +82,7 @@ class Team:
         Parameters
         -----------
         format: Optional[:class:`str`]
-            The format to attempt to convert the avatar to.
+            The format to attempt to convert the icon to.
             If the format is ``None``, then it is automatically detected into either 'jpg'.
         size: :class:`int`
             The size of the image to display.

--- a/discord/team.py
+++ b/discord/team.py
@@ -75,7 +75,7 @@ class Team:
         """
         return self.icon_url_as()
 
-    def icon_url_as(self, *, format=None, size=1024):
+    def icon_url_as(self, *, format='None', size=1024):
         """Returns an :class:`Asset` for the icon the team has.
 
         The format must be one of 'webp', 'jpeg', 'jpg' or 'png'.
@@ -85,9 +85,8 @@ class Team:
 
         Parameters
         -----------
-        format: Optional[:class:`str`]
-            The format to attempt to convert the icon to.
-            If the format is ``None``, then it automatically uses 'webp'.
+        format: :class:`str`
+            The format to attempt to convert the icon to. Defaults to 'webp'.
         size: :class:`int`
             The size of the image to display.
 

--- a/discord/team.py
+++ b/discord/team.py
@@ -68,7 +68,11 @@ class Team:
 
     @property
     def icon_url(self):
-        """:class:`.Asset`: Retrieves the team's icon asset."""
+        """:class:`.Asset`: Retrieves the team's icon asset.
+
+        This is equivalent to calling :meth:`icon_url_as` with
+        the default parameters ('webp' format and a size of 1024).
+        """
         return self.icon_url_as()
 
     def icon_url_as(self, *, format=None, size=1024):

--- a/discord/team.py
+++ b/discord/team.py
@@ -83,7 +83,7 @@ class Team:
         -----------
         format: Optional[:class:`str`]
             The format to attempt to convert the icon to.
-            If the format is ``None``, then it is automatically detected into either 'jpg'.
+            If the format is ``None``, then it automatically uses 'webp'.
         size: :class:`int`
             The size of the image to display.
 


### PR DESCRIPTION
## Summary

Implements `icon_url_as` and `cover_image_url_as` methods similar to `avatar_url_as` methods.

Also fixes an issue where `cover_image_url` returned an incorrect url - tested with [this](https://gist.github.com/Cynosphere/c1e77f77f0e565ddaac2822977961e76) dataset.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
