### PR TITLE
Deprecate afk argument of Client.change_presence

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -1043,6 +1043,8 @@ class Client:
             client to know how to handle push notifications better
             for you in case you are actually idle and not lying.
 
+            .. deprecated:: 1.7
+
         Raises
         ------
         :exc:`.InvalidArgument`

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -490,6 +490,9 @@ class AutoShardedClient(Client):
             Indicates if you are going AFK. This allows the discord
             client to know how to handle push notifications better
             for you in case you are actually idle and not lying.
+
+            .. deprecated:: 1.7
+
         shard_id: Optional[:class:`int`]
             The shard_id to change the presence to. If not specified
             or ``None``, then it will change the presence of every


### PR DESCRIPTION
## Summary
Deprecates `afk` argument of Client/AutoSharededClient.change_presence.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
