### PR TITLE
Fix regression in Activity relying on `try_enum`

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -185,7 +185,10 @@ class Activity(BaseActivity):
         self.flags = kwargs.pop('flags', 0)
         self.sync_id = kwargs.pop('sync_id', None)
         self.session_id = kwargs.pop('session_id', None)
-        self.type = try_enum(ActivityType, kwargs.pop('type', -1))
+
+        activity_type = kwargs.pop('type', -1)
+        self.type = activity_type if isinstance(activity_type, ActivityType) else try_enum(ActivityType, activity_type)
+
         emoji = kwargs.pop('emoji', None)
         if emoji is not None:
             self.emoji = PartialEmoji.from_dict(emoji)

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -439,6 +439,9 @@ def try_enum(cls: Type[T], val: Any) -> T:
     If it fails it returns a proxy invalid value instead.
     """
 
+    if isinstance(val, cls._enum_value_cls_): # type: ignore
+        return val
+
     try:
         return cls._enum_value_map_[val] # type: ignore
     except (KeyError, TypeError, AttributeError):

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -439,9 +439,6 @@ def try_enum(cls: Type[T], val: Any) -> T:
     If it fails it returns a proxy invalid value instead.
     """
 
-    if isinstance(val, cls._enum_value_cls_): # type: ignore
-        return val
-
     try:
         return cls._enum_value_map_[val] # type: ignore
     except (KeyError, TypeError, AttributeError):


### PR DESCRIPTION
## Summary

Fixes a regression caused by 008432c creating an unknown type when given an enum value.

```py
>>> from discord import Activity, ActivityType
>>> Activity(type=ActivityType.watching, name='everyone')
<Activity type=<ActivityType.unknown_ActivityType.watching: <ActivityType.watching: 3>> name='everyone' url=None details=None application_id=None session_id=None emoji=None>
>>> _.to_dict() # (called internally)
Traceback (most recent call last):
  File "discord.py/discord/activity.py", line 220, in to_dict
    ret['type'] = int(self.type)
TypeError: __int__ returned non-int (type _EnumValue_ActivityType)
```

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
