### PR TITLE
Make Embed.copy() a deep copy

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -557,9 +557,16 @@ class Embed:
         # add in the raw data into the dict
         result = {
             key[1:]: getattr(self, key)
-            for key in self.__slots__
+            for key in ('title', 'url', 'type', '_timestamp', '_colour', '_footer',
+                        '_image', '_thumbnail', '_video', '_provider', '_author',
+                        'description')
             if key[0] == '_' and hasattr(self, key)
         }
+
+        # to prevent _fields list reference persistence
+        _fields = getattr(self,'_fields', [])
+        if _fields:
+            result['fields'] = [f for f in _fields]
 
         # deal with basic convenience wrappers
 


### PR DESCRIPTION
## Summary

I'm requesting that Embed.copy become a less shallow copy. The only difference here is that the fields will be copied by value instead of the whole list reference, because that's the only thing that persists between copies.

small repro:

- make embed
- loop
	- clear fields
	- add some fields
	- yield embed.copy()

all yielded embeds would have the final embed's fields.

---

I removed `self.__slots__` and replaced it with a hard-coded `'_field'`-less tuple of __slots__. There are multiple ways to do what I'm trying to solve here and this may not have been the cleanest, so I'm all ears for suggestions.

*marked as breaking change as it does actually change how the end results work*

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)