### PR TITLE
Mark User.avatar_url as attribute in Intents.members docstring

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -476,7 +476,7 @@ class Intents(BaseFlags):
         - :attr:`Member.nick`
         - :attr:`Member.premium_since`
         - :attr:`User.name`
-        - :attr:`User.avatar` (:meth:`User.avatar_url` and :meth:`User.avatar_url_as`)
+        - :attr:`User.avatar` (:attr:`User.avatar_url` and :meth:`User.avatar_url_as`)
         - :attr:`User.discriminator`
 
         For more information go to the :ref:`member intent documentation <need_members_intent>`.


### PR DESCRIPTION
The line currently comes out to `User.avatar (User.avatar_url() and User.avatar_url_as())` but `User.avatar_url` is not callable.