### PR TITLE
[commands] fully remove command when CommandRegistrationError is raised for alias

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1143,9 +1143,13 @@ class GroupMixin:
             raise CommandRegistrationError(command.name)
 
         self.all_commands[command.name] = command
+        to_undo = [command.name]
         for alias in command.aliases:
             if alias in self.all_commands:
+                for name in to_undo:
+                    self.all_commands.pop(name)
                 raise CommandRegistrationError(alias, alias_conflict=True)
+            to_undo.append(alias)
             self.all_commands[alias] = command
 
     def remove_command(self, name):


### PR DESCRIPTION
## Summary

Currently, `GroupMixin.add_command` will keep the command registered under the original name and any previously registered aliases if `CommandRegistrationError` is raised for an alias. This may sometimes leave the command in a "half-registered" state where only some of the aliases are registered to the Group. This change makes `add_command` atomic by fully removing the command if an alias fails to register.

Example:
```py
from discord.ext import commands

bot = commands.Bot('$')

@bot.command()
async def baz(ctx):
    pass

@commands.command(aliases=['foo', 'bar', 'baz', 'this_will_not_be_registered'])
async def example(ctx):
    pass

try:
    bot.add_command(example)
except:
    pass

print([c for c in bot.all_commands])  # ['help', 'baz', 'example', 'foo', 'bar']
# "example" is registered under 'example', 'foo', and 'bar' still, but not any other aliases.
# This is unexpected behavior.
```
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [N/A] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [X] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
