### PR TITLE
Add support for css-style shorthand colours

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -429,7 +429,7 @@ class ColourConverter(Converter):
         if arg[0] == '#':
             arg = arg[1:]
 
-        if len(arg) == 3:
+        if "#" in argument and len(arg) == 3:
             arg = ''.join(i * 2 for i in arg)
         try:
             value = int(arg, base=16)

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -428,6 +428,9 @@ class ColourConverter(Converter):
 
         if arg[0] == '#':
             arg = arg[1:]
+
+        if len(arg) == 3:
+            arg = ''.join(i * 2 for i in arg)
         try:
             value = int(arg, base=16)
             if not (0 <= value <= 0xFFFFFF):


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds support for css shorthand colour codes like `#abc` (which would be expanded to `#aabbcc`) to the colour converter in the commands extension.
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
