### PR TITLE
Update state.py

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -1074,7 +1074,7 @@ class ConnectionState:
             self.dispatch('relationship_remove', old)
 
     def _get_reaction_user(self, channel, user_id):
-        if isinstance(channel, TextChannel):
+        if self.intents.members and isinstance(channel, TextChannel):
             return channel.guild.get_member(user_id)
         return self.get_user(user_id)
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
if member intents are off on_reaction_add gets still dispatched because discord is sending the members data.
on_reaction_remove doesnt receive that data / doesnt get dispatched because of that.
either dispatch it with an user object or update documentation that on_reaction_remove needs the members intent enabled

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
