### PR TITLE
Add remaining template endpoints

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1570,7 +1570,7 @@ class Guild(Hashable):
 
         return result
     
-    async def create_template(self, *, name, description=utils._unset):
+    async def create_template(self, *, name, description=None):
         """|coro|
         
         Creates a template for the guild.
@@ -1593,7 +1593,7 @@ class Guild(Hashable):
             'name': name
         }
 
-        if description is not utils._unset:
+        if description:
             payload['description'] = description
         
         data = await self._state.http.create_template(self.id, payload)

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1460,6 +1460,29 @@ class Guild(Hashable):
 
         data = await self._state.http.prune_members(self.id, days, compute_prune_count=compute_prune_count, roles=roles, reason=reason)
         return data['pruned']
+    
+    async def templates(self):
+        """|coro|
+        
+        Gets the list of templates from this guild.
+
+        Requires :attr:`~.Permissions.manage_guild` permissions.
+
+        .. versionadded:: 1.7
+
+        Raises
+        -------
+        Forbidden
+            You don't have permissions to get the templates.
+        
+        Returns
+        --------
+        List[:class:`Template`]
+            The templates for this guild.
+        """
+        from .template import Template
+        data = await self._state.http.guild_templates(self.id)
+        return [Template(data=d, state=self._state) for d in data]
 
     async def webhooks(self):
         """|coro|
@@ -1546,6 +1569,36 @@ class Guild(Hashable):
             result.append(Invite(state=self._state, data=invite))
 
         return result
+    
+    async def create_template(self, *, name, description=utils._unset):
+        """|coro|
+        
+        Creates a template for the guild.
+
+        You must have the :attr:`~Permissions.manage_guild` permission to
+        do this.
+
+        .. versionadded:: 1.7
+
+        Parameters
+        -----------
+        name: :class:`str`
+            The name of the template.
+        description: Optional[:class:`str`]
+            The description of the template.
+        """
+        from .template import Template
+        
+        payload = {
+            'name': name
+        }
+
+        if description is not utils._unset:
+            payload['description'] = description
+        
+        data = await self._state.http.create_template(self.id, payload)
+
+        return Template(state=self._state, data=data)
 
     async def create_integration(self, *, type, id):
         """|coro|

--- a/discord/http.py
+++ b/discord/http.py
@@ -670,6 +670,21 @@ class HTTPClient:
     def get_template(self, code):
         return self.request(Route('GET', '/guilds/templates/{code}', code=code))
 
+    def guild_templates(self, guild_id):
+        return self.request(Route('GET', '/guilds/{guild_id}/templates', guild_id=guild_id))
+
+    def create_template(self, guild_id, payload):
+        return self.request(Route('POST', '/guilds/{guild_id}/templates', guild_id=guild_id), json=payload)
+
+    def sync_template(self, guild_id, code):
+        return self.request(Route('PUT', '/guilds/{guild_id}/templates/{code}', guild_id=guild_id, code=code))
+
+    def edit_template(self, guild_id, code, payload):
+        return self.request(Route('PATCH', '/guilds/{guild_id}/templates/{code}', guild_id=guild_id, code=code), json=payload)
+
+    def delete_template(self, guild_id, code):
+        return self.request(Route('DELETE', '/guilds/{guild_id}/templates/{code}', guild_id=guild_id, code=code))
+
     def create_from_template(self, code, name, region, icon):
         payload = {
             'name': name,

--- a/discord/http.py
+++ b/discord/http.py
@@ -680,6 +680,13 @@ class HTTPClient:
         return self.request(Route('PUT', '/guilds/{guild_id}/templates/{code}', guild_id=guild_id, code=code))
 
     def edit_template(self, guild_id, code, payload):
+        valid_keys = ( 
+            'name', 
+            'description',
+        )
+        payload = {
+            k: v for k, v in payload.items() if k in valid_keys
+        }
         return self.request(Route('PATCH', '/guilds/{guild_id}/templates/{code}', guild_id=guild_id, code=code), json=payload)
 
     def delete_template(self, guild_id, code):

--- a/discord/template.py
+++ b/discord/template.py
@@ -24,7 +24,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-from .utils import parse_time, _get_as_snowflake, _bytes_to_base64_data
+from .utils import parse_time, _get_as_snowflake, _bytes_to_base64_data, _unset
 from .enums import VoiceRegion
 from .guild import Guild
 
@@ -105,7 +105,9 @@ class Template:
 
     def __init__(self, *, state, data):
         self._state = state
-
+        self._store(data)
+    
+    def _store(self, data):
         self.code = data['code']
         self.uses = data['usage_count']
         self.name =  data['name']
@@ -117,11 +119,17 @@ class Template:
         self.updated_at = parse_time(data.get('updated_at'))
 
         id = _get_as_snowflake(data, 'source_guild_id')
-        source_serialised = data['serialized_source_guild']
-        source_serialised['id'] = id
-        state = _PartialTemplateState(state=self._state)
 
-        self.source_guild = Guild(data=source_serialised, state=state)
+        guild = self._state._get_guild(id)
+
+        if guild is None:
+            source_serialised = data['serialized_source_guild']
+            source_serialised['id'] = id
+            state = _PartialTemplateState(state=self._state)
+
+            guild = Guild(data=source_serialised, state=state)
+        
+        self.source_guild = guild
 
     def __repr__(self):
         return '<Template code={0.code!r} uses={0.uses} name={0.name!r}' \
@@ -167,4 +175,86 @@ class Template:
             region = region.value
 
         data = await self._state.http.create_from_template(self.code, name, region, icon)
-        return Guild(data=data, state=self._state)
+        return Guild(data=data, state=self._state)#
+    
+    async def sync(self):
+        """|coro|
+        
+        Sync the template to the guild's current state.
+
+        You must have the :attr:`~Permissions.manage_guild` permission in the
+        source guild to do this.
+
+        .. versionadded:: 1.7
+
+        Raises
+        -------
+        HTTPException
+            Editing the template failed.
+        Forbidden
+            You don't have permissions to edit the template.
+        NotFound
+            This template does not exist.
+        """
+
+        data = await self._state.http.sync_template(self.source_guild.id, self.code)
+
+        self._store(data)
+
+    async def edit(self, *, name=None, description=_unset):
+        """|coro|
+        
+        Edit the template metadata.
+        
+        You must have the :attr:`~Permissions.manage_guild` permission in the
+        source guild to do this.
+
+        .. versionadded:: 1.7
+        
+        Parameters
+        ------------
+        name: Optional[:class:`str`]
+            The template's new name.
+        description: Optional[:class:`str`]
+            The template's description.
+
+        Raises
+        -------
+        HTTPException
+            Editing the template failed.
+        Forbidden
+            You don't have permissions to edit the template.
+        NotFound
+            This template does not exist.
+        """
+        payload = {
+            'name': name or self.name
+        }
+
+        if description is not _unset:
+            payload['description'] = description
+        
+        data = await self._state.http.edit_template(self.source_guild.id, self.code, payload)
+
+        self._store(data)
+    
+    async def delete(self):
+        """|coro|
+        
+        Delete the template.
+        
+        You must have the :attr:`~Permissions.manage_guild` permission in the
+        source guild to do this.
+
+        .. versionadded:: 1.7
+
+        Raises
+        -------
+        HTTPException
+            Editing the template failed.
+        Forbidden
+            You don't have permissions to edit the template.
+        NotFound
+            This template does not exist.
+        """
+        await self._state.http.delete_template(self.source_guild.id, self.code)

--- a/discord/template.py
+++ b/discord/template.py
@@ -155,9 +155,9 @@ class Template:
 
         Raises
         ------
-        :exc:`.HTTPException`
+        HTTPException
             Guild creation failed.
-        :exc:`.InvalidArgument`
+        InvalidArgument
             Invalid icon image format given. Must be PNG or JPG.
 
         Returns

--- a/discord/template.py
+++ b/discord/template.py
@@ -175,7 +175,7 @@ class Template:
             region = region.value
 
         data = await self._state.http.create_from_template(self.code, name, region, icon)
-        return Guild(data=data, state=self._state)#
+        return Guild(data=data, state=self._state)
     
     async def sync(self):
         """|coro|

--- a/discord/template.py
+++ b/discord/template.py
@@ -24,7 +24,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-from .utils import parse_time, _get_as_snowflake, _bytes_to_base64_data, _unset
+from .utils import parse_time, _get_as_snowflake, _bytes_to_base64_data
 from .enums import VoiceRegion
 from .guild import Guild
 
@@ -126,7 +126,6 @@ class Template:
             source_serialised = data['serialized_source_guild']
             source_serialised['id'] = id
             state = _PartialTemplateState(state=self._state)
-
             guild = Guild(data=source_serialised, state=state)
         
         self.source_guild = guild
@@ -198,10 +197,9 @@ class Template:
         """
 
         data = await self._state.http.sync_template(self.source_guild.id, self.code)
-
         self._store(data)
 
-    async def edit(self, *, name=None, description=_unset):
+    async def edit(self, **kwargs):
         """|coro|
         
         Edit the template metadata.
@@ -227,15 +225,7 @@ class Template:
         NotFound
             This template does not exist.
         """
-        payload = {
-            'name': name or self.name
-        }
-
-        if description is not _unset:
-            payload['description'] = description
-        
-        data = await self._state.http.edit_template(self.source_guild.id, self.code, payload)
-
+        data = await self._state.http.edit_template(self.source_guild.id, self.code, kwargs)
         self._store(data)
     
     async def delete(self):

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -548,8 +548,3 @@ def escape_mentions(text):
         The text with the mentions removed.
     """
     return re.sub(r'@(everyone|here|[!&]?[0-9]{17,21})', '@\u200b\\1', text)
-
-class _Unset:
-    ...
-
-_unset = _Unset()

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -549,7 +549,6 @@ def escape_mentions(text):
     """
     return re.sub(r'@(everyone|here|[!&]?[0-9]{17,21})', '@\u200b\\1', text)
 
-
 class _Unset:
     ...
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -548,3 +548,9 @@ def escape_mentions(text):
         The text with the mentions removed.
     """
     return re.sub(r'@(everyone|here|[!&]?[0-9]{17,21})', '@\u200b\\1', text)
+
+
+class _Unset:
+    ...
+
+_unset = _Unset()


### PR DESCRIPTION
## Summary

Implement `Guild.templates`, `Guild.create_template`, `Template.edit`, `Template.sync`, and `Template.delete`.

Also gets the source guild in-cache if available.
Critique is welcome.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
