### PR TITLE
Add feature  url_as for emoji

### DIFF
--- a/discord/asset.py
+++ b/discord/asset.py
@@ -153,6 +153,19 @@ class Asset:
 
         return cls(state, '/stickers/{0.id}/{0.image}.png?size={2}'.format(sticker, format, size))
 
+    @classmethod
+    def _from_emoji(cls, state, emoji, *, format=None, static_format='png'):
+        if format is not None and format not in VALID_AVATAR_FORMATS:
+            raise InvalidArgument("format must be None or one of {}".format(VALID_AVATAR_FORMATS))
+        if format == "gif" and not emoji.animated:
+            raise InvalidArgument("non animated emoji's do not support gif format")
+        if static_format not in VALID_STATIC_FORMATS:
+            raise InvalidArgument("static_format must be one of {}".format(VALID_STATIC_FORMATS))
+        if format is None:
+            format = 'gif' if emoji.animated else static_format
+
+        return cls(state, '/emojis/{0.id}.{1}'.format(emoji, format))
+    
     def __str__(self):
         return self.BASE + self._url if self._url is not None else ''
 

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -156,19 +156,19 @@ class Emoji(_EmojiTag):
         return self._state._get_guild(self.guild_id)
 
 
-    def url_as(self,*,format=None,static_format="png"):
+    def url_as(self, *, format=None, static_format="png"):
         """Returns an :class:`Asset` for the emoji's url.
 
-        The format must be one of 'webp', 'jpeg', 'jpg', 'png' or 'gif', and
+        The format must be one of 'webp', 'jpeg', 'jpg', 'png' or 'gif'.
         'gif' is only valid for animated emojis. 
 
         Parameters
         -----------
         format: Optional[:class:`str`]
-            The format to attempt to convert the emoji to.
+            The format to attempt to convert the emojis to.
             If the format is ``None``, then it is automatically
-            detected into either 'gif' or static_format depending on the
-            emoji being animated or not.
+            detected as either 'gif' or static_format, depending on wether the
+            emoji is animated or not.
         static_format: Optional[:class:`str`]
             Format to attempt to convert only non-animated emoji's to.
             Defaults to 'png'
@@ -176,7 +176,7 @@ class Emoji(_EmojiTag):
         Raises
         ------
         InvalidArgument
-            Bad image format passed to ``format`` or ``static_format``
+            Bad image format passed to ``format`` or ``static_format``.
 
         Returns
         --------

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -167,7 +167,7 @@ class Emoji(_EmojiTag):
         format: Optional[:class:`str`]
             The format to attempt to convert the emojis to.
             If the format is ``None``, then it is automatically
-            detected as either 'gif' or static_format, depending on wether the
+            detected as either 'gif' or static_format, depending on whether the
             emoji is animated or not.
         static_format: Optional[:class:`str`]
             Format to attempt to convert only non-animated emoji's to.

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -174,7 +174,7 @@ class Emoji(_EmojiTag):
             Defaults to 'png'
 
         Raises
-        ------
+        -------
         InvalidArgument
             Bad image format passed to ``format`` or ``static_format``.
 

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -131,10 +131,12 @@ class Emoji(_EmojiTag):
 
     @property
     def url(self):
-        """:class:`Asset`: Returns the asset of the emoji."""
-        _format = 'gif' if self.animated else 'png'
-        url = "/emojis/{0.id}.{1}".format(self, _format)
-        return Asset(self._state, url)
+        """:class:`Asset`: Returns the asset of the emoji.
+        
+        This is equivalent to calling :meth:`url_as` with
+        the default parameters (i.e. png/gif detection).
+        """
+        return self.url_as(format=None)
 
     @property
     def roles(self):
@@ -152,6 +154,37 @@ class Emoji(_EmojiTag):
     def guild(self):
         """:class:`Guild`: The guild this emoji belongs to."""
         return self._state._get_guild(self.guild_id)
+
+
+    def url_as(self,*,format=None,static_format="png"):
+        """Returns an :class:`Asset` for the emoji's url.
+
+        The format must be one of 'webp', 'jpeg', 'jpg', 'png' or 'gif', and
+        'gif' is only valid for animated emojis. 
+
+        Parameters
+        -----------
+        format: Optional[:class:`str`]
+            The format to attempt to convert the emoji to.
+            If the format is ``None``, then it is automatically
+            detected into either 'gif' or static_format depending on the
+            emoji being animated or not.
+        static_format: Optional[:class:`str`]
+            Format to attempt to convert only non-animated emoji's to.
+            Defaults to 'png'
+
+        Raises
+        ------
+        InvalidArgument
+            Bad image format passed to ``format`` or ``static_format``
+
+        Returns
+        --------
+        :class:`Asset`
+            The resulting CDN asset.
+        """
+        return Asset._from_emoji(self._state, self, format=format, static_format=static_format)
+
 
     def is_usable(self):
         """:class:`bool`: Whether the bot can use this emoji.


### PR DESCRIPTION
## Summary

Adds a new method for an emoji named `url_as` to allow a user to customize the emoji asset produced. It does this by adding a `_from_emoji` classmethod for Asset. It also modifies the way `emoji.url` works internally

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
