### PR TITLE
Fix embed suppression when using client-wide allowed_mentions

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -1019,7 +1019,7 @@ class Message(Hashable):
             else:
                 allowed_mentions = {'replied_user': mention_author}
             fields['allowed_mentions'] = allowed_mentions
-        elif self._state.allowed_mentions is not None:
+        elif self._state.allowed_mentions is not None and self._state.self_id == self.author.id:
             fields['allowed_mentions'] = self._state.allowed_mentions.to_dict()
 
         if fields:


### PR DESCRIPTION
## Summary

Fixes being unable to suppress embeds on other users' messages when the client was created with an initial `allowed_mentions` value, as including the `allowed_mentions` field will return a 403 from the API. 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
