### PR TITLE
[tasks] remove redundant condition in Loop.next_iteration

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -154,7 +154,7 @@ class Loop:
 
         .. versionadded:: 1.3
         """
-        if self._task is None and self._sleep:
+        if self._task is None:
             return None
         elif self._task and self._task.done() or self._stop_next_iteration:
             return None


### PR DESCRIPTION
## Summary

Removes a redundant condition from the [`Loop.next_iteration`](https://discordpy.readthedocs.io/en/latest/ext/tasks/index.html#discord.ext.tasks.Loop.next_iteration) property.

`self._task` is only `None` if the Loop has never been started before, which means `None` should always be returned regardless of how many seconds was passed into the constructor.
    
This didn't break anything before because `self._next_iteration` will be `None` as well if `self._task` is `None` (the Loop was never started) so `None` was still returned.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
