### PR TITLE
[docs] make *await* text appear before 'inherited' async methods on Member

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -24,6 +24,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
+import inspect
 import itertools
 import sys
 from operator import attrgetter
@@ -106,8 +107,12 @@ def flatten_user(cls):
             # It probably breaks something in Sphinx.
             # probably a member function by now
             def generate_function(x):
-                def general(self, *args, **kwargs):
-                    return getattr(self._user, x)(*args, **kwargs)
+                if inspect.iscoroutinefunction(value):
+                    async def general(self, *args, **kwargs):
+                        return await getattr(self._user, x)(*args, **kwargs)
+                else:
+                    def general(self, *args, **kwargs):
+                        return getattr(self._user, x)(*args, **kwargs)
 
                 general.__name__ = x
                 return general

--- a/discord/member.py
+++ b/discord/member.py
@@ -107,6 +107,7 @@ def flatten_user(cls):
             # It probably breaks something in Sphinx.
             # probably a member function by now
             def generate_function(x):
+                # We want sphinx to properly show coroutine functions as coroutines
                 if inspect.iscoroutinefunction(value):
                     async def general(self, *args, **kwargs):
                         return await getattr(self._user, x)(*args, **kwargs)


### PR DESCRIPTION
## Summary

Makes sphinx see "inherited" async methods on discord.Member as coroutines so *`await`* is added before the method in the documentation.

<img width="347" alt="Screen Shot 2021-03-21 at 5 54 32 AM" src="https://user-images.githubusercontent.com/44045823/111905647-ebc7a300-8a09-11eb-9f74-61248926071c.png">

Also see: https://github.com/Rapptz/discord.py/issues/6553#issuecomment-803550712

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
