### PR TITLE
Add support for fail_if_not_exists in MessageReference

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -804,7 +804,7 @@ class Messageable(metaclass=abc.ABCMeta):
     async def send(self, content=None, *, tts=False, embed=None, file=None,
                                           files=None, delete_after=None, nonce=None,
                                           allowed_mentions=None, reference=None,
-                                          mention_author=None, fail_if_not_exists=None):
+                                          mention_author=None):
         """|coro|
 
         Sends a message to the destination with the content given.
@@ -854,9 +854,7 @@ class Messageable(metaclass=abc.ABCMeta):
             A reference to the :class:`~discord.Message` to which you are replying, this can be created using
             :meth:`~discord.Message.to_reference` or passed directly as a :class:`~discord.Message`. You can control
             whether this mentions the author of the referenced message using the :attr:`~discord.AllowedMentions.replied_user`
-            attribute of ``allowed_mentions`` or by setting ``mention_author``. To control whether replying should
-            fail if the referenced message has been deleted set :attr:`~discord.MessageReference.fail_if_not_exists`
-            or ``fail_if_not_exists``.
+            attribute of ``allowed_mentions`` or by setting ``mention_author``.
 
             .. versionadded:: 1.6
 
@@ -864,11 +862,6 @@ class Messageable(metaclass=abc.ABCMeta):
             If set, overrides the :attr:`~discord.AllowedMentions.replied_user` attribute of ``allowed_mentions``.
 
             .. versionadded:: 1.6
-
-        fail_if_not_exists: Optional[:class:`bool`]
-            If set, overrides :attr:`~discord.MessageReference.fail_if_not_exists` attribute of ``reference``.
-
-            .. versionadded:: 1.7
 
         Raises
         --------
@@ -911,12 +904,6 @@ class Messageable(metaclass=abc.ABCMeta):
                 reference = reference.to_message_reference_dict()
             except AttributeError:
                 raise InvalidArgument('reference parameter must be Message or MessageReference') from None
-
-        if fail_if_not_exists is not None:
-            if reference is None:
-                raise InvalidArgument('fail_if_not_exists requires reference parameter to be set') from None
-
-            reference['fail_if_not_exists'] = fail_if_not_exists
 
         if file is not None and files is not None:
             raise InvalidArgument('cannot pass both file and files parameter to send()')

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -804,7 +804,7 @@ class Messageable(metaclass=abc.ABCMeta):
     async def send(self, content=None, *, tts=False, embed=None, file=None,
                                           files=None, delete_after=None, nonce=None,
                                           allowed_mentions=None, reference=None,
-                                          mention_author=None):
+                                          mention_author=None, fail_if_not_exists=None):
         """|coro|
 
         Sends a message to the destination with the content given.
@@ -854,7 +854,9 @@ class Messageable(metaclass=abc.ABCMeta):
             A reference to the :class:`~discord.Message` to which you are replying, this can be created using
             :meth:`~discord.Message.to_reference` or passed directly as a :class:`~discord.Message`. You can control
             whether this mentions the author of the referenced message using the :attr:`~discord.AllowedMentions.replied_user`
-            attribute of ``allowed_mentions`` or by setting ``mention_author``.
+            attribute of ``allowed_mentions`` or by setting ``mention_author``. To control whether replying should
+            fail if the referenced message has been deleted set :attr:`~discord.MessageReference.fail_if_not_exists`
+            or ``fail_if_not_exists``.
 
             .. versionadded:: 1.6
 
@@ -862,6 +864,11 @@ class Messageable(metaclass=abc.ABCMeta):
             If set, overrides the :attr:`~discord.AllowedMentions.replied_user` attribute of ``allowed_mentions``.
 
             .. versionadded:: 1.6
+
+        fail_if_not_exists: Optional[:class:`bool`]
+            If set, overrides :attr:`~discord.MessageReference.fail_if_not_exists` attribute of ``reference``.
+
+            .. versionadded:: 1.7
 
         Raises
         --------
@@ -904,6 +911,12 @@ class Messageable(metaclass=abc.ABCMeta):
                 reference = reference.to_message_reference_dict()
             except AttributeError:
                 raise InvalidArgument('reference parameter must be Message or MessageReference') from None
+
+        if fail_if_not_exists is not None:
+            if reference is None:
+                raise InvalidArgument('fail_if_not_exists requires reference parameter to be set') from None
+
+            reference['fail_if_not_exists'] = fail_if_not_exists
 
         if file is not None and files is not None:
             raise InvalidArgument('cannot pass both file and files parameter to send()')

--- a/discord/message.py
+++ b/discord/message.py
@@ -279,6 +279,12 @@ class MessageReference:
         The channel id of the message referenced.
     guild_id: Optional[:class:`int`]
         The guild id of the message referenced.
+    fail_if_not_exists: Optional[:class:`bool`]
+        Whether replying to the referenced message should raise :class:`HTTPException`
+        if the message has been deleted or reply without the message reference attached.
+
+        .. versionadded:: 1.7
+
     resolved: Optional[Union[:class:`Message`, :class:`DeletedReferencedMessage`]]
         The message that this reference resolved to. If this is ``None``
         then the original message was not fetched either due to the Discord API
@@ -291,14 +297,15 @@ class MessageReference:
         .. versionadded:: 1.6
     """
 
-    __slots__ = ('message_id', 'channel_id', 'guild_id', 'resolved', '_state')
+    __slots__ = ('message_id', 'channel_id', 'guild_id', 'fail_if_not_exists', 'resolved', '_state')
 
-    def __init__(self, *, message_id, channel_id, guild_id=None):
+    def __init__(self, *, message_id, channel_id, guild_id=None, fail_if_not_exists=None):
         self._state = None
         self.resolved = None
         self.message_id = message_id
         self.channel_id = channel_id
         self.guild_id = guild_id
+        self.fail_if_not_exists = fail_if_not_exists
 
     @classmethod
     def with_state(cls, state, data):
@@ -352,6 +359,8 @@ class MessageReference:
         result['channel_id'] = self.channel_id
         if self.guild_id is not None:
             result['guild_id'] = self.guild_id
+        if self.fail_if_not_exists is not None:
+            result['fail_if_not_exists'] = self.fail_if_not_exists
         return result
 
     to_message_reference_dict = to_dict

--- a/discord/message.py
+++ b/discord/message.py
@@ -281,7 +281,7 @@ class MessageReference:
         The guild id of the message referenced.
     fail_if_not_exists: :class:`bool`
         Whether replying to the referenced message should raise :class:`HTTPException`
-        if the message has been deleted or reply without the message reference attached.
+        if the message no longer exists or Discord could not fetch the message.
 
         .. versionadded:: 1.7
 
@@ -329,7 +329,7 @@ class MessageReference:
             The message to be converted into a reference.
         fail_if_not_exists: :class:`bool`
             Whether replying to the referenced message should raise :class:`HTTPException`
-            if the message has been deleted or reply without the message reference attached.
+            if the message no longer exists or Discord could not fetch the message.
 
             .. versionadded:: 1.7
 
@@ -1334,7 +1334,7 @@ class Message(Hashable):
         ----------
         fail_if_not_exists: :class:`bool`
             Whether replying using the message reference should raise :class:`HTTPException`
-            if the message has been deleted or reply without the message reference attached.
+            if the message no longer exists or Discord could not fetch the message.
 
             .. versionadded:: 1.7
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -279,7 +279,7 @@ class MessageReference:
         The channel id of the message referenced.
     guild_id: Optional[:class:`int`]
         The guild id of the message referenced.
-    fail_if_not_exists: Optional[:class:`bool`]
+    fail_if_not_exists: :class:`bool`
         Whether replying to the referenced message should raise :class:`HTTPException`
         if the message has been deleted or reply without the message reference attached.
 
@@ -327,7 +327,7 @@ class MessageReference:
         ----------
         message: :class:`~discord.Message`
             The message to be converted into a reference.
-        fail_if_not_exists: Optional[:class:`bool`]
+        fail_if_not_exists: :class:`bool`
             Whether replying to the referenced message should raise :class:`HTTPException`
             if the message has been deleted or reply without the message reference attached.
 
@@ -1332,7 +1332,7 @@ class Message(Hashable):
 
         Parameters
         ----------
-        fail_if_not_exists: Optional[:class:`bool`]
+        fail_if_not_exists: :class:`bool`
             Whether replying using the message reference should raise :class:`HTTPException`
             if the message has been deleted or reply without the message reference attached.
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -299,7 +299,7 @@ class MessageReference:
 
     __slots__ = ('message_id', 'channel_id', 'guild_id', 'fail_if_not_exists', 'resolved', '_state')
 
-    def __init__(self, *, message_id, channel_id, guild_id=None, fail_if_not_exists=None):
+    def __init__(self, *, message_id, channel_id, guild_id=None, fail_if_not_exists=True):
         self._state = None
         self.resolved = None
         self.message_id = message_id
@@ -318,7 +318,7 @@ class MessageReference:
         return self
 
     @classmethod
-    def from_message(cls, message):
+    def from_message(cls, message, *, fail_if_not_exists=True):
         """Creates a :class:`MessageReference` from an existing :class:`~discord.Message`.
 
         .. versionadded:: 1.6
@@ -327,13 +327,18 @@ class MessageReference:
         ----------
         message: :class:`~discord.Message`
             The message to be converted into a reference.
+        fail_if_not_exists: Optional[:class:`bool`]
+            Whether replying to the referenced message should raise :class:`HTTPException`
+            if the message has been deleted or reply without the message reference attached.
+
+            .. versionadded:: 1.7
 
         Returns
         -------
         :class:`MessageReference`
             A reference to the message.
         """
-        self = cls(message_id=message.id, channel_id=message.channel.id, guild_id=getattr(message.guild, 'id', None))
+        self = cls(message_id=message.id, channel_id=message.channel.id,guild_id=getattr(message.guild, 'id', None), fail_if_not_exists=fail_if_not_exists)
         self._state = message._state
         return self
 
@@ -1320,10 +1325,18 @@ class Message(Hashable):
 
         return await self.channel.send(content, reference=self, **kwargs)
 
-    def to_reference(self):
+    def to_reference(self, *, fail_if_not_exists=True):
         """Creates a :class:`~discord.MessageReference` from the current message.
 
         .. versionadded:: 1.6
+
+        Parameters
+        ----------
+        fail_if_not_exists: Optional[:class:`bool`]
+            Whether replying using the message reference should raise :class:`HTTPException`
+            if the message has been deleted or reply without the message reference attached.
+
+            .. versionadded:: 1.7
 
         Returns
         ---------
@@ -1331,7 +1344,7 @@ class Message(Hashable):
             The reference to this message.
         """
 
-        return MessageReference.from_message(self)
+        return MessageReference.from_message(self, fail_if_not_exists=fail_if_not_exists)
 
     def to_message_reference_dict(self):
         data = {

--- a/discord/message.py
+++ b/discord/message.py
@@ -338,7 +338,7 @@ class MessageReference:
         :class:`MessageReference`
             A reference to the message.
         """
-        self = cls(message_id=message.id, channel_id=message.channel.id,guild_id=getattr(message.guild, 'id', None), fail_if_not_exists=fail_if_not_exists)
+        self = cls(message_id=message.id, channel_id=message.channel.id, guild_id=getattr(message.guild, 'id', None), fail_if_not_exists=fail_if_not_exists)
         self._state = message._state
         return self
 


### PR DESCRIPTION
## Summary

Allows replying to a message which may have been deleted without needing to re-try if this is the case.
Also adds a shortcut to `Messageable.send` to set this field, similarly to `mention_author` for allowed mentions.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

# Other

I'm unsure whether all of the docstrings are correct, please let me know if they aren't.
