### PR TITLE
[docs] change the return value of Guild.voice_client

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -381,7 +381,7 @@ class Guild(Hashable):
 
     @property
     def voice_client(self):
-        """Optional[:class:`VoiceProtocol`]: Returns the :class:`VoiceProtocol` associated with this guild, if any."""
+        """Optional[:class:`VoiceClient`]: Returns the :class:`VoiceClient` associated with this guild, if any."""
         return self._state._get_voice_client(self.id)
 
     @property


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

The API Reference says that the return value of Guild.voice_client is VoiceProtocol, but it returns VoiceClient.  

<img width="347" alt="voice_client" src="https://user-images.githubusercontent.com/80200187/111975137-968fac80-8b43-11eb-875a-1ffb6ef891c2.png">


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
