### PR TITLE
[matrix] Apply settings before DOM Content loads.

### DIFF
--- a/docs/_static/settings.js
+++ b/docs/_static/settings.js
@@ -94,10 +94,13 @@ function updateSetting(element) {
   }
 }
 
+for (const setting of settings) {
+  setting.load();
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   settingsModal = new Modal(document.querySelector('div#settings.modal'));
   for (const setting of settings) {
-    setting.load();
     setting.setElement();
   }
 });


### PR DESCRIPTION
## Summary

PR changes the behaviour of settings in docs such that settings are applied before the DOM content loads. (dark theme would take a second to apply on chrome specifically prior to this change.)

Note: If future settings require the DOM to be loaded before being applied perhaps a boolean should be added to the setting class to set when to load?

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
