### PR TITLE
Fix Command duplicates in `HelpCommand.get_bot_mapping` due to aliases

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -376,7 +376,7 @@ class HelpCommand:
             cog: cog.get_commands()
             for cog in bot.cogs.values()
         }
-        mapping[None] = [c for c in bot.all_commands.values() if c.cog is None]
+        mapping[None] = [c for c in bot.commands if c.cog is None]
         return mapping
 
     @property


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fix Command duplicates in `HelpCommand.get_bot_mapping` due to Command aliases being present in the previous method.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
