### PR TITLE
Update permission class methods for v1.7

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -144,7 +144,7 @@ class Permissions(BaseFlags):
         
         .. versionchanged:: 1.7
            Added :attr:`use_slash_commands` permission.
-       """
+        """
         return cls(0b11111111111111111111111111111111)
 
     @classmethod
@@ -185,9 +185,6 @@ class Permissions(BaseFlags):
         """A factory method that creates a :class:`Permissions` with all
         "Membership" permissions from the official Discord UI set to ``True``.
         
-        Membership permissions include :attr:`create_instant_invite`, :attr:`kick_members`,
-        :attr:`ban_members`, :attr:`change_nickname` and :attr:`manage_nicknames`.
-        
         .. versionadded:: 1.7
         """
         return cls(0b00001100000000000000000000000111)
@@ -213,8 +210,6 @@ class Permissions(BaseFlags):
     def advanced(cls):
         """A factory method that creates a :class:`Permissions` with all
         "Advanced" permissions from the official Discord UI set to ``True``.
-        
-        Advanced permissions only contain the :attr:`administrator` permission.
         
         .. versionadded: 1.7
         """

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -141,9 +141,6 @@ class Permissions(BaseFlags):
     def all(cls):
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``True``.
-        
-        .. versionchanged:: 1.7
-           Added :attr:`use_slash_commands` permission.
         """
         return cls(0b11111111111111111111111111111111)
 

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -140,41 +140,83 @@ class Permissions(BaseFlags):
     @classmethod
     def all(cls):
         """A factory method that creates a :class:`Permissions` with all
-        permissions set to ``True``."""
-        return cls(0b01111111111111111111111111111111)
+        permissions set to ``True``.
+        
+        .. versionchanged:: 1.7
+           Added :attr:`use_slash_commands` permission."""
+        return cls(0b11111111111111111111111111111111)
 
     @classmethod
     def all_channel(cls):
         """A :class:`Permissions` with all channel-specific permissions set to
         ``True`` and the guild-specific ones set to ``False``. The guild-specific
         permissions are currently:
-
+        - manage_emojis
+        - view_audit_log
+        - view_guild_insights
         - manage_guild
+        - change_nickname
+        - manage_nicknames
         - kick_members
         - ban_members
         - administrator
-        - change_nickname
-        - manage_nicknames
+        
+        .. versionchanged:: 1.7
+           Added :attr:`stream`, :attr:`priority_speaker` and :attr:`use_slash_commands` permissions.
         """
-        return cls(0b00110011111101111111110001010001)
+        return cls(0b10110011111101111111111101010001)
 
     @classmethod
     def general(cls):
         """A factory method that creates a :class:`Permissions` with all
-        "General" permissions from the official Discord UI set to ``True``."""
-        return cls(0b01111100000010000000000010111111)
-
+        "General" permissions from the official Discord UI set to ``True``.
+        
+        .. versionchanged:: 1.7
+           Permission :attr:`read_messages` is now included in the general permissions, but
+           permissions :attr:`administrator`, :attr:`create_instant_invite`, :attr:`kick_members`,
+           :attr:`ban_members`, :attr:`change_nickname` and :attr:`manage_nicknames` are
+           no longer part of the general permissions.
+        """
+        return cls(0b01110000000010000000010010110000)
+    
+    @classmethod
+    def membership(cls):
+        """A factory method that creates a :class:`Permissions` with all
+        "Membership" permissions from the official Discord UI set to ``True``.
+        
+        Membership permissions include :attr:`create_instant_invite`, :attr:`kick_members`,
+        :attr:`ban_members`, :attr:`change_nickname` and :attr:`manage_nicknames`.
+        
+        .. versionadded:: 1.7
+        """
+        return cls(0b00001100000000000000000000000111)
+    
     @classmethod
     def text(cls):
         """A factory method that creates a :class:`Permissions` with all
-        "Text" permissions from the official Discord UI set to ``True``."""
-        return cls(0b00000000000001111111110001000000)
+        "Text" permissions from the official Discord UI set to ``True``.
+        
+        .. versionchanged:: 1.7
+           Permission :attr:`read_messages` is no longer part of the text permissions. Added :attr:`use_slash_commands` permission.
+        """
+        return cls(0b10000000000001111111100001000000)
 
     @classmethod
     def voice(cls):
         """A factory method that creates a :class:`Permissions` with all
         "Voice" permissions from the official Discord UI set to ``True``."""
         return cls(0b00000011111100000000001100000000)
+    
+    @classmethod
+    def advanced(cls):
+        """A factory method that creates a :class:`Permissions` with all
+        "Advanced" permissions from the official Discord UI set to ``True``.
+        
+        Advanced permissions only contain the :attr:`administrator` permission.
+        
+        .. versionadded: 1.7
+        """
+        return cls(1 << 3)
 
 
     def update(self, **kwargs):

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -143,7 +143,8 @@ class Permissions(BaseFlags):
         permissions set to ``True``.
         
         .. versionchanged:: 1.7
-           Added :attr:`use_slash_commands` permission."""
+           Added :attr:`use_slash_commands` permission.
+       """
         return cls(0b11111111111111111111111111111111)
 
     @classmethod

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -198,7 +198,8 @@ class Permissions(BaseFlags):
         "Text" permissions from the official Discord UI set to ``True``.
         
         .. versionchanged:: 1.7
-           Permission :attr:`read_messages` is no longer part of the text permissions. Added :attr:`use_slash_commands` permission.
+           Permission :attr:`read_messages` is no longer part of the text permissions. 
+           Added :attr:`use_slash_commands` permission.
         """
         return cls(0b10000000000001111111100001000000)
 


### PR DESCRIPTION
## Summary

The Discord UI has recently changed its permission categories, which are as follows:
- **General Permissions** no longer have the `administrator`, `create_instant_invite`, `change_nickname`, `manage_nicknames`, `kick_members` and `ban_members` permissions. It now has the `view_channel`/`read_messages` permission.
- New **Membership Permissions** which contain `create_instant_invite`, `change_nickname`, `manage_nicknames`, `kick_members` and `ban_members` permissions
- **Text Permissions** no longer have the `view_channel`/`read_messages` permission (this has been moved to the **General Permissions**). It now contains the `use_slash_commands` permission, which has been released on Discord officially.
- New **Advanced Permissions** which only contain the `administrator` permission.

The commit is therefore reflecting these changed. More specifically:
- [`Permissions.all()`](https://github.com/Rapptz/discord.py/blob/master/discord/permissions.py#L141) now contains the `use_slash_commands` permission.
- [`Permissions.general()`](https://github.com/Rapptz/discord.py/blob/master/discord/permissions.py#L162) has been updated according to the Discord UI general permissions.
- Added `Permissions.membership()` which contains the `create_instant_invite`, `change_nickname`, `manage_nicknames`, `kick_members` and `ban_members` permissions.
- [`Permissions.text()`](https://github.com/Rapptz/discord.py/blob/master/discord/permissions.py#L168) no longer contain the `read_messages`/`view_channel` permission. It now contains the `use_slash_commands` permission.
- Added `Permissions.advanced()` which is an alias for `Permission.administrator`.

This commit also modifies the [`Permissions.all_channel()`](https://github.com/Rapptz/discord.py/blob/master/discord/permissions.py#L147) class method, by adding the `stream`, `priority_speaker` and `use_slash_commands` permissions which were missing.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)