### PR TITLE
Add StoreChannelConverter

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -50,6 +50,7 @@ __all__ = (
     'PartialEmojiConverter',
     'CategoryChannelConverter',
     'IDConverter',
+    'StoreChannelConverter',
     'clean_content',
     'Greedy',
 )
@@ -434,6 +435,45 @@ class CategoryChannelConverter(IDConverter):
                 result = _get_from_guilds(bot, 'get_channel', channel_id)
 
         if not isinstance(result, discord.CategoryChannel):
+            raise ChannelNotFound(argument)
+
+        return result
+    
+class StoreChannelConverter(IDConverter):
+    """Converts to a :class:`~discord.StoreChannel`.
+
+    All lookups are via the local guild. If in a DM context, then the lookup
+    is done by the global cache.
+
+    The lookup strategy is as follows (in order):
+
+    1. Lookup by ID.
+    2. Lookup by mention.
+    3. Lookup by name
+    """
+    
+    async def convert(self, ctx, argument):
+        bot = ctx.bot
+        match = self._get_id_match(argument) or re.match(r'<#([0-9]+)>$', argument)
+        result = None
+        guild = ctx.guild
+        
+        if match is None:
+            # not a mention
+            if guild:
+                result = discord.utils.get(guild.channels, name=argument)
+            else:
+                def check(c):
+                    return isinstance(c, discord.StoreChannel) and c.name == argument
+                result = discord.utils.find(check, bot.get_all_channels())
+        else:
+            channel_id = int(match.group(1))
+            if guild:
+                result = guild.get_channel(channel_id)
+            else:
+                result = _get_from_guilds(bot, 'get_channel', channel_id)
+
+        if not isinstance(result, discord.StoreChannel):
             raise ChannelNotFound(argument)
 
         return result


### PR DESCRIPTION
Add a channel converter to convert an argument to a StoreChannelConverter

## Summary

This is to add a converter to convert an argument to a StoreChannel.

When i was making a command to get a channel's info... i found out that StoreChannel doesn't have its own converter
(or even proper docs) so I want to add one because it'd be useful even if only a few guilds have store channels

Its in the same style as all the other channel converters

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
