### PR TITLE
Add MessageReference.fetch_message

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -341,6 +341,8 @@ class MessageReference:
 
         Retrieves the :class:`Message` from the destination.
 
+        The channel or guild may be a partial object if it is not found.
+
         This can only be used by bot accounts.
 
         .. versionadded:: 2.0

--- a/discord/message.py
+++ b/discord/message.py
@@ -35,7 +35,7 @@ from .emoji import Emoji
 from .partial_emoji import PartialEmoji
 from .calls import CallMessage
 from .enums import MessageType, ChannelType, try_enum
-from .errors import InvalidArgument, ClientException, HTTPException
+from .errors import InvalidArgument, ClientException, HTTPException, ChannelNotFound
 from .embeds import Embed
 from .member import Member
 from .flags import MessageFlags
@@ -334,6 +334,37 @@ class MessageReference:
     def cached_message(self):
         """Optional[:class:`~discord.Message`]: The cached message, if found in the internal message cache."""
         return self._state._get_message(self.message_id)
+
+    async def fetch_message(self):
+        """|coro|
+
+        Retrieves the :class:`Message` from the destination.
+
+        This can only be used by bot accounts.
+
+        .. versionadded:: 2.0
+
+        Raises
+        --------
+        ~discord.NotFound
+            The message was not found.
+        ~discord.ChannelNotFound
+            The message's channel was not found.
+        ~discord.Forbidden
+            You do not have the permissions required to get a message.
+        ~discord.HTTPException
+            Retrieving the message failed.
+
+        Returns
+        --------
+        :class:`Message`
+            The message asked for.
+        """
+
+        channel = self._state.get_channel(self.channel_id)
+        if channel is None:
+            raise ChannelNotFound(self.channel_id)
+        return await channel.fetch_message(self.message_id)
 
     def __repr__(self):
         return '<MessageReference message_id={0.message_id!r} channel_id={0.channel_id!r} guild_id={0.guild_id!r}>'.format(self)

--- a/discord/message.py
+++ b/discord/message.py
@@ -367,6 +367,8 @@ class MessageReference:
             guild = state.get_guild(self.guild_id)
             if guild:
                 channel = guild.get_channel(self.channel_id)
+            else:
+                channel = None
         else:
             channel = state.get_channel(self.channel_id)
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -349,8 +349,6 @@ class MessageReference:
         --------
         ~discord.NotFound
             The message was not found.
-        ~discord.ChannelNotFound
-            The message's channel was not found.
         ~discord.Forbidden
             You do not have the permissions required to get a message.
         ~discord.HTTPException


### PR DESCRIPTION
## Summary

This adds a convenient way to *fetch* the reference's message. Currently, you can only easily *get* the message.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
