### PR TITLE
Remove `private_channel_(delete/create)` events

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -627,7 +627,6 @@ class Intents(BaseFlags):
         - :func:`on_message_delete` (both guilds and DMs)
         - :func:`on_raw_message_delete` (both guilds and DMs)
         - :func:`on_raw_message_edit` (both guilds and DMs)
-        - :func:`on_private_channel_create`
 
         This also corresponds to the following attributes and classes in terms of cache:
 
@@ -682,7 +681,6 @@ class Intents(BaseFlags):
         - :func:`on_message_delete` (only for DMs)
         - :func:`on_raw_message_delete` (only for DMs)
         - :func:`on_raw_message_edit` (only for DMs)
-        - :func:`on_private_channel_create`
 
         This also corresponds to the following attributes and classes in terms of cache:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -596,16 +596,6 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param interaction: The interaction data.
     :type interaction: :class:`Interaction`
 
-.. function:: on_private_channel_delete(channel)
-              on_private_channel_create(channel)
-
-    Called whenever a private channel is deleted or created.
-
-    This requires :attr:`Intents.messages` to be enabled.
-
-    :param channel: The private channel that got created or deleted.
-    :type channel: :class:`abc.PrivateChannel`
-
 .. function:: on_private_channel_update(before, after)
 
     Called whenever a private group DM is updated. e.g. changed name or topic.


### PR DESCRIPTION
## Summary

Bots no longer receive `CHANNEL_CREATE` and `CHANNEL_DELETE` for private channels on v8.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
