### PR TITLE
Update cog.walk_commands when removing a command from a Cog.

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1176,6 +1176,11 @@ class GroupMixin:
             # we're removing an alias so we don't want to remove the rest
             return command
 
+        if command.cog is not None:
+            # removes the command instance from the cog.
+            cog = command.cog
+            cog.__cog_commands__ = tuple(c for c in cog.__cog_commands__ if c is not command)
+
         # we're not removing the alias so let's delete the rest of them.
         for alias in command.aliases:
             cmd = self.all_commands.pop(alias, None)


### PR DESCRIPTION
## Summary

When `bot.remove_command` removes a command from a Cog, `cog.__cog_commands__` does not get updated. This lead to `Cog.walk_commands` not updated.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
