### PR TITLE
Fix documented type of `Command.usage`

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -144,7 +144,7 @@ class Command(_BaseCommand):
         The long help text for the command.
     brief: Optional[:class:`str`]
         The short help text for the command.
-    usage: :class:`str`
+    usage: Optional[:class:`str`]
         A replacement for arguments in the default help text.
     aliases: Union[List[:class:`str`], Tuple[:class:`str`]]
         The list of aliases the command can be invoked under.


### PR DESCRIPTION
## Summary

`Command.usage` can be `None` but the documentation only shows `str` as its type. This addresses that documentation bug.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
