### PR TITLE
Implementation of the Discord API v8

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -59,6 +59,7 @@ from .audit_logs import AuditLogChanges, AuditLogEntry, AuditLogDiff
 from .raw_models import *
 from .team import *
 from .sticker import Sticker
+from .command import *
 
 VersionInfo = namedtuple('VersionInfo', 'major minor micro releaselevel serial')
 

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -72,7 +72,7 @@ def _transform_overwrites(entry, data):
 
         ow_type = elem['type']
         ow_id = int(elem['id'])
-        if ow_type == str(0):
+        if ow_type == 'role':
             target = entry.guild.get_role(ow_id)
         else:
             target = entry._get_member(ow_id)

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -72,7 +72,7 @@ def _transform_overwrites(entry, data):
 
         ow_type = elem['type']
         ow_id = int(elem['id'])
-        if ow_type == 'role':
+        if ow_type == str(0):
             target = entry.guild.get_role(ow_id)
         else:
             target = entry._get_member(ow_id)

--- a/discord/client.py
+++ b/discord/client.py
@@ -29,7 +29,6 @@ import logging
 import signal
 import sys
 import traceback
-import re
 
 import aiohttp
 

--- a/discord/command.py
+++ b/discord/command.py
@@ -1,0 +1,603 @@
+# -*- coding: utf-8 -*-
+
+"""
+The MIT License (MIT)
+
+Copyright (c) 2021-present Trainjo
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+import re
+
+from . import utils
+from .enums import ApplicationCommandOptionType, try_enum
+from .mixins import Hashable
+from .errors import InvalidArgument
+
+__all__ = (
+    'ApplicationCommand',
+    'ApplicationCommandOption',
+    'ApplicationCommandOptionChoice',
+)
+
+NAME_PATTERN = re.compile("^[\w-]{1,32}$")
+DESCRIPTION_PATTERN = re.compile("^.{1,100}$")
+CHOICE_NAME_PATTERN = re.compile("^.{1,100}$")
+CHOICE_VALUE_PATTERN = re.compile("^.{1,100}$")
+
+SUB_COMMAND_OPTIONS = (ApplicationCommandOptionType.string,
+                       ApplicationCommandOptionType.integer,
+                       ApplicationCommandOptionType.boolean,
+                       ApplicationCommandOptionType.user,
+                       ApplicationCommandOptionType.channel,
+                       ApplicationCommandOptionType.role,
+                       )
+SUB_COMMAND_GROUP_OPTIONS = (ApplicationCommandOptionType.sub_command,
+                             )
+
+def is_valid_name(name):
+    """Return whether ``name`` is valid as a name for
+    :class:`ApplicationCommand` or :class:`ApplicationCommandOption`
+
+    """
+    return NAME_PATTERN.match(name) is not None
+
+def is_valid_description(description):
+    """Return whether ``description`` is valid as a description for
+    :class:`ApplicationCommand` or :class:`ApplicationCommandOption`
+
+    """
+    return DESCRIPTION_PATTERN.match(description) is not None
+
+def is_valid_choice_name(name):
+    """Return whether ``name`` is valid as a name for
+    :class:`ApplicationCommandOptionChoice`
+
+    """
+    return CHOICE_NAME_PATTERN.match(name) is not None
+
+def is_valid_choice_value(value):
+    """Return whether ``value`` is valid as a value for
+    :class:`ApplicationCommandOptionChoice`
+
+    """
+    return CHOICE_VALUE_PATTERN.match(value) is not None
+
+class ApplicationCommand(Hashable):
+    """Represents a Discord application command.
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two commands are equal.
+
+        .. describe:: x != y
+
+            Checks if two commands are not equal.
+
+        .. describe:: hash(x)
+    
+            Return the command's hash
+
+    Attributes
+    ----------
+    id: :class:`int`
+        The command ID.
+    application_id: :class:`int`
+        The ID of the application this command belongs to.
+    guild: Optional[:class:`Guild`]
+        The Guild this command belongs to, if any.
+    name: :class:`str`
+        The name of this command
+    description: :class:`str`
+        The description of this command.
+    options: List[:class:`ApplicationCommandOption`]
+        A list of command options.
+    
+    """
+
+    __slots__ = ('id', 'application_id', 'name', 'description',
+                 'options', '_state', 'guild')
+    
+    def __init__(self, *, state, guild=None, data):
+        self._state = state
+        self._update(guild=guild, data=data)
+
+    def _update(self, *, guild=None, data):
+        self.guild = guild or getattr(self, "guild", None)
+        self.id = utils._get_as_snowflake(data, 'id')
+        self.application_id = utils._get_as_snowflake(data, 'application_id')
+        self.name = data['name']
+        self.description = data['description']
+        self.options = [ApplicationCommandOption(data=option) for option in data.get('options', [])]
+
+    def __repr__(self):
+        result = f"<ApplicationCommand name={self.name} id={self.id} application_id={self.application_id}"
+        if self.guild is not None:
+            result += f" guild_id={self.guild.id}"
+        result += ">"
+        return result
+
+    def copy(self):
+        """Make a copy of this ApplicationCommmand."""
+        data = {'id' : self.id,
+                'application_id' : self.application_id,
+                'name' : self.name,
+                'description' : self.description,
+                'options' : [option.to_dict() for option in self.options]}
+        return ApplicationCommand(state=self._state, guild=self.guild, data=data)
+
+    async def edit(self, **data):
+        """|coro|
+
+        Edit this command.
+
+        Parameters
+        -----------
+        name: :class:`str`
+            The new name for the command.
+        description: :class:`str`
+            The new description of the command.
+        options: Optional[List[:class:`ApplicationCommandOption`]]
+            The new list of :class:`ApplicationCommandOption` for this command.
+            Can be set to `None` to remove all options from this command.
+
+        Raises
+        -------
+        :exc:`HTTPException`
+            Editing the command failed.
+
+        """
+
+        payload = {}
+
+        name = data.get('name')
+        if name is not None:
+            payload['name'] = name
+
+        description = data.get('description')
+        if description is not None:
+            payload['description'] = description
+
+        try:
+            options = data['options']
+        except KeyError:
+            pass
+        else:
+            if options is not None:
+                options = [option.to_dict() for option in options]
+            payload['options'] = options
+
+        if self.guild is None:
+            data = await self._state.http.edit_global_application_command(self.application_id, self.id, **payload)
+        else:
+            data = await self._state.http.edit_guild_application_command(self.application_id, self.guild.id,
+                                                                         self.id, **payload)
+        self._update(data=data)
+
+    async def delete(self):
+        """|coro|
+
+        Delete this command.
+
+        Raises
+        -------
+        :exc:`HTTPException`
+            Deleting this command failed.
+
+        """
+        if self.guild is None:
+            await self._state.http.delete_global_application_command(self.application_id, self.id)
+        else:
+            await self._state.http.delete_guild_application_command(self.application_id, self.guild.id, self.id)
+        self._state._remove_command(self)
+
+class ApplicationCommandOption:
+    """Represents an option of a Discord command.
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two options are equal.
+
+        .. describe:: x != y
+
+            Checks if two options are not equal.
+
+    Attributes
+    -----------
+    name: :class:`str`
+        The name of the command option.
+    description: :class:`str`
+        The description of the command option.
+    required: :class:`bool`
+        Whether this command option is required or optional.
+    choices: List[:class:`ApplicationCommandOptionChoice`]
+        A list of choices for this command option. Only non-empty when the command option
+        has type :attr:`.enums.ApplicationCommandOptionType.string`
+        or :attr:`.enums.ApplicationCommandOptionType.integer`.
+    options: List[:class:`ApplicationCommandOption`]
+        A list of options for this command option. Only non-empty when the command option
+        has type :attr:`.enums.ApplicationCommandOptionType.sub_command`
+        or :attr:`.enums.ApplicationCommandOptionType.sub_command_group`.
+
+    """
+
+    __slots__ = ('_state', '_type', 'name', 'description', 'required',
+                 'choices', 'options')
+
+    def __init__(self, *, data):
+        self._update(data)
+
+    def _update(self, data):
+        self._type = data['type']
+        self.name = data['name']
+        self.description = data['description']
+        self.required = data.get('required', False)
+        self.choices = [ApplicationCommandOptionChoice(data=choice) for choice in data.get('choices', [])]
+        self.options = [ApplicationCommandOption(data=option) for option in data.get('options', [])]
+
+    @property
+    def type(self):
+        """:class:`.enums.ApplicationCommandOptionType`: The type of the command option."""
+        return try_enum(ApplicationCommandOptionType, self._type)
+
+    def to_dict(self):
+        result = {'type' : self.type.value,
+                  'name' : self.name,
+                  'description' : self.description}
+        if self.required:
+            result['required'] = self.required
+        if len(self.choices) > 0:
+            result['choices'] = [choice.to_dict() for choice in self.choices]
+        if len(self.options) > 0:
+            result['options'] = [option.to_dict() for option in self.options]
+        return result
+
+    def __eq__(self, other):
+        return (isinstance(other, ApplicationCommandOption) and
+                self.type == other.type and
+                self.name == other.name and
+                self.required == other.required and
+                self.choices == other.choices and
+                self.options == other.options)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return f"<ApplicationCommandOption type={self.type} name={self.name}>"
+
+    @classmethod
+    def SubCommand(cls, *, name, description, options=None):
+        """Create a command option that is a sub command.
+
+        Attributes
+        -----------
+        name: :class:`str`
+            The 1-32 character name of the command. It may only consist of letters
+            and the dash '-' symbol.
+        description: :class:`str`
+            The 1-100 character description of the command.
+        options: Optional[List[:class:`.ApplicationCommandOption`]]
+            A list of options for the command. Can be set to ``None`` to not include any options.
+            May not contain options of type :attr:`.enums.ApplicationCommandOptionType.sub_command`
+            or :attr:`.enums.ApplicationCommandOptionType.sub_command_group`. Can contain at most
+            25 options.
+
+        Raises
+        -------
+        :exc:`.InvalidArgument`
+            One of the arguments is invalid.
+        
+        """
+        if not is_valid_name(name):
+            raise InvalidArgument(f"The name '{name}' is not valid.")        
+        if not is_valid_description(description):
+            raise InvalidArgument(f"The description '{description}' is not valid.")
+        if options is None:
+            options = []
+        if len(options) > 25:
+            raise InvalidArgument(f"The options '{options}' contain more than 25 choices.")
+        for option in options:
+            if option.type not in SUB_COMMAND_OPTIONS:
+                raise InvalidArgument(f"Options of type '{option.type}' are invalid for sub commands.")
+        t = ApplicationCommandOptionType.sub_command
+        return cls(data={'type' : t, 'name' : name, 'description' : description,
+                         'options' : [option.to_dict() for option in options]})
+
+    @classmethod
+    def SubCommandGroup(cls, *, name, description, options=None):
+        """Create a command option that is a sub command group.
+
+        Attributes
+        -----------
+        name: :class:`str`
+            The 1-32 character name of the command group. It may only consist of letters
+            and the dash '-' symbol.
+        description: :class:`str`
+            The 1-100 character description of the command group.
+        options: Optional[List[:class:`.ApplicationCommandOption`]]
+            A list of options for the command group. Can be set to ``None`` to not include any options.
+            May only contain options of type :attr:`.enums.ApplicationCommandOptionType.sub_command`.
+            Can contain at most 25 options.
+
+        Raises
+        -------
+        :exc:`.InvalidArgument`
+            One of the arguments is invalid.
+        
+        """
+        if not is_valid_name(name):
+            raise InvalidArgument(f"The name '{name}' is not valid.")        
+        if not is_valid_description(description):
+            raise InvalidArgument(f"The description '{description}' is not valid.")
+        if options is None:
+            options = []
+        if len(options) > 25:
+            raise InvalidArgument(f"The options '{options}' contain more than 25 choices.")
+        for option in options:
+            if option.type not in SUB_COMMAND_GROUP_OPTIONS:
+                raise InvalidArgument(f"Options of type '{option.type}' are invalid for sub command groups.")
+        t = ApplicationCommandOptionType.sub_command_group
+        return cls(data={'type' : t, 'name' : name, 'description' : description,
+                         'options' : [option.to_dict() for option in options]})
+
+    @classmethod
+    def String(cls, *, name, description, required=True, choices=None):
+        """Create a command option that is a String argument.
+
+        Attributes
+        -----------
+        name: :class:`str`
+            The 1-32 character name of the argument. It may only consist of letters
+            and the dash '-' symbol.
+        description: :class:`str`
+            The 1-100 character description of the argument.
+        required: :class:`bool`
+            Whether this argument is required or optional. By default set to ``True```
+        choices: Optional[Mapping[:class:`str`, :class`str`]]
+            A mapping of choice names to their corresponding values. If set to ``None`` this option
+            will have no choices, but accepts any :class:`str`. There may be at most 25 choices,
+            where each choice name and value must be between 1 and 100 characters.
+
+        Raises
+        -------
+        :exc:`.InvalidArgument`
+            One of the arguments is invalid.
+        
+        """
+        if not is_valid_name(name):
+            raise InvalidArgument(f"The name '{name}' is not valid.")        
+        if not is_valid_description(description):
+            raise InvalidArgument(f"The description '{description}' is not valid.")
+        if choices is None:
+            choices = {}
+        if len(choices) > 25:
+            raise InvalidArgument(f"The choices '{choices}' contain more than 25 choices.")
+        choice_list = []
+        for n, v in choices.items():
+            if not is_valid_choice_name(n):
+                raise InvalidArgument(f"The name '{n}' is not valid for a choice.")
+            if not is_valid_choice_value(v):
+                raise InvalidArgument(f"The value '{v}' is not valid for a choice.")
+            choice_list.append({'name' : n, 'value' : v})
+        t = ApplicationCommandOptionType.string
+        return cls(data={'type' : t, 'name' : name, 'description' : description,
+                         'required' : required, 'choices' : choice_list})
+
+    @classmethod
+    def Integer(cls, *, name, description, required=True, choices=None):
+        """Create a command option that is a Integer argument.
+
+        Attributes
+        -----------
+        name: :class:`str`
+            The 1-32 character name of the argument. It may only consist of letters
+            and the dash '-' symbol.
+        description: :class:`str`
+            The 1-100 character description of the argument.
+        required: :class:`bool`
+            Whether this argument is required or optional. By default set to ``True```
+        choices: Optional[Mapping[:class:`str`, :class`int`]]
+            A mapping of choice names to their corresponding values. If set to ``None`` this option
+            will have no choices, but accepts any :class:`int`. There may be at most 25 choices,
+            where each choice name must be between 1 and 100 characters.
+
+        Raises
+        -------
+        :exc:`.InvalidArgument`
+            One of the arguments is invalid.
+        
+        """
+        if not is_valid_name(name):
+            raise InvalidArgument(f"The name '{name}' is not valid.")        
+        if not is_valid_description(description):
+            raise InvalidArgument(f"The description '{description}' is not valid.")
+        if choices is None:
+            choices = {}
+        if len(choices) > 25:
+            raise InvalidArgument(f"The choices '{choices}' contain more than 25 choices.")
+        choice_list = []
+        for n, v in choices.items():
+            if not is_valid_choice_name(n):
+                raise InvalidArgument(f"The name '{n}' is not valid for a choice.")
+            if not isinstance(v, int):
+                raise InvalidArgument(f"The value '{v}' is not valid for a choice.")
+            choice_list.append({'name' : n, 'value' : v})
+        t = ApplicationCommandOptionType.integer
+        return cls(data={'type' : t, 'name' : name, 'description' : description,
+                         'required' : required, 'choices' : choice_list})
+
+    @classmethod
+    def Boolean(cls, *, name, description, required=True):
+        """Create a command option that is a Boolean argument.
+
+        Attributes
+        -----------
+        name: :class:`str`
+            The 1-32 character name of the argument. It may only consist of letters
+            and the dash '-' symbol.
+        description: :class:`str`
+            The 1-100 character description of the argument.
+        required: :class:`bool`
+            Whether this argument is required or optional. By default set to ``True```
+
+        Raises
+        -------
+        :exc:`.InvalidArgument`
+            One of the arguments is invalid.
+        
+        """
+        if not is_valid_name(name):
+            raise InvalidArgument(f"The name '{name}' is not valid.")        
+        if not is_valid_description(description):
+            raise InvalidArgument(f"The description '{description}' is not valid.")
+        t = ApplicationCommandOptionType.boolean
+        return cls(data={'type' : t, 'name' : name, 'description' : description, 'required' : required})
+
+    @classmethod
+    def User(cls, *, name, description, required=True):
+        """Create a command option that is a User argument.
+
+        Attributes
+        -----------
+        name: :class:`str`
+            The 1-32 character name of the argument. It may only consist of letters
+            and the dash '-' symbol.
+        description: :class:`str`
+            The 1-100 character description of the argument.
+        required: :class:`bool`
+            Whether this argument is required or optional. By default set to ``True```
+
+        Raises
+        -------
+        :exc:`.InvalidArgument`
+            One of the arguments is invalid.
+        
+        """
+        if not is_valid_name(name):
+            raise InvalidArgument(f"The name '{name}' is not valid.")        
+        if not is_valid_description(description):
+            raise InvalidArgument(f"The description '{description}' is not valid.")
+        t = ApplicationCommandOptionType.user
+        return cls(data={'type' : t, 'name' : name, 'description' : description, 'required' : required})
+
+    @classmethod
+    def Channel(cls, *, name, description, required=True):
+        """Create a command option that is a Channel argument.
+
+        Attributes
+        -----------
+        name: :class:`str`
+            The 1-32 character name of the argument. It may only consist of letters
+            and the dash '-' symbol.
+        description: :class:`str`
+            The 1-100 character description of the argument.
+        required: :class:`bool`
+            Whether this argument is required or optional. By default set to ``True```
+
+        Raises
+        -------
+        :exc:`.InvalidArgument`
+            One of the arguments is invalid.
+        
+        """
+        if not is_valid_name(name):
+            raise InvalidArgument(f"The name '{name}' is not valid.")        
+        if not is_valid_description(description):
+            raise InvalidArgument(f"The description '{description}' is not valid.")
+        t = ApplicationCommandOptionType.channel
+        return cls(data={'type' : t, 'name' : name, 'description' : description, 'required' : required})
+
+    @classmethod
+    def Role(cls, *, name, description, required=True):
+        """Create a command option that is a Role argument.
+
+        Attributes
+        -----------
+        name: :class:`str`
+            The 1-32 character name of the argument. It may only consist of letters
+            and the dash '-' symbol.
+        description: :class:`str`
+            The 1-100 character description of the argument.
+        required: :class:`bool`
+            Whether this argument is required or optional. By default set to ``True```
+
+        Raises
+        -------
+        :exc:`.InvalidArgument`
+            One of the arguments is invalid.
+        
+        """
+        if not is_valid_name(name):
+            raise InvalidArgument(f"The name '{name}' is not valid.")        
+        if not is_valid_description(description):
+            raise InvalidArgument(f"The description '{description}' is not valid.")
+        t = ApplicationCommandOptionType.role
+        return cls(data={'type' : t, 'name' : name, 'description' : description, 'required' : required})
+
+class ApplicationCommandOptionChoice:
+    """Represents a choice for a Discord command option.
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two options are equal.
+
+        .. describe:: x != y
+
+            Checks if two options are not equal.
+
+    Attributes
+    -----------
+    name: :class:`str`
+        The name of the choice.
+    value: Union[:class:`str`, :class:`int`]
+        The value of the choice. The type of the value depends on
+        the type of the corresponding option.
+
+    """
+
+    def __init__(self, *, data):
+        self._update(data)
+
+    def _update(self, data):
+        self.name = data['name']
+        self.value = data['value']
+
+    def to_dict(self):
+        return {'name' : self.name,
+                'value' : self.value}
+
+    def __eq__(self, other):
+        return (isinstance(other, ApplicationCommandOptionChoice) and
+                self.name == other.name and
+                self.value == other.value)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return f"<ApplicationCommandOptionChoice name={self.name} value={self.value}>"
+

--- a/discord/command.py
+++ b/discord/command.py
@@ -3,7 +3,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Trainjo
+Copyright (c) 2021-present Rapptz
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -288,7 +288,7 @@ class ApplicationCommandOption:
         return f"<ApplicationCommandOption type={self.type} name={self.name}>"
 
     @classmethod
-    def SubCommand(cls, *, name, description, options=None):
+    def sub_command(cls, *, name, description, options=None):
         """Create a command option that is a sub command.
 
         Attributes
@@ -326,7 +326,7 @@ class ApplicationCommandOption:
                          'options' : [option.to_dict() for option in options]})
 
     @classmethod
-    def SubCommandGroup(cls, *, name, description, options=None):
+    def sub_command_group(cls, *, name, description, options=None):
         """Create a command option that is a sub command group.
 
         Attributes
@@ -363,7 +363,7 @@ class ApplicationCommandOption:
                          'options' : [option.to_dict() for option in options]})
 
     @classmethod
-    def String(cls, *, name, description, required=True, choices=None):
+    def string(cls, *, name, description, required=True, choices=None):
         """Create a command option that is a String argument.
 
         Attributes
@@ -406,7 +406,7 @@ class ApplicationCommandOption:
                          'required' : required, 'choices' : choice_list})
 
     @classmethod
-    def Integer(cls, *, name, description, required=True, choices=None):
+    def integer(cls, *, name, description, required=True, choices=None):
         """Create a command option that is a Integer argument.
 
         Attributes
@@ -449,7 +449,7 @@ class ApplicationCommandOption:
                          'required' : required, 'choices' : choice_list})
 
     @classmethod
-    def Boolean(cls, *, name, description, required=True):
+    def boolean(cls, *, name, description, required=True):
         """Create a command option that is a Boolean argument.
 
         Attributes
@@ -476,7 +476,7 @@ class ApplicationCommandOption:
         return cls(data={'type' : t, 'name' : name, 'description' : description, 'required' : required})
 
     @classmethod
-    def User(cls, *, name, description, required=True):
+    def user(cls, *, name, description, required=True):
         """Create a command option that is a User argument.
 
         Attributes
@@ -503,7 +503,7 @@ class ApplicationCommandOption:
         return cls(data={'type' : t, 'name' : name, 'description' : description, 'required' : required})
 
     @classmethod
-    def Channel(cls, *, name, description, required=True):
+    def channel(cls, *, name, description, required=True):
         """Create a command option that is a Channel argument.
 
         Attributes
@@ -530,7 +530,7 @@ class ApplicationCommandOption:
         return cls(data={'type' : t, 'name' : name, 'description' : description, 'required' : required})
 
     @classmethod
-    def Role(cls, *, name, description, required=True):
+    def role(cls, *, name, description, required=True):
         """Create a command option that is a Role argument.
 
         Attributes

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -470,8 +470,8 @@ class InteractionType(Enum):
 
 class InteractionResponseType(Enum):
     pong = 1
-    acknowledge = 2
-    channel_message = 3
+    acknowledge = 2 # deprecated
+    channel_message = 3 # deprecated
     channel_message_with_source = 4
     deferred_channel_message_with_source = 5
 

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -53,6 +53,7 @@ __all__ = (
     'ExpireBehaviour',
     'ExpireBehavior',
     'StickerType',
+    'PermissionOverwriteType',
 )
 
 def _create_value_cls(name):
@@ -181,6 +182,8 @@ class MessageType(Enum):
     guild_discovery_requalified                  = 15
     guild_discovery_grace_period_initial_warning = 16
     guild_discovery_grace_period_final_warning   = 17
+    reply                                        = 19
+    application_command                          = 20
 
 class VoiceRegion(Enum):
     us_west       = 'us-west'
@@ -455,6 +458,10 @@ class StickerType(Enum):
     png = 1
     apng = 2
     lottie = 3
+
+class PermissionOverwriteType(Enum):
+    role = 0
+    member = 1
 
 def try_enum(cls, val):
     """A function that tries to turn the value into enum ``cls``.

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -54,6 +54,7 @@ __all__ = (
     'ExpireBehavior',
     'StickerType',
     'PermissionOverwriteType',
+    'InteractionType',
 )
 
 def _create_value_cls(name):
@@ -462,6 +463,27 @@ class StickerType(Enum):
 class PermissionOverwriteType(Enum):
     role = 0
     member = 1
+
+class InteractionType(Enum):
+    ping = 1
+    application_command = 2
+
+class InteractionResponseType(Enum):
+    pong = 1
+    acknowledge = 2
+    channel_message = 3
+    channel_message_with_source = 4
+    deferred_channel_message_with_source = 5
+
+class ApplicationCommandOptionType(Enum):
+    sub_command = 1
+    sub_command_group = 2
+    string = 3
+    integer = 4
+    boolean = 5
+    user = 6
+    channel = 7
+    role = 8
 
 def try_enum(cls, val):
     """A function that tries to turn the value into enum ``cls``.

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -390,7 +390,7 @@ class DiscordWebSocket:
         if state._activity is not None or state._status is not None:
             payload['d']['presence'] = {
                 'status': state._status,
-                'game': state._activity,
+                'activities': [state._activity],
                 'since': 0,
                 'afk': False
             }
@@ -613,7 +613,7 @@ class DiscordWebSocket:
         payload = {
             'op': self.PRESENCE,
             'd': {
-                'game': activity,
+                'activities': [activity],
                 'afk': afk,
                 'since': since,
                 'status': status

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1936,7 +1936,7 @@ class Guild(Hashable):
         try:
             perms = fields.pop('permissions')
         except KeyError:
-            fields['permissions'] = str(0)
+            fields['permissions'] = "0"
         else:
             fields['permissions'] = str(perms.value)
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -833,9 +833,9 @@ class Guild(Hashable):
             }
 
             if isinstance(target, Role):
-                payload['type'] = 'role'
+                payload['type'] = 0
             else:
-                payload['type'] = 'member'
+                payload['type'] = 1
 
             perms.append(payload)
 
@@ -1818,9 +1818,9 @@ class Guild(Hashable):
         try:
             perms = fields.pop('permissions')
         except KeyError:
-            fields['permissions'] = 0
+            fields['permissions'] = str(0)
         else:
-            fields['permissions'] = perms.value
+            fields['permissions'] = str(perms.value)
 
         try:
             colour = fields.pop('colour')

--- a/discord/http.py
+++ b/discord/http.py
@@ -145,7 +145,6 @@ class HTTPClient:
         # header creation
         headers = {
             'User-Agent': self.user_agent,
-            'X-Ratelimit-Precision': 'millisecond', # Ignored, but is in miliseconds anyway
         }
 
         if self.token is not None:
@@ -940,7 +939,7 @@ class HTTPClient:
             'name' : name,
             'description' : description,
         }
-        if options != None:
+        if options is not None:
             payload['options'] = options
         r = Route('POST', '/applications/{application_id}/commands', application_id=application_id)
         return self.request(r, json=payload)
@@ -970,7 +969,7 @@ class HTTPClient:
             'name' : name,
             'description' : description,
         }
-        if options != None:
+        if options is not None:
             payload['options'] = options
         r = Route('POST', '/applications/{application_id}/guilds/{guild_id}/commands',
                   application_id=application_id, guild_id=guild_id)
@@ -1010,10 +1009,10 @@ class HTTPClient:
         r = Route('POST', '/webhooks/{application_id}/{interaction_token}',
                   application_id=application_id, interaction_token=interaction_token)
 
-        if (file != None or files != None):
+        if file is not None or files is not None:
             form = aiohttp.FormData()
             form.add_field('payload_json', utils.to_json(payload))
-            if file != None:
+            if file is not None:
                 if files is None:
                     files = []
                 files.append(file)

--- a/discord/http.py
+++ b/discord/http.py
@@ -51,7 +51,7 @@ async def json_or_text(response):
     return text
 
 class Route:
-    BASE = 'https://discord.com/api/v7'
+    BASE = 'https://discord.com/api/v8'
 
     def __init__(self, method, path, **parameters):
         self.path = path
@@ -145,7 +145,7 @@ class HTTPClient:
         # header creation
         headers = {
             'User-Agent': self.user_agent,
-            'X-Ratelimit-Precision': 'millisecond',
+            'X-Ratelimit-Precision': 'millisecond', # Ignored, but is in miliseconds anyway
         }
 
         if self.token is not None:
@@ -408,7 +408,7 @@ class HTTPClient:
         return self.request(r, reason=reason)
 
     def delete_messages(self, channel_id, message_ids, *, reason=None):
-        r = Route('POST', '/channels/{channel_id}/messages/bulk_delete', channel_id=channel_id)
+        r = Route('POST', '/channels/{channel_id}/messages/bulk-delete', channel_id=channel_id)
         payload = {
             'messages': message_ids
         }
@@ -934,7 +934,7 @@ class HTTPClient:
     def application_info(self):
         return self.request(Route('GET', '/oauth2/applications/@me'))
 
-    async def get_gateway(self, *, encoding='json', v=6, zlib=True):
+    async def get_gateway(self, *, encoding='json', v=8, zlib=True):
         try:
             data = await self.request(Route('GET', '/gateway'))
         except HTTPException as exc:
@@ -945,7 +945,7 @@ class HTTPClient:
             value = '{0}?encoding={1}&v={2}'
         return value.format(data['url'], encoding, v)
 
-    async def get_bot_gateway(self, *, encoding='json', v=6, zlib=True):
+    async def get_bot_gateway(self, *, encoding='json', v=8, zlib=True):
         try:
             data = await self.request(Route('GET', '/gateway/bot'))
         except HTTPException as exc:

--- a/discord/http.py
+++ b/discord/http.py
@@ -1005,26 +1005,24 @@ class HTTPClient:
                   application_id=application_id, interaction_token=interaction_token)
         return self.request(r)
 
-    def create_followup_message(self, application_id, interaction_token, *, file=None, files=None, **payload):
+    def send_followup_message(self, application_id, interaction_token, *, **payload):
+        r = Route('POST', '/webhooks/{application_id}/{interaction_token}',
+                  application_id=application_id, interaction_token=interaction_token)
+        return self.request(r, json=payload)
+
+    def send_followup_files(self, application_id, interaction_token, *, files=None, **payload):
         r = Route('POST', '/webhooks/{application_id}/{interaction_token}',
                   application_id=application_id, interaction_token=interaction_token)
 
-        if file is not None or files is not None:
-            form = aiohttp.FormData()
-            form.add_field('payload_json', utils.to_json(payload))
-            if file is not None:
-                if files is None:
-                    files = []
-                files.append(file)
-            if len(files) == 1:
-                file = files[0]
-                form.add_field('file', file.fp, filename=file.filename, content_type='application/octet-stream')
-            else:
-                for index, file in enumerate(files):
-                    form.add_field('file%s' % index, file.fp, filename=file.filename, content_type='application/octet-stream')
-            return self.request(r, data=form, files=files)
+        form = aiohttp.FormData()
+        form.add_field('payload_json', utils.to_json(payload))
+        if len(files) == 1:
+            file = files[0]
+            form.add_field('file', file.fp, filename=file.filename, content_type='application/octet-stream')
         else:
-            return self.request(r, json=payload)
+            for index, file in enumerate(files):
+                form.add_field('file%s' % index, file.fp, filename=file.filename, content_type='application/octet-stream')
+        return self.request(r, data=form, files=files)
 
     def edit_followup_message(self, application_id, interaction_token, message_id, **payload):
         r = Route('PATCH', '/webhooks/{application_id}/{interaction_token}/messages/{message_id}',

--- a/discord/http.py
+++ b/discord/http.py
@@ -929,6 +929,114 @@ class HTTPClient:
         }
         return self.request(r, json=payload)
 
+    # Interaction related
+
+    def get_global_application_commands(self, application_id):
+        r = Route('GET', '/applications/{application_id}/commands', application_id=application_id)
+        return self.request(r)
+
+    def create_global_application_command(self, application_id, *, name, description, options=None):
+        payload = {
+            'name' : name,
+            'description' : description,
+        }
+        if options != None:
+            payload['options'] = options
+        r = Route('POST', '/applications/{application_id}/commands', application_id=application_id)
+        return self.request(r, json=payload)
+
+    def get_global_application_command(self, application_id, command_id):
+        r = Route('GET', '/applications/{application_id}/commands/{command_id}',
+                  application_id=application_id, command_id=command_id)
+        return self.request(r)
+
+    def edit_global_application_command(self, application_id, command_id, **payload):
+        r = Route('PATCH', '/applications/{application_id}/commands/{command_id}',
+                  application_id=application_id, command_id=command_id)
+        return self.request(r, json=payload)
+
+    def delete_global_application_command(self, application_id, command_id):
+        r = Route('DELETE', '/applications/{application_id}/commands/{command_id}',
+                  application_id=application_id, command_id=command_id)
+        return self.request(r)
+
+    def get_guild_application_commands(self, application_id, guild_id):
+        r = Route('GET', '/applications/{application_id}/guilds/{guild_id}/commands',
+                  application_id=application_id, guild_id=guild_id)
+        return self.request(r)
+
+    def create_guild_application_command(self, application_id, guild_id, name, description, options=None):
+        payload = {
+            'name' : name,
+            'description' : description,
+        }
+        if options != None:
+            payload['options'] = options
+        r = Route('POST', '/applications/{application_id}/guilds/{guild_id}/commands',
+                  application_id=application_id, guild_id=guild_id)
+        return self.request(r, json=payload)
+
+    def get_guild_application_command(self, application_id, guild_id, command_id):
+        r = Route('GET', '/applications/{application_id}/guilds/{guild_id}/commands/{command_id}',
+                  application_id=application_id, guild_id=guild_id, command_id=command_id)
+        return self.request(r)
+
+    def edit_guild_application_command(self, application_id, guild_id, command_id, **payload):
+        r = Route('PATCH', '/applications/{application_id}/guilds/{guild_id}/commands/{command_id}',
+                  application_id=application_id, guild_id=guild_id, command_id=command_id)
+        return self.request(r, json=payload)
+
+    def delete_guild_application_command(self, application_id, guild_id, command_id):
+        r = Route('DELETE', '/applications/{application_id}/guilds/{guild_id}/commands/{command_id}',
+                  application_id=application_id, guild_id=guild_id, command_id=command_id)
+        return self.request(r)
+
+    def create_interaction_response(self, interaction_id, interaction_token, response):
+        r = Route('POST', '/interactions/{interaction_id}/{interaction_token}/callback',
+                  interaction_id=interaction_id, interaction_token=interaction_token)
+        return self.request(r, json=response)
+
+    def edit_interaction_response(self, application_id, interaction_token, **payload):
+        r = Route('PATCH', '/webhooks/{application_id}/{interaction_token}/messages/@original',
+                  application_id=application_id, interaction_token=interaction_token)
+        return self.request(r, json=payload)
+
+    def delete_interaction_response(self, application_id, interaction_token):
+        r = Route('DELETE', '/webhooks/{application_id}/{interaction_token}/messages/@original',
+                  application_id=application_id, interaction_token=interaction_token)
+        return self.request(r)
+
+    def create_followup_message(self, application_id, interaction_token, *, file=None, files=None, **payload):
+        r = Route('POST', '/webhooks/{application_id}/{interaction_token}',
+                  application_id=application_id, interaction_token=interaction_token)
+
+        if (file != None or files != None):
+            form = aiohttp.FormData()
+            form.add_field('payload_json', utils.to_json(payload))
+            if file != None:
+                if files is None:
+                    files = []
+                files.append(file)
+            if len(files) == 1:
+                file = files[0]
+                form.add_field('file', file.fp, filename=file.filename, content_type='application/octet-stream')
+            else:
+                for index, file in enumerate(files):
+                    form.add_field('file%s' % index, file.fp, filename=file.filename, content_type='application/octet-stream')
+            return self.request(r, data=form, files=files)
+        else:
+            return self.request(r, json=payload)
+
+    def edit_followup_message(self, application_id, interaction_token, message_id, **payload):
+        r = Route('PATCH', '/webhooks/{application_id}/{interaction_token}/messages/{message_id}',
+                  application_id=application_id, interaction_token=interaction_token, message_id=message_id)
+        return self.request(r, json=payload)
+
+    def delete_followup_message(self, application_id, interaction_token, message_id):
+        r = Route('DELETE', '/webhooks/{application_id}/{interaction_token}/messages/{message_id}',
+                  application_id=application_id, interaction_token=interaction_token, message_id=message_id)
+        return self.request(r)
+
     # Misc
 
     def application_info(self):

--- a/discord/interaction.py
+++ b/discord/interaction.py
@@ -1,0 +1,661 @@
+# -*- coding: utf-8 -*-
+
+"""
+The MIT License (MIT)
+
+Copyright (c) 2021-present Trainjo
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from .enums import InteractionType, InteractionResponseType, ApplicationCommandOptionType, try_enum
+from .member import Member
+from .user import User
+from .mixins import Hashable
+from .message import Message
+from .errors import InvalidArgument
+
+__all__ = (
+    'Interaction',
+    'InteractionMessage',
+)
+
+def _parse_command_interaction_options_raw(options):
+    result = {}
+    for option in options:
+        name = option['name']
+        try:
+            value = option['value']
+        except KeyError:
+            value = _parse_command_interaction_options_raw(option.get('options', []))
+        result[name] = value
+    return result
+
+def _parse_command_interaction_options(state, options, values, guild=None):
+    result = {}
+    for option in options:
+        try:
+            value = values[option.name]
+        except KeyError:
+            continue
+        
+        if (option.type == ApplicationCommandOptionType.sub_command or
+            option.type == ApplicationCommandOptionType.sub_command_group):
+            value = _parse_command_interaction_options(state, option.options, value, guild=guild)
+            
+        if option.type == ApplicationCommandOptionType.string:
+            value = str(value)
+            
+        if option.type == ApplicationCommandOptionType.integer:
+            value = int(value)
+            
+        if option.type == ApplicationCommandOptionType.boolean:
+            value = bool(value)
+            
+        if option.type == ApplicationCommandOptionType.user:
+            value = state.get_user(int(value))
+            
+        if option.type == ApplicationCommandOptionType.channel:
+            value = state.get_channel(int(value))
+            
+        if option.type == ApplicationCommandOptionType.role:
+            if guild is not None:
+                value = guild.get_role(int(value))
+
+        result[option.name] = value
+
+    return result
+
+class Interaction(Hashable):
+    """Represents a Discord interaction.
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two interactions are equal
+
+        .. describe:: x != y
+
+            Checks if two interactions are not equal
+
+        .. describe:: hash(x)
+
+            Returns the interaction's hash
+
+    Attributes
+    ----------
+    id: :class:`int`
+        The interaction ID.
+    channel: Optional[Union[:class:`abc.Messageable`]]
+        The :class:`TextChannel` that this interaction was invoked from, if any.
+        Could be a :class:`DMChannel`or :class:`GroupChannel` if invoked in a private channel.
+    guild: Optional[:class:`Guild`]
+        The :class:`Guild` that this interaction was invoked from, if any.
+    member: Optional[:class:`Member`]
+        The :class:`Member` that invoked this interaction, if invoked from a :class:`Guild`
+    version: :class:`int`
+        Always 1.
+    responded: :class:`bool`
+        Whether the bot has responded to this interaction yet.
+    command_id: Optional[:class:`int`]
+        The ID of the command that invoked this interaction, if any.
+    command_name: Optional[:class:`str`]
+        The name of the command that invoked this interaction, if any.
+    raw_options: Optional[Mapping[:class:`str`, Any]]
+        The options passed to the command as given by discord, if any. This is a mapping of
+        an option name to its value. If the option itself had sub options, the value is a
+        similar mapping. Use ``options`` for values of the correct type.
+    """
+
+    __slots__ = ('_state', 'id', '_type', 'channel', 'guild',
+                 'member', '_token', 'version', 'responded',
+                 'command_id', 'command_name', 'raw_options')
+    
+    def __init__(self, *, state, guild=None, channel=None, data):
+        self._state = state
+        self.id = int(data['id'])
+        self._type = data['type']
+        self.channel = channel
+        self.guild = guild
+        if self.is_command_interaction():
+            command_data = data['data']
+            self.command_id = int(command_data['id'])
+            self.command_name = command_data['name']
+            self.raw_options = _parse_command_interaction_options_raw(command_data.get('options', []))
+        else:
+            self.command_id = self.command = self.options = None
+        try:
+            self.member = Member(data=data['member'], guild=guild, state=state)
+        except KeyError:
+            self.member = None
+        if 'user' in data:
+            self.user = self._state.store_user(data['user'])
+        self._token = data['token']
+        self.version = data['version']
+        self.responded = False
+
+    @property
+    def user(self):
+        """Optional[:class:`User`]: The :class:`User` that invoked this interaction, if any."""
+        return getattr(self, "member", None)
+
+    @property
+    def type(self):
+        """:class:`InteractionType`: The interaction's Discord type."""
+        return try_enum(InteractionType, self._type)
+
+    @property
+    def command(self):
+        """Optional[:class:`ApplicationCommand`]: The command that invoked this interaction, if any.
+        If the command was not stored in the local state, this is always ``None``."""
+        return self.command_id and self._state._get_command(self.command_id)
+
+    @property
+    def options(self):
+        """Optional[Mapping[:class:`str`, Any]]: The options passed to the
+        command, if any.  This is a mapping of an option name to its
+        value. If the option itself had sub options, the value is a
+        similar mapping. Otherwise the value is of the type specified
+        by the command.
+
+        """
+        return (self.command and
+                self.raw_options and
+                _parse_command_interaction_options(self._state, self.command.options,
+                                                   self.raw_options, guild=self.guild))
+
+    def __repr__(self):
+        result = f"<Interaction id={self.id} type={self.type}"
+        if self.user != None:
+            result += f" user={self.user}"
+        if self.channel != None:
+            result += f" channel={self.channel}"
+        result += ">"
+        return result
+
+    def is_ping(self):
+        """Whether this Interaction is a ping."""
+        return self.type == InteractionType.ping
+
+    def is_command_interaction(self):
+        """Whether this Interaction was invoked by a command."""
+        return self.type == InteractionType.application_command
+    
+    async def send_response(self, content=None, *, tts=None, embed=None, embeds=None,
+                            allowed_mentions=None, ephemeral=False):
+        """|coro|
+
+        Responds to an interaction.
+
+        The content must be a type that can convert to a string through ``str(content)``.
+
+        If the ``embed`` parameter is provided, it must be of type :class:`Embed` and
+        it must be a rich embed type. You cannot mix the ``embed`` parameter with the
+        ``embeds`` parameter, which must be a :class:`list` of :class:`Embed` objects to send.
+
+        If this interaction is a ping all provided arguments are ignored.
+
+        One should use this method within 3 seconds of receiving the
+        interaction. After that the interaction will remain valid for 15 minutes. For long
+        computations you should use this method with ``None`` to create a temporary message
+        that the bot is thinking, which can later be edited with ``edit_response``.
+
+        Parameters
+        ------------
+        content: Optional[:class:`str`]
+            The content of the response to send. If set to ``None`` will display a
+            message that a response will be sent later
+        ephemeral: :class:`bool`
+            Whether the response should be visible only to the user that invoked
+            this interaction.
+        tts: :class:`bool`
+            Indicates if the response should be sent using text-to-speech.
+        embed: :class:`Embed`
+            The rich embed for the response. This cannot be mixed with
+            ``embeds`` parameter.
+        embeds: List[:class:`Embed`]
+            A list of embeds to send with the response. Maximum of 10. This cannot
+            be mixed with the ``embed`` parameter.
+        allowed_mentions: :class:`AllowedMentions`
+            Controls the mentions being processed in this response.
+
+        Raises
+        --------
+        HTTPException
+            Sending the response failed.
+        NotFound
+            This interaction was not found.
+        Forbidden
+            The interaction token has expired.
+        InvalidArgument
+            You have already sent a response to this interaction or you specified
+            both ``embed`` and ``embeds`` or the length of ``embeds`` was invalid.
+
+        """
+        if self.responded:
+            raise InvalidArgument(f"Can not respond to {self} twice, use edit_response instead.")
+        if embeds is not None and embed is not None:
+            raise InvalidArgument('Cannot mix embed and embeds keyword arguments.')
+        if (embeds is not None) and len(embeds) > 10:
+            raise InvalidArgument('embeds has a maximum of 10 elements.')
+
+        if embed is not None:
+            embeds = [embed]
+
+        if self.is_ping():
+            response = InteractionResponse(pong=True)
+        else:
+            response = InteractionResponse(content=content, tts=tts, embeds=embeds,
+                                           allowed_mentions=allowed_mentions, ephemeral=ephemeral)
+        await self._state.http.create_interaction_response(self.id, self._token, response.to_dict())
+        self.responded = True
+
+    def edit_response(self, **fields):
+        """|coro|
+
+        Edit the response to this interaction.
+
+        The content must be able to be transformed into a string via ``str(content)``.
+
+        Parameters
+        ------------
+        content: Optional[:class:`str`]
+            The content to edit the response with or ``None`` to clear it.
+        embeds: List[:class:`Embed`]
+            A list of embeds to edit the response with.
+        embed: Optional[:class:`Embed`]
+            The embed to edit the response with. ``None`` suppresses the embeds.
+            This should not be mixed with the ``embeds`` parameter.
+        allowed_mentions: Optional[:class:`AllowedMentions`]
+            Controls the mentions being processed in the response. ``None``
+            suppresses all mentions.
+
+        Raises
+        -------
+        HTTPException
+            Editing the response failed.
+        Forbidden
+            The interaction token has expired.
+        InvalidArgument
+            You have not responded to this interaction yet or you specified
+            both ``embed`` and ``embeds`` or the length of ``embeds`` was invalid.
+        """
+        payload = {}
+        
+        if not self.responded:
+            raise InvalidArgument(f"Can not edit a response of {self} if no response was sent yet.")
+
+        try:
+            content = fields['content']
+        except KeyError:
+            pass
+        else:
+            if content is not None:
+                content = str(content)
+            payload['content'] = content
+
+        try:
+            embeds = fields['embeds']
+        except KeyError:
+            pass
+        else:
+            if embeds is None:
+                payload['embeds'] = None
+            else:
+                if len(embeds) > 10:
+                    raise InvalidArgument('embeds has a maximum of 10 elements')
+                payload['embeds'] = [embed.to_dict() for embed in embeds]
+
+        try:
+            embed = fields['embed']
+        except KeyError:
+            pass
+        else:
+            if 'embeds' in payload:
+                raise InvalidArgument('Cannot mix embed and embeds keyword arguments')
+            if embed is None:
+                payload['embeds'] = None
+            else:
+                payload['embeds'] = [embed.to_dict()]
+                
+        try:
+            allowed_mentions = fields['allowed_mentions']
+        except KeyError:
+            pass
+        else:
+            payload['allowed_mentions'] = allowed_mentions.to_dict()
+
+        return self._state.http.edit_interaction_response(self._state.application_id, self._token, **payload)
+
+    def delete_response(self):
+        """|coro|
+
+        Delete the response to this interaction.
+
+        Raises
+        ------
+        Forbidden
+            The interaction token has expired.
+        NotFound
+            There was no response for this interaction or the response was ephemeral.
+        HTTPException
+            Deleting the response failed.
+        """
+        return self._state.http.delete_interaction_response(self._state.application_id, self._token)
+
+    async def send_message(self, content=None, *, username=None,
+                           avatar_url=None, tts=False, file=None, files=None, embed=None,
+                           embeds=None, allowed_mentions=None, ephemeral=False):
+        """|coro|
+
+        Sends a followup message on this interaction.
+
+        The content must be a type that can convert to a string through ``str(content)``.
+
+        To upload a single file, the ``file`` parameter should be used with a
+        single :class:`File` object.
+
+        If the ``embed`` parameter is provided, it must be of type :class:`Embed` and
+        it must be a rich embed type. You cannot mix the ``embed`` parameter with the
+        ``embeds`` parameter, which must be a :class:`list` of :class:`Embed` objects to send.
+
+        Parameters
+        ------------
+        content: :class:`str`
+            The content of the message to send.
+        username: :class:`str`
+            The username to send with this message. Right now this is ignored by
+            discord and the default username is always used.
+        avatar_url: Union[:class:`str`, :class:`Asset`]
+            The avatar URL to send with this message. Right now this is ignored by
+            discord and the default avatar is always used.
+        tts: :class:`bool`
+            Indicates if the message should be sent using text-to-speech.
+        file: :class:`File`
+            The file to upload. This cannot be mixed with ``files`` parameter.
+        files: List[:class:`File`]
+            A list of files to send with the content. This cannot be mixed with the
+            ``file`` parameter.
+        embed: :class:`Embed`
+            The rich embed for the content to send. This cannot be mixed with
+            ``embeds`` parameter.
+        embeds: List[:class:`Embed`]
+            A list of embeds to send with the content. Maximum of 10. This cannot
+            be mixed with the ``embed`` parameter.
+        allowed_mentions: :class:`AllowedMentions`
+            Controls the mentions being processed in this message.
+        ephemeral: :class:`bool`
+            Whether this message should be visible only to the user that invoked
+            this interaction.
+
+        Raises
+        --------
+        HTTPException
+            Sending the message failed.
+        InvalidArgument
+            You specified both ``file`` and ``files`` or you specified both
+            ``embed`` and ``embeds`` or the length of ``embeds`` was invalid.
+
+        Returns
+        ---------
+        :class:`InteractionMessage`
+            The message that was sent.
+        """
+
+        payload = {}
+        if files is not None and file is not None:
+            raise InvalidArgument('Cannot mix file and files keyword arguments.')
+        if embeds is not None and embed is not None:
+            raise InvalidArgument('Cannot mix embed and embeds keyword arguments.')
+
+        if embeds is not None:
+            if len(embeds) > 10:
+                raise InvalidArgument('embeds has a maximum of 10 elements.')
+            payload['embeds'] = [e.to_dict() for e in embeds]
+
+        if embed is not None:
+            payload['embeds'] = [embed.to_dict()]
+
+        if content is not None:
+            payload['content'] = str(content)
+
+        payload['tts'] = tts
+        if avatar_url is not None:
+            payload['avatar_url'] = str(avatar_url)
+        if username is not None:
+            payload['username'] = username
+
+        if allowed_mentions is not None:
+            payload['allowed_mentions'] = allowed_mentions.to_dict()
+
+        if ephemeral:
+            payload['flags'] = 64
+
+        data = await self._state.http.create_followup_message(self._state.application_id, self._token, file=file, files=files, **payload)
+        return InteractionMessage(interaction=self, data=data)
+
+    def edit_message(self, message_id, **fields):
+        """|coro|
+
+        Edits a message sent on this interaction.
+
+        This is a lower level interface to :meth:`InteractionMessage.edit` in case
+        you only have an ID.
+
+        Parameters
+        ------------
+        message_id: :class:`int`
+            The message ID to edit.
+        content: Optional[:class:`str`]
+            The content to edit the message with or ``None`` to clear it.
+        embeds: List[:class:`Embed`]
+            A list of embeds to edit the message with.
+        embed: Optional[:class:`Embed`]
+            The embed to edit the message with. ``None`` suppresses the embeds.
+            This should not be mixed with the ``embeds`` parameter.
+        allowed_mentions: :class:`AllowedMentions`
+            Controls the mentions being processed in this message.
+
+        Raises
+        -------
+        HTTPException
+            Editing the message failed.
+        InvalidArgument
+            You specified both ``embed`` and ``embeds`` or the length of
+            ``embeds`` was invalid.
+        """
+
+        payload = {}
+
+        try:
+            content = fields['content']
+        except KeyError:
+            pass
+        else:
+            if content is not None:
+                content = str(content)
+            payload['content'] = content
+
+        try:
+            embeds = fields['embeds']
+        except KeyError:
+            pass
+        else:
+            if embeds is None:
+                payload['embeds'] = None
+            else:
+                if len(embeds) > 10:
+                    raise InvalidArgument('embeds has a maximum of 10 elements')
+                payload['embeds'] = [embed.to_dict() for embed in embeds]
+
+        try:
+            embed = fields['embed']
+        except KeyError:
+            pass
+        else:
+            if 'embeds' in payload:
+                raise InvalidArgument('Cannot mix embed and embeds keyword arguments')
+            if embed is None:
+                payload['embeds'] = None
+            else:
+                payload['embeds'] = [embed.to_dict()]
+                
+        try:
+            allowed_mentions = fields['allowed_mentions']
+        except KeyError:
+            pass
+        else:
+            payload['allowed_mentions'] = allowed_mentions.to_dict()
+
+        return self._state.http.edit_followup_message(self._state.application_id, self._token, message_id, **payload)
+
+    def delete_message(self, message_id):
+        """|coro|
+
+        Deletes a message sent on this interaction.
+
+        This is a lower level interface to :meth:`InteractionMessage.delete` in case
+        you only have an ID.
+
+        Parameters
+        ------------
+        message_id: :class:`int`
+            The message ID to delete.
+
+        Raises
+        -------
+        HTTPException
+            Deleting the message failed.
+        """
+        return self._state.http.delete_followup_message(self._state.application_id, self._token, message_id)
+
+class InteractionResponse:
+    """Represents a response to an :class:`Interaction`
+    
+    """
+
+    def __init__(self, *, pong=False, content=None, tts=None,
+                 embeds=None, allowed_mentions=None, ephemeral=False):
+        if pong:
+            self.type = InteractionResponseType.pong
+        else:
+            if content is None and embeds is None:
+                self.type = InteractionResponseType.deferred_channel_message_with_source
+            else:
+                self.type = InteractionResponseType.channel_message_with_source
+            self.content = content
+            self.tts = tts
+            self.embeds = embeds
+            self.allowed_mentions = allowed_mentions
+            self.ephemeral = ephemeral
+
+    def to_dict(self):
+        result = {'type' : self.type.value}
+
+        data = {}
+        if self.content is not None:
+            data['content'] = str(self.content)
+        if self.tts != None:
+            data['tts'] = self.tts
+        if self.embeds is not None:
+            data['embeds'] = [embed.to_dict() for embed in self.embeds]
+        if self.allowed_mentions is not None:
+            data['allowed_mentions'] = self.allowed_mentions.to_dict()
+        if self.ephemeral:
+            data['flags'] = 64
+        if len(data) > 0:
+            result['data'] = data
+            
+        return result
+
+class InteractionMessage(Message):
+    """Represents a message sent through an interaction.
+
+    This allows you to edit or delete a message sent through an
+    interaction you received.
+
+    This inherits from :class:`discord.Message` with changes to
+    :meth:`edit` and :meth:`delete` to work.
+
+    """
+
+    __slots__ = ('_interaction')
+    
+    def __init__(self, *, interaction, data):
+        self._interaction = interaction
+        Message.__init__(self, state=interaction._state, channel=interaction.channel, data=data)
+
+    def edit(self, **fields):
+        """|coro|
+
+        Edits the message.
+
+        The content must be able to be transformed into a string via ``str(content)``.
+
+        Parameters
+        ------------
+        content: Optional[:class:`str`]
+            The content to edit the message with or ``None`` to clear it.
+        embeds: List[:class:`Embed`]
+            A list of embeds to edit the message with.
+        embed: Optional[:class:`Embed`]
+            The embed to edit the message with. ``None`` suppresses the embeds.
+            This should not be mixed with the ``embeds`` parameter.
+        allowed_mentions: :class:`AllowedMentions`
+            Controls the mentions being processed in this message.
+            See :meth:`.abc.Messageable.send` for more information.
+
+        Raises
+        -------
+        HTTPException
+            Editing the message failed.
+        InvalidArgument
+            You specified both ``embed`` and ``embeds`` or the length of
+            ``embeds`` was invalid.
+        """
+        return self._interaction.edit_message(self.id, **fields)
+
+    def _delete_delay_sync(self, delay):
+        time.sleep(delay)
+        return self._state._webhook.delete_message(self.id)
+
+    async def _delete_delay_async(self, delay):
+        async def inner_call():
+            await asyncio.sleep(delay)
+            try:
+                await self._state._webhook.delete_message(self.id)
+            except HTTPException:
+                pass
+
+        asyncio.ensure_future(inner_call(), loop=self._state.loop)
+        return await asyncio.sleep(0)
+
+    def delete(self):
+        """|coro|
+
+        Deletes the message.
+
+        Raises
+        ------
+        HTTPException
+            Deleting the message failed.
+        """
+
+        return self._interaction.delete_message(self.id)

--- a/discord/interaction.py
+++ b/discord/interaction.py
@@ -425,6 +425,9 @@ class Interaction(Hashable):
         if embed is not None:
             payload['embeds'] = [embed.to_dict()]
 
+        if file is not None:
+            files = [file]
+
         if content is not None:
             payload['content'] = str(content)
 
@@ -440,7 +443,12 @@ class Interaction(Hashable):
         if ephemeral:
             payload['flags'] = 64
 
-        data = await self._state.http.create_followup_message(self._state.application_id, self._token, file=file, files=files, **payload)
+        if files:
+            data = await self._state.http.send_followup_files(self._state.application_id, self._token,
+                                                              files=files, **payload)
+        else:
+            data = await self._state.http.send_followup_message(self._state.application_id, self._token, **payload)
+            
         return InteractionMessage(interaction=self, data=data)
 
     def edit_message(self, message_id, **fields):

--- a/discord/interaction.py
+++ b/discord/interaction.py
@@ -134,7 +134,7 @@ class Interaction(Hashable):
         self._type = data['type']
         self.channel = channel
         self.guild = guild
-        if self.is_command_interaction():
+        if self.type == InteractionType.application_command:
             command_data = data['data']
             self.command_id = int(command_data['id'])
             self.command_name = command_data['name']
@@ -189,14 +189,6 @@ class Interaction(Hashable):
             result += f" channel={self.channel}"
         result += ">"
         return result
-
-    def is_ping(self):
-        """Whether this Interaction is a ping."""
-        return self.type == InteractionType.ping
-
-    def is_command_interaction(self):
-        """Whether this Interaction was invoked by a command."""
-        return self.type == InteractionType.application_command
     
     async def send_response(self, content=None, *, tts=None, embed=None, embeds=None,
                             allowed_mentions=None, ephemeral=False):
@@ -259,7 +251,7 @@ class Interaction(Hashable):
         if embed is not None:
             embeds = [embed]
 
-        if self.is_ping():
+        if self.type == InteractionType.ping:
             response = InteractionResponse(pong=True)
         else:
             response = InteractionResponse(content=content, tts=tts, embeds=embeds,

--- a/discord/interaction.py
+++ b/discord/interaction.py
@@ -3,7 +3,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2021-present Trainjo
+Copyright (c) 2021-present Rapptz
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -183,9 +183,9 @@ class Interaction(Hashable):
 
     def __repr__(self):
         result = f"<Interaction id={self.id} type={self.type}"
-        if self.user != None:
+        if self.user is not None:
             result += f" user={self.user}"
-        if self.channel != None:
+        if self.channel is not None:
             result += f" channel={self.channel}"
         result += ">"
         return result
@@ -253,7 +253,7 @@ class Interaction(Hashable):
             raise InvalidArgument(f"Can not respond to {self} twice, use edit_response instead.")
         if embeds is not None and embed is not None:
             raise InvalidArgument('Cannot mix embed and embeds keyword arguments.')
-        if (embeds is not None) and len(embeds) > 10:
+        if embeds is not None and len(embeds) > 10:
             raise InvalidArgument('embeds has a maximum of 10 elements.')
 
         if embed is not None:
@@ -631,21 +631,6 @@ class InteractionMessage(Message):
             ``embeds`` was invalid.
         """
         return self._interaction.edit_message(self.id, **fields)
-
-    def _delete_delay_sync(self, delay):
-        time.sleep(delay)
-        return self._state._webhook.delete_message(self.id)
-
-    async def _delete_delay_async(self, delay):
-        async def inner_call():
-            await asyncio.sleep(delay)
-            try:
-                await self._state._webhook.delete_message(self.id)
-            except HTTPException:
-                pass
-
-        asyncio.ensure_future(inner_call(), loop=self._state.loop)
-        return await asyncio.sleep(0)
 
     def delete(self):
         """|coro|

--- a/discord/member.py
+++ b/discord/member.py
@@ -175,7 +175,12 @@ class Member(discord.abc.Messageable, _BaseUser):
         self.guild = guild
         self.joined_at = utils.parse_time(data.get('joined_at'))
         self.premium_since = utils.parse_time(data.get('premium_since'))
-        self._update_roles(data)
+        if 'roles' in data:
+            self._update_roles(data)
+        else:
+            # No roles when created by PRESENCE_UPDATE
+            # Should hopefully be overridden soon
+            self._roles = []
         self._client_status = {
             None: 'offline'
         }

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -96,7 +96,10 @@ class Permissions(BaseFlags):
 
     def __init__(self, permissions=0, **kwargs):
         if not isinstance(permissions, int):
-            raise TypeError('Expected int parameter, received %s instead.' % permissions.__class__.__name__)
+            try:
+                permissions = int(permissions)
+            except ValueError:
+                raise TypeError('Expected int parameter, received %s instead.' % permissions.__class__.__name__)
 
         self.value = permissions
         for key, value in kwargs.items():

--- a/discord/role.py
+++ b/discord/role.py
@@ -188,7 +188,7 @@ class Role(Hashable):
 
     def _update(self, data):
         self.name = data['name']
-        self._permissions = int(data.get('permissions_new', 0))
+        self._permissions = int(data.get('permissions', 0))
         self.position = data.get('position', 0)
         self._colour = data.get('color', 0)
         self.hoist = data.get('hoist', False)


### PR DESCRIPTION
## Summary

Since discord has marked v8 of their API as default (and I wanted to use discord.py with slashcommands myself), I decided to put in the work and make all the necessary changes. This includes:
- minor changes in some existing code to reflect changes announced in [this post](https://discord.com/developers/docs/change-log#api-and-gateway-v8). Do not seem to be breaking changes. Public methods work the same and documentation remains the same
- Added classes ApplicationCommand, ApplicationCommandOption, ApplicationCommandOptionChoice, Interaction, and InteractionResponse for the [corresponding Discord objects](https://discord.com/developers/docs/interactions/slash-commands#data-models-and-types).
- Additional enums for the types of the objects mentioned.
- Modified Client and Guild with methods to create and fetch ApplicationCommand objects
- ApplicationComand comes with methods to edit and delete the command.
- Interaction comes with methods to send, edit and delete both responses and followup messages.
- Guild and ConnectionState were modified to track ApplicationCommand objects such that Interaction can refer to them without fetching.
- ConnectionState now saves the application_id send on the READY gateway event, so creating an ApplicationCommand does not require a fetch of the application information.
- ConnectionState was modified to parse the new gateway events: APPLICATION_COMMAND_CREATE, APPLICATION_COMMAND_UPDATE, APPLICATION_COMMAND_DELETE, and INTERACTION_CREATE. These now fire command_create, command_update, command_delete, and interaction events respectively with the data converted to the corresponding python object.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

## Testing the changes

I made a simple program that will go through most of the added features to test them. I put it on a separate branch [here](https://github.com/jmvlangen/discord.py/tree/testing)

## About the choices made

- To avoid confusion with the normal discord.py command framework, I have chosen to implement the commands under the name ApplicationCommand as used in the [API documention](https://discord.com/developers/docs/interactions/slash-commands#applicationcommand). This is also reflected in the corresponding methods. Although the methods of client use the term "global_command" instead, as to avoid long names like "create_global_application_command"
- I have chosen for a barebones implementation of slash commands here, just providing the necessary python interfaces to interact with all features of slash comands documented in the discord API documentation. This leaves handling commands to the bot creator by listening to the interaction event. I think a way to use commands like the bot framework in discord.py would be good to implement, but probably should not be implemented in the core discord module. Also to avoid confusion with the normal command framework.
