### PR TITLE
[Help] Right strip before truncating text in `shorten_text` function

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -931,7 +931,7 @@ class DefaultHelpCommand(HelpCommand):
     def shorten_text(self, text):
         """:class:`str`: Shortens text to fit into the :attr:`width`."""
         if len(text) > self.width:
-            return text[:self.width - 3] + '...'
+            return text[:self.width - 3].rstrip() + '...'
         return text
 
     def get_ending_note(self):


### PR DESCRIPTION
## Summary

Strip whitespace on the right of the text to avoid spaces before ellipsis in the `shorten_text` function.

## Checklist

- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
