### PR TITLE
Handle priority_speaker permission differently

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -481,15 +481,15 @@ class Member(discord.abc.Messageable, _BaseUser):
         administrator implication.
         """
 
-        if self.guild.owner_id == self.id:
-            return Permissions.all()
-
         base = Permissions.none()
         for r in self.roles:
             base.value |= r.permissions.value
 
-        if base.administrator:
-            return Permissions.all()
+        if self.guild.owner_id == self.id or base.administrator:
+            all_ = Permissions.all()
+            all_.priority_speaker = False
+
+            base.value |= all_.value
 
         return base
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

When a member is the server owner or has the administrator permission, discord.py automatically sets all the `guild_permission` flags for this member. However in discord, the `priority_speaker` flag is handled independently from the administrator permission (see screenshot from discord integrations).  
This pull request prevents the `priority_speaker` flag from being automatically set if the member has the administrator permission or is the server owner.

![permissions](https://user-images.githubusercontent.com/30043959/111532340-d5012200-8765-11eb-9373-f9c634a6ead0.png)



## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
