### PR TITLE
Implement WelcomeScreen

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -40,6 +40,7 @@ from .colour import *
 from .integrations import *
 from .invite import *
 from .template import *
+from .welcome_screen import *
 from .widget import *
 from .object import *
 from .reaction import *

--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -50,6 +50,7 @@ from . import (
     ui as ui,
     app_commands as app_commands,
 )
+from .welcome_screen import WelcomeScreen, WelcomeChannel
 from .enums import *
 from .embeds import *
 from .mentions import *

--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -51,7 +51,6 @@ from . import (
     ui as ui,
     app_commands as app_commands,
 )
-from .welcome_screen import WelcomeScreen, WelcomeChannel
 from .enums import *
 from .embeds import *
 from .mentions import *

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3138,7 +3138,7 @@ class Guild(Hashable):
 
         return roles
 
-    async def welcome_screen(self):
+    async def welcome_screen(self) -> WelcomeScreen:
         """|coro|
 
         Returns the guild's welcome screen.
@@ -3148,7 +3148,7 @@ class Guild(Hashable):
         You must have the :attr:`~Permissions.manage_guild` permission to use
         this as well.
 
-        .. versionadded:: 1.7
+        .. versionadded:: 2.0
 
         Raises
         -------
@@ -3165,6 +3165,20 @@ class Guild(Hashable):
         data = await self._state.http.get_welcome_screen(self.id)
         return WelcomeScreen(data=data, guild=self)
 
+    @overload
+    async def edit_welcome_screen(
+        self,
+        *,
+        description: Optional[str] = ...,
+        welcome_channels: Optional[List[WelcomeChannel]] = ...,
+        enabled: Optional[bool] = ...,
+    ) -> WelcomeScreen:
+        ...
+
+    @overload
+    async def edit_welcome_screen(self) -> None:
+        ...
+
     async def edit_welcome_screen(self, **kwargs):
         """|coro|
 
@@ -3176,7 +3190,7 @@ class Guild(Hashable):
         You must have the :attr:`~Permissions.manage_guild` permission to use
         this as well.
 
-        .. versionadded:: 1.7
+        .. versionadded:: 2.0
 
         Returns
         --------

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3165,21 +3165,14 @@ class Guild(Hashable):
         data = await self._state.http.get_welcome_screen(self.id)
         return WelcomeScreen(data=data, guild=self)
 
-    @overload
     async def edit_welcome_screen(
         self,
         *,
-        description: Optional[str] = ...,
-        welcome_channels: Optional[List[WelcomeChannel]] = ...,
-        enabled: Optional[bool] = ...,
+        description: str = MISSING,
+        welcome_channels: List[WelcomeChannel] = MISSING,
+        enabled: bool = MISSING,
+        reason: Optional[str] = None,
     ) -> WelcomeScreen:
-        ...
-
-    @overload
-    async def edit_welcome_screen(self) -> None:
-        ...
-
-    async def edit_welcome_screen(self, **kwargs):
         """|coro|
 
         A shorthand method of :attr:`WelcomeScreen.edit` without needing
@@ -3197,21 +3190,24 @@ class Guild(Hashable):
         :class:`WelcomeScreen`
             The edited welcome screen.
         """
-        try:
-            welcome_channels = kwargs['welcome_channels']
-        except KeyError:
-            pass
-        else:
+        fields = {}
+
+        if welcome_channels is not MISSING:
             welcome_channels_serialised = []
             for wc in welcome_channels:
                 if not isinstance(wc, WelcomeChannel):
-                    raise InvalidArgument('welcome_channels parameter must be a list of WelcomeChannel')
+                    raise TypeError('welcome_channels parameter must be a list of WelcomeChannel')
                 welcome_channels_serialised.append(wc.to_dict())
-            kwargs['welcome_channels'] = welcome_channels_serialised
+            fields['welcome_channels'] = welcome_channels_serialised
 
-        if kwargs:
-            data = await self._state.http.edit_welcome_screen(self.id, kwargs)
-            return WelcomeScreen(data=data, guild=self)
+        if description is not MISSING:
+            fields['description'] = description
+
+        if enabled is not MISSING:
+            fields['enabled'] = enabled
+
+        data = await self._state.http.edit_welcome_screen(self.id, reason=reason, **fields)
+        return WelcomeScreen(data=data, guild=self)
 
     async def kick(self, user: Snowflake, *, reason: Optional[str] = None) -> None:
         """|coro|

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3193,6 +3193,7 @@ class Guild(Hashable):
                 if not isinstance(wc, WelcomeChannel):
                     raise InvalidArgument('welcome_channels parameter must be a list of WelcomeChannel')
                 welcome_channels_serialised.append(wc.to_dict())
+            kwargs['welcome_channels'] = welcome_channels_serialised
 
         if kwargs:
             data = await self._state.http.edit_welcome_screen(self.id, kwargs)

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -86,6 +86,7 @@ from .sticker import GuildSticker
 from .file import File
 from .audit_logs import AuditLogEntry
 from .object import OLDEST_OBJECT, Object
+from .welcome_screen import WelcomeScreen, WelcomeChannel
 
 
 __all__ = (
@@ -3136,6 +3137,66 @@ class Guild(Hashable):
             self._roles[role.id] = role
 
         return roles
+
+    async def welcome_screen(self):
+        """|coro|
+
+        Returns the guild's welcome screen.
+
+        The guild must have ``COMMUNITY`` in :attr:`~Guild.features`.
+
+        You must have the :attr:`~Permissions.manage_guild` permission to use
+        this as well.
+
+        .. versionadded:: 1.7
+
+        Raises
+        -------
+        Forbidden
+            You do not have the proper permissions to get this.
+        HTTPException
+            Retrieving the welcome screen failed.
+
+        Returns
+        --------
+        :class:`WelcomeScreen`
+            The welcome screen.
+        """
+        data = await self._state.http.get_welcome_screen(self.id)
+        return WelcomeScreen(data=data, guild=self)
+
+    async def edit_welcome_screen(self, **kwargs):
+        """|coro|
+
+        A shorthand method of :attr:`WelcomeScreen.edit` without needing
+        to fetch the welcome screen beforehand.
+
+        The guild must have ``COMMUNITY`` in :attr:`~Guild.features`.
+
+        You must have the :attr:`~Permissions.manage_guild` permission to use
+        this as well.
+
+        .. versionadded:: 1.7
+
+        Returns
+        --------
+        :class:`WelcomeScreen`
+            The edited welcome screen.
+        """
+        try:
+            welcome_channels = kwargs['welcome_channels']
+        except KeyError:
+            pass
+        else:
+            welcome_channels_serialised = []
+            for wc in welcome_channels:
+                if not isinstance(wc, WelcomeChannel):
+                    raise InvalidArgument('welcome_channels parameter must be a list of WelcomeChannel')
+                welcome_channels_serialised.append(wc.to_dict())
+
+        if kwargs:
+            data = await self._state.http.edit_welcome_screen(self.id, kwargs)
+            return WelcomeScreen(data=data, guild=self)
 
     async def kick(self, user: Snowflake, *, reason: Optional[str] = None) -> None:
         """|coro|

--- a/discord/http.py
+++ b/discord/http.py
@@ -1216,16 +1216,18 @@ class HTTPClient:
     def get_welcome_screen(self, guild_id: Snowflake) -> Response[welcome_screen.WelcomeScreen]:
         return self.request(Route('GET', '/guilds/{guild_id}/welcome-screen', guild_id=guild_id))
 
-    def edit_welcome_screen(self, guild_id: Snowflake, payload: Any) -> Response[welcome_screen.WelcomeScreen]:
+    def edit_welcome_screen(
+        self, guild_id: Snowflake, *, reason: Optional[str] = None, **fields: Any
+    ) -> Response[welcome_screen.WelcomeScreen]:
         valid_keys = (
             'description',
             'welcome_channels',
             'enabled',
         )
-        payload = {
-            k: v for k, v in payload.items() if k in valid_keys
-        }
-        return self.request(Route('PATCH', '/guilds/{guild_id}/welcome-screen', guild_id=guild_id), json=payload)
+        payload = {k: v for k, v in fields.items() if k in valid_keys}
+        return self.request(
+            Route('PATCH', '/guilds/{guild_id}/welcome-screen', guild_id=guild_id), json=payload, reason=reason
+        )
 
     def get_ban(self, user_id: Snowflake, guild_id: Snowflake) -> Response[guild.Ban]:
         return self.request(Route('GET', '/guilds/{guild_id}/bans/{user_id}', guild_id=guild_id, user_id=user_id))

--- a/discord/http.py
+++ b/discord/http.py
@@ -1212,6 +1212,20 @@ class HTTPClient:
 
         return self.request(Route('GET', '/guilds/{guild_id}/bans', guild_id=guild_id), params=params)
 
+    def get_welcome_screen(self, guild_id):
+        return self.request(Route('GET', '/guilds/{guild_id}/welcome-screen', guild_id=guild_id))
+
+    def edit_welcome_screen(self, guild_id, payload):
+        valid_keys = (
+            'description',
+            'welcome_channels',
+            'enabled',
+        )
+        payload = {
+            k: v for k, v in payload.items() if k in valid_keys
+        }
+        return self.request(Route('PATCH', '/guilds/{guild_id}/welcome-screen', guild_id=guild_id), json=payload)
+
     def get_ban(self, user_id: Snowflake, guild_id: Snowflake) -> Response[guild.Ban]:
         return self.request(Route('GET', '/guilds/{guild_id}/bans/{user_id}', guild_id=guild_id, user_id=user_id))
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -87,6 +87,7 @@ if TYPE_CHECKING:
         threads,
         scheduled_event,
         sticker,
+        welcome_screen,
     )
     from .types.snowflake import Snowflake, SnowflakeList
 
@@ -1212,10 +1213,10 @@ class HTTPClient:
 
         return self.request(Route('GET', '/guilds/{guild_id}/bans', guild_id=guild_id), params=params)
 
-    def get_welcome_screen(self, guild_id):
+    def get_welcome_screen(self, guild_id: Snowflake) -> Response[welcome_screen.WelcomeScreen]:
         return self.request(Route('GET', '/guilds/{guild_id}/welcome-screen', guild_id=guild_id))
 
-    def edit_welcome_screen(self, guild_id, payload):
+    def edit_welcome_screen(self, guild_id: Snowflake, payload: Any) -> Response[welcome_screen.WelcomeScreen]:
         valid_keys = (
             'description',
             'welcome_channels',

--- a/discord/welcome_screen.py
+++ b/discord/welcome_screen.py
@@ -87,7 +87,7 @@ class WelcomeChannel:
 
         return cls(channel=channel, description=description, emoji=emoji)  # type: ignore
 
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> WelcomeScreenChannelPayload:
         ret = {
             'channel_id': self.channel.id,
             'description': self.description,

--- a/discord/welcome_screen.py
+++ b/discord/welcome_screen.py
@@ -88,7 +88,7 @@ class WelcomeChannel:
         return cls(channel=channel, description=description, emoji=emoji)  # type: ignore
 
     def to_dict(self) -> WelcomeScreenChannelPayload:
-        ret = {
+        ret: WelcomeScreenChannelPayload = {
             'channel_id': self.channel.id,
             'description': self.description,
             'emoji_id': None,

--- a/discord/welcome_screen.py
+++ b/discord/welcome_screen.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-present Rapptz
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from .utils import _get_as_snowflake, get
+from .errors import InvalidArgument
+from .partial_emoji import _EmojiTag
+
+
+class WelcomeChannel:
+    """Represents a :class:`WelcomeScreen` welcome channel.
+
+    .. versionadded:: 1.7
+
+    Attributes
+    -----------
+    channel: :class:`abc.Snowflake`
+        The guild channel that is being referenced.
+    description: :class:`str`
+        The description shown of the channel.
+    emoji: Optional[:class:`PartialEmoji`, :class:`Emoji`, :class:`str`]
+        The emoji used beside the channel description.
+    """
+    def __init__(self, *, channel, description, emoji=None):
+        self.channel = channel
+        self.description = description
+        self.emoji = emoji
+    
+    def __repr__(self):
+        return '<WelcomeChannel channel={0.channel!r} description={0.description!r} emoji={0.emoji}>'.format(self)
+
+    @classmethod
+    def _from_dict(cls, *, data, guild):
+        channel_id = _get_as_snowflake(data, 'channel_id')
+        channel = guild.get_channel(channel_id)
+        description = data['description']
+        _emoji_id  = _get_as_snowflake(data, 'emoji_id')
+        _emoji_name = data['emoji_name']
+
+        if _emoji_id:
+            # custom
+            emoji = get(guild.emojis, id=_emoji_id)
+        else:
+            # unicode or None
+            emoji = _emoji_name
+
+        return cls(channel=channel, description=description, emoji=emoji)
+
+    def to_dict(self):
+        ret = {
+            'channel_id': self.channel.id,
+            'description': self.description,
+            'emoji_id': None,
+            'emoji_name': None,
+        }
+
+        if isinstance(self.emoji, _EmojiTag):
+            ret['emoji_id'] = self.emoji.id
+            ret['emoji_name'] = self.emoji.name
+        else:
+            # unicode or None
+            ret['emoji_name'] = self.emoji
+
+        return ret
+
+class WelcomeScreen:
+    """Represents a :class:`Guild` welcome screen.
+
+    .. versionadded:: 1.7
+
+    Attributes
+    -----------
+    description: :class:`str`
+        The description shown on the welcome screen.
+    welcome_channels: List[:class:`WelcomeChannel`]
+        The channels shown on the welcome screen.
+    """
+    def __init__(self, *, data, guild):
+        self._state = guild._state
+        self._guild = guild
+        self._store(data)
+    
+    def _store(self, data):
+        self.description = data['description']
+        welcome_channels = data.get('welcome_channels', [])
+        self.welcome_channels = [WelcomeChannel._from_dict(data=wc, guild=self._guild) for wc in welcome_channels]
+
+    def __repr__(self):
+        return '<WelcomeScreen description={0.description!r} welcome_channels={0.welcome_channels!r} enabled={0.enabled}>'.format(self)
+
+    @property
+    def enabled(self):
+        """:class:`bool`: Whether the welcome screen is displayed.
+        
+        This is equivalent to checking if ``WELCOME_SCREEN_ENABLED``
+        is present in :attr:`Guild.features`.
+        """
+        return 'WELCOME_SCREEN_ENABLED' in self._guild.features
+
+    async def edit(self, **kwargs):
+        """|coro|
+        
+        Edit the welcome screen.
+        
+        You must have the :attr:`~Permissions.manage_guild` permission in the
+        guild to do this.
+
+        Usage: ::
+
+            channel_1 = guild.get_channel(12345678)
+            channel_2 = guild.get_channel(87654321)
+
+            custom_emoji = utils.get(guild.emojis, name='loudspeaker')
+
+            await welcome_screen.edit(
+                description='This is a very cool community server!',
+                welcome_channels=[
+                    WelcomeChannel(channel=channel_one, description='Read the rules!', emoji='👨‍🏫'),
+                    WelcomeChannel(channel=channel_two, description='Watch out for announcements!', emoji=custom_emoji), 
+                ]
+            )
+        
+        .. note::
+
+            Welcome channels can only accept custom emojis if :attr:`~Guild.premium_tier` is level 2 or above.
+        
+        Parameters
+        ------------
+        description: Optional[:class:`str`]
+            The template's description.
+        welcome_channels: Optional[List[:class:`WelcomeChannel`]]
+            The welcome channels, in their respective order.
+        enabled: Optional[:class:`bool`]
+            Whether the welcome screen should be displayed.
+
+        Raises
+        -------
+        HTTPException
+            Editing the welcome screen failed failed.
+        Forbidden
+            You don't have permissions to edit the welcome screen.
+        NotFound
+            This welcome screen does not exist.
+        """
+        try:
+            welcome_channels = kwargs['welcome_channels']
+        except KeyError:
+            pass
+        else:
+            welcome_channels_serialised = []
+            for wc in welcome_channels:
+                if not isinstance(wc, WelcomeChannel):
+                    raise InvalidArgument('welcome_channels parameter must be a list of WelcomeChannel')
+                welcome_channels_serialised.append(wc.to_dict())
+            kwargs['welcome_channels'] = welcome_channels_serialised
+
+        if kwargs:
+            data = await self._state.http.edit_welcome_screen(self._guild.id, kwargs)
+            self._store(data)

--- a/discord/welcome_screen.py
+++ b/discord/welcome_screen.py
@@ -129,16 +129,16 @@ class WelcomeScreen:
 
         Usage: ::
 
-            channel_1 = guild.get_channel(12345678)
-            channel_2 = guild.get_channel(87654321)
+            rules_channel = guild.get_channel(12345678)
+            announcements_channel = guild.get_channel(87654321)
 
             custom_emoji = utils.get(guild.emojis, name='loudspeaker')
 
             await welcome_screen.edit(
                 description='This is a very cool community server!',
                 welcome_channels=[
-                    WelcomeChannel(channel=channel_one, description='Read the rules!', emoji='👨‍🏫'),
-                    WelcomeChannel(channel=channel_two, description='Watch out for announcements!', emoji=custom_emoji), 
+                    WelcomeChannel(channel=rules_channel, description='Read the rules!', emoji='👨‍🏫'),
+                    WelcomeChannel(channel=announcements_channel, description='Watch out for announcements!', emoji=custom_emoji), 
                 ]
             )
         

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3982,6 +3982,22 @@ Template
 .. autoclass:: Template()
     :members:
 
+WelcomeScreen
+~~~~~~~~~~~~~~~
+
+.. attributetable:: WelcomeScreen
+
+.. autoclass:: WelcomeScreen()
+    :members:
+
+WelcomeChannel
+~~~~~~~~~~~~~~~
+
+.. attributetable:: WelcomeChannel
+
+.. autoclass:: WelcomeChannel()
+    :members:
+
 WidgetChannel
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary

Implements the welcome screen which can be enabled in community guilds.

The only thing not tested is providing a custom emoji as my guilds do not have a level 2 premium tier.

I have not implemented the property present in invites as it seemed useless for most cases and introduced a confusing API.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
