### PR TITLE
Changed documentation design

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -150,14 +150,14 @@ class Permissions(BaseFlags):
         ``True`` and the guild-specific ones set to ``False``. The guild-specific
         permissions are currently:
         
-        - :attr:`manage_emojis`\n
-        - :attr:`view_audit_log`\n
-        - :attr:`view_guild_insights`\n
-        - :attr:`manage_guild`\n
-        - :attr:`change_nickname`\n
-        - :attr:`manage_nicknames`\n
-        - :attr:`kick_members`\n
-        - :attr:`ban_members`\n
+        - :attr:`manage_emojis`
+        - :attr:`view_audit_log`
+        - :attr:`view_guild_insights`
+        - :attr:`manage_guild`
+        - :attr:`change_nickname`
+        - :attr:`manage_nicknames`
+        - :attr:`kick_members`
+        - :attr:`ban_members`
         - :attr:`administrator`
         
         .. versionchanged:: 1.7

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -149,15 +149,16 @@ class Permissions(BaseFlags):
         """A :class:`Permissions` with all channel-specific permissions set to
         ``True`` and the guild-specific ones set to ``False``. The guild-specific
         permissions are currently:
-        - manage_emojis
-        - view_audit_log
-        - view_guild_insights
-        - manage_guild
-        - change_nickname
-        - manage_nicknames
-        - kick_members
-        - ban_members
-        - administrator
+        
+        - :attr:`manage_emojis`\n
+        - :attr:`view_audit_log`\n
+        - :attr:`view_guild_insights`\n
+        - :attr:`manage_guild`\n
+        - :attr:`change_nickname`\n
+        - :attr:`manage_nicknames`\n
+        - :attr:`kick_members`\n
+        - :attr:`ban_members`\n
+        - :attr:`administrator`
         
         .. versionchanged:: 1.7
            Added :attr:`stream`, :attr:`priority_speaker` and :attr:`use_slash_commands` permissions.
@@ -208,7 +209,7 @@ class Permissions(BaseFlags):
         """A factory method that creates a :class:`Permissions` with all
         "Advanced" permissions from the official Discord UI set to ``True``.
         
-        .. versionadded: 1.7
+        .. versionadded:: 1.7
         """
         return cls(1 << 3)
 


### PR DESCRIPTION
## Summary

I noticed two little problems with the documentation design.

The first one was with the [`Permissions.all_channel()`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Permissions.all_channel) class method, where all the permissions were stacked up together instead of being separated by a newline.

The second one was with the [`Permissions.advanced()`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Permissions.advanced) class method, where **New in version 1.7** didn't appear.

This pull request is to fix those two issues.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
