### PR TITLE
Modifies documentation for wait_for to handle emojis

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -920,17 +920,21 @@ class Client:
             async def on_message(message):
                 if message.content.startswith('$thumb'):
                     channel = message.channel
-                    await channel.send('Send me that \N{THUMBS UP SIGN} reaction, mate')
+                    await channel.send('Send me that \N{THUMBS UP SIGN}\N{VARIATION SELECTOR-16} reaction, mate')
 
                     def check(reaction, user):
-                        return user == message.author and str(reaction.emoji) == '\N{THUMBS UP SIGN}'
+                        # We compare the first character because the user's client may add things
+                        # such as Variation Selector-16, Skin tone modifiers, or both of these.
+                        # This approach can not be used in all cases as some emojis (such as flags)
+                        # are composed of multiple emojis.
+                        return user == message.author and str(reaction.emoji)[0] == '\N{THUMBS UP SIGN}'
 
                     try:
                         reaction, user = await client.wait_for('reaction_add', timeout=60.0, check=check)
                     except asyncio.TimeoutError:
-                        await channel.send('\N{THUMBS DOWN SIGN}')
+                        await channel.send('\N{THUMBS DOWN SIGN}\N{VARIATION SELECTOR-16}')
                     else:
-                        await channel.send('\N{THUMBS UP SIGN}')
+                        await channel.send('\N{THUMBS UP SIGN}\N{VARIATION SELECTOR-16}')
 
 
         Parameters


### PR DESCRIPTION

## Summary

This modifies documentation regarding wait_for surrounding emoji use which may not be obvious if people are unaware of the specifics of unicode. I suspect the docs may also benefit from a section on emojis, unicode, and discord but that is not part of this change set.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
