### PR TITLE
Fix mention prefixes

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -46,7 +46,7 @@ def when_mentioned(bot, msg):
 
     These are meant to be passed into the :attr:`.Bot.command_prefix` attribute.
     """
-    return [bot.user.mention + ' ', '<@!%s> ' % bot.user.id]
+    return [bot.user.mention + ' ', '<@!%s> ' % bot.user.id, bot.user.mention + '  ']
 
 def when_mentioned_or(*prefixes):
     """A callable that implements when mentioned or other prefixes provided.

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -46,7 +46,7 @@ def when_mentioned(bot, msg):
 
     These are meant to be passed into the :attr:`.Bot.command_prefix` attribute.
     """
-    return [bot.user.mention + ' ', '<@!%s> ' % bot.user.id, bot.user.mention + '  ']
+    return [bot.user.mention + ' ', '<@!%s> ' % bot.user.id, bot.user.mention + '  '] #2 space versions as users may add 1 by themselves
 
 def when_mentioned_or(*prefixes):
     """A callable that implements when mentioned or other prefixes provided.


### PR DESCRIPTION
## Summary

It fixes mention-prefixes not being triggered when users add 1 space after the mention by themselves.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ x] This PR fixes an issue.
- [ x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ x] This PR is **not** a code change (e.g. documentation, README, ...)
