### PR TITLE
Properly document that categories throw 404's on create_invite.

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -739,7 +739,7 @@ class GuildChannel:
             Invite creation failed.
 
         ~discord.NotFound
-            The channel that was passed is a category or a invalid channel.
+            The channel that was passed is a category or an invalid channel.
 
         Returns
         --------

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -739,7 +739,7 @@ class GuildChannel:
             Invite creation failed.
 
         ~discord.NotFound
-            The channel that was passed is a category, or a invalid channel.
+            The channel that was passed is a category or a invalid channel.
 
         Returns
         --------

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -738,6 +738,9 @@ class GuildChannel:
         ~discord.HTTPException
             Invite creation failed.
 
+        ~discord.NotFound
+            The channel that was passed is a category, or a invalid channel.
+
         Returns
         --------
         :class:`~discord.Invite`

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -710,7 +710,7 @@ class GuildChannel:
     async def create_invite(self, *, reason=None, **fields):
         """|coro|
 
-        Creates an instant invite.
+        Creates an instant invite from a text or voice channel.
 
         You must have the :attr:`~Permissions.create_instant_invite` permission to
         do this.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Categories will throw 404's when channel.create_invite is used. This was a bit confusing for me since
```py
;jsk py
guild = _ctx.guild
guildchannels = [channel for channel in guild.channels]
channel = guildchannels[0]
invite_link = await channel.create_invite()
return await _ctx.send(invite_link)
```
threw NotFound, which was because the first channel was a category, it would be nice if the docs properly showed that categories will throw this error.
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
