### PR TITLE
Allow `Guild.create_role` to accept an int as the `colour` parameter.

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1736,7 +1736,7 @@ class Guild(Hashable):
             The role name. Defaults to 'new role'.
         permissions: :class:`Permissions`
             The permissions to have. Defaults to no permissions.
-        colour: :class:`Colour`
+        colour: Union[:class:`Colour`, :class:`int`]
             The colour for the role. Defaults to :meth:`Colour.default`.
             This is aliased to ``color`` as well.
         hoist: :class:`bool`
@@ -1775,6 +1775,8 @@ class Guild(Hashable):
         except KeyError:
             colour = fields.get('color', Colour.default())
         finally:
+            if isinstance(colour, int):
+                colour = Colour(value=colour)
             fields['color'] = colour.value
 
         valid_keys = ('name', 'permissions', 'color', 'hoist', 'mentionable')


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? Does it fix any issues? -->

Allows you to pass an `int` to `Guild.create_role()` as the `colour` parameter

## Checklist
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
