### PR TITLE
Fix attribute error when converter doesn't have a convert attribute

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -444,7 +444,7 @@ class Command(_BaseCommand):
 
         try:
             if inspect.isclass(converter):
-                if inspect.ismethod(converter.convert):
+                if inspect.ismethod(getattr(converter, 'convert', None)):
                     if converter.convert.__self__ is converter:
                         # class method
                         func = converter.convert


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This pull request fixes a `AttributeError` when the converter passed to [`_actual_conversion`](https://github.com/Rapptz/discord.py/blob/master/discord/ext/commands/core.py#L433-L472) doesn't have the `convert` attribute.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
