### PR TITLE
Make extension unloading atomic

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -563,15 +563,14 @@ class BotBase(GroupMixin):
         for cogname, cog in self.__cogs.copy().items():
             if _is_submodule(name, cog.__module__):
                 try:
+                    removed_cogs.append(cog)
                     self.remove_cog(cogname)
                 except Exception as exc:
                     # a cog raised an exception in cog_unload
                     # add all cogs back to the module and propagate the exception
                     for removed_cog in removed_cogs:
-                        self.add_cog(remove_cog)
+                        self.add_cog(removed_cog)
                     raise exc
-                else:
-                    removed_cogs.append(cog)
 
         # remove all the commands from the module
         for cmd in self.all_commands.copy().values():

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -565,7 +565,7 @@ class BotBase(GroupMixin):
                 try:
                     removed_cogs.append(cog)
                     self.remove_cog(cogname)
-                except Exception as exc:
+                except BaseException as exc:
                     # a cog raised an exception in cog_unload
                     # add all cogs back to the module and propagate the exception
                     for removed_cog in removed_cogs:

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -565,7 +565,7 @@ class BotBase(GroupMixin):
                 try:
                     removed_cogs.append(cog)
                     self.remove_cog(cogname)
-                except BaseException as exc:
+                except Exception as exc:
                     # a cog raised an exception in cog_unload
                     # add all cogs back to the module and propagate the exception
                     for removed_cog in removed_cogs:


### PR DESCRIPTION
## Summary

Closes #6113 

edit: talked with Danny on discord briefly. Extension unloading isn't meant to be atomic, but hasn't looked at #6113 yet.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [N/A] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [N/A] This PR adds something new (e.g. new method or parameters).
- [N/A] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [N/A] This PR is **not** a code change (e.g. documentation, README, ...)
