### PR TITLE
 Allow AuditLogEntry to be Hashable

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -29,6 +29,7 @@ from .object import Object
 from .permissions import PermissionOverwrite, Permissions
 from .colour import Colour
 from .invite import Invite
+from .mixins import Hashable
 
 def _transform_verification_level(entry, data):
     return enums.try_enum(enums.VerificationLevel, data)
@@ -186,7 +187,7 @@ class AuditLogChanges:
 
         setattr(second, 'roles', data)
 
-class AuditLogEntry:
+class AuditLogEntry(Hashable):
     r"""Represents an Audit Log entry.
 
     You retrieve these via :meth:`Guild.audit_logs`.

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -206,6 +206,9 @@ class AuditLogEntry(Hashable):
 
             Returns the entry's hash.
 
+    .. versionchanged:: 1.7
+        Audit log entries are now comparable and hashable.
+
     Attributes
     -----------
     action: :class:`AuditLogAction`

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -192,6 +192,20 @@ class AuditLogEntry(Hashable):
 
     You retrieve these via :meth:`Guild.audit_logs`.
 
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two entries are equal.
+
+        .. describe:: x != y
+
+            Checks if two entries are not equal.
+
+        .. describe:: hash(x)
+
+            Returns the entry's hash.
+
     Attributes
     -----------
     action: :class:`AuditLogAction`


### PR DESCRIPTION
## Summary

Allows comparing audit log entries by their ID.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
