### PR TITLE
Fixed `HTTPClient.delete_messages()` method

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -391,7 +391,7 @@ class HTTPClient:
         return self.request(r, reason=reason)
 
     def delete_messages(self, channel_id, message_ids, *, reason=None):
-        r = Route('POST', '/channels/{channel_id}/messages/bulk_delete', channel_id=channel_id)
+        r = Route('POST', '/channels/{channel_id}/messages/bulk-delete', channel_id=channel_id)
         payload = {
             'messages': message_ids
         }


### PR DESCRIPTION
## Summary

In some reason, URL `"/channels/{channel_id}/messages/bulk_delete"` doesn't work anymore, but `"/channels/{channel_id}/messages/bulk-delete"` does (there's dash instead of underscore).
It's also specified that way in official documentation.

**UPD:** turns out, this applies only to API `v8`

## Checklist

- [x] Tested the code with/without the fix
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
