### PR TITLE
Remove empty permissions from permissions_synced

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -441,8 +441,21 @@ class GuildChannel:
 
         .. versionadded:: 1.3
         """
+        def remove_empty_permissions(overwrite):
+            new_overwrite = [] # Able to keep it as a list since this is never getting passed
+                               # to the user.
+            for ow in overwrite: 
+                if not ((ow.allow == 0) and (ow.deny == 0)): # Only compare permissions that
+                    new_overwrite.append(ow)                 # actually matter.
+
+            return new_overwrite
+        
         category = self.guild.get_channel(self.category_id)
-        return bool(category and category.overwrites == self.overwrites)
+
+        category_overwrites = remove_empty_permissions(category._overwrites)
+        channel_overwrites = remove_empty_permissions(self._overwrites)
+        
+        return bool(category and category_overwrites == channel_overwrites)
 
     def permissions_for(self, member):
         """Handles permission resolution for the current :class:`~discord.Member`.

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -445,8 +445,8 @@ class GuildChannel:
             new_overwrite = [] # Able to keep it as a list since this is never getting passed
                                # to the user.
             for ow in overwrite: 
-                if not (ow.allow == 0 and ow.deny == 0): # Only compare permissions that
-                    new_overwrite.append(ow)                 # actually matter.
+                if not (ow.allow == 0 and ow.deny == 0): # Only compare permissions
+                    new_overwrite.append(ow)             # that actually matter.
 
             return new_overwrite
         

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -445,7 +445,7 @@ class GuildChannel:
             new_overwrite = [] # Able to keep it as a list since this is never getting passed
                                # to the user.
             for ow in overwrite: 
-                if not ((ow.allow == 0) and (ow.deny == 0)): # Only compare permissions that
+                if not (ow.allow == 0 and ow.deny == 0): # Only compare permissions that
                     new_overwrite.append(ow)                 # actually matter.
 
             return new_overwrite

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -441,20 +441,28 @@ class GuildChannel:
 
         .. versionadded:: 1.3
         """
-        def remove_empty_permissions(overwrite):
+        def in_opposite(id, overwrite):
+            for ow in overwrite:
+                if ow.id == id:
+                    return ow
+            return None     
+
+        def remove_empty_permissions(overwrite, opposite_overwrite):
             new_overwrite = [] # Able to keep it as a list since this is never getting passed
                                # to the user.
-            for ow in overwrite: 
-                if not (ow.allow == 0 and ow.deny == 0): # Only compare permissions
-                    new_overwrite.append(ow)             # that actually matter.
+            for ow in overwrite:
+                if in_opposite(ow.id, opposite_overwrite):
+                    new_overwrite.append(ow._asdict())
+                elif not (ow.allow == 0 and ow.deny == 0):
+                    new_overwrite.append(ow._asdict())
 
             return new_overwrite
-        
+
         category = self.guild.get_channel(self.category_id)
 
-        category_overwrites = remove_empty_permissions(category._overwrites)
-        channel_overwrites = remove_empty_permissions(self._overwrites)
-        
+        category_overwrites = remove_empty_permissions(category._overwrites, self._overwrites)
+        channel_overwrites = remove_empty_permissions(self._overwrites, category._overwrites)
+
         return bool(category and category_overwrites == channel_overwrites)
 
     def permissions_for(self, member):


### PR DESCRIPTION
## Summary

This removes empty permissions to be compared when using `permissions_synced`.
Empty permissions causes the two overwrites to be unequal when comparing. Essentially, I loop through all the permissions in the overwrite and only add non-zero perms to the list, which then I compare.
This fixes #6464.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
