### PR TITLE
remove fail-safe for retrieving all tasks

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -55,13 +55,7 @@ from .appinfo import AppInfo
 log = logging.getLogger(__name__)
 
 def _cancel_tasks(loop):
-    try:
-        task_retriever = asyncio.Task.all_tasks
-    except AttributeError:
-        # future proofing for 3.9 I guess
-        task_retriever = asyncio.all_tasks
-
-    tasks = {t for t in task_retriever(loop=loop) if not t.done()}
+    tasks = {t for t in asyncio.all_tasks(loop=loop) if not t.done()}
 
     if not tasks:
         return


### PR DESCRIPTION
## Summary

Removes the try-except block for retrieving all tasks to cancel them and uses only [`asyncio.all_tasks`](https://docs.python.org/3/library/asyncio-task.html#asyncio.all_tasks) instead.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
