### PR TITLE
[docs] fix Context.channel property type

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -229,8 +229,8 @@ class Context(discord.abc.Messageable):
 
     @discord.utils.cached_property
     def channel(self):
-        """Union[:class:`abc.Messageable`]:
-        Returns the channel associated with this context's command. Shorthand for :attr:`.Message.channel`.
+        """Union[:class:`.abc.Messageable`]: Returns the channel associated with this context's command.
+        Shorthand for :attr:`.Message.channel`.
         """
         return self.message.channel
 

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -229,7 +229,7 @@ class Context(discord.abc.Messageable):
 
     @discord.utils.cached_property
     def channel(self):
-        """:class:`.TextChannel`:
+        """Union[:class:`abc.Messageable`]:
         Returns the channel associated with this context's command. Shorthand for :attr:`.Message.channel`.
         """
         return self.message.channel


### PR DESCRIPTION
## Summary

Resolves #6510 by making the documented type for `Context.channel` match `Message.channel`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
