### PR TITLE
Correct ChannelNotFound docstring

### DIFF
--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -289,7 +289,7 @@ class ChannelNotFound(BadArgument):
 
     Attributes
     -----------
-    channel: :class:`str`
+    argument: :class:`str`
         The channel supplied by the caller that was not found
     """
     def __init__(self, argument):


### PR DESCRIPTION
## Summary

Corrects the documentation for `ChannelNotFound` to correctly indicate that the attribute stored on the class is called `argument`, not `channel`.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
