### PR TITLE
Use f-strings in bot template.

### DIFF
--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -64,10 +64,10 @@ class Bot(commands.{base}):
             try:
                 self.load_extension(cog)
             except Exception as exc:
-                print('Could not load extension {{0}} due to {{1.__class__.__name__}}: {{1}}'.format(cog, exc))
+                print(f'Could not load extension {{cog}} due to {{exc.__class__.__name__}}: {{exc}}')
 
     async def on_ready(self):
-        print('Logged on as {{0}} (ID: {{0.id}})'.format(self.user))
+        print(f'Logged on as {{self.user}} (ID: {{self.user.id}})')
 
 
 bot = Bot()


### PR DESCRIPTION
Use f-strings in the bot template for consistency sakes

## Summary

Since the library is now switching to using f-strings I feel this just makes sense.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
