### PR TITLE
added tribool behaviour to HelpCommand.verify_checks

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -272,7 +272,7 @@ class HelpCommand:
     show_hidden: :class:`bool`
         Specifies if hidden commands should be shown in the output.
         Defaults to ``False``.
-    verify_checks: Union[:class:`bool`, :class:`None`]
+    verify_checks: Optional[:class:`bool`]
         Specifies if commands should have their :attr:`.Command.checks` called
         and verified. Defaults to ``True``.
     command_attrs: :class:`dict`

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -274,9 +274,9 @@ class HelpCommand:
         Defaults to ``False``.
     verify_checks: Optional[:class:`bool`]
         Specifies if commands should have their :attr:`.Command.checks` called
-        and verified. If True; always calls :attr:`.Commands.checks`.
-        If None; only calls :attr:`.Commands.checks` in a guild setting.
-        If False; never calls :attr:`.Commands.checks`. Defaults to ``True``.
+        and verified. If ``True``, always calls :attr:`.Commands.checks`.
+        If ``None``, only calls :attr:`.Commands.checks` in a guild setting.
+        If ``False``, never calls :attr:`.Commands.checks`. Defaults to ``True``.
 
         ..versionchanged:: 1.7
     command_attrs: :class:`dict`

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -272,7 +272,7 @@ class HelpCommand:
     show_hidden: :class:`bool`
         Specifies if hidden commands should be shown in the output.
         Defaults to ``False``.
-    verify_checks: :class:`bool`
+    verify_checks: Union[:class:`bool`, :class:`None`]
         Specifies if commands should have their :attr:`.Command.checks` called
         and verified. Defaults to ``True``.
     command_attrs: :class:`dict`
@@ -571,6 +571,10 @@ class HelpCommand:
         if not self.verify_checks:
             # if we do not need to verify the checks then we can just
             # run it straight through normally without using await.
+            return sorted(iterator, key=key) if sort else list(iterator)
+
+        if self.verify_checks is None and not self.context.guild:
+            # if verify_checks is None and we're in a DM, don't verify
             return sorted(iterator, key=key) if sort else list(iterator)
 
         # if we're here then we need to check every command if it can run

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -274,7 +274,11 @@ class HelpCommand:
         Defaults to ``False``.
     verify_checks: Optional[:class:`bool`]
         Specifies if commands should have their :attr:`.Command.checks` called
-        and verified. Defaults to ``True``.
+        and verified. If True; always calls :attr:`.Commands.checks`.
+        If None; only calls :attr:`.Commands.checks` in a guild setting.
+        If False; never calls :attr:`.Commands.checks`. Defaults to ``True``.
+
+        ..versionchanged:: 1.7
     command_attrs: :class:`dict`
         A dictionary of options to pass in for the construction of the help command.
         This allows you to change the command behaviour without actually changing

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -568,7 +568,7 @@ class HelpCommand:
 
         iterator = commands if self.show_hidden else filter(lambda c: not c.hidden, commands)
 
-        if not self.verify_checks:
+        if self.verify_checks is False:
             # if we do not need to verify the checks then we can just
             # run it straight through normally without using await.
             return sorted(iterator, key=key) if sort else list(iterator)


### PR DESCRIPTION
## Summary
Allows verify_checks to be None, giving finer control over when check are run
Closes #2008 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
