### PR TITLE
[docs] fix inconsistencies within the documentation

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -370,7 +370,7 @@ class GuildChannel:
             whose overwrite to get.
 
         Returns
-        ---------
+        --------
         :class:`~discord.PermissionOverwrite`
             The permission overwrites for this object.
         """
@@ -454,12 +454,12 @@ class GuildChannel:
         - Member overrides
 
         Parameters
-        ----------
+        -----------
         member: :class:`~discord.Member`
             The member to resolve permissions for.
 
         Returns
-        -------
+        --------
         :class:`~discord.Permissions`
             The resolved permissions for the member.
         """
@@ -686,7 +686,7 @@ class GuildChannel:
         .. versionadded:: 1.1
 
         Parameters
-        ------------
+        -----------
         name: Optional[:class:`str`]
             The name of the new channel. If not provided, defaults to this
             channel name.
@@ -716,7 +716,7 @@ class GuildChannel:
         do this.
 
         Parameters
-        ------------
+        -----------
         max_age: :class:`int`
             How long the invite should last in seconds. If it's 0 then the invite
             doesn't expire. Defaults to ``0``.
@@ -765,7 +765,7 @@ class GuildChannel:
             An error occurred while fetching the information.
 
         Returns
-        -------
+        --------
         List[:class:`~discord.Invite`]
             The list of invites that are currently active.
         """
@@ -821,7 +821,7 @@ class Messageable(metaclass=abc.ABCMeta):
         it must be a rich embed type.
 
         Parameters
-        ------------
+        -----------
         content: :class:`str`
             The content of the message to send.
         tts: :class:`bool`
@@ -863,7 +863,7 @@ class Messageable(metaclass=abc.ABCMeta):
             .. versionadded:: 1.6
 
         Raises
-        --------
+        -------
         ~discord.HTTPException
             Sending the message failed.
         ~discord.Forbidden
@@ -875,7 +875,7 @@ class Messageable(metaclass=abc.ABCMeta):
             or :class:`~discord.MessageReference`.
 
         Returns
-        ---------
+        --------
         :class:`~discord.Message`
             The message that was sent.
         """
@@ -979,12 +979,12 @@ class Messageable(metaclass=abc.ABCMeta):
         This can only be used by bot accounts.
 
         Parameters
-        ------------
+        -----------
         id: :class:`int`
             The message ID to look for.
 
         Raises
-        --------
+        -------
         ~discord.NotFound
             The specified message was not found.
         ~discord.Forbidden
@@ -1073,7 +1073,7 @@ class Messageable(metaclass=abc.ABCMeta):
             ``after`` is specified, otherwise ``False``.
 
         Raises
-        ------
+        -------
         ~discord.Forbidden
             You do not have permissions to get channel message history.
         ~discord.HTTPException

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -35,7 +35,7 @@ class AppInfo:
 
 
     Attributes
-    -------------
+    -----------
     id: :class:`int`
         The application ID.
     name: :class:`str`
@@ -154,7 +154,7 @@ class AppInfo:
             The size of the image to display.
 
         Raises
-        ------
+        -------
         InvalidArgument
             Bad image format passed to ``format`` or invalid ``size``.
 
@@ -194,7 +194,7 @@ class AppInfo:
             The size of the image to display.
 
         Raises
-        ------
+        -------
         InvalidArgument
             Bad image format passed to ``format`` or invalid ``size``.
 

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -203,7 +203,7 @@ class Asset:
         .. versionadded:: 1.1
 
         Raises
-        ------
+        -------
         DiscordException
             There was no valid URL or internal connection state.
         HTTPException
@@ -212,7 +212,7 @@ class Asset:
             The asset was deleted.
 
         Returns
-        -------
+        --------
         :class:`bytes`
             The content of the asset.
         """
@@ -230,14 +230,14 @@ class Asset:
         Saves this asset into a file-like object.
 
         Parameters
-        ----------
+        -----------
         fp: Union[BinaryIO, :class:`os.PathLike`]
             Same as in :meth:`Attachment.save`.
         seek_begin: :class:`bool`
             Same as in :meth:`Attachment.save`.
 
         Raises
-        ------
+        -------
         DiscordException
             There was no valid URL or internal connection state.
         HTTPException

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -179,7 +179,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             attribute.
 
         Returns
-        ---------
+        --------
         Optional[:class:`Message`]
             The last message in this channel or ``None`` if not found.
         """
@@ -200,7 +200,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             The ``type`` keyword-only parameter was added.
 
         Parameters
-        ----------
+        -----------
         name: :class:`str`
             The new channel name.
         topic: :class:`str`
@@ -229,7 +229,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             :class:`PermissionOverwrite` to apply to the channel.
 
         Raises
-        ------
+        -------
         InvalidArgument
             If position is less than 0 or greater than the number of channels, or if
             the permission overwrite information is not in proper form.
@@ -273,7 +273,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             An iterable of messages denoting which ones to bulk delete.
 
         Raises
-        ------
+        -------
         ClientException
             The number of messages to delete was more than 100.
         Forbidden
@@ -443,7 +443,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             Added the ``reason`` keyword-only parameter.
 
         Parameters
-        -------------
+        -----------
         name: :class:`str`
             The webhook's name.
         avatar: Optional[:class:`bytes`]
@@ -526,12 +526,12 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         .. versionadded:: 1.6
 
         Parameters
-        ------------
+        -----------
         message_id: :class:`int`
             The message ID to create a partial message for.
 
         Returns
-        ---------
+        --------
         :class:`PartialMessage`
             The partial message.
         """
@@ -684,7 +684,7 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
             The ``overwrites`` keyword-only parameter was added.
 
         Parameters
-        ----------
+        -----------
         name: :class:`str`
             The new channel's name.
         bitrate: :class:`int`
@@ -706,7 +706,7 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
             :class:`PermissionOverwrite` to apply to the channel.
 
         Raises
-        ------
+        -------
         InvalidArgument
             If the permission overwrite information is not in proper form.
         Forbidden
@@ -803,7 +803,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
             The ``overwrites`` keyword-only parameter was added.
 
         Parameters
-        ----------
+        -----------
         name: :class:`str`
             The new category's name.
         position: :class:`int`
@@ -817,7 +817,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
             :class:`PermissionOverwrite` to apply to the channel.
 
         Raises
-        ------
+        -------
         InvalidArgument
             If position is less than 0 or greater than the number of categories.
         Forbidden
@@ -865,7 +865,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
         A shortcut method to :meth:`Guild.create_text_channel` to create a :class:`TextChannel` in the category.
 
         Returns
-        -------
+        --------
         :class:`TextChannel`
             The channel that was just created.
         """
@@ -877,7 +877,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
         A shortcut method to :meth:`Guild.create_voice_channel` to create a :class:`VoiceChannel` in the category.
 
         Returns
-        -------
+        --------
         :class:`VoiceChannel`
             The channel that was just created.
         """
@@ -976,7 +976,7 @@ class StoreChannel(discord.abc.GuildChannel, Hashable):
         use this.
 
         Parameters
-        ----------
+        -----------
         name: :class:`str`
             The new channel name.
         position: :class:`int`
@@ -998,7 +998,7 @@ class StoreChannel(discord.abc.GuildChannel, Hashable):
             .. versionadded:: 1.3
 
         Raises
-        ------
+        -------
         InvalidArgument
             If position is less than 0 or greater than the number of channels, or if
             the permission overwrite information is not in proper form.
@@ -1031,7 +1031,7 @@ class DMChannel(discord.abc.Messageable, Hashable):
             Returns a string representation of the channel
 
     Attributes
-    ----------
+    -----------
     recipient: :class:`User`
         The user you are participating with in the direct message channel.
     me: :class:`ClientUser`
@@ -1105,12 +1105,12 @@ class DMChannel(discord.abc.Messageable, Hashable):
         .. versionadded:: 1.6
 
         Parameters
-        ------------
+        -----------
         message_id: :class:`int`
             The message ID to create a partial message for.
 
         Returns
-        ---------
+        --------
         :class:`PartialMessage`
             The partial message.
         """
@@ -1140,7 +1140,7 @@ class GroupChannel(discord.abc.Messageable, Hashable):
             Returns a string representation of the channel
 
     Attributes
-    ----------
+    -----------
     recipients: List[:class:`User`]
         The users you are participating with in the group channel.
     me: :class:`ClientUser`
@@ -1223,7 +1223,7 @@ class GroupChannel(discord.abc.Messageable, Hashable):
             The size of the image to display.
 
         Raises
-        ------
+        -------
         InvalidArgument
             Bad image format passed to ``format`` or invalid ``size``.
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -431,7 +431,7 @@ class Client:
 
         Raises
         -------
-        InvalidArgument
+        :exc:`.InvalidArgument`
             If any guild is unavailable in the collection.
         """
         if any(g.unavailable for g in guilds):

--- a/discord/client.py
+++ b/discord/client.py
@@ -431,7 +431,7 @@ class Client:
 
         Raises
         -------
-        :exc:`.InvalidArgument`
+        InvalidArgument
             If any guild is unavailable in the collection.
         """
         if any(g.unavailable for g in guilds):
@@ -460,7 +460,7 @@ class Client:
         .. versionadded:: 1.4
 
         Parameters
-        ------------
+        -----------
         shard_id: :class:`int`
             The shard ID that requested being IDENTIFY'd
         initial: :class:`bool`
@@ -496,7 +496,7 @@ class Client:
             token or not.
 
         Raises
-        ------
+        -------
         :exc:`.LoginFailure`
             The wrong credentials are passed.
         :exc:`.HTTPException`
@@ -944,7 +944,7 @@ class Client:
 
 
         Parameters
-        ------------
+        -----------
         event: :class:`str`
             The event name, similar to the :ref:`event reference <discord-api-events>`,
             but without the ``on_`` prefix, to wait for.
@@ -1003,7 +1003,7 @@ class Client:
                 print('Ready!')
 
         Raises
-        --------
+        -------
         TypeError
             The coroutine passed is not actually a coroutine.
         """
@@ -1029,7 +1029,7 @@ class Client:
             await client.change_presence(status=discord.Status.idle, activity=game)
 
         Parameters
-        ----------
+        -----------
         activity: Optional[:class:`.BaseActivity`]
             The activity being done. ``None`` if no currently active activity is done.
         status: Optional[:class:`.Status`]
@@ -1041,7 +1041,7 @@ class Client:
             for you in case you are actually idle and not lying.
 
         Raises
-        ------
+        -------
         :exc:`.InvalidArgument`
             If the ``activity`` parameter is not the proper type.
         """
@@ -1116,7 +1116,7 @@ class Client:
             If a date is provided it must be a timezone-naive datetime representing UTC time.
 
         Raises
-        ------
+        -------
         :exc:`.HTTPException`
             Getting the guilds failed.
 
@@ -1173,7 +1173,7 @@ class Client:
             The guild's ID to fetch from.
 
         Raises
-        ------
+        -------
         :exc:`.Forbidden`
             You do not have access to the guild.
         :exc:`.HTTPException`
@@ -1195,7 +1195,7 @@ class Client:
         Bot accounts in more than 10 guilds are not allowed to create guilds.
 
         Parameters
-        ----------
+        -----------
         name: :class:`str`
             The name of the guild.
         region: :class:`.VoiceRegion`
@@ -1210,14 +1210,14 @@ class Client:
             .. versionadded:: 1.4
 
         Raises
-        ------
+        -------
         :exc:`.HTTPException`
             Guild creation failed.
         :exc:`.InvalidArgument`
             Invalid icon image format given. Must be PNG or JPG.
 
         Returns
-        -------
+        --------
         :class:`.Guild`
             The guild created. This is not the same guild that is
             added to cache.
@@ -1284,7 +1284,7 @@ class Client:
         the associated guild to do this.
 
         Parameters
-        ----------
+        -----------
         invite: Union[:class:`.Invite`, :class:`str`]
             The invite to revoke.
 
@@ -1395,7 +1395,7 @@ class Client:
             This can only be used by non-bot accounts.
 
         Parameters
-        ------------
+        -----------
         user_id: :class:`int`
             The ID of the user to fetch their profile for.
 
@@ -1475,7 +1475,7 @@ class Client:
         Retrieves a :class:`.Webhook` with the specified ID.
 
         Raises
-        --------
+        -------
         :exc:`.HTTPException`
             Retrieving the webhook failed.
         :exc:`.NotFound`
@@ -1484,7 +1484,7 @@ class Client:
             You do not have permission to fetch this webhook.
 
         Returns
-        ---------
+        --------
         :class:`.Webhook`
             The webhook you requested.
         """

--- a/discord/client.py
+++ b/discord/client.py
@@ -497,9 +497,9 @@ class Client:
 
         Raises
         -------
-        :exc:`.LoginFailure`
+        LoginFailure
             The wrong credentials are passed.
-        :exc:`.HTTPException`
+        HTTPException
             An unknown HTTP related error occurred,
             usually when it isn't 200 or the known incorrect credentials
             passing status code.
@@ -540,10 +540,10 @@ class Client:
 
         Raises
         -------
-        :exc:`.GatewayNotFound`
+        GatewayNotFound
             If the gateway to connect to Discord is not found. Usually if this
             is thrown then there is a Discord API outage.
-        :exc:`.ConnectionClosed`
+        ConnectionClosed
             The websocket connection has been terminated.
         """
 
@@ -1042,7 +1042,7 @@ class Client:
 
         Raises
         -------
-        :exc:`.InvalidArgument`
+        InvalidArgument
             If the ``activity`` parameter is not the proper type.
         """
 
@@ -1117,7 +1117,7 @@ class Client:
 
         Raises
         -------
-        :exc:`.HTTPException`
+        HTTPException
             Getting the guilds failed.
 
         Yields
@@ -1139,9 +1139,9 @@ class Client:
 
         Raises
         -------
-        :exc:`.NotFound`
+        NotFound
             The template is invalid.
-        :exc:`.HTTPException`
+        HTTPException
             Getting the template failed.
 
         Returns
@@ -1174,9 +1174,9 @@ class Client:
 
         Raises
         -------
-        :exc:`.Forbidden`
+        Forbidden
             You do not have access to the guild.
-        :exc:`.HTTPException`
+        HTTPException
             Getting the guild failed.
 
         Returns
@@ -1211,9 +1211,9 @@ class Client:
 
         Raises
         -------
-        :exc:`.HTTPException`
+        HTTPException
             Guild creation failed.
-        :exc:`.InvalidArgument`
+        InvalidArgument
             Invalid icon image format given. Must be PNG or JPG.
 
         Returns
@@ -1260,9 +1260,9 @@ class Client:
 
         Raises
         -------
-        :exc:`.NotFound`
+        NotFound
             The invite has expired or is invalid.
-        :exc:`.HTTPException`
+        HTTPException
             Getting the invite failed.
 
         Returns
@@ -1290,11 +1290,11 @@ class Client:
 
         Raises
         -------
-        :exc:`.Forbidden`
+        Forbidden
             You do not have permissions to revoke invites.
-        :exc:`.NotFound`
+        NotFound
             The invite is invalid or expired.
-        :exc:`.HTTPException`
+        HTTPException
             Revoking the invite failed.
         """
 
@@ -1319,9 +1319,9 @@ class Client:
 
         Raises
         -------
-        :exc:`.Forbidden`
+        Forbidden
             The widget for this guild is disabled.
-        :exc:`.HTTPException`
+        HTTPException
             Retrieving the widget failed.
 
         Returns
@@ -1340,7 +1340,7 @@ class Client:
 
         Raises
         -------
-        :exc:`.HTTPException`
+        HTTPException
             Retrieving the information failed somehow.
 
         Returns
@@ -1372,9 +1372,9 @@ class Client:
 
         Raises
         -------
-        :exc:`.NotFound`
+        NotFound
             A user with this ID does not exist.
-        :exc:`.HTTPException`
+        HTTPException
             Fetching the user failed.
 
         Returns
@@ -1401,9 +1401,9 @@ class Client:
 
         Raises
         -------
-        :exc:`.Forbidden`
+        Forbidden
             Not allowed to fetch profiles.
-        :exc:`.HTTPException`
+        HTTPException
             Fetching the profile failed.
 
         Returns
@@ -1440,13 +1440,13 @@ class Client:
 
         Raises
         -------
-        :exc:`.InvalidData`
+        InvalidData
             An unknown channel type was received from Discord.
-        :exc:`.HTTPException`
+        HTTPException
             Retrieving the channel failed.
-        :exc:`.NotFound`
+        NotFound
             Invalid Channel ID.
-        :exc:`.Forbidden`
+        Forbidden
             You do not have permission to fetch this channel.
 
         Returns
@@ -1476,11 +1476,11 @@ class Client:
 
         Raises
         -------
-        :exc:`.HTTPException`
+        HTTPException
             Retrieving the webhook failed.
-        :exc:`.NotFound`
+        NotFound
             Invalid webhook ID.
-        :exc:`.Forbidden`
+        Forbidden
             You do not have permission to fetch this webhook.
 
         Returns

--- a/discord/client.py
+++ b/discord/client.py
@@ -497,9 +497,9 @@ class Client:
 
         Raises
         -------
-        LoginFailure
+        :exc:`.LoginFailure`
             The wrong credentials are passed.
-        HTTPException
+        :exc:`.HTTPException`
             An unknown HTTP related error occurred,
             usually when it isn't 200 or the known incorrect credentials
             passing status code.
@@ -540,10 +540,10 @@ class Client:
 
         Raises
         -------
-        GatewayNotFound
+        :exc:`.GatewayNotFound`
             If the gateway to connect to Discord is not found. Usually if this
             is thrown then there is a Discord API outage.
-        ConnectionClosed
+        :exc:`.ConnectionClosed`
             The websocket connection has been terminated.
         """
 
@@ -1042,7 +1042,7 @@ class Client:
 
         Raises
         -------
-        InvalidArgument
+        :exc:`.InvalidArgument`
             If the ``activity`` parameter is not the proper type.
         """
 
@@ -1117,7 +1117,7 @@ class Client:
 
         Raises
         -------
-        HTTPException
+        :exc:`.HTTPException`
             Getting the guilds failed.
 
         Yields
@@ -1139,9 +1139,9 @@ class Client:
 
         Raises
         -------
-        NotFound
+        :exc:`.NotFound`
             The template is invalid.
-        HTTPException
+        :exc:`.HTTPException`
             Getting the template failed.
 
         Returns
@@ -1174,9 +1174,9 @@ class Client:
 
         Raises
         -------
-        Forbidden
+        :exc:`.Forbidden`
             You do not have access to the guild.
-        HTTPException
+        :exc:`.HTTPException`
             Getting the guild failed.
 
         Returns
@@ -1211,9 +1211,9 @@ class Client:
 
         Raises
         -------
-        HTTPException
+        :exc:`.HTTPException`
             Guild creation failed.
-        InvalidArgument
+        :exc:`.InvalidArgument`
             Invalid icon image format given. Must be PNG or JPG.
 
         Returns
@@ -1260,9 +1260,9 @@ class Client:
 
         Raises
         -------
-        NotFound
+        :exc:`.NotFound`
             The invite has expired or is invalid.
-        HTTPException
+        :exc:`.HTTPException`
             Getting the invite failed.
 
         Returns
@@ -1290,11 +1290,11 @@ class Client:
 
         Raises
         -------
-        Forbidden
+        :exc:`.Forbidden`
             You do not have permissions to revoke invites.
-        NotFound
+        :exc:`.NotFound`
             The invite is invalid or expired.
-        HTTPException
+        :exc:`.HTTPException`
             Revoking the invite failed.
         """
 
@@ -1319,9 +1319,9 @@ class Client:
 
         Raises
         -------
-        Forbidden
+        :exc:`.Forbidden`
             The widget for this guild is disabled.
-        HTTPException
+        :exc:`.HTTPException`
             Retrieving the widget failed.
 
         Returns
@@ -1340,7 +1340,7 @@ class Client:
 
         Raises
         -------
-        HTTPException
+        :exc:`.HTTPException`
             Retrieving the information failed somehow.
 
         Returns
@@ -1372,9 +1372,9 @@ class Client:
 
         Raises
         -------
-        NotFound
+        :exc:`.NotFound`
             A user with this ID does not exist.
-        HTTPException
+        :exc:`.HTTPException`
             Fetching the user failed.
 
         Returns
@@ -1401,9 +1401,9 @@ class Client:
 
         Raises
         -------
-        Forbidden
+        :exc:`.Forbidden`
             Not allowed to fetch profiles.
-        HTTPException
+        :exc:`.HTTPException`
             Fetching the profile failed.
 
         Returns
@@ -1440,13 +1440,13 @@ class Client:
 
         Raises
         -------
-        InvalidData
+        :exc:`.InvalidData`
             An unknown channel type was received from Discord.
-        HTTPException
+        :exc:`.HTTPException`
             Retrieving the channel failed.
-        NotFound
+        :exc:`.NotFound`
             Invalid Channel ID.
-        Forbidden
+        :exc:`.Forbidden`
             You do not have permission to fetch this channel.
 
         Returns
@@ -1476,11 +1476,11 @@ class Client:
 
         Raises
         -------
-        HTTPException
+        :exc:`.HTTPException`
             Retrieving the webhook failed.
-        NotFound
+        :exc:`.NotFound`
             Invalid webhook ID.
-        Forbidden
+        :exc:`.Forbidden`
             You do not have permission to fetch this webhook.
 
         Returns

--- a/discord/client.py
+++ b/discord/client.py
@@ -850,7 +850,7 @@ class Client:
             be used for that.
 
         Yields
-        ------
+        -------
         :class:`.abc.GuildChannel`
             A channel the client can 'access'.
         """
@@ -869,7 +869,7 @@ class Client:
                     yield member
 
         Yields
-        ------
+        -------
         :class:`.Member`
             A member the client can see.
         """
@@ -1121,7 +1121,7 @@ class Client:
             Getting the guilds failed.
 
         Yields
-        --------
+        -------
         :class:`.Guild`
             The guild with the guild data parsed.
         """

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -635,14 +635,14 @@ class BotBase(GroupMixin):
         point must have a single argument, the ``bot``.
 
         Parameters
-        ------------
+        -----------
         name: :class:`str`
             The extension name to load. It must be dot separated like
             regular Python imports if accessing a sub-module. e.g.
             ``foo.test`` if you want to import ``foo/test.py``.
 
         Raises
-        --------
+        -------
         ExtensionNotFound
             The extension could not be imported.
         ExtensionAlreadyLoaded
@@ -674,7 +674,7 @@ class BotBase(GroupMixin):
         :meth:`~.Bot.load_extension`.
 
         Parameters
-        ------------
+        -----------
         name: :class:`str`
             The extension name to unload. It must be dot separated like
             regular Python imports if accessing a sub-module. e.g.
@@ -702,7 +702,7 @@ class BotBase(GroupMixin):
         the bot will roll-back to the prior working state.
 
         Parameters
-        ------------
+        -----------
         name: :class:`str`
             The extension name to reload. It must be dot separated like
             regular Python imports if accessing a sub-module. e.g.

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -262,13 +262,13 @@ class Cog(metaclass=CogMeta):
         This is the cog equivalent of :meth:`.Bot.listen`.
 
         Parameters
-        ------------
+        -----------
         name: :class:`str`
             The name of the event being listened to. If not provided, it
             defaults to the function's name.
 
         Raises
-        --------
+        -------
         TypeError
             The function is not a coroutine function or a string was not passed as
             the name.

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -229,7 +229,7 @@ class Cog(metaclass=CogMeta):
         """An iterator that recursively walks through this cog's commands and subcommands.
 
         Yields
-        ------
+        -------
         Union[:class:`.Command`, :class:`.Group`]
             A command or group from the cog.
         """

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -669,7 +669,7 @@ class clean_content(Converter):
     This behaves similarly to :attr:`~discord.Message.clean_content`.
 
     Attributes
-    ------------
+    -----------
     fix_channel_mentions: :class:`bool`
         Whether to clean channel mentions.
     use_nicknames: :class:`bool`

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -93,9 +93,9 @@ class Converter:
 
         Raises
         -------
-        :exc:`.CommandError`
+        CommandError
             A generic exception occurred when converting the argument.
-        :exc:`.BadArgument`
+        BadArgument
             The converter failed to convert the argument.
         """
         raise NotImplementedError('Derived classes need to implement this.')

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -93,9 +93,9 @@ class Converter:
 
         Raises
         -------
-        CommandError
+        :exc:`.CommandError`
             A generic exception occurred when converting the argument.
-        BadArgument
+        :exc:`.BadArgument`
             The converter failed to convert the argument.
         """
         raise NotImplementedError('Derived classes need to implement this.')

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1550,7 +1550,7 @@ def check_any(*checks):
     .. versionadded:: 1.3
 
     Parameters
-    ------------
+    -----------
     \*checks: Callable[[:class:`Context`], :class:`bool`]
         An argument list of checks that have been decorated with
         the :func:`check` decorator.
@@ -1755,7 +1755,7 @@ def has_permissions(**perms):
     that is inherited from :exc:`.CheckFailure`.
 
     Parameters
-    ------------
+    -----------
     perms
         An argument list of permissions to check for.
 
@@ -1951,7 +1951,7 @@ def cooldown(rate, per, type=BucketType.default):
     A command can only have a single cooldown.
 
     Parameters
-    ------------
+    -----------
     rate: :class:`int`
         The number of times a command can be used before triggering a cooldown.
     per: :class:`float`
@@ -1979,7 +1979,7 @@ def max_concurrency(number, per=BucketType.default, *, wait=False):
     .. versionadded:: 1.3
 
     Parameters
-    -------------
+    -----------
     number: :class:`int`
         The maximum number of invocations of this command that can be running at the same time.
     per: :class:`.BucketType`

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1200,7 +1200,7 @@ class GroupMixin:
             Duplicates due to aliases are no longer returned
 
         Yields
-        ------
+        -------
         Union[:class:`.Command`, :class:`.Group`]
             A command or group from the internal list of commands.
         """

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1134,7 +1134,7 @@ class GroupMixin:
 
         Raises
         -------
-        CommandRegistrationError
+        :exc:`.CommandRegistrationError`
             If the command or its alias is already registered by different command.
         TypeError
             If the command passed is not a subclass of :class:`.Command`.

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1134,7 +1134,7 @@ class GroupMixin:
 
         Raises
         -------
-        :exc:`.CommandRegistrationError`
+        CommandRegistrationError
             If the command or its alias is already registered by different command.
         TypeError
             If the command passed is not a subclass of :class:`.Command`.

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -126,7 +126,7 @@ class Paginator:
             Indicates if another empty line should be added.
 
         Raises
-        ------
+        -------
         RuntimeError
             The line was too big for the current :attr:`max_size`.
         """
@@ -265,7 +265,7 @@ class HelpCommand:
         the same between command invocations would not work as expected.
 
     Attributes
-    ------------
+    -----------
     context: Optional[:class:`Context`]
         The context that invoked this help formatter. This is generally set after
         the help command assigned, :func:`command_callback`\, has been called.
@@ -341,7 +341,7 @@ class HelpCommand:
         .. versionadded:: 1.4
 
         Parameters
-        ----------
+        -----------
         func
             The function that will be used as a check.
         """
@@ -364,7 +364,7 @@ class HelpCommand:
         .. versionadded:: 1.4
 
         Parameters
-        ----------
+        -----------
         func
             The function to remove from the checks.
         """
@@ -409,7 +409,7 @@ class HelpCommand:
         then it returns the internal command name of the help command.
 
         Returns
-        ---------
+        --------
         :class:`str`
             The command name that triggered this invocation.
         """
@@ -423,7 +423,7 @@ class HelpCommand:
         """Retrieves the signature portion of the help page.
 
         Parameters
-        ------------
+        -----------
         command: :class:`Command`
             The command to get the signature of.
 
@@ -451,7 +451,7 @@ class HelpCommand:
         This includes ``@everyone``, ``@here``, member mentions and role mentions.
 
         Returns
-        -------
+        --------
         :class:`str`
             The string with mentions removed.
         """
@@ -496,13 +496,13 @@ class HelpCommand:
         Defaults to ``No command called {0} found.``
 
         Parameters
-        ------------
+        -----------
         string: :class:`str`
             The string that contains the invalid command. Note that this has
             had mentions removed to prevent abuse.
 
         Returns
-        ---------
+        --------
         :class:`str`
             The string to use when a command has not been found.
         """
@@ -522,7 +522,7 @@ class HelpCommand:
             - If the ``command`` parameter has subcommands but not one named ``string``.
 
         Parameters
-        ------------
+        -----------
         command: :class:`Command`
             The command that did not have the subcommand requested.
         string: :class:`str`
@@ -530,7 +530,7 @@ class HelpCommand:
             had mentions removed to prevent abuse.
 
         Returns
-        ---------
+        --------
         :class:`str`
             The string to use when the command did not have the subcommand requested.
         """
@@ -547,7 +547,7 @@ class HelpCommand:
         attributes.
 
         Parameters
-        ------------
+        -----------
         commands: Iterable[:class:`Command`]
             An iterable of commands that are getting filtered.
         sort: :class:`bool`
@@ -558,7 +558,7 @@ class HelpCommand:
             passed as ``True`` then this will default as the command name.
 
         Returns
-        ---------
+        --------
         List[:class:`Command`]
             A list of commands that passed the filter.
         """
@@ -594,7 +594,7 @@ class HelpCommand:
         """Returns the largest name length of the specified command list.
 
         Parameters
-        ------------
+        -----------
         commands: Sequence[:class:`Command`]
             A sequence of commands to check for the largest size.
 
@@ -618,7 +618,7 @@ class HelpCommand:
         By default this returns the context's channel.
 
         Returns
-        -------
+        --------
         :class:`.abc.Messageable`
             The destination where the help command will be output.
         """
@@ -641,7 +641,7 @@ class HelpCommand:
             You can access the invocation context with :attr:`HelpCommand.context`.
 
         Parameters
-        ------------
+        -----------
         error: :class:`str`
             The error message to display to the user. Note that this has
             had mentions removed to prevent abuse.
@@ -662,7 +662,7 @@ class HelpCommand:
         error handlers.
 
         Parameters
-        ------------
+        -----------
         ctx: :class:`Context`
             The invocation context.
         error: :class:`CommandError`
@@ -691,7 +691,7 @@ class HelpCommand:
             you will have to call :meth:`filter_commands` yourself.
 
         Parameters
-        ------------
+        -----------
         mapping: Mapping[Optional[:class:`Cog`], List[:class:`Command`]]
             A mapping of cogs to commands that have been requested by the user for help.
             The key of the mapping is the :class:`~.commands.Cog` that the command belongs to, or
@@ -885,7 +885,7 @@ class DefaultHelpCommand(HelpCommand):
     It extends it with the following attributes.
 
     Attributes
-    ------------
+    -----------
     width: :class:`int`
         The maximum number of characters that fit in a line.
         Defaults to 80.
@@ -986,7 +986,7 @@ class DefaultHelpCommand(HelpCommand):
         """A utility function to format the non-indented block of commands and groups.
 
         Parameters
-        ------------
+        -----------
         command: :class:`Command`
             The command to format.
         """
@@ -1086,7 +1086,7 @@ class MinimalHelpCommand(HelpCommand):
     This inherits from :class:`HelpCommand`.
 
     Attributes
-    ------------
+    -----------
     sort_commands: :class:`bool`
         Whether to sort the commands in the output alphabetically. Defaults to ``True``.
     commands_heading: :class:`str`
@@ -1141,7 +1141,7 @@ class MinimalHelpCommand(HelpCommand):
             You can also use `{prefix}{command_name} [category]` for more info on a category.
 
         Returns
-        -------
+        --------
         :class:`str`
             The help command opening note.
         """
@@ -1158,7 +1158,7 @@ class MinimalHelpCommand(HelpCommand):
         The default implementation does nothing.
 
         Returns
-        -------
+        --------
         :class:`str`
             The help command ending note.
         """
@@ -1222,7 +1222,7 @@ class MinimalHelpCommand(HelpCommand):
         """A utility function to format commands and groups.
 
         Parameters
-        ------------
+        -----------
         command: :class:`Command`
             The command to format.
         """

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -168,7 +168,7 @@ class Loop:
         .. versionadded:: 1.6
 
         Parameters
-        ------------
+        -----------
         \*args
             The arguments to use.
         \*\*kwargs
@@ -184,19 +184,19 @@ class Loop:
         r"""Starts the internal task in the event loop.
 
         Parameters
-        ------------
+        -----------
         \*args
             The arguments to use.
         \*\*kwargs
             The keyword arguments to use.
 
         Raises
-        --------
+        -------
         RuntimeError
             A task has already been launched and is running.
 
         Returns
-        ---------
+        --------
         :class:`asyncio.Task`
             The task that has been created.
         """
@@ -251,7 +251,7 @@ class Loop:
             returned like :meth:`start`.
 
         Parameters
-        ------------
+        -----------
         \*args
             The arguments to to use.
         \*\*kwargs
@@ -277,12 +277,12 @@ class Loop:
         raises its own set of exceptions.
 
         Parameters
-        ------------
+        -----------
         \*exceptions: Type[:class:`BaseException`]
             An argument list of exception classes to handle.
 
         Raises
-        --------
+        -------
         TypeError
             An exception passed is either not a class or not inherited from :class:`BaseException`.
         """
@@ -308,12 +308,12 @@ class Loop:
         r"""Removes exception types from being handled during the reconnect logic.
 
         Parameters
-        ------------
+        -----------
         \*exceptions: Type[:class:`BaseException`]
             An argument list of exception classes to handle.
 
         Returns
-        ---------
+        --------
         :class:`bool`
             Whether all exceptions were successfully removed.
         """
@@ -357,7 +357,7 @@ class Loop:
         The coroutine must take no arguments (except ``self`` in a class context).
 
         Parameters
-        ------------
+        -----------
         coro: :ref:`coroutine <coroutine>`
             The coroutine to register before the loop runs.
 
@@ -385,7 +385,7 @@ class Loop:
             whether :meth:`is_being_cancelled` is ``True`` or not.
 
         Parameters
-        ------------
+        -----------
         coro: :ref:`coroutine <coroutine>`
             The coroutine to register after the loop finishes.
 
@@ -412,7 +412,7 @@ class Loop:
         .. versionadded:: 1.4
 
         Parameters
-        ------------
+        -----------
         coro: :ref:`coroutine <coroutine>`
             The coroutine to register in the event of an unhandled exception.
 
@@ -441,7 +441,7 @@ class Loop:
         .. versionadded:: 1.2
 
         Parameters
-        ------------
+        -----------
         seconds: :class:`float`
             The number of seconds between every iteration.
         minutes: :class:`float`
@@ -469,7 +469,7 @@ def loop(*, seconds=0, minutes=0, hours=0, count=None, reconnect=True, loop=None
     optional reconnect logic. The decorator returns a :class:`Loop`.
 
     Parameters
-    ------------
+    -----------
     seconds: :class:`float`
         The number of seconds between every iteration.
     minutes: :class:`float`
@@ -488,7 +488,7 @@ def loop(*, seconds=0, minutes=0, hours=0, count=None, reconnect=True, loop=None
         defaults to :func:`asyncio.get_event_loop`.
 
     Raises
-    --------
+    -------
     ValueError
         An invalid value was given.
     TypeError

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -552,7 +552,7 @@ class DiscordWebSocket:
         """Polls for a DISPATCH event and handles the general gateway loop.
 
         Raises
-        ------
+        -------
         ConnectionClosed
             The websocket connection was terminated for unhandled reasons.
         """

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -75,7 +75,7 @@ class Guild(Hashable):
             Returns the guild's name.
 
     Attributes
-    ----------
+    -----------
     name: :class:`str`
         The guild name.
     emojis: Tuple[:class:`Emoji`, ...]
@@ -622,7 +622,7 @@ class Guild(Hashable):
             The size of the image to display.
 
         Raises
-        ------
+        -------
         InvalidArgument
             Bad image format passed to ``format`` or invalid ``size``.
 
@@ -652,7 +652,7 @@ class Guild(Hashable):
             The size of the image to display.
 
         Raises
-        ------
+        -------
         InvalidArgument
             Bad image format passed to ``format`` or invalid ``size``.
 
@@ -682,7 +682,7 @@ class Guild(Hashable):
             The size of the image to display.
 
         Raises
-        ------
+        -------
         InvalidArgument
             Bad image format passed to ``format`` or invalid ``size``.
 
@@ -717,7 +717,7 @@ class Guild(Hashable):
             The size of the image to display.
 
         Raises
-        ------
+        -------
         InvalidArgument
             Bad image format passed to ``format`` or invalid ``size``.
 
@@ -922,7 +922,7 @@ class Guild(Hashable):
             The permission overwrite information is not in proper form.
 
         Returns
-        -------
+        --------
         :class:`TextChannel`
             The channel that was just created.
         """
@@ -947,7 +947,7 @@ class Guild(Hashable):
             The channel's limit for number of members that can be in a voice channel.
 
         Raises
-        ------
+        -------
         Forbidden
             You do not have the proper permissions to create this channel.
         HTTPException
@@ -956,7 +956,7 @@ class Guild(Hashable):
             The permission overwrite information is not in proper form.
 
         Returns
-        -------
+        --------
         :class:`VoiceChannel`
             The channel that was just created.
         """
@@ -978,7 +978,7 @@ class Guild(Hashable):
             cannot have categories.
 
         Raises
-        ------
+        -------
         Forbidden
             You do not have the proper permissions to create this channel.
         HTTPException
@@ -987,7 +987,7 @@ class Guild(Hashable):
             The permission overwrite information is not in proper form.
 
         Returns
-        -------
+        --------
         :class:`CategoryChannel`
             The channel that was just created.
         """
@@ -1011,7 +1011,7 @@ class Guild(Hashable):
             via :meth:`delete`.
 
         Raises
-        --------
+        -------
         HTTPException
             Leaving the guild failed.
         """
@@ -1024,7 +1024,7 @@ class Guild(Hashable):
         guild.
 
         Raises
-        --------
+        -------
         HTTPException
             Deleting the guild failed.
         Forbidden
@@ -1045,7 +1045,7 @@ class Guild(Hashable):
             The `rules_channel` and `public_updates_channel` keyword-only parameters were added.
 
         Parameters
-        ----------
+        -----------
         name: :class:`str`
             The new name of the guild.
         description: :class:`str`
@@ -1244,7 +1244,7 @@ class Guild(Hashable):
             Retrieving the channels failed.
 
         Returns
-        -------
+        --------
         List[:class:`abc.GuildChannel`]
             All channels in the guild.
         """
@@ -1275,7 +1275,7 @@ class Guild(Hashable):
         All parameters are optional.
 
         Parameters
-        ----------
+        -----------
         limit: Optional[:class:`int`]
             The number of members to retrieve. Defaults to 1000.
             Pass ``None`` to fetch all members. Note that this is potentially slow.
@@ -1284,7 +1284,7 @@ class Guild(Hashable):
             If a date is provided it must be a timezone-naive datetime representing UTC time.
 
         Raises
-        ------
+        -------
         ClientException
             The members intent is not enabled.
         HTTPException
@@ -1357,7 +1357,7 @@ class Guild(Hashable):
             The user to get ban information from.
 
         Raises
-        ------
+        -------
         Forbidden
             You do not have proper permissions to get the information.
         NotFound
@@ -1366,7 +1366,7 @@ class Guild(Hashable):
             An error occurred while fetching the information.
 
         Returns
-        -------
+        --------
         :class:`BanEntry`
             The :class:`BanEntry` object for the specified user.
         """
@@ -1446,7 +1446,7 @@ class Guild(Hashable):
             An integer was not passed for ``days``.
 
         Returns
-        ---------
+        --------
         Optional[:class:`int`]
             The number of members pruned. If ``compute_prune_count`` is ``False``
             then this returns ``None``.
@@ -1505,7 +1505,7 @@ class Guild(Hashable):
             An integer was not passed for ``days``.
 
         Returns
-        ---------
+        --------
         :class:`int`
             The number of members estimated to be pruned.
         """
@@ -1532,7 +1532,7 @@ class Guild(Hashable):
             An error occurred while fetching the information.
 
         Returns
-        -------
+        --------
         List[:class:`Invite`]
             The list of invites that are currently active.
         """
@@ -1608,7 +1608,7 @@ class Guild(Hashable):
             This method is an API call. For general usage, consider :attr:`emojis` instead.
 
         Raises
-        ---------
+        -------
         HTTPException
             An error occurred fetching the emojis.
 
@@ -1631,12 +1631,12 @@ class Guild(Hashable):
             For general usage, consider iterating over :attr:`emojis` instead.
 
         Parameters
-        -------------
+        -----------
         emoji_id: :class:`int`
             The emoji's ID.
 
         Raises
-        ---------
+        -------
         NotFound
             The emoji requested could not be found.
         HTTPException
@@ -1709,7 +1709,7 @@ class Guild(Hashable):
             Retrieving the roles failed.
 
         Returns
-        -------
+        --------
         List[:class:`Role`]
             All roles in the guild.
         """

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1291,7 +1291,7 @@ class Guild(Hashable):
             Getting the members failed.
 
         Yields
-        ------
+        -------
         :class:`.Member`
             The member with the member data parsed.
 
@@ -2043,7 +2043,7 @@ class Guild(Hashable):
             An error occurred while fetching the audit logs.
 
         Yields
-        --------
+        -------
         :class:`AuditLogEntry`
             The audit log entry.
         """

--- a/discord/message.py
+++ b/discord/message.py
@@ -72,7 +72,7 @@ class Attachment:
     """Represents an attachment from Discord.
 
     Attributes
-    ------------
+    -----------
     id: :class:`int`
         The attachment ID.
     size: :class:`int`
@@ -134,7 +134,7 @@ class Attachment:
             on some types of attachments.
 
         Raises
-        --------
+        -------
         HTTPException
             Saving the attachment failed.
         NotFound
@@ -173,7 +173,7 @@ class Attachment:
             on some types of attachments.
 
         Raises
-        ------
+        -------
         HTTPException
             Downloading the attachment failed.
         Forbidden
@@ -182,7 +182,7 @@ class Attachment:
             The attachment was deleted.
 
         Returns
-        -------
+        --------
         :class:`bytes`
             The contents of the attachment.
         """
@@ -215,7 +215,7 @@ class Attachment:
             .. versionadded:: 1.4
 
         Raises
-        ------
+        -------
         HTTPException
             Downloading the attachment failed.
         Forbidden
@@ -224,7 +224,7 @@ class Attachment:
             The attachment was deleted.
 
         Returns
-        -------
+        --------
         :class:`File`
             The attachment as a file suitable for sending.
         """
@@ -317,12 +317,12 @@ class MessageReference:
         .. versionadded:: 1.6
 
         Parameters
-        ----------
+        -----------
         message: :class:`~discord.Message`
             The message to be converted into a reference.
 
         Returns
-        -------
+        --------
         :class:`MessageReference`
             A reference to the message.
         """
@@ -940,7 +940,7 @@ class Message(Hashable):
             before deleting the message. If the deletion fails then it is silently ignored.
 
         Raises
-        ------
+        -------
         Forbidden
             You do not have proper permissions to delete the message.
         NotFound
@@ -1139,12 +1139,12 @@ class Message(Hashable):
         emoji, the :attr:`~Permissions.add_reactions` permission is required.
 
         Parameters
-        ------------
+        -----------
         emoji: Union[:class:`Emoji`, :class:`Reaction`, :class:`PartialEmoji`, :class:`str`]
             The emoji to react with.
 
         Raises
-        --------
+        -------
         HTTPException
             Adding the reaction failed.
         Forbidden
@@ -1172,14 +1172,14 @@ class Message(Hashable):
         the :class:`abc.Snowflake` abc.
 
         Parameters
-        ------------
+        -----------
         emoji: Union[:class:`Emoji`, :class:`Reaction`, :class:`PartialEmoji`, :class:`str`]
             The emoji to remove.
         member: :class:`abc.Snowflake`
             The member for which to remove the reaction.
 
         Raises
-        --------
+        -------
         HTTPException
             Removing the reaction failed.
         Forbidden
@@ -1214,7 +1214,7 @@ class Message(Hashable):
             The emoji to clear.
 
         Raises
-        --------
+        -------
         HTTPException
             Clearing the reaction failed.
         Forbidden
@@ -1236,7 +1236,7 @@ class Message(Hashable):
         You need the :attr:`~Permissions.manage_messages` permission to use this.
 
         Raises
-        --------
+        -------
         HTTPException
             Removing the reactions failed.
         Forbidden
@@ -1273,7 +1273,7 @@ class Message(Hashable):
         .. versionadded:: 1.6
 
         Raises
-        --------
+        -------
         ~discord.HTTPException
             Sending the message failed.
         ~discord.Forbidden
@@ -1283,7 +1283,7 @@ class Message(Hashable):
             you specified both ``file`` and ``files``.
 
         Returns
-        ---------
+        --------
         :class:`Message`
             The message that was sent.
         """
@@ -1296,7 +1296,7 @@ class Message(Hashable):
         .. versionadded:: 1.6
 
         Returns
-        ---------
+        --------
         :class:`~discord.MessageReference`
             The reference to this message.
         """
@@ -1409,7 +1409,7 @@ class PartialMessage(Hashable):
         Fetches the partial message to a full :class:`Message`.
 
         Raises
-        --------
+        -------
         NotFound
             The message was not found.
         Forbidden
@@ -1472,7 +1472,7 @@ class PartialMessage(Hashable):
             edited a message's content or embed that isn't yours.
 
         Returns
-        ---------
+        --------
         Optional[:class:`Message`]
             The message that was edited.
         """

--- a/discord/player.py
+++ b/discord/player.py
@@ -182,7 +182,7 @@ class FFmpegPCMAudio(FFmpegAudio):
         variable in order for this to work.
 
     Parameters
-    ------------
+    -----------
     source: Union[:class:`str`, :class:`io.BufferedIOBase`]
         The input that ffmpeg will take and convert to PCM bytes.
         If ``pipe`` is ``True`` then this is a file-like object that is
@@ -201,7 +201,7 @@ class FFmpegPCMAudio(FFmpegAudio):
         Extra command line arguments to pass to ffmpeg after the ``-i`` flag.
 
     Raises
-    --------
+    -------
     ClientException
         The subprocess failed to be created.
     """
@@ -255,7 +255,7 @@ class FFmpegOpusAudio(FFmpegAudio):
         variable in order for this to work.
 
     Parameters
-    ------------
+    -----------
     source: Union[:class:`str`, :class:`io.BufferedIOBase`]
         The input that ffmpeg will take and convert to Opus bytes.
         If ``pipe`` is ``True`` then this is a file-like object that is
@@ -289,7 +289,7 @@ class FFmpegOpusAudio(FFmpegAudio):
         Extra command line arguments to pass to ffmpeg after the ``-i`` flag.
 
     Raises
-    --------
+    -------
     ClientException
         The subprocess failed to be created.
     """
@@ -356,7 +356,7 @@ class FFmpegOpusAudio(FFmpegAudio):
             voice_client.play(source)
 
         Parameters
-        ------------
+        -----------
         source
             Identical to the ``source`` parameter for the constructor.
         method: Optional[Union[:class:`str`, Callable[:class:`str`, :class:`str`]]]
@@ -370,7 +370,7 @@ class FFmpegOpusAudio(FFmpegAudio):
             excluding ``bitrate`` and ``codec``.
 
         Raises
-        --------
+        -------
         AttributeError
             Invalid probe method, must be ``'native'`` or ``'fallback'``.
         TypeError
@@ -393,7 +393,7 @@ class FFmpegOpusAudio(FFmpegAudio):
         Probes the input source for bitrate and codec information.
 
         Parameters
-        ------------
+        -----------
         source
             Identical to the ``source`` parameter for :class:`FFmpegOpusAudio`.
         method
@@ -402,14 +402,14 @@ class FFmpegOpusAudio(FFmpegAudio):
             Identical to the ``executable`` parameter for :class:`FFmpegOpusAudio`.
 
         Raises
-        --------
+        -------
         AttributeError
             Invalid probe method, must be ``'native'`` or ``'fallback'``.
         TypeError
             Invalid value for ``probe`` parameter, must be :class:`str` or a callable.
 
         Returns
-        ---------
+        --------
         Tuple[Optional[:class:`str`], Optional[:class:`int`]]
             A 2-tuple with the codec and bitrate of the input source.
         """
@@ -502,7 +502,7 @@ class PCMVolumeTransformer(AudioSource):
     set to ``True``.
 
     Parameters
-    ------------
+    -----------
     original: :class:`AudioSource`
         The original AudioSource to transform.
     volume: :class:`float`

--- a/discord/reaction.py
+++ b/discord/reaction.py
@@ -180,7 +180,7 @@ class Reaction:
             Getting the users for the reaction failed.
 
         Yields
-        --------
+        -------
         Union[:class:`User`, :class:`Member`]
             The member (if retrievable) or the user that has reacted
             to this message. The case where it can be a :class:`Member` is

--- a/discord/reaction.py
+++ b/discord/reaction.py
@@ -131,7 +131,7 @@ class Reaction:
         .. versionadded:: 1.3
 
         Raises
-        --------
+        -------
         HTTPException
             Clearing the reaction failed.
         Forbidden
@@ -166,7 +166,7 @@ class Reaction:
             await channel.send('{} has won the raffle.'.format(winner))
 
         Parameters
-        ------------
+        -----------
         limit: :class:`int`
             The maximum number of results to return.
             If not provided, returns all the users who
@@ -175,7 +175,7 @@ class Reaction:
             For pagination, reactions are sorted by member.
 
         Raises
-        --------
+        -------
         HTTPException
             Getting the users for the reaction failed.
 

--- a/discord/relationship.py
+++ b/discord/relationship.py
@@ -56,7 +56,7 @@ class Relationship:
         Deletes the relationship.
 
         Raises
-        ------
+        -------
         HTTPException
             Deleting the relationship failed.
         """

--- a/discord/role.py
+++ b/discord/role.py
@@ -42,7 +42,7 @@ class RoleTags:
     .. versionadded:: 1.6
 
     Attributes
-    ------------
+    -----------
     bot_id: Optional[:class:`int`]
         The bot's user ID that manages this role.
     integration_id: Optional[:class:`int`]
@@ -114,7 +114,7 @@ class Role(Hashable):
             Returns the role's name.
 
     Attributes
-    ----------
+    -----------
     id: :class:`int`
         The ID for the role.
     name: :class:`str`
@@ -363,7 +363,7 @@ class Role(Hashable):
             The reason for deleting this role. Shows up on the audit log.
 
         Raises
-        --------
+        -------
         Forbidden
             You do not have permissions to delete the role.
         HTTPException

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -203,7 +203,7 @@ class ShardInfo:
     .. versionadded:: 1.4
 
     Attributes
-    ------------
+    -----------
     id: :class:`int`
         The shard ID for this shard.
     shard_count: Optional[:class:`int`]
@@ -290,7 +290,7 @@ class AutoShardedClient(Client):
     0 to ``shard_count - 1``.
 
     Attributes
-    ------------
+    -----------
     shard_ids: Optional[List[:class:`int`]]
         An optional list of shard_ids to launch the shards with.
     """
@@ -480,7 +480,7 @@ class AutoShardedClient(Client):
             await client.change_presence(status=discord.Status.idle, activity=game)
 
         Parameters
-        ----------
+        -----------
         activity: Optional[:class:`BaseActivity`]
             The activity being done. ``None`` if no currently active activity is done.
         status: Optional[:class:`Status`]
@@ -496,7 +496,7 @@ class AutoShardedClient(Client):
             shard the bot can see.
 
         Raises
-        ------
+        -------
         InvalidArgument
             If the ``activity`` parameter is not of proper type.
         """

--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -49,7 +49,7 @@ class Sticker(Hashable):
            Checks if the sticker is not equal to another sticker
 
     Attributes
-    ----------
+    -----------
     name: :class:`str`
         The sticker's name
     id: :class:`int`
@@ -104,7 +104,7 @@ class Sticker(Hashable):
             This will return ``None`` if the format is ``StickerType.lottie``
 
         Returns
-        -------
+        --------
         Optional[:class:`Asset`]
             The resulting CDN asset.
         """
@@ -124,12 +124,12 @@ class Sticker(Hashable):
             The size of the image to display.
 
         Raises
-        ------
+        -------
         InvalidArgument
             Invalid ``size``.
 
         Returns
-        -------
+        --------
         Optional[:class:`Asset`]
             The resulting CDN asset or ``None``.
         """

--- a/discord/team.py
+++ b/discord/team.py
@@ -38,7 +38,7 @@ class Team:
     """Represents an application team for a bot provided by Discord.
 
     Attributes
-    -------------
+    -----------
     id: :class:`int`
         The team ID.
     name: :class:`str`
@@ -91,7 +91,7 @@ class Team:
             The size of the image to display.
 
         Raises
-        ------
+        -------
         InvalidArgument
             Bad image format passed to ``format`` or invalid ``size``.
 
@@ -131,7 +131,7 @@ class TeamMember(BaseUser):
     .. versionadded:: 1.3
 
     Attributes
-    -------------
+    -----------
     name: :class:`str`
         The team member's username.
     id: :class:`int`

--- a/discord/template.py
+++ b/discord/template.py
@@ -135,7 +135,7 @@ class Template:
         Bot accounts in more than 10 guilds are not allowed to create guilds.
 
         Parameters
-        ----------
+        -----------
         name: :class:`str`
             The name of the guild.
         region: :class:`.VoiceRegion`
@@ -146,14 +146,14 @@ class Template:
             for more details on what is expected.
 
         Raises
-        ------
+        -------
         :exc:`.HTTPException`
             Guild creation failed.
         :exc:`.InvalidArgument`
             Invalid icon image format given. Must be PNG or JPG.
 
         Returns
-        -------
+        --------
         :class:`.Guild`
             The guild created. This is not the same guild that is
             added to cache.

--- a/discord/template.py
+++ b/discord/template.py
@@ -147,9 +147,9 @@ class Template:
 
         Raises
         -------
-        :exc:`.HTTPException`
+        HTTPException
             Guild creation failed.
-        :exc:`.InvalidArgument`
+        InvalidArgument
             Invalid icon image format given. Must be PNG or JPG.
 
         Returns

--- a/discord/template.py
+++ b/discord/template.py
@@ -147,9 +147,9 @@ class Template:
 
         Raises
         -------
-        HTTPException
+        :exc:`.HTTPException`
             Guild creation failed.
-        InvalidArgument
+        :exc:`.InvalidArgument`
             Invalid icon image format given. Must be PNG or JPG.
 
         Returns

--- a/discord/user.py
+++ b/discord/user.py
@@ -178,7 +178,7 @@ class BaseUser(_BaseUser):
             The size of the image to display.
 
         Raises
-        ------
+        -------
         InvalidArgument
             Bad image format passed to ``format`` or ``static_format``, or
             invalid ``size``.
@@ -265,7 +265,7 @@ class BaseUser(_BaseUser):
             The message to check if you're mentioned in.
 
         Returns
-        -------
+        --------
         :class:`bool`
             Indicates if the user is mentioned in the message.
         """
@@ -441,7 +441,7 @@ class ClientUser(BaseUser):
             Could be ``None`` to denote no avatar.
 
         Raises
-        ------
+        -------
         HTTPException
             Editing your profile failed.
         InvalidArgument
@@ -527,7 +527,7 @@ class ClientUser(BaseUser):
             This does not include yourself.
 
         Returns
-        -------
+        --------
         :class:`GroupChannel`
             The new group channel.
         """
@@ -551,7 +551,7 @@ class ClientUser(BaseUser):
             This can only be used by non-bot accounts.
 
         Parameters
-        -------
+        -----------
         afk_timeout: :class:`int`
             How long (in seconds) the user needs to be AFK until Discord
             sends push notifications to your mobile device.
@@ -613,7 +613,7 @@ class ClientUser(BaseUser):
             The client is a bot user and not a user account.
 
         Returns
-        -------
+        --------
         :class:`dict`
             The client user's updated settings.
         """
@@ -726,7 +726,7 @@ class User(BaseUser, discord.abc.Messageable):
         people.
 
         Returns
-        -------
+        --------
         :class:`.DMChannel`
             The channel that was created.
         """
@@ -765,7 +765,7 @@ class User(BaseUser, discord.abc.Messageable):
             Getting mutual friends failed.
 
         Returns
-        -------
+        --------
         List[:class:`User`]
             The users that are mutual friends.
         """

--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -55,7 +55,7 @@ class WebhookAdapter:
     """Base class for all webhook adapters.
 
     Attributes
-    ------------
+    -----------
     webhook: :class:`Webhook`
         The webhook that owns this adapter.
     """
@@ -115,7 +115,7 @@ class WebhookAdapter:
         Subclasses must implement this.
 
         Parameters
-        ------------
+        -----------
         data
             The data that was returned from the request.
         wait: :class:`bool`
@@ -445,7 +445,7 @@ class WebhookMessage(Message):
         .. versionadded:: 1.6
 
         Parameters
-        ------------
+        -----------
         content: Optional[:class:`str`]
             The content to edit the message with or ``None`` to clear it.
         embeds: List[:class:`Embed`]
@@ -498,7 +498,7 @@ class WebhookMessage(Message):
             are ignored. If this is not a coroutine then the delay blocks the thread.
 
         Raises
-        ------
+        -------
         Forbidden
             You do not have proper permissions to delete the message.
         NotFound
@@ -574,7 +574,7 @@ class Webhook(Hashable):
         Webhooks are now comparable and hashable.
 
     Attributes
-    ------------
+    -----------
     id: :class:`int`
         The webhook's ID
     type: :class:`WebhookType`
@@ -667,7 +667,7 @@ class Webhook(Hashable):
         """Creates a partial :class:`Webhook` from a webhook URL.
 
         Parameters
-        ------------
+        -----------
         url: :class:`str`
             The URL of the webhook.
         adapter: :class:`WebhookAdapter`
@@ -771,7 +771,7 @@ class Webhook(Hashable):
             The size of the image to display.
 
         Raises
-        ------
+        -------
         InvalidArgument
             Bad image format passed to ``format`` or invalid ``size``.
 
@@ -804,7 +804,7 @@ class Webhook(Hashable):
         not a coroutine.
 
         Parameters
-        ------------
+        -----------
         reason: Optional[:class:`str`]
             The reason for deleting this webhook. Shows up on the audit log.
 
@@ -835,7 +835,7 @@ class Webhook(Hashable):
         not a coroutine.
 
         Parameters
-        ------------
+        -----------
         name: Optional[:class:`str`]
             The webhook's new default name.
         avatar: Optional[:class:`bytes`]
@@ -900,7 +900,7 @@ class Webhook(Hashable):
         ``embeds`` parameter, which must be a :class:`list` of :class:`Embed` objects to send.
 
         Parameters
-        ------------
+        -----------
         content: :class:`str`
             The content of the message to send.
         wait: :class:`bool`
@@ -932,7 +932,7 @@ class Webhook(Hashable):
             .. versionadded:: 1.4
 
         Raises
-        --------
+        -------
         HTTPException
             Sending the message failed.
         NotFound
@@ -945,7 +945,7 @@ class Webhook(Hashable):
             this webhook.
 
         Returns
-        ---------
+        --------
         Optional[:class:`WebhookMessage`]
             The message that was sent.
         """
@@ -1002,7 +1002,7 @@ class Webhook(Hashable):
         .. versionadded:: 1.6
 
         Parameters
-        ------------
+        -----------
         message_id: :class:`int`
             The message ID to edit.
         content: Optional[:class:`str`]
@@ -1090,7 +1090,7 @@ class Webhook(Hashable):
         .. versionadded:: 1.6
 
         Parameters
-        ------------
+        -----------
         message_id: :class:`int`
             The message ID to delete.
 


### PR DESCRIPTION
## Summary

The successor of #5067, but only touches on docstrings, not the actual rendered documentation.

- Standardizes header indicators for docstring headers (`Attributes`, `Parameters`, `Raises`, `Returns`, `Yields`) to be `len(header) + 1` (as it is in the majority of places)
- ~~Removes unnecessary :exc:`.ExceptionName` from docstrings `Raises`.~~

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
