### PR TITLE
Moved region attribute from guild to voice channel

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -29,7 +29,7 @@ import asyncio
 
 import discord.abc
 from .permissions import Permissions
-from .enums import ChannelType, try_enum
+from .enums import VoiceRegion, ChannelType, try_enum
 from .mixins import Hashable
 from . import utils
 from .asset import Asset

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -568,6 +568,11 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
         The guild the channel belongs to.
     id: :class:`int`
         The channel ID.
+    region: :class:`VoiceRegion`
+        The region the channel belongs on. There is a chance that the region
+        will be a :class:`str` if the value is not recognised by the enumerator.
+
+        .. versionadded:: 1.8
     category_id: Optional[:class:`int`]
         The category channel ID this channel belongs to, if applicable.
     position: :class:`int`
@@ -579,7 +584,7 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
         The channel's limit for number of members that can be in a voice channel.
     """
 
-    __slots__ = ('name', 'id', 'guild', 'bitrate', 'user_limit',
+    __slots__ = ('name', 'id', 'guild', 'region', 'bitrate', 'user_limit',
                  '_state', 'position', '_overwrites', 'category_id')
 
     def __init__(self, *, state, guild, data):
@@ -591,6 +596,7 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
         attrs = [
             ('id', self.id),
             ('name', self.name),
+            ('region', self.region),
             ('position', self.position),
             ('bitrate', self.bitrate),
             ('user_limit', self.user_limit),
@@ -612,6 +618,7 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
     def _update(self, guild, data):
         self.guild = guild
         self.name = data['name']
+        self.region = data['region']
         self.category_id = utils._get_as_snowflake(data, 'parent_id')
         self.position = data['position']
         self.bitrate = data.get('bitrate')
@@ -687,6 +694,10 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
         ----------
         name: :class:`str`
             The new channel's name.
+        region: :class:`VoiceRegion`
+            The new region for the channel's voice communication.
+            
+            .. versionadded:: 1.8
         bitrate: :class:`int`
             The new channel's bitrate.
         user_limit: :class:`int`

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -183,6 +183,7 @@ class MessageType(Enum):
     guild_discovery_grace_period_final_warning   = 17
 
 class VoiceRegion(Enum):
+    auto          = 'automatic'
     us_west       = 'us-west'
     us_east       = 'us-east'
     us_south      = 'us-south'

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -36,7 +36,7 @@ from .permissions import PermissionOverwrite
 from .colour import Colour
 from .errors import InvalidArgument, ClientException
 from .channel import *
-from .enums import VoiceRegion, ChannelType, try_enum, VerificationLevel, ContentFilter, NotificationLevel
+from .enums import ChannelType, try_enum, VerificationLevel, ContentFilter, NotificationLevel
 from .mixins import Hashable
 from .user import User
 from .invite import Invite
@@ -80,9 +80,6 @@ class Guild(Hashable):
         The guild name.
     emojis: Tuple[:class:`Emoji`, ...]
         All emojis that the guild owns.
-    region: :class:`VoiceRegion`
-        The region the guild belongs on. There is a chance that the region
-        will be a :class:`str` if the value is not recognised by the enumerator.
     afk_timeout: :class:`int`
         The timeout to get sent to the AFK channel.
     afk_channel: Optional[:class:`VoiceChannel`]
@@ -109,6 +106,9 @@ class Guild(Hashable):
             This attribute is only available via :meth:`.Client.fetch_guild`.
     max_video_channel_users: Optional[:class:`int`]
         The maximum amount of users in a video channel.
+
+        .. versionchanged:: 1.8
+    Removed `region` attribute, which is now passed per voice channel.
 
         .. versionadded:: 1.4
     banner: Optional[:class:`str`]
@@ -164,7 +164,7 @@ class Guild(Hashable):
     """
 
     __slots__ = ('afk_timeout', 'afk_channel', '_members', '_channels', 'icon',
-                 'name', 'id', 'unavailable', 'banner', 'region', '_state',
+                 'name', 'id', 'unavailable', 'banner', '_state',
                  '_roles', '_member_count', '_large',
                  'owner_id', 'mfa_level', 'emojis', 'features',
                  'verification_level', 'explicit_content_filter', 'splash',
@@ -273,7 +273,6 @@ class Guild(Hashable):
             self._member_count = member_count
 
         self.name = guild.get('name')
-        self.region = try_enum(VoiceRegion, guild.get('region'))
         self.verification_level = try_enum(VerificationLevel, guild.get('verification_level'))
         self.default_notifications = try_enum(NotificationLevel, guild.get('default_message_notifications'))
         self.explicit_content_filter = try_enum(ContentFilter, guild.get('explicit_content_filter', 0))
@@ -1041,6 +1040,9 @@ class Guild(Hashable):
         You must have the :attr:`~Permissions.manage_guild` permission
         to edit the guild.
 
+        .. versionchanged:: 1.8
+            Removed `region` attribute, which is now passed per voice channel.
+
         .. versionchanged:: 1.4
             The `rules_channel` and `public_updates_channel` keyword-only parameters were added.
 
@@ -1063,8 +1065,6 @@ class Guild(Hashable):
             Only PNG/JPEG supported. Could be ``None`` to denote removing the
             splash. This is only available to guilds that contain ``INVITE_SPLASH``
             in :attr:`Guild.features`.
-        region: :class:`VoiceRegion`
-            The new region for the guild's voice communication.
         afk_channel: Optional[:class:`VoiceChannel`]
             The new channel that is the AFK channel. Could be ``None`` for no AFK channel.
         afk_timeout: :class:`int`
@@ -1182,9 +1182,6 @@ class Guild(Hashable):
                 raise InvalidArgument('To transfer ownership you must be the owner of the guild.')
 
             fields['owner_id'] = fields['owner'].id
-
-        if 'region' in fields:
-            fields['region'] = str(fields['region'])
 
         level = fields.get('verification_level', self.verification_level)
         if not isinstance(level, VerificationLevel):


### PR DESCRIPTION
## Summary

Discord recently wrote [this article](https://support.discord.com/hc/en-us/articles/360060570993-Voice-Regions-Update) to state that they will change the way region works on guilds. The guilds will no longer have a region attribute: instead, it will be made per voice channel.

This pull request doesn't completely fix the problem, but it's a good start. I though we could set this to version 1.8.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
