### PR TITLE
logging.rst: Fix some typos and grammar errors

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -14,16 +14,16 @@ Configuration of the ``logging`` module can be as simple as::
     logging.basicConfig(level=logging.INFO)
 
 Placed at the start of the application. This will output the logs from
-discord as well as other libraries that uses the ``logging`` module
+discord as well as other libraries that use the ``logging`` module
 directly to the console.
 
 The optional ``level`` argument specifies what level of events to log
-out and can any of ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO``, and
+out and can be any of ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO``, and
 ``DEBUG`` and if not specified defaults to ``WARNING``.
 
-More advance setups are possible with the :mod:`logging` module.  To for
-example write the logs to a file called ``discord.log`` instead of
-outputting them to to the console the following snippet can be used::
+More advanced setups are possible with the :mod:`logging` module. For
+example to write the logs to a file called ``discord.log`` instead of
+outputting them to the console the following snippet can be used::
 
     import discord
     import logging
@@ -34,8 +34,8 @@ outputting them to to the console the following snippet can be used::
     handler.setFormatter(logging.Formatter('%(asctime)s:%(levelname)s:%(name)s: %(message)s'))
     logger.addHandler(handler)
 
-This is recommended, especially at verbose levels such as ``INFO``,
-and ``DEBUG`` as there are a lot of events logged and it would clog the
+This is recommended, especially at verbose levels such as ``INFO``
+and ``DEBUG``, as there are a lot of events logged and it would clog the
 stdout of your program.
 
 


### PR DESCRIPTION
## Summary

Fixes a couple of typos in the logging.rst file, and improves the grammar slightly.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
