### PR TITLE
Allow arguments to be passed to extension setup functions

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -647,6 +647,10 @@ class BotBase(GroupMixin):
             The extension name to load. It must be dot separated like
             regular Python imports if accessing a sub-module. e.g.
             ``foo.test`` if you want to import ``foo/test.py``.
+        args:
+            The position arguments to be passed to the extension setup function.
+        kwargs:
+            The keyword arguments to be passed to the extension setup function.
 
         Raises
         --------
@@ -714,6 +718,10 @@ class BotBase(GroupMixin):
             The extension name to reload. It must be dot separated like
             regular Python imports if accessing a sub-module. e.g.
             ``foo.test`` if you want to import ``foo/test.py``.
+        args:
+            The position arguments to be passed to the extension setup function.
+        kwargs:
+            The keyword arguments to be passed to the extension setup function.
 
         Raises
         -------


### PR DESCRIPTION
## Summary

This PR allows for `*args` and `**kwargs` to be passed to extension `setup` functions. 

Some notes about this:
 - Reduces the ability to add new features to `Bot.load_extension` and `Bot.reload_extension` without breaking changes.
 - When reloading an extension new arguments would need to be passed each time.
 - The same functionality could be acheived with the use of a botvar.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
