### PR TITLE
Added GuildChannel.add_permissions method

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -659,6 +659,25 @@ class GuildChannel:
         else:
             raise InvalidArgument('Invalid overwrite type provided.')
 
+    async def add_permissions(self, target, *, overwrite=_undefined, reason=None, **permissions):
+        """|coro|
+        
+        Same as `Channel.set_permissions` except it adds the channel overwrites instead of overwriting them.
+        """
+        channel_perms = self.overwrites_for(target)
+        
+        if isinstance(overwrite, _Undefined):
+            if len(permissions) == 0:
+                raise InvalidArgument('No overwrite provided.')
+            new_perms = permissions
+        else:
+            if len(permissions) > 0:
+                raise InvalidArgument('Cannot mix overwrite and keyword arguments.')
+            new_perms = dict(overwrite.pair())
+        
+        channel_perms.update(**new_perms)
+        await self.set_permissions(target, overwrite=channel_perms, reason=reason)
+
     async def _clone_impl(self, base_attrs, *, name=None, reason=None):
         base_attrs['permission_overwrites'] = [
             x._asdict() for x in self._overwrites


### PR DESCRIPTION
## Summary

Added `GuildChannel.add_permissions` method. This is the same as [`GuildChannel.set_permissions`](https://github.com/Rapptz/discord.py/blob/master/discord/abc.py#L567), except that it "keeps" the permissions that have not been overwritten.

For example, if a [`text_channel`](https://github.com/Rapptz/discord.py/blob/master/discord/channel.py#L52) has the `send_messages` permission set to `False` for **target**, calling `await text_channel.add_permissions(target, add_reactions=False)` will now result in this channel having the `send_messages` and `add_reactions`  permissions set to `False` for **target**, whereas `await text_channel.set_permissions(target, add_reactions=False)` will result only in the `add_reactions` permission set to `False` for **target**.

This can be very useful, for example, to lock a text channel by setting `send_messages` to `False` for `@everyone`, without changing the other channel permissions.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
