### PR TITLE
Add `delay` parameter to TextChannel.delete_messages

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -275,7 +275,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             If providedm the number of seconds to wait in the background
             before deleting the messages provided. If deletion fails then it is silently ignored.
 
-            .. versaionadded:: 1.7
+            .. versionadded:: 1.7
 
         Raises
         ------


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR adds the ability to pass a `delay` kwarg to `TextChannel.delete_messages`, similar to `Message.delete`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
