### PR TITLE
[commands] Allow relative paths when handling extensions

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -659,7 +659,11 @@ class BotBase(GroupMixin):
             The extension or its setup function had an execution error.
         """
 
-        name = importlib.util.resolve_name(name, package)
+        try:
+            name = importlib.util.resolve_name(name, package)
+        except ImportError:
+            raise errors.ExtensionNotFound(name)
+
         if name in self.__extensions:
             raise errors.ExtensionAlreadyLoaded(name)
 
@@ -695,11 +699,17 @@ class BotBase(GroupMixin):
 
         Raises
         -------
+        ExtensionNotFound
+            The name of the extension could not be resolved using the provided ``package`` parameter.
         ExtensionNotLoaded
             The extension was not loaded.
         """
 
-        name = importlib.util.resolve_name(name, package)
+        try:
+            name = importlib.util.resolve_name(name, package)
+        except ImportError:
+            raise errors.ExtensionNotFound(name)
+
         lib = self.__extensions.get(name)
         if lib is None:
             raise errors.ExtensionNotLoaded(name)
@@ -740,7 +750,11 @@ class BotBase(GroupMixin):
             The extension setup function had an execution error.
         """
 
-        name = importlib.util.resolve_name(name, package)
+        try:
+            name = importlib.util.resolve_name(name, package)
+        except ImportError:
+            raise errors.ExtensionNotFound(name)
+
         lib = self.__extensions.get(name)
         if lib is None:
             raise errors.ExtensionNotLoaded(name)

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -624,7 +624,7 @@ class BotBase(GroupMixin):
         else:
             self.__extensions[key] = lib
 
-    def _resolve_name(name, package):
+    def _resolve_name(self, name, package):
         try:
             name = importlib.util.resolve_name(name, package)
         except ImportError:

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -624,7 +624,7 @@ class BotBase(GroupMixin):
         else:
             self.__extensions[key] = lib
 
-    def load_extension(self, name):
+    def load_extension(self, name, package=None):
         """Loads an extension.
 
         An extension is a python module that contains commands, cogs, or
@@ -640,6 +640,12 @@ class BotBase(GroupMixin):
             The extension name to load. It must be dot separated like
             regular Python imports if accessing a sub-module. e.g.
             ``foo.test`` if you want to import ``foo/test.py``.
+        package: Optional[:class:`str`]
+            The package name to resolve relative imports with.
+            This is required when loading an extension using a relative path, e.g ``.foo.test``.
+            Defaults to ``None``.
+
+            .. versionadded:: 1.7
 
         Raises
         --------
@@ -653,6 +659,7 @@ class BotBase(GroupMixin):
             The extension or its setup function had an execution error.
         """
 
+        name = importlib.util.resolve_name(name, package)
         if name in self.__extensions:
             raise errors.ExtensionAlreadyLoaded(name)
 
@@ -662,7 +669,7 @@ class BotBase(GroupMixin):
 
         self._load_from_module_spec(spec, name)
 
-    def unload_extension(self, name):
+    def unload_extension(self, name, package=None):
         """Unloads an extension.
 
         When the extension is unloaded, all commands, listeners, and cogs are
@@ -679,6 +686,12 @@ class BotBase(GroupMixin):
             The extension name to unload. It must be dot separated like
             regular Python imports if accessing a sub-module. e.g.
             ``foo.test`` if you want to import ``foo/test.py``.
+        package: Optional[:class:`str`]
+            The package name to resolve relative imports with.
+            This is required when unloading an extension using a relative path, e.g ``.foo.test``.
+            Defaults to ``None``.
+
+            .. versionadded:: 1.7
 
         Raises
         -------
@@ -686,6 +699,7 @@ class BotBase(GroupMixin):
             The extension was not loaded.
         """
 
+        name = importlib.util.resolve_name(name, package)
         lib = self.__extensions.get(name)
         if lib is None:
             raise errors.ExtensionNotLoaded(name)
@@ -693,7 +707,7 @@ class BotBase(GroupMixin):
         self._remove_module_references(lib.__name__)
         self._call_module_finalizers(lib, name)
 
-    def reload_extension(self, name):
+    def reload_extension(self, name, package=None):
         """Atomically reloads an extension.
 
         This replaces the extension with the same extension, only refreshed. This is
@@ -707,6 +721,12 @@ class BotBase(GroupMixin):
             The extension name to reload. It must be dot separated like
             regular Python imports if accessing a sub-module. e.g.
             ``foo.test`` if you want to import ``foo/test.py``.
+        package: Optional[:class:`str`]
+            The package name to resolve relative imports with.
+            This is required when reloading an extension using a relative path, e.g ``.foo.test``.
+            Defaults to ``None``.
+
+            .. versionadded:: 1.7
 
         Raises
         -------
@@ -720,6 +740,7 @@ class BotBase(GroupMixin):
             The extension setup function had an execution error.
         """
 
+        name = importlib.util.resolve_name(name, package)
         lib = self.__extensions.get(name)
         if lib is None:
             raise errors.ExtensionNotLoaded(name)

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -624,6 +624,12 @@ class BotBase(GroupMixin):
         else:
             self.__extensions[key] = lib
 
+    def _resolve_name(name, package):
+        try:
+            name = importlib.util.resolve_name(name, package)
+        except ImportError:
+            raise errors.ExtensionNotFound(name)
+
     def load_extension(self, name, package=None):
         """Loads an extension.
 
@@ -651,6 +657,7 @@ class BotBase(GroupMixin):
         --------
         ExtensionNotFound
             The extension could not be imported.
+            This is also raised if the name of the extension could not be resolved using the provided ``package`` parameter.
         ExtensionAlreadyLoaded
             The extension is already loaded.
         NoEntryPointError
@@ -659,11 +666,7 @@ class BotBase(GroupMixin):
             The extension or its setup function had an execution error.
         """
 
-        try:
-            name = importlib.util.resolve_name(name, package)
-        except ImportError:
-            raise errors.ExtensionNotFound(name)
-
+        name = self._resolve_name(name, package)
         if name in self.__extensions:
             raise errors.ExtensionAlreadyLoaded(name)
 
@@ -705,11 +708,7 @@ class BotBase(GroupMixin):
             The extension was not loaded.
         """
 
-        try:
-            name = importlib.util.resolve_name(name, package)
-        except ImportError:
-            raise errors.ExtensionNotFound(name)
-
+        name = self._resolve_name(name, package)
         lib = self.__extensions.get(name)
         if lib is None:
             raise errors.ExtensionNotLoaded(name)
@@ -744,17 +743,14 @@ class BotBase(GroupMixin):
             The extension was not loaded.
         ExtensionNotFound
             The extension could not be imported.
+            This is also raised if the name of the extension could not be resolved using the provided ``package`` parameter.
         NoEntryPointError
             The extension does not have a setup function.
         ExtensionFailed
             The extension setup function had an execution error.
         """
 
-        try:
-            name = importlib.util.resolve_name(name, package)
-        except ImportError:
-            raise errors.ExtensionNotFound(name)
-
+        name = self._resolve_name(name, package)
         lib = self.__extensions.get(name)
         if lib is None:
             raise errors.ExtensionNotLoaded(name)

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -626,11 +626,11 @@ class BotBase(GroupMixin):
 
     def _resolve_name(self, name, package):
         try:
-            name = importlib.util.resolve_name(name, package)
+            return importlib.util.resolve_name(name, package)
         except ImportError:
             raise errors.ExtensionNotFound(name)
 
-    def load_extension(self, name, package=None):
+    def load_extension(self, name, *, package=None):
         """Loads an extension.
 
         An extension is a python module that contains commands, cogs, or
@@ -657,7 +657,8 @@ class BotBase(GroupMixin):
         --------
         ExtensionNotFound
             The extension could not be imported.
-            This is also raised if the name of the extension could not be resolved using the provided ``package`` parameter.
+            This is also raised if the name of the extension could not
+            be resolved using the provided ``package`` parameter.
         ExtensionAlreadyLoaded
             The extension is already loaded.
         NoEntryPointError
@@ -676,7 +677,7 @@ class BotBase(GroupMixin):
 
         self._load_from_module_spec(spec, name)
 
-    def unload_extension(self, name, package=None):
+    def unload_extension(self, name, *, package=None):
         """Unloads an extension.
 
         When the extension is unloaded, all commands, listeners, and cogs are
@@ -703,7 +704,8 @@ class BotBase(GroupMixin):
         Raises
         -------
         ExtensionNotFound
-            The name of the extension could not be resolved using the provided ``package`` parameter.
+            The name of the extension could not
+            be resolved using the provided ``package`` parameter.
         ExtensionNotLoaded
             The extension was not loaded.
         """
@@ -716,7 +718,7 @@ class BotBase(GroupMixin):
         self._remove_module_references(lib.__name__)
         self._call_module_finalizers(lib, name)
 
-    def reload_extension(self, name, package=None):
+    def reload_extension(self, name, *, package=None):
         """Atomically reloads an extension.
 
         This replaces the extension with the same extension, only refreshed. This is
@@ -743,7 +745,8 @@ class BotBase(GroupMixin):
             The extension was not loaded.
         ExtensionNotFound
             The extension could not be imported.
-            This is also raised if the name of the extension could not be resolved using the provided ``package`` parameter.
+            This is also raised if the name of the extension could not
+            be resolved using the provided ``package`` parameter.
         NoEntryPointError
             The extension does not have a setup function.
         ExtensionFailed


### PR DESCRIPTION
## Summary

Fixes #2465.
Adds an optional parameter to `load_extension`, `unload_extension` and `reload_extension` for resolving relative paths.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
