### PR TITLE
Ignore has_permissions and has_permissions in Dms

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1779,6 +1779,8 @@ def has_permissions(**perms):
         raise TypeError('Invalid permission(s): %s' % (', '.join(invalid)))
 
     def predicate(ctx):
+        if ctx.guild is None:
+            return True
         ch = ctx.channel
         permissions = ch.permissions_for(ctx.author)
 
@@ -1804,6 +1806,8 @@ def bot_has_permissions(**perms):
         raise TypeError('Invalid permission(s): %s' % (', '.join(invalid)))
 
     def predicate(ctx):
+        if ctx.guild is None:
+            return True
         guild = ctx.guild
         me = guild.me if guild is not None else ctx.bot.user
         permissions = ctx.channel.permissions_for(me)


### PR DESCRIPTION
## Summary

This PR fixes an error for commands used in DMs with has_permissions or has_permissions check.
This allows creating commands which can be used in DMs and on a server. If the command is used on a server, permissions get checked, otherwise, it gets ignored.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
