### PR TITLE
Update MessageConverter regexes to support message links with "www" and remove redundant parts

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -255,10 +255,10 @@ class MessageConverter(Converter):
          Raise :exc:`.ChannelNotFound`, `MessageNotFound` or `ChannelNotReadable` instead of generic :exc:`.BadArgument`
     """
     async def convert(self, ctx, argument):
-        id_regex = re.compile(r'^(?:(?P<channel_id>[0-9]{15,21})-)?(?P<message_id>[0-9]{15,21})$')
+        id_regex = re.compile(r'(?:(?P<channel_id>[0-9]{15,21})-)?(?P<message_id>[0-9]{15,21})$')
         link_regex = re.compile(
-            r'^https?://(?:(ptb|canary|www)\.)?discord(?:app)?\.com/channels/'
-            r'(?:([0-9]{15,21})|(@me))'
+            r'https?://(?:(ptb|canary|www)\.)?discord(?:app)?\.com/channels/'
+            r'(?:[0-9]{15,21}|@me)'
             r'/(?P<channel_id>[0-9]{15,21})/(?P<message_id>[0-9]{15,21})/?$'
         )
         match = id_regex.match(argument) or link_regex.match(argument)

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -254,11 +254,10 @@ class MessageConverter(Converter):
     .. versionchanged:: 1.5
          Raise :exc:`.ChannelNotFound`, `MessageNotFound` or `ChannelNotReadable` instead of generic :exc:`.BadArgument`
     """
-
     async def convert(self, ctx, argument):
         id_regex = re.compile(r'^(?:(?P<channel_id>[0-9]{15,21})-)?(?P<message_id>[0-9]{15,21})$')
         link_regex = re.compile(
-            r'^https?://(?:(ptb|canary)\.)?discord(?:app)?\.com/channels/'
+            r'^https?://(?:(ptb|canary|www)\.)?discord(?:app)?\.com/channels/'
             r'(?:([0-9]{15,21})|(@me))'
             r'/(?P<channel_id>[0-9]{15,21})/(?P<message_id>[0-9]{15,21})/?$'
         )


### PR DESCRIPTION
## Summary

This updates the `MessageConverter` link regex to support message links with "www", which are valid but previously not recognised by the `convert` method. In addition, some redundant parts in both the `id_regex` and the `link_regex` are removed:
- the `^` at the start of both regexes, which is unnecessary since `match` only matches at the beginning of the string anyway
- the parentheses around the guild ID and `@me`, these groups are not used for anything

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
