### PR TITLE
Changed to 99% as Slash commands are not supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Key Features
 
 - Modern Pythonic API using ``async`` and ``await``.
 - Proper rate limit handling.
-- 100% coverage of the supported Discord API.
+- 99% coverage of the supported Discord API.
 - Optimised in both speed and memory.
 
 Installing


### PR DESCRIPTION
## Summary

To change the 100% coverage to 99% coverage as slash commands are not supported

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
