### PR TITLE
HTTPClient: set a real user-agent string for selfbots

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -108,9 +108,7 @@ class HTTPClient:
         self.proxy = proxy
         self.proxy_auth = proxy_auth
         self.use_clock = not unsync_clock
-
-        user_agent = 'DiscordBot (https://github.com/Rapptz/discord.py {0}) Python/{1[0]}.{1[1]} aiohttp/{2}'
-        self.user_agent = user_agent.format(__version__, sys.version_info, aiohttp.__version__)
+        self.user_agent = None
 
     def recreate(self):
         if self.__session.closed:
@@ -282,6 +280,14 @@ class HTTPClient:
     # login management
 
     async def static_login(self, token, *, bot):
+        if self.user_agent is None:
+            if bot:
+                user_agent = 'DiscordBot (https://github.com/Rapptz/discord.py {0}) Python/{1[0]}.{1[1]} aiohttp/{2}'
+                self.user_agent = user_agent.format(__version__, sys.version_info, aiohttp.__version__)
+            else:
+                # Prevent us from getting locked behind an email verification gate
+                self.user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) discord/0.0.12 Chrome/78.0.3904.130 Electron/7.3.2 Safari/537.36'
+
         # Necessary to get aiohttp to stop complaining about session creation
         self.__session = aiohttp.ClientSession(connector=self.connector, ws_response_class=DiscordClientWebSocketResponse)
         old_token, old_bot = self.token, self.bot_token


### PR DESCRIPTION
## Summary

With the current discord.py user-agent string, selfbots get instantly flagged for email re-verification as soon as they make a request, and are subsequently prevented from making any further HTTP requests. This PR fixes that by setting a "real" user-agent string in static_login() if the user agent has not already been set. The `None` check is there to preserve the current behavior where the user can write:

```py
client = discord.Client(self_bot=True)
client.http.user_agent = SOME_USER_AGENT_STRING
```

**Yes, I am aware that self-bots are against Discord TOS.** However, discord.py supports them, and so I believe that if they do not work it is a bug in the library.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
