### PR TITLE
Add Permissions attributes

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -131,6 +131,26 @@ class Permissions(BaseFlags):
     __lt__ = is_strict_subset
     __gt__ = is_strict_superset
 
+    def __add__(self, other):
+        if not isinstance(other, Permissions):
+            raise TypeError("cannot compare {} with {}".format(self.__class__.__name__, other.__class__.__name__))
+        return Permissions(self.value | other.value)
+
+    def __sub__(self, other):
+        if not isinstance(other, Permissions):
+            raise TypeError("cannot compare {} with {}".format(self.__class__.__name__, other.__class__.__name__))
+        return Permissions(self.value & (~other.value))
+
+    def __bool__(self):
+        return bool(self.value)
+
+    def is_empty(self):
+        """Returns ``True`` if there are no permissions, ``False`` otherwise.
+        
+        .. versionadded:: 1.7
+        """
+        return self.value == 0
+
     @classmethod
     def none(cls):
         """A factory method that creates a :class:`Permissions` with all

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -155,6 +155,7 @@ class Permissions(BaseFlags):
 
     def is_empty(self):
         """Returns ``True`` if there are no permissions, ``False`` otherwise.
+
         .. versionadded:: 1.7
         """
         return self.value == 0
@@ -169,6 +170,7 @@ class Permissions(BaseFlags):
     def default(cls):
         """A factory method that creates a :class:`Permissions` with only
         the default permissions set to ``True``.
+
         .. versionadded:: 1.7
         """
         return cls(0b10000110001101111100111001000001)

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -160,7 +160,6 @@ class Permissions(BaseFlags):
     def default(cls):
         """A factory method that creates a :class:`Permissions` with only
         the default permissions set to ``True``.
-        
         .. versionadded:: 1.7
         """
         return cls(0b10000110001101111100111001000001)

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -136,6 +136,15 @@ class Permissions(BaseFlags):
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``False``."""
         return cls(0)
+    
+    @classmethod
+    def default(cls):
+        """A factory method that creates a :class:`Permissions` with only
+        the default permissions set to ``True``.
+        
+        .. versionadded:: 1.7
+        """
+        return cls(0b10000110001101111100111001000001)
 
     @classmethod
     def all(cls):

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -146,7 +146,6 @@ class Permissions(BaseFlags):
 
     def is_empty(self):
         """Returns ``True`` if there are no permissions, ``False`` otherwise.
-        
         .. versionadded:: 1.7
         """
         return self.value == 0

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -77,12 +77,21 @@ class Permissions(BaseFlags):
              Checks if a permission is a strict superset of another permission.
         .. describe:: hash(x)
 
-               Return the permission's hash.
+               Returns the permission's hash.
         .. describe:: iter(x)
 
                Returns an iterator of ``(perm, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
                Note that aliases are not shown.
+        .. describe:: x + y
+
+                Returns a new permission corresponding to the union of the two permissions.
+        .. describe:: x - y
+
+                Returns a new permission corresponding to the difference of the two permissions.
+        .. describe:: bool(x)
+
+                Returns ``True`` if permission is not empty, ``False`` otherwise.
 
     Attributes
     -----------


### PR DESCRIPTION
## Summary

This pull request adds these new things:
- `Permissions.default()` which corresponds to the default Discord permissions for roles
- Possibility to add and subtract [`Permissions`](https://github.com/Rapptz/discord.py/blob/master/discord/permissions.py#L47) directly. For example, we can now use `Permissions.text() + Permissions.voice()` to make a [`Permissions`](https://github.com/Rapptz/discord.py/blob/master/discord/permissions.py#L47) with all text and voice permissions, or `Permissions.all() - Permissions.general()` to make a [`Permissions`](https://github.com/Rapptz/discord.py/blob/master/discord/permissions.py#L47) with every permissions, except the **General** permissions. This is helpful to avoid dealing with [`Permissions.update()`](https://github.com/Rapptz/discord.py/blob/master/discord/permissions.py#L217) when adding/subtracting [`Permissions`](https://github.com/Rapptz/discord.py/blob/master/discord/permissions.py#L47) instances directly.
- Boolean method which returns `True` if and only if there are permissions (permission value different from 0), and `is_empty` method that returns the opposite - similar to [`PermissionOverwrite.is_empty()`](https://github.com/Rapptz/discord.py/blob/master/discord/permissions.py#L561)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
