### PR TITLE
[commands] Provide a dynamic cooldown system

### DIFF
--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -34,6 +34,7 @@ __all__ = (
     'BucketType',
     'Cooldown',
     'CooldownMapping',
+    'DynamicCooldownMapping',
     'MaxConcurrency',
 )
 
@@ -69,18 +70,14 @@ class BucketType(Enum):
 
 
 class Cooldown:
-    __slots__ = ('rate', 'per', 'type', '_window', '_tokens', '_last')
+    __slots__ = ('rate', 'per', '_window', '_tokens', '_last')
 
-    def __init__(self, rate, per, type):
+    def __init__(self, rate, per):
         self.rate = int(rate)
         self.per = float(per)
-        self.type = type
         self._window = 0.0
         self._tokens = self.rate
         self._last = 0.0
-
-        if not callable(self.type):
-            raise TypeError('Cooldown type must be a BucketType or callable')
 
     def get_tokens(self, current=None):
         if not current:
@@ -128,15 +125,19 @@ class Cooldown:
         self._last = 0.0
 
     def copy(self):
-        return Cooldown(self.rate, self.per, self.type)
+        return Cooldown(self.rate, self.per)
 
     def __repr__(self):
         return f'<Cooldown rate: {self.rate} per: {self.per} window: {self._window} tokens: {self._tokens}>'
 
 class CooldownMapping:
-    def __init__(self, original):
+    def __init__(self, original, type):
+        if not callable(type):
+            raise TypeError('Cooldown type must be a BucketType or callable')
+
         self._cache = {}
         self._cooldown = original
+        self._type = type
 
     def copy(self):
         ret = CooldownMapping(self._cooldown)
@@ -152,7 +153,7 @@ class CooldownMapping:
         return cls(Cooldown(rate, per, type))
 
     def _bucket_key(self, msg):
-        return self._cooldown.type(msg)
+        return self._type(msg)
 
     def _verify_cache_integrity(self, current=None):
         # we want to delete all cache objects that haven't been used
@@ -163,15 +164,19 @@ class CooldownMapping:
         for k in dead_keys:
             del self._cache[k]
 
+    def create_bucket(self, message):
+        return self._cooldown.copy()
+
     def get_bucket(self, message, current=None):
-        if self._cooldown.type is BucketType.default:
+        if self._type is BucketType.default:
             return self._cooldown
 
         self._verify_cache_integrity(current)
         key = self._bucket_key(message)
         if key not in self._cache:
-            bucket = self._cooldown.copy()
-            self._cache[key] = bucket
+            bucket = self.create_bucket(message)
+            if bucket is not None:
+                self._cache[key] = bucket
         else:
             bucket = self._cache[key]
 
@@ -180,6 +185,11 @@ class CooldownMapping:
     def update_rate_limit(self, message, current=None):
         bucket = self.get_bucket(message, current)
         return bucket.update_rate_limit(current)
+
+class DynamicCooldownMapping(CooldownMapping):
+
+    def create_bucket(self, message):
+        return self._cooldown(message)
 
 class _Semaphore:
     """This class is a version of a semaphore.

--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -189,12 +189,8 @@ class CooldownMapping:
 class DynamicCooldownMapping(CooldownMapping):
 
     def __init__(self, factory, type):
-        if not callable(type):
-            raise TypeError('Cooldown type must be a BucketType or callable')
-
-        self._cache = {}
+        super().__init__(None, type)
         self._factory = factory
-        self._type = type
 
     @property
     def valid(self):

--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -188,8 +188,20 @@ class CooldownMapping:
 
 class DynamicCooldownMapping(CooldownMapping):
 
+    def __init__(self, factory, type):
+        if not callable(type):
+            raise TypeError('Cooldown type must be a BucketType or callable')
+
+        self._cache = {}
+        self._factory = factory
+        self._type = type
+
+    @property
+    def valid(self):
+        return True
+
     def create_bucket(self, message):
-        return self._cooldown(message)
+        return self._factory(message)
 
 class _Semaphore:
     """This class is a version of a semaphore.

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -259,10 +259,8 @@ class Command(_BaseCommand):
         finally:
             if cooldown is None:
                 self._buckets = CooldownMapping(cooldown, BucketType.default)
-            elif callable(cooldown[0]):
-                self._buckets = DynamicCooldownMapping(*cooldown)
-            else:
-                self._buckets = CooldownMapping(*cooldown)
+            elif isinstance(cooldown, CooldownMapping):
+                self._buckets = cooldown
 
         try:
             max_concurrency = func.__commands_max_concurrency__
@@ -1988,7 +1986,7 @@ def cooldown(rate, per, type=BucketType.default):
         if isinstance(func, Command):
             func._buckets = CooldownMapping(Cooldown(rate, per), type)
         else:
-            func.__commands_cooldown__ = Cooldown(rate, per), type
+            func.__commands_cooldown__ = CooldownMapping(Cooldown(rate, per), type)
         return func
     return decorator
 
@@ -2027,7 +2025,7 @@ def dynamic_cooldown(cooldown, type=BucketType.default):
         if isinstance(func, Command):
             func._buckets = DynamicCooldownMapping(cooldown, type)
         else:
-            func.__commands_cooldown__ = cooldown, type
+            func.__commands_cooldown__ = DynamicCooldownMapping(cooldown, type)
         return func
     return decorator
 


### PR DESCRIPTION
## Summary

This provides a way to allow users a more dynamic system to control cooldowns, by allowing a callable to be used that returns a Cooldown object. This callable can even return None if no cooldown is meant to be applied in this situation, allowing for essentially a way to "whitelist" certain people/guilds/scenarios from the cooldown.

Couple notes:
- I moved the type to the cooldown mapping object. I'm unsure if this is really desirable, but since the checking of the bucket type only ever happened in CooldownMapping I figured this was fine. This was what I figured would be required to ensure it was the same BucketType no matter what Cooldown object the dynamic method provided returns. 
- To not have to add another if check on every cooldown check (inside of `CooldownMapping.create_bucket` to see if the cooldown is a callable/just a Cooldown object) I instead created a new class for the dynamic usage


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
