### PR TITLE
Strip _ from newcog class names

### DIFF
--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -250,8 +250,9 @@ def newcog(parser, args):
                 name = args.class_name
             else:
                 name = str(directory.stem)
-                if '-' in name:
-                    name = name.replace('-', ' ').title().replace(' ', '')
+                if '-' in name or '_' in name:
+                    translation = str.maketrans('-_', '  ')
+                    name = name.translate(translation).title().replace(' ', '')
                 else:
                     name = name.title()
 


### PR DESCRIPTION
## Summary

Strips the literal character `_` from class names when using the `newcog` command.

before `python -m discord newcog my_cog` would create a cog with class name `My_Cog` this PR changes this behaviour such that the classes name is `MyCog` instead.

Not sure about the checklist.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
