### PR TITLE
[docs] Fix `discord.RoleTags` resolution

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -38,7 +38,7 @@ from .asset import Asset
 from .errors import *
 from .calls import CallMessage, GroupCall
 from .permissions import Permissions, PermissionOverwrite
-from .role import Role
+from .role import Role, RoleTags
 from .file import File
 from .colour import Color, Colour
 from .integrations import Integration, IntegrationAccount


### PR DESCRIPTION
## Summary

```py
WARNING: autodoc: failed to import class 'RoleTags' from module 'discord'; the following exception was raised:
Traceback (most recent call last):
  File "sphinx\util\inspect.py", line 225, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: module 'discord' has no attribute 'RoleTags'
```

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
