### PR TITLE
[commands] make built-in converters use classmethods

### DIFF
--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -273,40 +273,28 @@ Converters
     :members:
 
 .. autoclass:: discord.ext.commands.MemberConverter
-    :members:
 
 .. autoclass:: discord.ext.commands.UserConverter
-    :members:
 
 .. autoclass:: discord.ext.commands.MessageConverter
-    :members:
 
 .. autoclass:: discord.ext.commands.TextChannelConverter
-    :members:
 
 .. autoclass:: discord.ext.commands.VoiceChannelConverter
-    :members:
 
 .. autoclass:: discord.ext.commands.CategoryChannelConverter
-    :members:
 
 .. autoclass:: discord.ext.commands.InviteConverter
-    :members:
 
 .. autoclass:: discord.ext.commands.RoleConverter
-    :members:
 
 .. autoclass:: discord.ext.commands.GameConverter
-    :members:
 
 .. autoclass:: discord.ext.commands.ColourConverter
-    :members:
 
 .. autoclass:: discord.ext.commands.EmojiConverter
-    :members:
 
 .. autoclass:: discord.ext.commands.PartialEmojiConverter
-    :members:
 
 .. autoclass:: discord.ext.commands.clean_content
     :members:


### PR DESCRIPTION
## Summary

None of the built-in object converters (aside from `clean_content`) currently utilise state. As such there is no reason for any of the built-in converters to use an instance method when a classmethod does the same.

This *can* be a breaking change in the case of converters being used as such:
```py
class CustomConverter(Converter):
    async def convert(self, ctx, argument):
        try:
            return MemberConverter.convert(self, ctx, argument)
        except BadArgument:
            ...
```

This is a draft waiting on the status of #6328.

This PR also removed the members of the autoclass, since the docstring is simply repeated from `commands.Converter`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [X] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
