### PR TITLE
Update docs to be clearer about discord limitations.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -478,6 +478,14 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
     This requires :attr:`Intents.reactions` to be enabled.
 
+    .. note::
+
+        This doesn't require :attr:`Intents.members` within a guild context,
+        but due to Discord not providing updated user information in a direct message
+        it's required for direct messages to receive this event.
+        Consider using :func:`on_raw_reaction_add` if you need this and do not otherwise want
+        to enable the members intent.
+
     :param reaction: The current state of the reaction.
     :type reaction: :class:`Reaction`
     :param user: The user who added the reaction.

--- a/docs/intents.rst
+++ b/docs/intents.rst
@@ -118,8 +118,9 @@ It should be noted that certain things do not need a member cache since Discord 
 
 - :func:`on_message` will have :attr:`Message.author` be a member even if cache is disabled.
 - :func:`on_voice_state_update` will have the ``member`` parameter be a member even if cache is disabled.
-- :func:`on_reaction_add` will have the ``user`` parameter be a member even if cache is disabled.
-- :func:`on_raw_reaction_add` will have :attr:`RawReactionActionEvent.member` be a member even if cache is disabled.
+- :func:`on_reaction_add` will have the ``user`` parameter be a member when in a guild even if cache is disabled.
+- :func:`on_raw_reaction_add` will have :attr:`RawReactionActionEvent.member` be a member when in a guild even if cache is disabled.
+- The reaction add events do not contain additional information when in direct messages. This is a Discord limitation.
 - The reaction removal events do not have the member information. This is a Discord limitation.
 
 Other events that take a :class:`Member` will require the use of the member cache. If absolute accuracy over the member cache is desirable, then it is advisable to have the :attr:`Intents.members` intent enabled.


### PR DESCRIPTION
## Summary

This clarifies that reaction add events may not function outside of guilds without the member cache, while correctly pointing to this being a [limitation made by discord](https://discord.com/developers/docs/topics/gateway#message-reaction-add-message-reaction-add-event-fields)

This has been a point of confusion for a few users (see #6280 , #6427).

The related [discussion about a stale cache issue](https://github.com/Rapptz/discord.py/discussions/6034) (and [commit fixing this](https://github.com/Rapptz/discord.py/commit/7a3a571e0a641aaeb061e86d8a6e851c5cd4c381)) for why this doesn't use the user cache indicate that this just needs to be made clearer for users about what they need and what they should use and that the library should not be changed to work around this limitation.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
