### PR TITLE
ensure encoder is set in send_audio_packet

### DIFF
--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -630,6 +630,8 @@ class VoiceClient(VoiceProtocol):
 
         self.checked_add('sequence', 1, 65535)
         if encode:
+            if not self.encoder:
+                self.encoder = opus.Encoder()
             encoded_data = self.encoder.encode(data, self.encoder.SAMPLES_PER_FRAME)
         else:
             encoded_data = data


### PR DESCRIPTION
## Summary

encoder is not always set in send_audio_packet. this makes sure it gets set if it's not already

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
