### PR TITLE
Add __eq__ method to Embed object

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -123,6 +123,9 @@ class Embed:
         else:
             self.timestamp = timestamp
 
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.to_dict() == other.to_dict()
+
     @classmethod
     def from_dict(cls, data):
         """Converts a :class:`dict` to a :class:`Embed` provided it is in the


### PR DESCRIPTION
Resolves issue #5962, compare Embeds by dictionary rather than object

## Summary
Currently, comparing two Embeds with the same attributes will not work because the objects are different.
This change fixes that odd behavior by comparing the dict representations of the two objects in the `__eq__` method.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
