### PR TITLE
Add linesep kwarg to Paginator

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -81,6 +81,7 @@ class Paginator:
         The maximum amount of codepoints allowed in a page.
     linesep: :class:`str`
         The character string inserted between lines. e.g. a newline character.
+            .. versionadded:: 1.6
     """
     def __init__(self, prefix='```', suffix='```', max_size=2000, linesep='\n'):
         self.prefix = prefix
@@ -169,8 +170,8 @@ class Paginator:
         return self._pages
 
     def __repr__(self):
-        fmt = '<Paginator prefix: {0.prefix} suffix: {0.suffix} linesep: {1} max_size: {0.max_size} count: {0._count}>'
-        return fmt.format(self, repr(self.linesep))
+        fmt = '<Paginator prefix: {0.prefix!r} suffix: {0.suffix!r} linesep: {0.linesep!r} max_size: {0.max_size} count: {0._count}>'
+        return fmt.format(self)
 
 def _not_overriden(f):
     f.__help_command_not_overriden__ = True

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -79,18 +79,21 @@ class Paginator:
         The suffix appended at the end of every page. e.g. three backticks.
     max_size: :class:`int`
         The maximum amount of codepoints allowed in a page.
+    linesep: :class:`str`
+        The character string inserted between lines. e.g. a newline character.
     """
-    def __init__(self, prefix='```', suffix='```', max_size=2000):
+    def __init__(self, prefix='```', suffix='```', max_size=2000, linesep='\n'):
         self.prefix = prefix
         self.suffix = suffix
         self.max_size = max_size
+        self.linesep = linesep
         self.clear()
 
     def clear(self):
         """Clears the paginator to have no pages."""
         if self.prefix is not None:
             self._current_page = [self.prefix]
-            self._count = len(self.prefix) + 1 # prefix + newline
+            self._count = len(self.prefix) + self._linesep_len # prefix + newline
         else:
             self._current_page = []
             self._count = 0
@@ -103,6 +106,10 @@ class Paginator:
     @property
     def _suffix_len(self):
         return len(self.suffix) if self.suffix else 0
+
+    @property
+    def _linesep_len(self):
+        return len(self.linesep)
 
     def add_line(self, line='', *, empty=False):
         """Adds a line to the current page.
@@ -122,29 +129,29 @@ class Paginator:
         RuntimeError
             The line was too big for the current :attr:`max_size`.
         """
-        max_page_size = self.max_size - self._prefix_len - self._suffix_len - 2
+        max_page_size = self.max_size - self._prefix_len - self._suffix_len - 2 * self._linesep_len
         if len(line) > max_page_size:
             raise RuntimeError('Line exceeds maximum page size %s' % (max_page_size))
 
-        if self._count + len(line) + 1 > self.max_size - self._suffix_len:
+        if self._count + len(line) + self._linesep_len > self.max_size - self._suffix_len:
             self.close_page()
 
-        self._count += len(line) + 1
+        self._count += len(line) + self._linesep_len
         self._current_page.append(line)
 
         if empty:
             self._current_page.append('')
-            self._count += 1
+            self._count += self._linesep_len
 
     def close_page(self):
         """Prematurely terminate a page."""
         if self.suffix is not None:
             self._current_page.append(self.suffix)
-        self._pages.append('\n'.join(self._current_page))
+        self._pages.append(self.linesep.join(self._current_page))
 
         if self.prefix is not None:
             self._current_page = [self.prefix]
-            self._count = len(self.prefix) + 1 # prefix + newline
+            self._count = len(self.prefix) + self._linesep_len # prefix + linesep
         else:
             self._current_page = []
             self._count = 0
@@ -162,8 +169,8 @@ class Paginator:
         return self._pages
 
     def __repr__(self):
-        fmt = '<Paginator prefix: {0.prefix} suffix: {0.suffix} max_size: {0.max_size} count: {0._count}>'
-        return fmt.format(self)
+        fmt = '<Paginator prefix: {0.prefix} suffix: {0.suffix} linesep: {1} max_size: {0.max_size} count: {0._count}>'
+        return fmt.format(self, repr(self.linesep))
 
 def _not_overriden(f):
     f.__help_command_not_overriden__ = True

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -81,7 +81,7 @@ class Paginator:
         The maximum amount of codepoints allowed in a page.
     linesep: :class:`str`
         The character string inserted between lines. e.g. a newline character.
-            .. versionadded:: 1.6
+            .. versionadded:: 1.7
     """
     def __init__(self, prefix='```', suffix='```', max_size=2000, linesep='\n'):
         self.prefix = prefix

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -11,6 +11,16 @@ Changelog
 This page keeps a detailed human friendly rendering of what's new and changed
 in specific versions.
 
+.. _vp1p6p0:
+
+v1.6.0
+-------
+
+Miscellaneous
+~~~~~~~~~~~~~~~
+
+- Add :attr:`Paginator.linesep` to allow further customization of the Paginator.
+
 .. _vp1p5p1:
 
 v1.5.1

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -11,16 +11,6 @@ Changelog
 This page keeps a detailed human friendly rendering of what's new and changed
 in specific versions.
 
-.. _vp1p6p0:
-
-v1.6.0
--------
-
-Miscellaneous
-~~~~~~~~~~~~~~~
-
-- Add :attr:`Paginator.linesep` to allow further customization of the Paginator.
-
 .. _vp1p5p1:
 
 v1.5.1


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Extends the commands.Paginator class to allow custom line separators, for example if you want to
- add individual words rather than whole lines (useful if your input material is all on one line)
- make an Emoji paginator with no spaces between Emoji objects
- clap 👏 at 👏 your 👏 friends

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
