### PR TITLE
Create decompressed_raw_receive event

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -427,6 +427,9 @@ class DiscordWebSocket:
             msg = self._zlib.decompress(self._buffer)
             msg = msg.decode('utf-8')
             self._buffer = bytearray()
+
+        self._dispatch('decompressed_raw_receive', msg)
+
         msg = json.loads(msg)
 
         log.debug('For Shard ID %s: WebSocket Event: %s', self.shard_id, msg)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -200,7 +200,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
 .. function:: on_disconnect()
 
-    Called when the client has disconnected from Discord, or a connection attempt to Discord has failed. 
+    Called when the client has disconnected from Discord, or a connection attempt to Discord has failed.
     This could happen either through the internet being disconnected, explicit calls to logout,
     or Discord terminating the connection one way or the other.
 
@@ -281,6 +281,25 @@ to handle it, which defaults to print a traceback and ignoring the exception.
         exception.
     :param kwargs: The keyword arguments for the event that raised the
         exception.
+
+    .. function:: on_decompressed_raw_receive(msg)
+
+    Called whenever a message is received from the WebSocket and decompressed,
+    but before any further processing has been done to the message. This event
+    is always dispatched when the gateway receives a message. Moreover, no
+    additional processing other than handling decompression is performed.
+
+    This event is mainly useful for debugging and testing purposes.
+
+    .. note::
+
+        This event like the on_socket_raw_receive is only triggered by the
+        client websocket. Voice Websockets will not trigger this event.
+
+    :param msg: The message passed in from the WebSocket library.
+                Could be :class:`bytes` for a binary message or :class:`str`
+                for a regular message.
+    :type msg: Union[:class:`bytes`, :class:`str`]
 
 .. function:: on_socket_raw_receive(msg)
 
@@ -512,7 +531,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
         To get the message being reacted, access it via :attr:`Reaction.message`.
 
     This requires both :attr:`Intents.reactions` and :attr:`Intents.members` to be enabled.
-    
+
     .. note::
 
         Consider using :func:`on_raw_reaction_remove` if you need this and do not want
@@ -1148,7 +1167,7 @@ of :class:`enum.Enum`.
 
         .. versionadded:: 1.7
     .. attribute:: guild_discovery_grace_period_initial_warning
-    
+
         The system message denoting that the guild has failed to meet the Server
         Discovery requirements for one week.
 
@@ -1157,7 +1176,7 @@ of :class:`enum.Enum`.
 
         The system message denoting that the guild has failed to meet the Server
         Discovery requirements for 3 weeks in a row.
-    
+
         .. versionadded:: 1.7
 
 .. class:: ActivityType


### PR DESCRIPTION
A rather simple event to avoid the needing to having to handle decompressing any received data unlike on_socket_raw_receive(msg).

## Summary

A rather simple addition. It simply creates an event called on_decompressed_raw_receive(msg). on_socket_raw_receive(msg) one is required to handle decompression to get any easily readable output when logging or debugging. So this event makes things a little simpler.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
