### PR TITLE
Implement PartialMessage.edit

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -1424,7 +1424,7 @@ class PartialMessage(Hashable):
         The content must be able to be transformed into a string via ``str(content)``.
 
         .. versionchanged:: 1.7
-            :class:`discord.Message` is returned instead of ``None`` on edit.
+            :class:`discord.Message` is returned instead of ``None`` if an edit took place.
 
         Parameters
         -----------

--- a/discord/message.py
+++ b/discord/message.py
@@ -1423,6 +1423,9 @@ class PartialMessage(Hashable):
 
         The content must be able to be transformed into a string via ``str(content)``.
 
+        .. versionchanged:: 1.7
+            :class:`discord.Message` is returned instead of ``None`` on edit.
+
         Parameters
         -----------
         content: Optional[:class:`str`]
@@ -1448,8 +1451,6 @@ class PartialMessage(Hashable):
             If no object is passed at all then the defaults given by :attr:`~discord.Client.allowed_mentions`
             are used instead.
 
-            .. versionadded:: 1.7
-
         Raises
         -------
         NotFound
@@ -1462,7 +1463,7 @@ class PartialMessage(Hashable):
 
         Returns
         ---------
-        :class:`Message`
+        Optional[:class:`Message`]
             The message that was edited.
         """
 


### PR DESCRIPTION
## Summary

This PR implements a separate `edit` method for `PartialMessage` which returns a `Message` Object on edit. Additionally the `flags` on this edit will default since `ParitalMessage.flags` attribute doesn't exist, closes #6276.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
