### PR TITLE
Remove extraneous "three" from has_any_role doc

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1648,7 +1648,7 @@ def has_role(item):
 def has_any_role(*items):
     r"""A :func:`.check` that is added that checks if the member invoking the
     command has **any** of the roles specified. This means that if they have
-    one out of the three roles specified, then this check will return `True`.
+    one out of the roles specified, then this check will return `True`.
 
     Similar to :func:`.has_role`\, the names or IDs passed in must be exact.
 


### PR DESCRIPTION
## Summary

Removes a word from the documentation of `commands.has_any_role` to address a point of user confusion.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
