### PR TITLE
Include pending as a possible member_update trigger

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -669,6 +669,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     - activity
     - nickname
     - roles
+    - pending
 
     This requires :attr:`Intents.members` to be enabled.
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
With the new pending attribute, I feel this is going to be a very common use case for `on_member_update` so it should be included here

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
