### PR TITLE
Rework the reaction roles example

### DIFF
--- a/examples/reaction_roles.py
+++ b/examples/reaction_roles.py
@@ -8,25 +8,28 @@ class RoleReactClient(discord.Client):
 
         self.role_message_id = 0  # ID of message that can be reacted to to add role
         self.emoji_to_role = {
-            'partial_emoji_1': 0,  # ID of role associated with partial emoji object 'partial_emoji_1'
-            'partial_emoji_2': 0  # ID of role associated with partial emoji object 'partial_emoji_2'
+            '🔴': 0,  # ID of the role associated with unicode emoji '🔴'
+            '🟡': 0,  # ID of the role associated with unicode emoji '🟡'
+            0: 0, # ID of the role associated with a partial emoji's id.
         }
 
-    async def on_raw_reaction_add(self, payload):
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
         """Gives a role based on a reaction emoji."""
         # Make sure that the message the user is reacting to is the one we care about
         if payload.message_id != self.role_message_id:
             return
 
-        try:
-            role_id = self.emoji_to_role[payload.emoji]
-        except KeyError:
-            # If the emoji isn't the one we care about then exit as well.
-            return
-
         guild = self.get_guild(payload.guild_id)
         if guild is None:
             # Check if we're still in the guild and it's cached.
+            return
+
+        try:
+            # If it is a unicode emoji, it should use .name, otherwise it should use .id.
+            emoji = payload.emoji.name if payload.emoji.is_unicode_emoji() else payload.emoji.id
+            role_id = self.emoji_to_role[emoji]
+        except KeyError:
+            # If the emoji isn't the one we care about then exit as well.
             return
 
         role = guild.get_role(role_id)
@@ -41,21 +44,23 @@ class RoleReactClient(discord.Client):
             # If we want to do something in case of errors we'd do it here.
             pass
 
-    async def on_raw_reaction_remove(self, payload):
+    async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
         """Removes a role based on a reaction emoji."""
         # Make sure that the message the user is reacting to is the one we care about
         if payload.message_id != self.role_message_id:
             return
 
-        try:
-            role_id = self.emoji_to_role[payload.emoji]
-        except KeyError:
-            # If the emoji isn't the one we care about then exit as well.
-            return
-
         guild = self.get_guild(payload.guild_id)
         if guild is None:
             # Check if we're still in the guild and it's cached.
+            return
+
+        try:
+            # If it is a unicode emoji, it should use the name, otherwise it should use the ID.
+            emoji = payload.emoji.name if payload.emoji.is_unicode_emoji() else payload.emoji.id
+            role_id = self.emoji_to_role[emoji]
+        except KeyError:
+            # If the emoji isn't the one we care about then exit as well.
             return
 
         role = guild.get_role(role_id)
@@ -80,4 +85,4 @@ intents = discord.Intents.default()
 intents.members = True
 
 client = RoleReactClient(intents=intents)
-client.run("token")
+client.run('token')

--- a/examples/reaction_roles.py
+++ b/examples/reaction_roles.py
@@ -8,8 +8,8 @@ class RoleReactClient(discord.Client):
 
         self.role_message_id = 0  # ID of message that can be reacted to to add role
         self.emoji_to_role = {
-            partial_emoji_1: 0,  # ID of role associated with partial emoji object 'partial_emoji_1'
-            partial_emoji_2: 0  # ID of role associated with partial emoji object 'partial_emoji_2'
+            'partial_emoji_1': 0,  # ID of role associated with partial emoji object 'partial_emoji_1'
+            'partial_emoji_2': 0  # ID of role associated with partial emoji object 'partial_emoji_2'
         }
 
     async def on_raw_reaction_add(self, payload):

--- a/examples/reaction_roles.py
+++ b/examples/reaction_roles.py
@@ -6,16 +6,16 @@ class MyClient(discord.Client):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.role_message_id = 0 # ID of the message that can be reacted to to add/remove a role
+        self.role_message_id = 0 # ID of the message that can be reacted to to add/remove a role.
         self.emoji_to_role = {
-            discord.PartialEmoji(name='🔴'): 0, # ID of the role associated with unicode emoji '🔴'
-            discord.PartialEmoji(name='🟡'): 0, # ID of the role associated with unicode emoji '🟡'
-            discord.PartialEmoji(name='green', id=0): 0, # ID of the role associated with a partial emoji's id.
+            discord.PartialEmoji(name='🔴'): 0, # ID of the role associated with unicode emoji '🔴'.
+            discord.PartialEmoji(name='🟡'): 0, # ID of the role associated with unicode emoji '🟡'.
+            discord.PartialEmoji(name='green', id=0): 0, # ID of the role associated with a partial emoji's ID.
         }
 
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
         """Gives a role based on a reaction emoji."""
-        # Make sure that the message the user is reacting to is the one we care about
+        # Make sure that the message the user is reacting to is the one we care about.
         if payload.message_id != self.role_message_id:
             return
 
@@ -44,7 +44,7 @@ class MyClient(discord.Client):
 
     async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
         """Removes a role based on a reaction emoji."""
-        # Make sure that the message the user is reacting to is the one we care about
+        # Make sure that the message the user is reacting to is the one we care about.
         if payload.message_id != self.role_message_id:
             return
 
@@ -64,11 +64,11 @@ class MyClient(discord.Client):
             # Make sure the role still exists and is valid.
             return
 
-        # The payload for raw_reaction_remove does not provide `.member`
+        # The payload for `on_raw_reaction_remove` does not provide `.member`
         # so we must get the member ourselves from the payload's `.user_id`.
         member = guild.get_member(payload.user_id)
         if member is None:
-            # Makes sure the member still exists and is valid.
+            # Make sure the member still exists and is valid.
             return
 
         try:

--- a/examples/reaction_roles.py
+++ b/examples/reaction_roles.py
@@ -6,11 +6,11 @@ class RoleReactClient(discord.Client):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.role_message_id = 0  # ID of message that can be reacted to to add role
+        self.role_message_id = 0 # ID of message that can be reacted to to add role
         self.emoji_to_role = {
-            '🔴': 0,  # ID of the role associated with unicode emoji '🔴'
-            '🟡': 0,  # ID of the role associated with unicode emoji '🟡'
-            0: 0, # ID of the role associated with a partial emoji's id.
+            discord.PartialEmoji(name='🔴'): 0, # ID of the role associated with unicode emoji '🔴'
+            discord.PartialEmoji(name='🟡'): 0, # ID of the role associated with unicode emoji '🟡'
+            discord.PartialEmoji(name='indigo', id=0): 0, # ID of the role associated with a partial emoji's id.
         }
 
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
@@ -26,8 +26,7 @@ class RoleReactClient(discord.Client):
 
         try:
             # If it is a unicode emoji, it should use .name, otherwise it should use .id.
-            emoji = payload.emoji.name if payload.emoji.is_unicode_emoji() else payload.emoji.id
-            role_id = self.emoji_to_role[emoji]
+            role_id = self.emoji_to_role[payload.emoji]
         except KeyError:
             # If the emoji isn't the one we care about then exit as well.
             return
@@ -57,8 +56,7 @@ class RoleReactClient(discord.Client):
 
         try:
             # If it is a unicode emoji, it should use the name, otherwise it should use the ID.
-            emoji = payload.emoji.name if payload.emoji.is_unicode_emoji() else payload.emoji.id
-            role_id = self.emoji_to_role[emoji]
+            role_id = self.emoji_to_role[payload.emoji]
         except KeyError:
             # If the emoji isn't the one we care about then exit as well.
             return

--- a/examples/reaction_roles.py
+++ b/examples/reaction_roles.py
@@ -1,16 +1,16 @@
-"""Uses a messages to add and remove roles through reactions."""
+# This example requires the 'members' privileged intents
 
 import discord
 
-class RoleReactClient(discord.Client):
+class MyClient(discord.Client):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.role_message_id = 0 # ID of message that can be reacted to to add role
+        self.role_message_id = 0 # ID of the message that can be reacted to to add/remove a role
         self.emoji_to_role = {
             discord.PartialEmoji(name='🔴'): 0, # ID of the role associated with unicode emoji '🔴'
             discord.PartialEmoji(name='🟡'): 0, # ID of the role associated with unicode emoji '🟡'
-            discord.PartialEmoji(name='indigo', id=0): 0, # ID of the role associated with a partial emoji's id.
+            discord.PartialEmoji(name='green', id=0): 0, # ID of the role associated with a partial emoji's id.
         }
 
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
@@ -25,7 +25,6 @@ class RoleReactClient(discord.Client):
             return
 
         try:
-            # If it is a unicode emoji, it should use .name, otherwise it should use .id.
             role_id = self.emoji_to_role[payload.emoji]
         except KeyError:
             # If the emoji isn't the one we care about then exit as well.
@@ -37,7 +36,7 @@ class RoleReactClient(discord.Client):
             return
 
         try:
-            # Finally add the role
+            # Finally, add the role.
             await payload.member.add_roles(role)
         except discord.HTTPException:
             # If we want to do something in case of errors we'd do it here.
@@ -55,7 +54,6 @@ class RoleReactClient(discord.Client):
             return
 
         try:
-            # If it is a unicode emoji, it should use the name, otherwise it should use the ID.
             role_id = self.emoji_to_role[payload.emoji]
         except KeyError:
             # If the emoji isn't the one we care about then exit as well.
@@ -66,21 +64,22 @@ class RoleReactClient(discord.Client):
             # Make sure the role still exists and is valid.
             return
 
+        # The payload for raw_reaction_remove does not provide `.member`
+        # so we must get the member ourselves from the payload's `.user_id`.
         member = guild.get_member(payload.user_id)
         if member is None:
-            # Makes sure the member still exists and is valid
+            # Makes sure the member still exists and is valid.
             return
 
         try:
-            # Finally, remove the role
+            # Finally, remove the role.
             await member.remove_roles(role)
         except discord.HTTPException:
             # If we want to do something in case of errors we'd do it here.
             pass
 
-# This bot requires the members and reactions intents.
 intents = discord.Intents.default()
 intents.members = True
 
-client = RoleReactClient(intents=intents)
+client = MyClient(intents=intents)
 client.run('token')


### PR DESCRIPTION
## Summary

Minor changes for the example to work as intended. Also allows Unicode emojis and custom emojis, although maybe the union-type for the `emoji_to_role` key might not be favourable.

Reviews are welcome.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
