### PR TITLE
remove 3.6 check for `loop.shutdown_asyncgens()`

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -86,8 +86,7 @@ def _cancel_tasks(loop):
 def _cleanup_loop(loop):
     try:
         _cancel_tasks(loop)
-        if sys.version_info >= (3, 6):
-            loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.run_until_complete(loop.shutdown_asyncgens())
     finally:
         log.info('Closing the event loop.')
         loop.close()


### PR DESCRIPTION
## Summary

Removes the version info check for 3.6+ to [shut down async generators](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.shutdown_asyncgens).

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
