### PR TITLE
Update docs for discord.Invite.max_uses

### DIFF
--- a/discord/invite.py
+++ b/discord/invite.py
@@ -273,7 +273,7 @@ class Invite(Hashable):
     uses: :class:`int`
         How many times the invite has been used.
     max_uses: :class:`int`
-        How many times the invite can be used.
+        How many times the invite can be used. A value of 0 indicates that an infinite number of people can use the invite.
     inviter: :class:`User`
         The user who created the invite.
     approximate_member_count: Optional[:class:`int`]

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -273,7 +273,8 @@ class Invite(Hashable):
     uses: :class:`int`
         How many times the invite has been used.
     max_uses: :class:`int`
-        How many times the invite can be used. A value of 0 indicates that an infinite number of people can use the invite.
+        How many times the invite can be used.
+        A value of ``0`` indicates that an infinite number of people can use the invite.
     inviter: :class:`User`
         The user who created the invite.
     approximate_member_count: Optional[:class:`int`]

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -258,7 +258,8 @@ class Invite(Hashable):
     Attributes
     -----------
     max_age: :class:`int`
-        How long the before the invite expires in seconds. A value of 0 indicates that it doesn't expire.
+        How long the before the invite expires in seconds.
+        A value of ``0`` indicates that it doesn't expire.
     code: :class:`str`
         The URL fragment used for the invite.
     guild: Optional[Union[:class:`Guild`, :class:`Object`, :class:`PartialInviteGuild`]]

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -275,7 +275,7 @@ class Invite(Hashable):
         How many times the invite has been used.
     max_uses: :class:`int`
         How many times the invite can be used.
-        A value of ``0`` indicates that an infinite number of people can use the invite.
+        A value of ``0`` indicates that it has unlimited uses.
     inviter: :class:`User`
         The user who created the invite.
     approximate_member_count: Optional[:class:`int`]


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Previously there was no indicator for if an invite can be used infinitely, update it to tell users 0 indicates infinite uses.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
