### PR TITLE
A (small) fix for 4098.

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -312,7 +312,7 @@ class GuildChannel:
             client = self._state.dispatch.__self__
             try:
                 await client.wait_for('guild_channel_update', check=lambda b, a: b.id == a.id, timeout=2)
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 # fallback, unfortunately we didn't receive the event in 2s
                 self._update(data)
 

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -317,7 +317,7 @@ class GuildChannel:
                 except asyncio.TimeoutError:
                     # fallback, we didn't receive the event within 2s
                     pass
-            self._update(data)
+            self._update(self.guild, data)
 
     def _fill_overwrites(self, data):
         self._overwrites = []

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -312,7 +312,7 @@ class GuildChannel:
             if 'parent_id' in options:
                 client = self._state._get_client()
                 try:
-                    await client.wait_for('guild_channel_update', check=lambda b, a: b.id == a.id, timeout=2)
+                    await client.wait_for('guild_channel_update', check=lambda b, a: b.id == a.id and b.id == self.id, timeout=2)
                     return
                 except asyncio.TimeoutError:
                     # fallback, we didn't receive the event within 2s

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -308,7 +308,13 @@ class GuildChannel:
 
         if options:
             data = await self._state.http.edit_channel(self.id, reason=reason, **options)
-            self._update(self.guild, data)
+            # this will look ugly but it works i'm sure of it
+            client = self._state.dispatch.__self__
+            try:
+                await client.wait_for('guild_channel_update', check=lambda b, a: b.id == a.id, timeout=2)
+            except TimeoutError:
+                # fallback, unfortunately we didn't receive the event in 2s
+                self._update(data)
 
     def _fill_overwrites(self, data):
         self._overwrites = []


### PR DESCRIPTION
## Summary

This essentially resolves #4098. It maintains that this issue may only happen when the category is being edited, or in terms of the API when `parent_id` is set. When this condition is met, it will wait for the channel update matching the edited channel's id to confirm that the properties have been updated and are consistent, before returning back to the user code. As discussed in the issue, there is the potential that there may be a failure in eventual consistency where the event is never received by the client. From my testing, it seems that the event is received fairly instantaneously, but for the benefit of the doubt, a generous 2-second timeout is provided before it will fallback to the regular method of updating itself. 

It may be beneficial to extensively test this with larger bots to make sure that it works as consistently as possible.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
