### PR TITLE
Implement voice region changing for voice channels

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -257,6 +257,11 @@ class GuildChannel:
         except KeyError:
             pass
 
+        try:
+            options['rtc_region'] = options.pop('rtc_region')
+        except KeyError:
+            pass
+
         lock_permissions = options.pop('sync_permissions', False)
 
         try:

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -258,9 +258,11 @@ class GuildChannel:
             pass
 
         try:
-            options['rtc_region'] = options.pop('rtc_region')
+            rtc_region = options.pop('rtc_region')
         except KeyError:
             pass
+        else:
+            options['rtc_region'] = None if rtc_region is None else str(rtc_region)
 
         lock_permissions = options.pop('sync_permissions', False)
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -575,10 +575,15 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
         The channel's preferred audio bitrate in bits per second.
     user_limit: :class:`int`
         The channel's limit for number of members that can be in a voice channel.
+    rtc_region: Optional[:class:`VoiceRegion`]
+        The new region for the voice channel's voice communication.
+
+        .. versionadded:: 1.7
     """
 
     __slots__ = ('name', 'id', 'guild', 'bitrate', 'user_limit',
-                 '_state', 'position', '_overwrites', 'category_id')
+                 '_state', 'position', '_overwrites', 'category_id',
+                 'rtc_region')
 
     def __init__(self, *, state, guild, data):
         self._state = state
@@ -589,6 +594,7 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
         attrs = [
             ('id', self.id),
             ('name', self.name),
+            ('rtc_region', self.rtc_region),
             ('position', self.position),
             ('bitrate', self.bitrate),
             ('user_limit', self.user_limit),
@@ -609,7 +615,8 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
 
     def _update(self, guild, data):
         self.guild = guild
-        self.name = data['name']
+        self.name = data.get('name')
+        self.rtc_region = data['rtc_region']
         self.category_id = utils._get_as_snowflake(data, 'parent_id')
         self.position = data['position']
         self.bitrate = data.get('bitrate')
@@ -700,6 +707,10 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
         overwrites: :class:`dict`
             A :class:`dict` of target (either a role or a member) to
             :class:`PermissionOverwrite` to apply to the channel.
+        rtc_region: Optional[:class:`VoiceRegion`]
+            The new region for the voice channel's voice communication.
+
+            .. versionadded:: 1.7
 
         Raises
         ------

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -576,7 +576,8 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
     user_limit: :class:`int`
         The channel's limit for number of members that can be in a voice channel.
     rtc_region: Optional[:class:`VoiceRegion`]
-        The new region for the voice channel's voice communication.
+        The region for the voice channel's voice communication.
+        A value of ``None`` indicates automatic voice region detection.
 
         .. versionadded:: 1.7
     """
@@ -711,6 +712,7 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
             :class:`PermissionOverwrite` to apply to the channel.
         rtc_region: Optional[:class:`VoiceRegion`]
             The new region for the voice channel's voice communication.
+            A value of ``None`` indicates automatic voice region detection.
 
             .. versionadded:: 1.7
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -29,7 +29,7 @@ import asyncio
 
 import discord.abc
 from .permissions import Permissions
-from .enums import ChannelType, try_enum
+from .enums import ChannelType, try_enum, VoiceRegion
 from .mixins import Hashable
 from . import utils
 from .asset import Asset
@@ -615,8 +615,10 @@ class VoiceChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hashable):
 
     def _update(self, guild, data):
         self.guild = guild
-        self.name = data.get('name')
-        self.rtc_region = data['rtc_region']
+        self.name = data['name']
+        self.rtc_region = data.get('rtc_region')
+        if self.rtc_region:
+            self.rtc_region = try_enum(VoiceRegion, self.rtc_region)
         self.category_id = utils._get_as_snowflake(data, 'parent_id')
         self.position = data['position']
         self.bitrate = data.get('bitrate')

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -840,6 +840,11 @@ class Guild(Hashable):
             perms.append(payload)
 
         try:
+            options['rate_limit_per_user'] = options.pop('slowmode_delay')
+        except KeyError:
+            pass
+
+        try:
             rtc_region = options.pop('rtc_region')
         except KeyError:
             pass

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -840,9 +840,11 @@ class Guild(Hashable):
             perms.append(payload)
 
         try:
-            options['rate_limit_per_user'] = options.pop('slowmode_delay')
+            rtc_region = options.pop('rtc_region')
         except KeyError:
             pass
+        else:
+            options['rtc_region'] = None if rtc_region is None else str(rtc_region)
 
         try:
             options['rtc_region'] = options.pop('rtc_region')

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -844,6 +844,11 @@ class Guild(Hashable):
         except KeyError:
             pass
 
+        try:
+            options['rtc_region'] = options.pop('rtc_region')
+        except KeyError:
+            pass
+
         parent_id = category.id if category else None
         return self._state.http.create_channel(self.id, channel_type.value, name=name, parent_id=parent_id,
                                                permission_overwrites=perms, **options)

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -846,11 +846,6 @@ class Guild(Hashable):
         else:
             options['rtc_region'] = None if rtc_region is None else str(rtc_region)
 
-        try:
-            options['rtc_region'] = options.pop('rtc_region')
-        except KeyError:
-            pass
-
         parent_id = category.id if category else None
         return self._state.http.create_channel(self.id, channel_type.value, name=name, parent_id=parent_id,
                                                permission_overwrites=perms, **options)

--- a/discord/http.py
+++ b/discord/http.py
@@ -584,11 +584,10 @@ class HTTPClient:
         r = Route('PATCH', '/channels/{channel_id}', channel_id=channel_id)
         valid_keys = ('name', 'parent_id', 'topic', 'bitrate', 'nsfw',
                       'user_limit', 'position', 'permission_overwrites', 'rate_limit_per_user',
-                      'type')
+                      'type', 'rtc_region')
         payload = {
             k: v for k, v in options.items() if k in valid_keys
         }
-
         return self.request(r, reason=reason, json=payload)
 
     def bulk_channel_update(self, guild_id, data, *, reason=None):
@@ -601,7 +600,8 @@ class HTTPClient:
         }
 
         valid_keys = ('name', 'parent_id', 'topic', 'bitrate', 'nsfw',
-                      'user_limit', 'position', 'permission_overwrites', 'rate_limit_per_user')
+                      'user_limit', 'position', 'permission_overwrites', 'rate_limit_per_user',
+                      'rtc_region')
         payload.update({
             k: v for k, v in options.items() if k in valid_keys and v is not None
         })


### PR DESCRIPTION
## Summary

Adds the ability change the voice region of a voice channel, by passing either ``None`` (to set it to Automatic) or a string of the region name.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
