### PR TITLE
Add a delete_markdown helper function

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -676,11 +676,14 @@ class clean_content(Converter):
         Whether to use nicknames when transforming mentions.
     escape_markdown: :class:`bool`
         Whether to also escape special markdown characters.
+    remove_markdown: :class:`bool`
+        Whether to also escape special markdown characters. This option is not supported with ``escape_markdown``
     """
-    def __init__(self, *, fix_channel_mentions=False, use_nicknames=True, escape_markdown=False):
+    def __init__(self, *, fix_channel_mentions=False, use_nicknames=True, escape_markdown=False, remove_markdown=False):
         self.fix_channel_mentions = fix_channel_mentions
         self.use_nicknames = use_nicknames
         self.escape_markdown = escape_markdown
+        self.remove_markdown = remove_markdown
 
     async def convert(self, ctx, argument):
         message = ctx.message
@@ -731,6 +734,8 @@ class clean_content(Converter):
 
         if self.escape_markdown:
             result = discord.utils.escape_markdown(result)
+        elif self.remove_markdown:
+            result = discord.utils.remove_markdown(result)
 
         # Completely ensure no mentions escape:
         return discord.utils.escape_mentions(result)

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -678,6 +678,8 @@ class clean_content(Converter):
         Whether to also escape special markdown characters.
     remove_markdown: :class:`bool`
         Whether to also escape special markdown characters. This option is not supported with ``escape_markdown``
+        
+        .. versionadded:: 1.7
     """
     def __init__(self, *, fix_channel_mentions=False, use_nicknames=True, escape_markdown=False, remove_markdown=False):
         self.fix_channel_mentions = fix_channel_mentions

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -677,7 +677,7 @@ class clean_content(Converter):
     escape_markdown: :class:`bool`
         Whether to also escape special markdown characters.
     remove_markdown: :class:`bool`
-        Whether to also escape special markdown characters. This option is not supported with ``escape_markdown``
+        Whether to also remove special markdown characters. This option is not supported with ``escape_markdown``
         
         .. versionadded:: 1.7
     """

--- a/discord/message.py
+++ b/discord/message.py
@@ -784,9 +784,9 @@ class Message(Hashable):
 
         .. note::
 
-            This *does not* escape markdown. If you want to escape
-            markdown then use :func:`utils.escape_markdown` along
-            with this function.
+            This *does not* affect markdown. If you want to escape
+            or remove markdown then use :func:`utils.escape_markdown` or :func:`utils.remove_markdown` along
+            with this function respectively.
         """
 
         transformations = {

--- a/discord/message.py
+++ b/discord/message.py
@@ -785,8 +785,8 @@ class Message(Hashable):
         .. note::
 
             This *does not* affect markdown. If you want to escape
-            or remove markdown then use :func:`utils.escape_markdown` or :func:`utils.remove_markdown` along
-            with this function respectively.
+            or remove markdown then use :func:`utils.escape_markdown` or :func:`utils.remove_markdown` 
+            respectively, along with this function.
         """
 
         transformations = {

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -479,13 +479,15 @@ _MARKDOWN_ESCAPE_COMMON = r'^>(?:>>)?\s|\[.+\]\(.+\)'
 
 _MARKDOWN_ESCAPE_REGEX = re.compile(r'(?P<markdown>%s|%s)' % (_MARKDOWN_ESCAPE_SUBREGEX, _MARKDOWN_ESCAPE_COMMON), re.MULTILINE)
 
-def delete_markdown(text, *, ignore_links=True):
+_URL_REGEX = r'(?P<url><[^: >]+:\/[^ >]+>|(?:https?|steam):\/\/[^\s<]+[^<.,:;\"\'\]\s])'
+
+def remove_markdown(text, *, ignore_links=True):
     r"""A helper function that remove markdown characters.
 
     Parameters
     -----------
     text: :class:`str`
-        The text to delete markdown from.
+        The text to remove markdown from.
     ignore_links: :class:`bool`
         Whether to leave links alone when removing markdown. For example,
         if a URL in the text contains characters such as ``_`` then it will
@@ -494,10 +496,9 @@ def delete_markdown(text, *, ignore_links=True):
     Returns
     --------
     :class:`str`
-        The text with the markdown special characters deleted.
+        The text with the markdown special characters removed.
     """
 
-    url_regex = r'(?P<url><[^: >]+:\/[^ >]+>|(?:https?|steam):\/\/[^\s<]+[^<.,:;\"\'\]\s])'
     def replacement(match):
         groupdict = match.groupdict()
         is_url = groupdict.get('url')
@@ -507,7 +508,7 @@ def delete_markdown(text, *, ignore_links=True):
 
     regex = r'(?P<markdown>[_\\~|\*`]|%s)' % _MARKDOWN_ESCAPE_COMMON
     if ignore_links:
-        regex = '(?:%s|%s)' % (url_regex, regex)
+        regex = '(?:%s|%s)' % (_URL_REGEX, regex)
     return re.sub(regex, replacement, text, 0, re.MULTILINE)
 
 def escape_markdown(text, *, as_needed=False, ignore_links=True):
@@ -536,7 +537,6 @@ def escape_markdown(text, *, as_needed=False, ignore_links=True):
     """
 
     if not as_needed:
-        url_regex = r'(?P<url><[^: >]+:\/[^ >]+>|(?:https?|steam):\/\/[^\s<]+[^<.,:;\"\'\]\s])'
         def replacement(match):
             groupdict = match.groupdict()
             is_url = groupdict.get('url')
@@ -546,7 +546,7 @@ def escape_markdown(text, *, as_needed=False, ignore_links=True):
 
         regex = r'(?P<markdown>[_\\~|\*`]|%s)' % _MARKDOWN_ESCAPE_COMMON
         if ignore_links:
-            regex = '(?:%s|%s)' % (url_regex, regex)
+            regex = '(?:%s|%s)' % (_URL_REGEX, regex)
         return re.sub(regex, replacement, text, 0, re.MULTILINE)
     else:
         text = re.sub(r'\\', r'\\\\', text)

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -499,6 +499,7 @@ def remove_markdown(text, *, ignore_links=True):
     --------
     :class:`str`
         The text with the markdown special characters removed.
+    .. versionadded:: 1.7
     """
 
     def replacement(match):

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -486,6 +486,12 @@ _MARKDOWN_STOCK_REGEX = r'(?P<markdown>[_\\~|\*`]|%s)' % _MARKDOWN_ESCAPE_COMMON
 def remove_markdown(text, *, ignore_links=True):
     r"""A helper function that remove markdown characters.
 
+    .. versionadded:: 1.7
+    
+    .. note::
+            This function is not markdown aware and may remove meaning from the original text. For example,
+            if the input contains ``10 * 5`` then it will be converted into ``10  5``.
+    
     Parameters
     -----------
     text: :class:`str`
@@ -499,12 +505,6 @@ def remove_markdown(text, *, ignore_links=True):
     --------
     :class:`str`
         The text with the markdown special characters removed.
-    
-    .. versionadded:: 1.7
-    
-    .. note::
-            This function is not markdown aware and may remove meaning from the original text. For example,
-            if the input contains ``10 * 5`` then it will be converted into ``10  5``.
     """
 
     def replacement(match):

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -484,7 +484,7 @@ _URL_REGEX = r'(?P<url><[^: >]+:\/[^ >]+>|(?:https?|steam):\/\/[^\s<]+[^<.,:;\"\
 _MARKDOWN_STOCK_REGEX = r'(?P<markdown>[_\\~|\*`]|%s)' % _MARKDOWN_ESCAPE_COMMON
 
 def remove_markdown(text, *, ignore_links=True):
-    r"""A helper function that removes markdown characters.
+    """A helper function that removes markdown characters.
 
     .. versionadded:: 1.7
     

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -509,10 +509,7 @@ def remove_markdown(text, *, ignore_links=True):
 
     def replacement(match):
         groupdict = match.groupdict()
-        is_url = groupdict.get('url')
-        if is_url:
-            return is_url
-        return ''
+        return groupdict.get('url', '')
 
     regex = _MARKDOWN_STOCK_REGEX
     if ignore_links:

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -479,6 +479,36 @@ _MARKDOWN_ESCAPE_COMMON = r'^>(?:>>)?\s|\[.+\]\(.+\)'
 
 _MARKDOWN_ESCAPE_REGEX = re.compile(r'(?P<markdown>%s|%s)' % (_MARKDOWN_ESCAPE_SUBREGEX, _MARKDOWN_ESCAPE_COMMON), re.MULTILINE)
 
+def delete_markdown(text, *, ignore_links=True):
+    r"""A helper function that deletes Discord's markdown.
+    Parameters
+    -----------
+    text: :class:`str`
+        The text to delete markdown from.
+    ignore_links: :class:`bool`
+        Whether to leave links alone when removing markdown. For example,
+        if a URL in the text contains characters such as ``_`` then it will
+        be left alone.
+        Defaults to ``True``.
+    Returns
+    --------
+    :class:`str`
+        The text with the markdown special characters deleted.
+    """
+
+    url_regex = r'(?P<url><[^: >]+:\/[^ >]+>|(?:https?|steam):\/\/[^\s<]+[^<.,:;\"\'\]\s])'
+    def replacement(match):
+        groupdict = match.groupdict()
+        is_url = groupdict.get('url')
+        if is_url:
+            return is_url
+        return ''
+
+    regex = r'(?P<markdown>[_\\~|\*`]|%s)' % _MARKDOWN_ESCAPE_COMMON
+    if ignore_links:
+        regex = '(?:%s|%s)' % (url_regex, regex)
+    return re.sub(regex, replacement, text, 0, re.MULTILINE)
+
 def escape_markdown(text, *, as_needed=False, ignore_links=True):
     r"""A helper function that escapes Discord's markdown.
 
@@ -521,36 +551,6 @@ def escape_markdown(text, *, as_needed=False, ignore_links=True):
         text = re.sub(r'\\', r'\\\\', text)
         return _MARKDOWN_ESCAPE_REGEX.sub(r'\\\1', text)
 
-def delete_markdown(text, *, ignore_links=True):
-    r"""A helper function that deletes Discord's markdown.
-    Parameters
-    -----------
-    text: :class:`str`
-        The text to delete markdown from.
-    ignore_links: :class:`bool`
-        Whether to leave links alone when removing markdown. For example,
-        if a URL in the text contains characters such as ``_`` then it will
-        be left alone.
-        Defaults to ``True``.
-    Returns
-    --------
-    :class:`str`
-        The text with the markdown special characters deleted.
-    """
-
-    url_regex = r'(?P<url><[^: >]+:\/[^ >]+>|(?:https?|steam):\/\/[^\s<]+[^<.,:;\"\'\]\s])'
-    def replacement(match):
-        groupdict = match.groupdict()
-        is_url = groupdict.get('url')
-        if is_url:
-            return is_url
-        return ''
-
-    regex = r'(?P<markdown>[_\\~|\*`]|%s)' % _MARKDOWN_ESCAPE_COMMON
-    if ignore_links:
-        regex = '(?:%s|%s)' % (url_regex, regex)
-    return re.sub(regex, replacement, text, 0, re.MULTILINE)
-    
 def escape_mentions(text):
     """A helper function that escapes everyone, here, role, and user mentions.
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -499,7 +499,12 @@ def remove_markdown(text, *, ignore_links=True):
     --------
     :class:`str`
         The text with the markdown special characters removed.
+    
     .. versionadded:: 1.7
+    
+    .. note::
+            This function is not markdown aware and may remove meaning from the original text. For example,
+            if the input contains ``10 * 5`` then it will be converted into ``10  5``.
     """
 
     def replacement(match):

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -484,7 +484,7 @@ _URL_REGEX = r'(?P<url><[^: >]+:\/[^ >]+>|(?:https?|steam):\/\/[^\s<]+[^<.,:;\"\
 _MARKDOWN_STOCK_REGEX = r'(?P<markdown>[_\\~|\*`]|%s)' % _MARKDOWN_ESCAPE_COMMON
 
 def remove_markdown(text, *, ignore_links=True):
-    r"""A helper function that remove markdown characters.
+    r"""A helper function that removes markdown characters.
 
     .. versionadded:: 1.7
     

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -480,7 +480,8 @@ _MARKDOWN_ESCAPE_COMMON = r'^>(?:>>)?\s|\[.+\]\(.+\)'
 _MARKDOWN_ESCAPE_REGEX = re.compile(r'(?P<markdown>%s|%s)' % (_MARKDOWN_ESCAPE_SUBREGEX, _MARKDOWN_ESCAPE_COMMON), re.MULTILINE)
 
 def delete_markdown(text, *, ignore_links=True):
-    r"""A helper function that deletes Discord's markdown.
+    r"""A helper function that remove markdown characters.
+
     Parameters
     -----------
     text: :class:`str`
@@ -488,8 +489,8 @@ def delete_markdown(text, *, ignore_links=True):
     ignore_links: :class:`bool`
         Whether to leave links alone when removing markdown. For example,
         if a URL in the text contains characters such as ``_`` then it will
-        be left alone.
-        Defaults to ``True``.
+        be left alone. Defaults to ``True``.
+
     Returns
     --------
     :class:`str`

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -521,6 +521,36 @@ def escape_markdown(text, *, as_needed=False, ignore_links=True):
         text = re.sub(r'\\', r'\\\\', text)
         return _MARKDOWN_ESCAPE_REGEX.sub(r'\\\1', text)
 
+def delete_markdown(text, *, ignore_links=True):
+    r"""A helper function that deletes Discord's markdown.
+    Parameters
+    -----------
+    text: :class:`str`
+        The text to delete markdown from.
+    ignore_links: :class:`bool`
+        Whether to leave links alone when removing markdown. For example,
+        if a URL in the text contains characters such as ``_`` then it will
+        be left alone.
+        Defaults to ``True``.
+    Returns
+    --------
+    :class:`str`
+        The text with the markdown special characters deleted.
+    """
+
+    url_regex = r'(?P<url><[^: >]+:\/[^ >]+>|(?:https?|steam):\/\/[^\s<]+[^<.,:;\"\'\]\s])'
+    def replacement(match):
+        groupdict = match.groupdict()
+        is_url = groupdict.get('url')
+        if is_url:
+            return is_url
+        return ''
+
+    regex = r'(?P<markdown>[_\\~|\*`]|%s)' % _MARKDOWN_ESCAPE_COMMON
+    if ignore_links:
+        regex = '(?:%s|%s)' % (url_regex, regex)
+    return re.sub(regex, replacement, text, 0, re.MULTILINE)
+    
 def escape_mentions(text):
     """A helper function that escapes everyone, here, role, and user mentions.
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -481,6 +481,8 @@ _MARKDOWN_ESCAPE_REGEX = re.compile(r'(?P<markdown>%s|%s)' % (_MARKDOWN_ESCAPE_S
 
 _URL_REGEX = r'(?P<url><[^: >]+:\/[^ >]+>|(?:https?|steam):\/\/[^\s<]+[^<.,:;\"\'\]\s])'
 
+_MARKDOWN_STOCK_REGEX = r'(?P<markdown>[_\\~|\*`]|%s)' % _MARKDOWN_ESCAPE_COMMON
+
 def remove_markdown(text, *, ignore_links=True):
     r"""A helper function that remove markdown characters.
 
@@ -506,7 +508,7 @@ def remove_markdown(text, *, ignore_links=True):
             return is_url
         return ''
 
-    regex = r'(?P<markdown>[_\\~|\*`]|%s)' % _MARKDOWN_ESCAPE_COMMON
+    regex = _MARKDOWN_STOCK_REGEX
     if ignore_links:
         regex = '(?:%s|%s)' % (_URL_REGEX, regex)
     return re.sub(regex, replacement, text, 0, re.MULTILINE)
@@ -544,7 +546,7 @@ def escape_markdown(text, *, as_needed=False, ignore_links=True):
                 return is_url
             return '\\' + groupdict['markdown']
 
-        regex = r'(?P<markdown>[_\\~|\*`]|%s)' % _MARKDOWN_ESCAPE_COMMON
+        regex = _MARKDOWN_STOCK_REGEX
         if ignore_links:
             regex = '(?:%s|%s)' % (_URL_REGEX, regex)
         return re.sub(regex, replacement, text, 0, re.MULTILINE)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -929,6 +929,8 @@ Utility Functions
 
 .. autofunction:: discord.utils.oauth_url
 
+.. autofunction:: discord.utils.delete_markdown
+
 .. autofunction:: discord.utils.escape_markdown
 
 .. autofunction:: discord.utils.escape_mentions

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -929,7 +929,7 @@ Utility Functions
 
 .. autofunction:: discord.utils.oauth_url
 
-.. autofunction:: discord.utils.delete_markdown
+.. autofunction:: discord.utils.remove_markdown
 
 .. autofunction:: discord.utils.escape_markdown
 


### PR DESCRIPTION
## Summary

Add a helper function to delete Discord's markdown. In my case I need to extract text cleaned of markdown from some user-provided input. Thought I'd make a PR as others might have a similar use case.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)