### PR TITLE
[commands] allow arbitrary callables in cooldown

### DIFF
--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -66,6 +66,9 @@ class BucketType(Enum):
             # recieving a DMChannel or GroupChannel which inherit from PrivateChannel and do
             return (msg.channel if isinstance(msg.channel, PrivateChannel) else msg.author.top_role).id
 
+    def __call__(self, msg):
+        return self.get_key(msg)
+
 
 class Cooldown:
     __slots__ = ('rate', 'per', 'type', '_window', '_tokens', '_last')
@@ -78,8 +81,8 @@ class Cooldown:
         self._tokens = self.rate
         self._last = 0.0
 
-        if not isinstance(self.type, BucketType):
-            raise TypeError('Cooldown type must be a BucketType')
+        if not callable(self.type):
+            raise TypeError('Cooldown type must be a BucketType or callable')
 
     def get_tokens(self, current=None):
         if not current:
@@ -151,7 +154,7 @@ class CooldownMapping:
         return cls(Cooldown(rate, per, type))
 
     def _bucket_key(self, msg):
-        return self._cooldown.type.get_key(msg)
+        return self._cooldown.type(msg)
 
     def _verify_cache_integrity(self, current=None):
         # we want to delete all cache objects that haven't been used

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1959,7 +1959,7 @@ def cooldown(rate, per, type=BucketType.default):
         The number of times a command can be used before triggering a cooldown.
     per: :class:`float`
         The amount of seconds to wait for a cooldown when it's been triggered.
-    type: Union[:class:`.BucketType`, Callable[:class:`.Message`, Any]]
+    type: Union[:class:`.BucketType`, Callable[[:class:`.Message`], Any]]
         The type of cooldown to have. If callable, should return a key for the mapping.
     """
 

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1959,8 +1959,8 @@ def cooldown(rate, per, type=BucketType.default):
         The number of times a command can be used before triggering a cooldown.
     per: :class:`float`
         The amount of seconds to wait for a cooldown when it's been triggered.
-    type: :class:`.BucketType`
-        The type of cooldown to have.
+    type: Union[:class:`.BucketType`, Callable[:class:`.Message`, Any]]
+        The type of cooldown to have. If callable, should return a key for the mapping.
     """
 
     def decorator(func):

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1961,6 +1961,9 @@ def cooldown(rate, per, type=BucketType.default):
         The amount of seconds to wait for a cooldown when it's been triggered.
     type: Union[:class:`.BucketType`, Callable[[:class:`.Message`], Any]]
         The type of cooldown to have. If callable, should return a key for the mapping.
+        
+        .. versionchanged:: 1.7
+            Callables are now supported for custom bucket types.
     """
 
     def decorator(func):


### PR DESCRIPTION
## Summary

This allows for easier use of non-default bucket keys.
This is especially useful in cases of global- or cog-check cooldowns that should apply to each command individually.

Previously:

```py
class CustomMapping(CooldownMapping):
    def _bucket_key(self, ctx):
      return (ctx.command.name, ctx.author.id)

mapping = CustomMapping.from_cooldown(1, 30, BucketType.user)  # anything but .default can be used here
```
or
```py
mappings = {}
default_mapping = CooldownMapping.from_cooldown(1, 30, BucketType.user)

def bot_check(ctx):
    mapping = mappings.setdefault(ctx.command.name, default_mapping.copy())
```

With this change:
```py
mapping = CooldownMapping.from_cooldown(1, 30, lambda ctx: (ctx.command.name, ctx.author.id))
```

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
