### PR TITLE
use __args__ and __origin__ where applicable

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1109,7 +1109,7 @@ class Command(_BaseCommand):
                 none_cls = type(None)
                 union_args = annotation.__args__
                 optional = union_args[-1] is none_cls
-                if optional:
+                if len(union_args) == 2 and optional:
                     annotation = union_args[0]
                     origin = getattr(annotation, '__origin__', None)
 

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -646,7 +646,7 @@ class BadUnionArgument(UserInputError):
             try:
                 return x.__name__
             except AttributeError:
-                if typing.get_origin(x) is not None:
+                if hasattr(x, '__origin__'):
                     return repr(x)
                 return x.__class__.__name__
 

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -23,7 +23,6 @@ DEALINGS IN THE SOFTWARE.
 """
 
 from discord.errors import ClientException, DiscordException
-import typing
 
 
 __all__ = (


### PR DESCRIPTION
## Summary

Uses __args__ and __origin__ dunders where applicable for GenericAlias handling.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
