### PR TITLE
Fix SyntaxError due to invalid escape sequence under Python 3.9

### DIFF
--- a/discord/file.py
+++ b/discord/file.py
@@ -28,7 +28,7 @@ import os.path
 import io
 
 class File:
-    """A parameter object used for :meth:`abc.Messageable.send`
+    r"""A parameter object used for :meth:`abc.Messageable.send`
     for sending file objects.
 
     .. note::


### PR DESCRIPTION
## Summary

This patch fixes a leftover from #2534/#2537 when the bot is run with Python 3.9. For me, it has surfaced during pytest invokation with [craftspider/dpytest](https://github.com/craftspider/dpytest) as `discord.ext.text`:

```
runtime/venv/lib/python3.9/site-packages/_pytest/python.py:571: in _importtestmodule
    mod = import_path(self.fspath, mode=importmode)
runtime/venv/lib/python3.9/site-packages/_pytest/pathlib.py:517: in import_path
    importlib.import_module(module_name)
/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:986: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:680: in _load_unlocked
    ???
runtime/venv/lib/python3.9/site-packages/_pytest/assertion/rewrite.py:171: in exec_module
    exec(co, module.__dict__)
tests/test_core.py:1: in <module>
    import discord.ext.test as dpytest
runtime/venv/lib/python3.9/site-packages/discord/__init__.py:25: in <module>
    from .client import Client
runtime/venv/lib/python3.9/site-packages/discord/client.py:35: in <module>
    from .user import User, Profile
runtime/venv/lib/python3.9/site-packages/discord/user.py:29: in <module>
    import discord.abc
runtime/venv/lib/python3.9/site-packages/discord/abc.py:39: in <module>
    from .file import File
E     File "/Users/whoever/development/whatever/runtime/venv/lib/python3.9/site-packages/discord/file.py", line 31
E       """A parameter object used for :meth:`abc.Messageable.send`
E       ^
E   SyntaxError: invalid escape sequence \s
```

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
