### PR TITLE
Adds an invoked_parents to context

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -212,7 +212,7 @@ class Context(discord.abc.Messageable):
 
     @property
     def invoked_parents(self):
-        """Mapping[:class:`Group`, :class:`str`] A readonly mapping of parent command to the alias used for that parent.
+        """Mapping[:class:`Group`, :class:`str`] A mapping of parent command to the alias used for that parent.
 
         .. versionadded:: 1.7
         """

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -210,6 +210,24 @@ class Context(discord.abc.Messageable):
             return None
         return self.command.cog
 
+    @property
+    def invoked_parents(self):
+        """Mapping[:class:`Command`, :class:`str`] A readonly mapping of parent command to the alias used for that parent.
+
+        .. versionadded:: 1.7
+        """
+        view = self.view
+        index, previous = view.index, view.previous
+        view.index = 0 + len(self.prefix)
+        view.previous = 0 + len(self.prefix)
+        invoked_parents = dict()    # there might be another Mapping that could be more efficient
+        for parent in self.command.parents:
+            invoked_parents[parent] = view.get_word()
+            view.skip_ws()
+        self.view.index = index     # resetting the view, just in case
+        self.view.previous = previous
+        return invoked_parents
+
     @discord.utils.cached_property
     def guild(self):
         """Optional[:class:`.Guild`]: Returns the guild associated with this context's command. None if not available."""

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -212,7 +212,7 @@ class Context(discord.abc.Messageable):
 
     @property
     def invoked_parents(self):
-        """Mapping[:class:`Command`, :class:`str`] A readonly mapping of parent command to the alias used for that parent.
+        """Mapping[:class:`Group`, :class:`str`] A readonly mapping of parent command to the alias used for that parent.
 
         .. versionadded:: 1.7
         """
@@ -220,11 +220,11 @@ class Context(discord.abc.Messageable):
         index, previous = view.index, view.previous
         view.index = 0 + len(self.prefix)
         view.previous = 0 + len(self.prefix)
-        invoked_parents = dict()    # there might be another Mapping that could be more efficient
+        invoked_parents = dict()
         for parent in self.command.parents:
             invoked_parents[parent] = view.get_word()
             view.skip_ws()
-        self.view.index = index     # resetting the view, just in case
+        self.view.index = index
         self.view.previous = previous
         return invoked_parents
 


### PR DESCRIPTION
## Summary
This adds an invoked_parents property allowing easy access to the aliases of the parent commands to be accessed in a mapping of {Group : str}

Closes #1874 
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
