### PR TITLE
[bug] fix `UnboundLocalError` for editing `public_updates_channel`

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1216,10 +1216,10 @@ class Guild(Hashable):
         except KeyError:
             pass
         else:
-            if rules_channel is None:
-                fields['public_updates_channel_id'] = rules_channel
+            if public_updates_channel is None:
+                fields['public_updates_channel_id'] = public_updates_channel
             else:
-                fields['public_updates_channel_id'] = rules_channel.id
+                fields['public_updates_channel_id'] = public_updates_channel.id
         await http.edit_guild(self.id, reason=reason, **fields)
 
     async def fetch_channels(self):


### PR DESCRIPTION
## Summary

```py
>>> await guild.edit(public_updates_channel=guild.public_updates_channel)
    if rules_channel is None:
UnboundLocalError: local variable 'rules_channel' referenced before assignment
```

Bug introduced in ed80ba6.

## Checklist

- [x] If code changes were made then they have **actually** been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
