### PR TITLE
Clarify docs to state that on_reaction_remove requires Intents.members

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -512,6 +512,11 @@ to handle it, which defaults to print a traceback and ignoring the exception.
         To get the message being reacted, access it via :attr:`Reaction.message`.
 
     This requires both :attr:`Intents.reactions` and :attr:`Intents.members` to be enabled.
+    
+    .. note::
+
+        Consider using :func:`on_raw_reaction_remove` if you need this and do not want
+        to enable the members intent.
 
     :param reaction: The current state of the reaction.
     :type reaction: :class:`Reaction`

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -511,7 +511,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
         To get the message being reacted, access it via :attr:`Reaction.message`.
 
-    This requires :attr:`Intents.reactions` to be enabled.
+    This requires both :attr:`Intents.reactions` and :attr:`Intents.members` to be enabled.
 
     :param reaction: The current state of the reaction.
     :type reaction: :class:`Reaction`


### PR DESCRIPTION
## Summary
Intents.members are required for on_reaction_remove to fire, but this isn't stated in the docs currently.


## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
