### PR TITLE
[matrix] Fix inconsistent monospace fonts

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -19,6 +19,7 @@ Historically however, thanks to:
 /* CSS variables would go here */
 :root {
   --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  --monospace-font-family: 'Consolas', 'Menlo', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', monospace;
 
   /* palette goes here */
   --white: #ffffff;
@@ -855,7 +856,7 @@ dl.field-list {
 /* internal references are forced to bold for some reason */
 a.reference.internal > strong {
   font-weight: unset;
-  font-family: monospace;
+  font-family: var(--monospace-font-family);
 }
 
 /* exception hierarchy */
@@ -950,7 +951,7 @@ pre {
 }
 
 pre, code {
-  font-family: 'Consolas', 'Menlo', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', monospace;
+  font-family: var(--monospace-font-family);
   font-size: 0.9em;
   overflow-wrap: break-word;
 }


### PR DESCRIPTION
## Summary

Internal references use a much simpler font stack that's different
compared to what's used for most `<pre>` and `<code>` elements on the page,
so let's make it more consistent by introducing a monospace font
variable that's used everywhere we want one.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
