### PR TITLE
[docs] suggest presence in constructor instead of change_presence

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -85,7 +85,8 @@ in the repository.
 How do I set the "Playing" status?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There is a method for this under :class:`Client` called :meth:`Client.change_presence`.
+You may specify the ``activity`` keyword argument in the :class:`Client` constructor.
+There is also a method for this called :meth:`Client.change_presence`.
 The relevant aspect of this is its ``activity`` keyword argument which takes in an :class:`Activity` object.
 
 The status type (playing, listening, streaming, watching) can be set using the :class:`ActivityType` enum.
@@ -96,11 +97,11 @@ For memory optimisation purposes, some activities are offered in slimmed down ve
 
 Putting both of these pieces of info together, you get the following: ::
 
-    await client.change_presence(activity=discord.Game(name='my game'))
+    client = discord.Client(activity=discord.Game(name='my game'))
 
     # or, for watching:
     activity = discord.Activity(name='my activity', type=discord.ActivityType.watching)
-    await client.change_presence(activity=activity)
+    client = discord.Client(activity=activity)
 
 How do I send a message to a specific channel?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -85,9 +85,15 @@ in the repository.
 How do I set the "Playing" status?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You may specify the ``activity`` keyword argument in the :class:`Client` constructor.
+The ``activity`` keyword argument may be passed in the :class:`Client` constructor, given an :class:`Activity` object.
+
 There is also a method for this called :meth:`Client.change_presence`.
-The relevant aspect of this is its ``activity`` keyword argument which takes in an :class:`Activity` object.
+
+.. warning::
+
+    It is highly discouraged to use :meth:`Client.change_presence` or API calls in :func:`on_ready` as this event may be called many times while running, not just once.
+
+    Discord has a high chance to completely disconnect you during the ``READY`` or ``GUILD_CREATE`` events (``1006`` close code) and there is nothing you can do to prevent it.
 
 The status type (playing, listening, streaming, watching) can be set using the :class:`ActivityType` enum.
 For memory optimisation purposes, some activities are offered in slimmed down versions:

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -93,7 +93,7 @@ There is also a method for this called :meth:`Client.change_presence`.
 
     It is highly discouraged to use :meth:`Client.change_presence` or API calls in :func:`on_ready` as this event may be called many times while running, not just once.
 
-    Discord has a high chance to completely disconnect you during the ``READY`` or ``GUILD_CREATE`` events (``1006`` close code) and there is nothing you can do to prevent it.
+    There is a high chance of disconnecting if presences are changed right after connecting.
 
 The status type (playing, listening, streaming, watching) can be set using the :class:`ActivityType` enum.
 For memory optimisation purposes, some activities are offered in slimmed down versions:

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -85,9 +85,9 @@ in the repository.
 How do I set the "Playing" status?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``activity`` keyword argument may be passed in the :class:`Client` constructor, given an :class:`Activity` object.
+The ``activity`` keyword argument may be passed in the :class:`Client` constructor or :meth:`Client.change_presence`, given an :class:`Activity` object.
 
-There is also a method for this called :meth:`Client.change_presence`.
+The constructor may be used for static activities, while :meth:`Client.change_presence` may be used to update the activity at runtime.
 
 .. warning::
 


### PR DESCRIPTION
## Summary

Change the `How do I set the “Playing” status?` FAQ entry to point out the `activity` keyword arg in the `Client` constructor.
Also replaces the examples to show setting the activity by the constructor instead of `change_presence`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
