### PR TITLE
change command.params back to an OrderedDict

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -37,6 +37,7 @@ import inspect
 import datetime
 import types
 import sys
+import collections
 
 import discord
 
@@ -143,10 +144,10 @@ def resolve_annotation(annotation: Any, globalns: Dict[str, Any], cache: Dict[st
         annotation = ForwardRef(annotation)
     return _evaluate_annotation(annotation, globalns, cache)
 
-def get_signature_parameters(function: types.FunctionType) -> Dict[str, inspect.Parameter]:
+def get_signature_parameters(function: types.FunctionType) -> collections.OrderedDict[str, inspect.Parameter]:
     globalns = function.__globals__
     signature = inspect.signature(function)
-    params = {}
+    params = collections.OrderedDict()
     cache: Dict[str, Any] = {}
     for name, parameter in signature.parameters.items():
         annotation = parameter.annotation

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -30,6 +30,7 @@ from typing import (
     Literal,
     Tuple,
     Union,
+    OrderedDict
 )
 import asyncio
 import functools
@@ -144,7 +145,7 @@ def resolve_annotation(annotation: Any, globalns: Dict[str, Any], cache: Dict[st
         annotation = ForwardRef(annotation)
     return _evaluate_annotation(annotation, globalns, cache)
 
-def get_signature_parameters(function: types.FunctionType) -> collections.OrderedDict[str, inspect.Parameter]:
+def get_signature_parameters(function: types.FunctionType) -> OrderedDict[str, inspect.Parameter]:
     globalns = function.__globals__
     signature = inspect.signature(function)
     params = collections.OrderedDict()


### PR DESCRIPTION
## Summary

fixes command.clean_params as it relies on `popitem` having a `last` parameter

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
