### PR TITLE
Fix versionadded not showing in docs for Attachment.content_type

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -111,7 +111,7 @@ class Attachment(Hashable):
     content_type: Optional[:class:`str`]
         The attachment's `media type <https://en.wikipedia.org/wiki/Media_type>`_
 
-        .. versionadded: 1.7
+        .. versionadded:: 1.7
     """
 
     __slots__ = ('id', 'size', 'height', 'width', 'filename', 'url', 'proxy_url', '_http', 'content_type')


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes the versionadded not showing in the documentation for [Attachment.content_type](https://discordpy.readthedocs.io/en/latest/api.html#discord.Attachment.content_type)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
