### PR TITLE
Ensure Message.call is None by default

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -504,6 +504,7 @@ class Message(Hashable):
         self.application = data.get('application')
         self.activity = data.get('activity')
         self.channel = channel
+        self.call = None
         self._edited_timestamp = utils.parse_time(data['edited_timestamp'])
         self.type = try_enum(MessageType, data['type'])
         self.pinned = data['pinned']


### PR DESCRIPTION
`Message` has an attribute `call` which is claimed to have type
`Optional[CallMessage]`. From
https://docs.python.org/3/library/typing.html#typing.Optional:

    Optional[X] is equivalent to Union[X, None].

But `Message` doesn't actually ensure that `call` is initialized to a value in
`__init__`. This commit fixes that inconsistency.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
