### PR TITLE
Clarify on_raw_message_edit cached message nature

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -97,7 +97,8 @@ class RawMessageUpdateEvent(_RawReprMixin):
     data: :class:`dict`
         The raw data given by the `gateway <https://discord.com/developers/docs/topics/gateway#message-update>`_
     cached_message: Optional[:class:`Message`]
-        The cached message, if found in the internal message cache.
+        The cached message, if found in the internal message cache. Represents the message before
+        it is modified by the data in :attr:`RawMessageUpdateEvent.data`.
     """
 
     __slots__ = ('message_id', 'channel_id', 'data', 'cached_message')

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -448,7 +448,10 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     regardless of the state of the internal message cache.
 
     If the message is found in the message cache,
-    it can be accessed via :attr:`RawMessageUpdateEvent.cached_message`
+    it can be accessed via :attr:`RawMessageUpdateEvent.cached_message`. The cached message represents
+    the message before it has been edited. For example, if the content of a message is modified and
+    triggers the :func:`on_raw_message_edit` coroutine, the :attr:`RawMessageUpdateEvent.cached_message`
+    will return a :class:`Message` object that represents the message before the content was modified.
 
     Due to the inherently raw nature of this event, the data parameter coincides with
     the raw data given by the `gateway <https://discord.com/developers/docs/topics/gateway#message-update>`_.


### PR DESCRIPTION
## Summary

This PR amends the documentation to clarify the nature of the RawMessageUpdateEvent.cached_message attribute. Specifically, the previous documentation was not clear whether the cached Message object represented the message pre-edit, or post-edit.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
