### PR TITLE
Deprecate Client.logout

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -511,10 +511,13 @@ class Client:
         await self.http.static_login(token.strip(), bot=bot)
         self._connection.is_bot = bot
 
+    @utils.deprecated('Client.close')
     async def logout(self):
         """|coro|
 
         Logs out of Discord and closes all connections.
+        
+        .. deprecated:: 1.7
 
         .. note::
 
@@ -675,7 +678,7 @@ class Client:
             try:
                 loop.run_until_complete(start(*args, **kwargs))
             except KeyboardInterrupt:
-                loop.run_until_complete(logout())
+                loop.run_until_complete(close())
                 # cancel all tasks lingering
             finally:
                 loop.close()

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -201,7 +201,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 .. function:: on_disconnect()
 
     Called when the client has disconnected from Discord, or a connection attempt to Discord has failed. 
-    This could happen either through the internet being disconnected, explicit calls to logout,
+    This could happen either through the internet being disconnected, explicit calls to close,
     or Discord terminating the connection one way or the other.
 
     This function can be called many times without a corresponding :func:`on_connect` call.


### PR DESCRIPTION
## Summary
Deprecates `Client.logout` which is just an alias of `Client.close`, and change documents to replace "logout" with "close".

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
