### PR TITLE
[commands] Add Context.invoked_parents

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -57,6 +57,14 @@ class Context(discord.abc.Messageable):
     invoked_with: :class:`str`
         The command name that triggered this invocation. Useful for finding out
         which alias called the command.
+    invoked_parents: List[:class:`str`]
+        The command names of the parents that triggered this invocation. Useful for
+        finding out which aliases called the command.
+
+        For example in commands ``?a b c test``, the invoked parents are ``['a', 'b', 'c']``.
+
+        .. versionadded:: 1.7
+
     invoked_subcommand: :class:`Command`
         The subcommand that was invoked.
         If no valid subcommand was invoked then this is equal to ``None``.
@@ -79,6 +87,7 @@ class Context(discord.abc.Messageable):
         self.command = attrs.pop('command', None)
         self.view = attrs.pop('view', None)
         self.invoked_with = attrs.pop('invoked_with', None)
+        self.invoked_parents = attrs.pop('invoked_parents', [])
         self.invoked_subcommand = attrs.pop('invoked_subcommand', None)
         self.subcommand_passed = attrs.pop('subcommand_passed', None)
         self.command_failed = attrs.pop('command_failed', False)
@@ -180,6 +189,7 @@ class Context(discord.abc.Messageable):
             to_call = cmd.root_parent or cmd
             view.index = len(self.prefix)
             view.previous = 0
+            self.invoked_parents = []
             view.get_word() # advance to get the root command
         else:
             to_call = cmd
@@ -192,6 +202,7 @@ class Context(discord.abc.Messageable):
             view.previous = previous
             self.invoked_with = invoked_with
             self.invoked_subcommand = invoked_subcommand
+            self.invoked_parents = invoked_parents
             self.subcommand_passed = subcommand_passed
 
     @property

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -190,7 +190,7 @@ class Context(discord.abc.Messageable):
             view.index = len(self.prefix)
             view.previous = 0
             self.invoked_parents = []
-            view.get_word() # advance to get the root command
+            self.invoked_with = view.get_word() # advance to get the root command
         else:
             to_call = cmd
 

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1342,6 +1342,8 @@ class Group(GroupMixin, Command):
             injected = hooked_wrapped_callback(self, ctx, self.callback)
             await injected(*ctx.args, **ctx.kwargs)
 
+        ctx.invoked_parents.append(ctx.invoked_with)
+
         if trigger and ctx.invoked_subcommand:
             ctx.invoked_with = trigger
             await ctx.invoked_subcommand.invoke(ctx)
@@ -1379,6 +1381,8 @@ class Group(GroupMixin, Command):
             finally:
                 if call_hooks:
                     await self.call_after_hooks(ctx)
+
+        ctx.invoked_parents.append(ctx.invoked_with)
 
         if trigger and ctx.invoked_subcommand:
             ctx.invoked_with = trigger


### PR DESCRIPTION
## Summary

Adds `Context.invoked_parents`, resolves #1874

Also resolves #6461 which I found during testing, and including the commit here because it's easier to merge.

This PR can be merged without squashing.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
