### PR TITLE
Minimise code duplication in channel converters

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -769,9 +769,12 @@ class clean_content(Converter[str]):
                 r = _find(_id)
                 return '@' + r.name if r else '@deleted-role'
 
+            # fmt: off
             transformations.update(
-                (f'<@&{role_id}>', resolve_role(role_id)) for role_id in message.raw_role_mentions
-            )  # fmt: off
+                (f'<@&{role_id}>', resolve_role(role_id))
+                for role_id in message.raw_role_mentions
+            )
+            # fmt: on
 
         def repl(obj):
             return transformations.get(obj.group(0), '')


### PR DESCRIPTION
## Summary

Moved the duplicated code to be a staticmethod under `TextChannelConverter`. Can be moved if needed.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
