### PR TITLE
Fix AttributeError on HTTPClient.send_file to be send_files

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -409,7 +409,7 @@ class HTTPClient:
 
         return self.request(route, form=form, files=files)
 
-    def send_file(
+    def send_files(
         self,
         channel_id,
         *,


### PR DESCRIPTION
## Summary

Fixes sending files with a Message, the old method was removed

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
