### PR TITLE
Use Hashable mixin to make Message hashable

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -42,6 +42,7 @@ from .flags import MessageFlags
 from .file import File
 from .utils import escape_mentions
 from .guild import Guild
+from .mixins import Hashable
 
 
 class Attachment:
@@ -252,7 +253,7 @@ def flatten_handlers(cls):
     return cls
 
 @flatten_handlers
-class Message:
+class Message(Hashable):
     r"""Represents a message from Discord.
 
     There should be no need to create one of these manually.
@@ -387,9 +388,6 @@ class Message:
 
     def __repr__(self):
         return '<Message id={0.id} channel={0.channel!r} type={0.type!r} author={0.author!r} flags={0.flags!r}>'.format(self)
-
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.id == other.id
 
     def _try_patch(self, data, key, transform=None):
         try:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR will use an available mixin instead of making another method. Fixes #5866 

I also removed the `__eq__` method because Hashable implements the exact same method.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
