### PR TITLE
Add NSFW for Guilds

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -92,6 +92,12 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         in this channel. A value of `0` denotes that it is disabled.
         Bots and users with :attr:`~Permissions.manage_channels` or
         :attr:`~Permissions.manage_messages` bypass slowmode.
+    nsfw: :class:`bool`
+        If the channel is marked as "not safe for work".
+        
+        .. note::
+        
+            To check if the channel or the guild of that channel are marked as NSFW, consider :meth:`is_nsfw` instead.
     """
 
     __slots__ = ('name', 'id', 'guild', 'topic', '_state', 'nsfw',
@@ -157,7 +163,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
 
     def is_nsfw(self):
         """:class:`bool`: Checks if the channel is NSFW."""
-        return self.nsfw
+        return self.nsfw or self.guild.nsfw
 
     def is_news(self):
         """:class:`bool`: Checks if the channel is a news channel."""
@@ -886,6 +892,12 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
     position: :class:`int`
         The position in the category list. This is a number that starts at 0. e.g. the
         top category is position 0.
+    nsfw: :class:`bool`
+        If the channel is marked as "not safe for work".
+        
+        .. note::
+        
+            To check if the channel or the guild of that channel are marked as NSFW, consider :meth:`is_nsfw` instead.
     """
 
     __slots__ = ('name', 'id', 'guild', 'nsfw', '_state', 'position', '_overwrites', 'category_id')
@@ -917,7 +929,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
 
     def is_nsfw(self):
         """:class:`bool`: Checks if the category is NSFW."""
-        return self.nsfw
+        return self.nsfw or self.guild.nsfw
 
     @utils.copy_doc(discord.abc.GuildChannel.clone)
     async def clone(self, *, name=None, reason=None):
@@ -1082,6 +1094,12 @@ class StoreChannel(discord.abc.GuildChannel, Hashable):
     position: :class:`int`
         The position in the channel list. This is a number that starts at 0. e.g. the
         top channel is position 0.
+    nsfw: :class:`bool`
+        If the channel is marked as "not safe for work".
+        
+        .. note::
+        
+            To check if the channel or the guild of that channel are marked as NSFW, consider :meth:`is_nsfw` instead.
     """
     __slots__ = ('name', 'id', 'guild', '_state', 'nsfw',
                  'category_id', 'position', '_overwrites',)
@@ -1122,7 +1140,7 @@ class StoreChannel(discord.abc.GuildChannel, Hashable):
 
     def is_nsfw(self):
         """:class:`bool`: Checks if the channel is NSFW."""
-        return self.nsfw
+        return self.nsfw or self.guild.nsfw
 
     @utils.copy_doc(discord.abc.GuildChannel.clone)
     async def clone(self, *, name=None, reason=None):

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -179,7 +179,7 @@ class Guild(Hashable):
                  'description', 'max_presences', 'max_members', 'max_video_channel_users',
                  'premium_tier', 'premium_subscription_count', '_system_channel_flags',
                  'preferred_locale', 'discovery_splash', '_rules_channel_id',
-                 '_public_updates_channel_id')
+                 '_public_updates_channel_id', 'nsfw')
 
     _PREMIUM_GUILD_LIMITS = {
         None: _GuildLimit(emoji=50, bitrate=96e3, filesize=8388608),
@@ -314,6 +314,7 @@ class Guild(Hashable):
         self.discovery_splash = guild.get('discovery_splash')
         self._rules_channel_id = utils._get_as_snowflake(guild, 'rules_channel_id')
         self._public_updates_channel_id = utils._get_as_snowflake(guild, 'public_updates_channel_id')
+        self.nsfw = guild.get('nsfw')
 
         cache_joined = self._state.member_cache_flags.joined
         self_id = self._state.self_id
@@ -788,6 +789,10 @@ class Guild(Hashable):
     def created_at(self):
         """:class:`datetime.datetime`: Returns the guild's creation time in UTC."""
         return utils.snowflake_time(self.id)
+
+    def is_nsfw(self):
+        """:class:`bool`: Checks if the guild is NSFW."""
+        return self.nsfw
 
     def get_member_named(self, name):
         """Returns the first member found that matches the name provided.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -170,7 +170,7 @@ class Guild(Hashable):
         .. versionadded:: 1.3
 
     nsfw: :class:`bool`
-        If the channel is marked as "not safe for work".
+        If the guild is marked as "not safe for work".
 
         .. versionadded:: 2.0
     """

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -168,6 +168,11 @@ class Guild(Hashable):
         The guild's discovery splash.
 
         .. versionadded:: 1.3
+
+    nsfw: :class:`bool`
+        If the channel is marked as "not safe for work".
+
+        .. versionadded:: 2.0
     """
 
     __slots__ = ('afk_timeout', 'afk_channel', '_members', '_channels', 'icon',
@@ -314,7 +319,7 @@ class Guild(Hashable):
         self.discovery_splash = guild.get('discovery_splash')
         self._rules_channel_id = utils._get_as_snowflake(guild, 'rules_channel_id')
         self._public_updates_channel_id = utils._get_as_snowflake(guild, 'public_updates_channel_id')
-        self.nsfw = guild.get('nsfw')
+        self.nsfw = guild.get('nsfw', False)
 
         cache_joined = self._state.member_cache_flags.joined
         self_id = self._state.self_id
@@ -789,10 +794,6 @@ class Guild(Hashable):
     def created_at(self):
         """:class:`datetime.datetime`: Returns the guild's creation time in UTC."""
         return utils.snowflake_time(self.id)
-
-    def is_nsfw(self):
-        """:class:`bool`: Checks if the guild is NSFW."""
-        return self.nsfw
 
     def get_member_named(self, name):
         """Returns the first member found that matches the name provided.

--- a/discord/types/guild.py
+++ b/discord/types/guild.py
@@ -119,6 +119,7 @@ class Guild(_BaseGuildPreview, _GuildOptional):
     explicit_content_filter: ExplicitContentFilterLevel
     roles: List[Role]
     mfa_level: MFALevel
+    nsfw: bool
     application_id: Optional[Snowflake]
     system_channel_id: Optional[Snowflake]
     system_channel_flags: int


### PR DESCRIPTION
This reflects the Update of the API: discord/discord-api-docs#2805

## Summary

- Add NSFW-Attribute to Guild
- Add ``is_nsfw()`` to Guild
- Check for ``Channel.nsfw`` or ``Guild.nsfw`` in ``Channel.is_nsfw()``
- Add ``Channel.nsfw`` to doc_string

Changing the NSFW status of a guild must be done by discord stuff yet, so nsfw is not part of ``Guild.edit()`` 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
