### PR TITLE
[bug] call super constructor for `CustomActivity` to fix `created_at`

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -685,6 +685,7 @@ class CustomActivity(BaseActivity):
     __slots__ = ('name', 'emoji', 'state')
 
     def __init__(self, name, *, emoji=None, **extra):
+        super().__init__(**extra)
         self.name = name
         self.state = extra.pop('state', None)
         if self.name == 'Custom Status':


### PR DESCRIPTION
## Summary

`CustomActivity` didn't call `BaseActivity`'s constructor, resulting in an uninitiated `created_at`.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
