### PR TITLE
use datetime.fromisoformat for timestamp parsing

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -104,9 +104,7 @@ class SequenceProxy(collections.abc.Sequence):
         return self.__proxied.count(value)
 
 def parse_time(timestamp):
-    if timestamp:
-        return datetime.datetime(*map(int, re.split(r'[^\d]', timestamp.replace('+00:00', ''))))
-    return None
+    return timestamp and datetime.datetime.fromisoformat(timestamp)
 
 def copy_doc(original):
     def decorator(overriden):


### PR DESCRIPTION
## Summary

Uses [datetime.datetime.fromisoformat](https://docs.python.org/3/library/datetime.html#datetime.date.fromisoformat) for utils.parse_time.

It doesn't accept `None` so we still have to keep the helper function.

"Testing": I ran my bot and commands worked.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
