### PR TITLE
Add markdown-inspired newline handling for help messages obtained from wrapped Command docstrings.

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1401,9 +1401,10 @@ def command(name=None, cls=None, **attrs):
     By default the ``help`` attribute is received automatically from the
     docstring of the function and is cleaned up with the use of
     ``inspect.cleandoc``. Additionally, like in Markdown, single newlines in
-    the cleaned docstring will be transformed into spaces, and double newlines
-    will be transformed into single newlines. If the docstring is ``bytes``,
-    then it is decoded into :class:`str` using utf-8 encoding.
+    the cleaned docstring will be transformed into spaces, and multiple
+    consecutive newlines will be transformed into a single newline.
+    If the docstring is ``bytes``, then it is decoded into :class:`str` using
+    utf-8 encoding.
 
     All checks added using the :func:`.check` & co. decorators are added into
     the function. There is no way to supply your own checks through this

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -230,6 +230,9 @@ class Command(_BaseCommand):
             help_doc = inspect.getdoc(func)
             if isinstance(help_doc, bytes):
                 help_doc = help_doc.decode('utf-8')
+            if help_doc is not None:
+                # Markdown-inspired newline handling for help message obtained from docstring
+                help_doc = help_doc.replace('\n\n', '\r').replace('\n', ' ').replace('\r', '\n')
 
         self.help = help_doc
 

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -27,6 +27,7 @@ DEALINGS IN THE SOFTWARE.
 import asyncio
 import functools
 import inspect
+from io import StringIO
 import typing
 import datetime
 
@@ -230,9 +231,26 @@ class Command(_BaseCommand):
             help_doc = inspect.getdoc(func)
             if isinstance(help_doc, bytes):
                 help_doc = help_doc.decode('utf-8')
+
             if help_doc is not None:
                 # Markdown-inspired newline handling for help message obtained from docstring
-                help_doc = help_doc.replace('\n\n', '\r').replace('\n', ' ').replace('\r', '\n')
+                help_doc_clean = StringIO()
+                newlines_seen = 0
+                for c in help_doc:
+                    if c == '\n':
+                        # Count consecutive newlines
+                        newlines_seen += 1
+                    else:
+                        if newlines_seen == 1:
+                            # Only one newline; add a space in its place
+                            help_doc_clean.write(' ')
+                            newlines_seen = 0
+                        elif newlines_seen > 1:
+                            # Multiple newlines; add a single newline in their place
+                            help_doc_clean.write('\n')
+                            newlines_seen = 0
+                        help_doc_clean.write(c)
+                help_doc = help_doc_clean.getvalue()
 
         self.help = help_doc
 

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1382,8 +1382,10 @@ def command(name=None, cls=None, **attrs):
 
     By default the ``help`` attribute is received automatically from the
     docstring of the function and is cleaned up with the use of
-    ``inspect.cleandoc``. If the docstring is ``bytes``, then it is decoded
-    into :class:`str` using utf-8 encoding.
+    ``inspect.cleandoc``. Additionally, like in Markdown, single newlines in
+    the cleaned docstring will be transformed into spaces, and double newlines
+    will be transformed into single newlines. If the docstring is ``bytes``,
+    then it is decoded into :class:`str` using utf-8 encoding.
 
     All checks added using the :func:`.check` & co. decorators are added into
     the function. There is no way to supply your own checks through this


### PR DESCRIPTION
## Summary

Command help messages obtained from function docstrings now handle newlines similarly to Markdown. Single newlines will be replaced with a space, and double newlines will be replaced with a single newline. Before, newlines in docstrings were preserved (not affected by `inspect.cleandoc`/`inspect.getdoc`), and it caused issues long wrapped docstrings.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
