### PR TITLE
[docs] fix unintended backslashes

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -492,8 +492,8 @@ def escape_markdown(text, *, as_needed=False, ignore_links=True):
     as_needed: :class:`bool`
         Whether to escape the markdown characters as needed. This
         means that it does not escape extraneous characters if it's
-        not necessary, e.g. ``**hello**`` is escaped into ``\*\*hello**``
-        instead of ``\*\*hello\*\*``. Note however that this can open
+        not necessary, e.g. ``**hello**`` is escaped into ``**hello**``
+        instead of ``**hello**``. Note however that this can open
         you up to some clever syntax abuse. Defaults to ``False``.
     ignore_links: :class:`bool`
         Whether to leave links alone when escaping markdown. For example,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -250,7 +250,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param shard_id: The shard ID that has resumed.
     :type shard_id: :class:`int`
 
-.. function:: on_error(event, \*args, \*\*kwargs)
+.. function:: on_error(event, *args, **kwargs)
 
     Usually when an event raises an uncaught exception, a traceback is
     printed to stderr and the exception is ignored. If you want to


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes unintended backslashes in the documentation

before:

<img width="388" alt="Screen Shot 2021-02-21 at 4 27 37 AM" src="https://user-images.githubusercontent.com/44045823/108624985-220b0600-73fd-11eb-8c9b-02cb9ade0a48.png">
<img width="639" alt="Screen Shot 2021-02-21 at 4 27 53 AM" src="https://user-images.githubusercontent.com/44045823/108624992-2c2d0480-73fd-11eb-93b2-bd5f299b5975.png">

after:

<img width="396" alt="Screen Shot 2021-02-21 at 4 28 51 AM" src="https://user-images.githubusercontent.com/44045823/108625012-4ff04a80-73fd-11eb-877e-f76713c5826e.png">
<img width="578" alt="Screen Shot 2021-02-21 at 4 29 41 AM" src="https://user-images.githubusercontent.com/44045823/108625029-6bf3ec00-73fd-11eb-8501-c2bc3076b063.png">


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
