### PR TITLE
Deprecate afk kwarg in change_presence

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -1039,9 +1039,9 @@ class Client:
             Indicates if you are going AFK. This allows the discord
             client to know how to handle push notifications better
             for you in case you are actually idle and not lying.
-            
+
             .. deprecated:: 1.7
-            
+
         Raises
         ------
         :exc:`.InvalidArgument`

--- a/discord/client.py
+++ b/discord/client.py
@@ -1039,7 +1039,9 @@ class Client:
             Indicates if you are going AFK. This allows the discord
             client to know how to handle push notifications better
             for you in case you are actually idle and not lying.
-
+            
+            .. deprecated:: 1.7
+            
         Raises
         ------
         :exc:`.InvalidArgument`


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR aims to deprecate the `afk` kwarg (which is non-bot) in `change_presence` in preparation for its removal at v2.0. (like #6454)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
