### PR TITLE
Fix wrong documented permission for GuildChannel.invites()

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -755,7 +755,7 @@ class GuildChannel:
 
         Returns a list of all active instant invites from this channel.
 
-        You must have :attr:`~Permissions.manage_guild` to get this information.
+        You must have :attr:`~Permissions.manage_channels` to get this information.
 
         Raises
         -------


### PR DESCRIPTION
I tested it just now, and `manage_guild` is not the permission you need to fetch invites from a given channel. You need `manage_channels`.

Note that this isn't the same as `Guild.invites()`, which *does* use `manage_guild`.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
