### PR TITLE
Added empty string attribute

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -102,6 +102,7 @@ class Embed:
                  '_fields', 'description')
 
     Empty = EmptyEmbed
+    EmptyString = "\u200b"
 
     def __init__(self, **kwargs):
         # swap the colour/color aliases


### PR DESCRIPTION
## Summary

A very straightforward pull request which is just meant to add an `EmptyString` attribute in embeds. This is equal to `"\u200b"` and I think it is useful to define it here, considering that this technique is pretty commonly used to make empty field names/values. Example:

```python3
import discord
embed = discord.Embed()
embed.add_field(name="->", value=discord.Embed.EmptyString)
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
