### PR TITLE
Convert title/description/url to str

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -111,10 +111,19 @@ class Embed:
             colour = kwargs.get('color', EmptyEmbed)
 
         self.colour = colour
-        self.title = str(kwargs.get('title', EmptyEmbed))
+        self.title = kwargs.get('title', EmptyEmbed)
         self.type = kwargs.get('type', 'rich')
-        self.url = str(kwargs.get('url', EmptyEmbed))
-        self.description = str(kwargs.get('description', EmptyEmbed))
+        self.url = kwargs.get('url', EmptyEmbed)
+        self.description = kwargs.get('description', EmptyEmbed)
+
+        if self.title is not EmptyEmbed:
+            self.title = str(self.title)
+
+        if self.description is not EmptyEmbed:
+            self.description = str(self.description)
+
+        if self.url is not EmptyEmbed:
+            self.url = str(self.url)
 
         try:
             timestamp = kwargs['timestamp']
@@ -144,10 +153,19 @@ class Embed:
 
         # fill in the basic fields
 
-        self.title = str(data.get('title', EmptyEmbed))
+        self.title = data.get('title', EmptyEmbed)
         self.type = data.get('type', EmptyEmbed)
-        self.description = str(data.get('description', EmptyEmbed))
-        self.url = str(data.get('url', EmptyEmbed))
+        self.description = data.get('description', EmptyEmbed)
+        self.url = data.get('url', EmptyEmbed)
+
+        if self.title is not EmptyEmbed:
+            self.title = str(self.title)
+
+        if self.description is not EmptyEmbed:
+            self.description = str(self.description)
+
+        if self.url is not EmptyEmbed:
+            self.url = str(self.url)
 
         # try to fill in the more rich fields
 

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -111,10 +111,10 @@ class Embed:
             colour = kwargs.get('color', EmptyEmbed)
 
         self.colour = colour
-        self.title = kwargs.get('title', EmptyEmbed)
+        self.title = str(kwargs.get('title', EmptyEmbed))
         self.type = kwargs.get('type', 'rich')
-        self.url = kwargs.get('url', EmptyEmbed)
-        self.description = kwargs.get('description', EmptyEmbed)
+        self.url = str(kwargs.get('url', EmptyEmbed))
+        self.description = str(kwargs.get('description', EmptyEmbed))
 
         try:
             timestamp = kwargs['timestamp']

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -144,10 +144,10 @@ class Embed:
 
         # fill in the basic fields
 
-        self.title = data.get('title', EmptyEmbed)
+        self.title = str(data.get('title', EmptyEmbed))
         self.type = data.get('type', EmptyEmbed)
-        self.description = data.get('description', EmptyEmbed)
-        self.url = data.get('url', EmptyEmbed)
+        self.description = str(data.get('description', EmptyEmbed))
+        self.url = str(data.get('url', EmptyEmbed))
 
         # try to fill in the more rich fields
 


### PR DESCRIPTION
## Summary

As mentioned in bikeshedding in the discord.py server, there was an oversight where these 3 values were not cast to str though it was specified in the documentation. This PR fixes this.

## Checklist


- [ x] If code changes were made then they have been tested.
    - [ x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
