### PR TITLE
Fix Team.icon_url_as format argument default value

### DIFF
--- a/discord/team.py
+++ b/discord/team.py
@@ -75,7 +75,7 @@ class Team:
         """
         return self.icon_url_as()
 
-    def icon_url_as(self, *, format='None', size=1024):
+    def icon_url_as(self, *, format='webp', size=1024):
         """Returns an :class:`Asset` for the icon the team has.
 
         The format must be one of 'webp', 'jpeg', 'jpg' or 'png'.


### PR DESCRIPTION
## Summary

`Team.icon_url_as()` has a default value of `'None'` (a string) for the `format` argument. According to the method documentation, this should be `'webp'`.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
