### PR TITLE
Only run main() if the module is being executed as a script

### DIFF
--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -301,4 +301,5 @@ def main():
     parser, args = parse_args()
     args.func(parser, args)
 
-main()
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Currently, if `discord.__main__` is imported by a tool like `stubtest` (provided by `mypy`), it parses the command line and exits early. This can be demonstrated by creating a simple script and running it on the command line with options that `discord.__main__` doesn't recognize:

```python
#!/usr/bin/env python

import discord.__main__
```

```
$ python args-test.py --blah
usage: discord [-h] [-v] {newbot,newcog} ...
discord: error: unrecognized arguments: --blah
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
