### PR TITLE
add stagechannel to abc.guildchannel docs

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -185,6 +185,7 @@ class GuildChannel(Protocol):
     - :class:`~discord.TextChannel`
     - :class:`~discord.VoiceChannel`
     - :class:`~discord.CategoryChannel`
+    - :class:`~discord.StageChannel`
 
     This ABC must also implement :class:`~discord.abc.Snowflake`.
 


### PR DESCRIPTION
## Summary

In 1.7, StageChannel was added, which implements abc.GuildChannel, but this was not documented in the docs. This pr adds it

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
