### PR TITLE
Add note to `escape_mentions()` utility function pointing to discord.AllowedMentions

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -533,6 +533,12 @@ def escape_mentions(text):
 
         This does not include channel mentions.
 
+    .. note::
+
+        For more granular control over what mentions should be escaped
+        within messages, refer to the :class:`~discord.AllowedMentions`
+        class.
+
     Parameters
     -----------
     text: :class:`str`


### PR DESCRIPTION
## Summary
Add a note to the documentation for the `escape_mentions()` utility function pointing users to the `discord.AllowedMentions` class.

Per discussion under #5892, the `escape_mentions()` utility *most likely* should not be used by developers for granular control over what mentions should and should not be escaped in discord.py messages. Instead, the `discord.AllowedMentions` class should be used for this purpose. The added note increases awareness and visibility into the `discord.AllowedMentions` class.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
