### PR TITLE
[chore] Remove redundant imports

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -64,11 +64,4 @@ VersionInfo = namedtuple('VersionInfo', 'major minor micro releaselevel serial')
 
 version_info = VersionInfo(major=1, minor=6, micro=0, releaselevel='alpha', serial=0)
 
-try:
-    from logging import NullHandler
-except ImportError:
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
-
-logging.getLogger(__name__).addHandler(NullHandler())
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -32,7 +32,7 @@ import asyncio
 from .iterators import HistoryIterator
 from .context_managers import Typing
 from .enums import ChannelType
-from .errors import InvalidArgument, ClientException, HTTPException
+from .errors import InvalidArgument, ClientException
 from .permissions import PermissionOverwrite, Permissions
 from .role import Role
 from .invite import Invite

--- a/discord/client.py
+++ b/discord/client.py
@@ -33,14 +33,12 @@ import traceback
 import aiohttp
 
 from .user import User, Profile
-from .asset import Asset
 from .invite import Invite
 from .template import Template
 from .widget import Widget
 from .guild import Guild
 from .channel import _channel_factory
 from .enums import ChannelType
-from .member import Member
 from .mentions import AllowedMentions
 from .errors import *
 from .enums import Status, VoiceRegion

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -30,12 +30,11 @@ import inspect
 import importlib.util
 import sys
 import traceback
-import re
 import types
 
 import discord
 
-from .core import GroupMixin, Command
+from .core import GroupMixin
 from .view import StringView
 from .context import Context
 from . import errors

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -30,14 +30,13 @@ from collections import namedtuple
 from . import utils
 from .role import Role
 from .member import Member, VoiceState
-from .activity import create_activity
 from .emoji import Emoji
 from .errors import InvalidData
 from .permissions import PermissionOverwrite
 from .colour import Colour
 from .errors import InvalidArgument, ClientException
 from .channel import *
-from .enums import VoiceRegion, Status, ChannelType, try_enum, VerificationLevel, ContentFilter, NotificationLevel
+from .enums import VoiceRegion, ChannelType, try_enum, VerificationLevel, ContentFilter, NotificationLevel
 from .mixins import Hashable
 from .user import User
 from .invite import Invite

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -28,7 +28,7 @@ import asyncio
 import datetime
 
 from .errors import NoMoreItems
-from .utils import DISCORD_EPOCH, time_snowflake, maybe_coroutine
+from .utils import time_snowflake, maybe_coroutine
 from .object import Object
 from .audit_logs import AuditLogEntry
 

--- a/discord/member.py
+++ b/discord/member.py
@@ -34,7 +34,7 @@ from . import utils
 from .user import BaseUser, User
 from .activity import create_activity
 from .permissions import Permissions
-from .enums import Status, try_enum, UserFlags, HypeSquadHouse
+from .enums import Status, try_enum
 from .colour import Colour
 from .object import Object
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -43,7 +43,6 @@ from .file import File
 from .utils import escape_mentions
 from .guild import Guild
 from .mixins import Hashable
-from .mentions import AllowedMentions
 from .sticker import Sticker
 
 __all__ = (

--- a/discord/state.py
+++ b/discord/state.py
@@ -30,7 +30,6 @@ import copy
 import datetime
 import itertools
 import logging
-import math
 import weakref
 import warnings
 import inspect
@@ -53,7 +52,6 @@ from .role import Role
 from .enums import ChannelType, try_enum, Status
 from . import utils
 from .flags import Intents, MemberCacheFlags
-from .embeds import Embed
 from .object import Object
 from .invite import Invite
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -31,7 +31,6 @@ import unicodedata
 from base64 import b64encode
 from bisect import bisect_left
 import datetime
-from email.utils import parsedate_to_datetime
 import functools
 from inspect import isawaitable as _isawaitable
 from operator import attrgetter
@@ -40,7 +39,6 @@ import re
 import warnings
 
 from .errors import InvalidArgument
-from .object import Object
 
 DISCORD_EPOCH = 1420070400000
 MAX_ASYNCIO_SECONDS = 3456000


### PR DESCRIPTION
## Summary

Removes redundant imports. This also removes the historical patch for NullHandler implemented in bbf1c54, as it has been available since Python 3.1.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
