### PR TITLE
Make the style of external and internal cross-references consistent

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -899,6 +899,10 @@ a.reference > strong {
   font-weight: unset;
   font-family: var(--monospace-font-family);
 }
+a.reference.pep > strong,
+a.reference.rfc > strong {
+  font-family: inherit;
+}
 
 /* exception hierarchy */
 

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -894,8 +894,8 @@ dl.field-list {
   display: block;
 }
 
-/* internal references are forced to bold for some reason */
-a.reference.internal > strong {
+/* cross-references are forced to bold for some reason */
+a.reference > strong {
   font-weight: unset;
   font-family: var(--monospace-font-family);
 }


### PR DESCRIPTION
## Summary

The cross-references have inconsistent formatting:
![image](https://user-images.githubusercontent.com/6032823/105902440-ee67d680-601e-11eb-987b-5fe915c5bee7.png)

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
