### PR TITLE
Emphasize intents in constructors.

### DIFF
--- a/docs/intents.rst
+++ b/docs/intents.rst
@@ -157,7 +157,7 @@ Due to an :ref:`API change <intents_member_cache>` Discord is now forcing develo
 For example:
 
 .. code-block:: python3
-   :emphasize-lines: 3,5,7,8
+   :emphasize-lines: 3,6,8,9
 
     import discord
     intents = discord.Intents.default()

--- a/docs/intents.rst
+++ b/docs/intents.rst
@@ -19,6 +19,7 @@ The intents that are necessary for your bot can only be dictated by yourself. Ea
 For example, if you want a bot that functions without spammy events like presences or typing then we could do the following:
 
 .. code-block:: python3
+   :emphasize-lines: 7,9,10
 
     import discord
     intents = discord.Intents.default()
@@ -26,16 +27,17 @@ For example, if you want a bot that functions without spammy events like presenc
     intents.presences = False
 
     # Somewhere else:
-    client = discord.Client(intents=intents)
+    # client = discord.Client(intents=intents)
     # or
-    from discord.ext import commands
-    bot = commands.Bot(command_prefix='!', intents=intents)
+    # from discord.ext import commands
+    # bot = commands.Bot(command_prefix='!', intents=intents)
 
 Note that this doesn't enable :attr:`Intents.members` since it's a privileged intent.
 
 Another example showing a bot that only deals with messages and guild information:
 
 .. code-block:: python3
+   :emphasize-lines: 6,8,9
 
     import discord
     intents = discord.Intents(messages=True, guilds=True)
@@ -43,10 +45,10 @@ Another example showing a bot that only deals with messages and guild informatio
     # intents.reactions = True
 
     # Somewhere else:
-    client = discord.Client(intents=intents)
+    # client = discord.Client(intents=intents)
     # or
-    from discord.ext import commands
-    bot = commands.Bot(command_prefix='!', intents=intents)
+    # from discord.ext import commands
+    # bot = commands.Bot(command_prefix='!', intents=intents)
 
 .. _privileged_intents:
 
@@ -155,6 +157,7 @@ Due to an :ref:`API change <intents_member_cache>` Discord is now forcing develo
 For example:
 
 .. code-block:: python3
+   :emphasize-lines: 3,5,7,8
 
     import discord
     intents = discord.Intents.default()

--- a/docs/intents.rst
+++ b/docs/intents.rst
@@ -26,10 +26,10 @@ For example, if you want a bot that functions without spammy events like presenc
     intents.presences = False
 
     # Somewhere else:
-    # client = discord.Client(intents=intents)
+    client = discord.Client(intents=intents)
     # or
-    # from discord.ext import commands
-    # bot = commands.Bot(command_prefix='!', intents=intents)
+    from discord.ext import commands
+    bot = commands.Bot(command_prefix='!', intents=intents)
 
 Note that this doesn't enable :attr:`Intents.members` since it's a privileged intent.
 
@@ -43,10 +43,10 @@ Another example showing a bot that only deals with messages and guild informatio
     # intents.reactions = True
 
     # Somewhere else:
-    # client = discord.Client(intents=intents)
+    client = discord.Client(intents=intents)
     # or
-    # from discord.ext import commands
-    # bot = commands.Bot(command_prefix='!', intents=intents)
+    from discord.ext import commands
+    bot = commands.Bot(command_prefix='!', intents=intents)
 
 .. _privileged_intents:
 

--- a/docs/intents.rst
+++ b/docs/intents.rst
@@ -37,7 +37,7 @@ Note that this doesn't enable :attr:`Intents.members` since it's a privileged in
 Another example showing a bot that only deals with messages and guild information:
 
 .. code-block:: python3
-   :emphasize-lines: 6,8,9
+   :emphasize-lines: 7,9,10
 
     import discord
     intents = discord.Intents(messages=True, guilds=True)


### PR DESCRIPTION
## Summary

A lot of people in the help channel seem to not realize you need to pass the intents into the constructor. Uncommenting this may help.
Edit: Replaced with line emphasis.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
