### PR TITLE
Fix typo in event reference documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -713,7 +713,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     Called when a guild becomes available or unavailable. The guild must have
     existed in the :attr:`Client.guilds` cache.
 
-    This requires :attr:`Intents.emojis` to be enabled.
+    This requires :attr:`Intents.guilds` to be enabled.
 
     :param guild: The :class:`Guild` that has changed availability.
 


### PR DESCRIPTION
## Summary

Fix an incorrect intent in the event reference documentation.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
