### PR TITLE
Add discord.Guild converter and GuildNotFound error

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -531,7 +531,7 @@ class GuildConverter(IDConverter):
     The lookup strategy is as follows (in order):
 
     1. Lookup by ID.
-    2. Lookup by name.
+    2. Lookup by name. (There is no disambiguation for Guilds with multiple matching names).
 
     .. versionadded:: 1.7
     """
@@ -543,14 +543,14 @@ class GuildConverter(IDConverter):
         if match is not None:
             guild_id = int(match.group(1))
             result = ctx.bot.get_guild(guild_id)
-            return result
 
-        predicate = lambda g: g.name == argument
-        result = discord.utils.find(predicate, ctx.bot.guilds)
-        if result is not None:
-            return result
+        if result is None:
+            predicate = lambda g: g.name == argument
+            result = discord.utils.find(predicate, ctx.bot.guilds)
 
-        raise GuildNotFound(argument)
+            if result is None:
+                raise GuildNotFound(argument)
+        return result
 
 class EmojiConverter(IDConverter):
     """Converts to a :class:`~discord.Emoji`.

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -545,8 +545,7 @@ class GuildConverter(IDConverter):
             result = ctx.bot.get_guild(guild_id)
 
         if result is None:
-            predicate = lambda g: g.name == argument
-            result = discord.utils.find(predicate, ctx.bot.guilds)
+            result = discord.utils.get(ctx.bot.guilds, name=argument)
 
             if result is None:
                 raise GuildNotFound(argument)

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -45,6 +45,7 @@ __all__ = (
     'NotOwner',
     'MessageNotFound',
     'MemberNotFound',
+    'GuildNotFound',
     'UserNotFound',
     'ChannelNotFound',
     'ChannelNotReadable',
@@ -229,6 +230,22 @@ class MemberNotFound(BadArgument):
     def __init__(self, argument):
         self.argument = argument
         super().__init__('Member "{}" not found.'.format(argument))
+
+class GuildNotFound(BadArgument):
+    """Exception raised when the guild provided was not found in the bot's cache.
+
+    This inherits from :exc:`BadArgument`
+
+    .. versionadded:: 1.7
+
+    Attributes
+    -----------
+    argument: :class:`str`
+        The guild supplied by the called that was not found
+    """
+    def __init__(self, argument):
+        self.argument = argument
+        super().__init__('Guild "{}" not found.'.format(argument))
 
 class UserNotFound(BadArgument):
     """Exception raised when the user provided was not found in the bot's

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -296,6 +296,9 @@ Converters
 .. autoclass:: discord.ext.commands.InviteConverter
     :members:
 
+.. autoclass:: discord.ext.commands.GuildConverter
+    :members:
+
 .. autoclass:: discord.ext.commands.RoleConverter
     :members:
 
@@ -408,6 +411,9 @@ Exceptions
     :members:
 
 .. autoexception:: discord.ext.commands.MemberNotFound
+    :members:
+
+.. autoexception:: discord.ext.commands.GuildNotFound
     :members:
 
 .. autoexception:: discord.ext.commands.UserNotFound


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This adds a `discord.Guild` converter as well as the resulting error if a match is not found.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
