### PR TITLE
Add `clean_prefix` attribute to commands.Context

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -212,7 +212,11 @@ class Context(discord.abc.Messageable):
 
     @property
     def clean_prefix(self):
-        """:class:`str`: The cleaned up invoke prefix. i.e. mentions are ``@name`` instead of ``<@id>``."""
+        """clean_prefix: :class:`str`
+        The cleaned up invoke prefix. i.e. mentions are ``@name`` instead of ``<@id>``.
+        
+        .. versionadded:: 2.0
+        """
         user = self.context.guild.me if self.context.guild else self.context.bot.user
         # this breaks if the prefix mention is not the bot itself but I
         # consider this to be an *incredibly* strange use case. I'd rather go

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -212,11 +212,7 @@ class Context(discord.abc.Messageable):
 
     @property
     def clean_prefix(self):
-        """clean_prefix: :class:`str`
-        The cleaned up invoke prefix. i.e. mentions are ``@name`` instead of ``<@id>``.
-        
-        .. versionadded:: 2.0
-        """
+        """:class:`str`The cleaned up invoke prefix. i.e. mentions are ``@name`` instead of ``<@id>``."""
         user = self.context.guild.me if self.context.guild else self.context.bot.user
         # this breaks if the prefix mention is not the bot itself but I
         # consider this to be an *incredibly* strange use case. I'd rather go

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -213,7 +213,7 @@ class Context(discord.abc.Messageable):
     @property
     def clean_prefix(self):
         """:class:`str`The cleaned up invoke prefix. i.e. mentions are ``@name`` instead of ``<@id>``."""
-        user = self.context.guild.me if self.context.guild else self.context.bot.user
+        user = self.guild.me if self.guild else self.bot.user
         # this breaks if the prefix mention is not the bot itself but I
         # consider this to be an *incredibly* strange use case. I'd rather go
         # for this common use case rather than waste performance for the

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -54,6 +54,10 @@ class Context(discord.abc.Messageable):
         :func:`on_command_error` event then this dict could be incomplete.
     prefix: :class:`str`
         The prefix that was used to invoke the command.
+    clean_prefix: :class:`str`
+        The cleaned up invoke prefix. i.e. mentions are ``@name`` instead of ``<@id>``.
+        
+        .. versionadded:: 2.0
     command: :class:`Command`
         The command that is being invoked currently.
     invoked_with: :class:`str`
@@ -205,6 +209,17 @@ class Context(discord.abc.Messageable):
 
     async def _get_channel(self):
         return self.channel
+
+    @property
+    def clean_prefix(self):
+        """:class:`str`: The cleaned up invoke prefix. i.e. mentions are ``@name`` instead of ``<@id>``."""
+        user = self.context.guild.me if self.context.guild else self.context.bot.user
+        # this breaks if the prefix mention is not the bot itself but I
+        # consider this to be an *incredibly* strange use case. I'd rather go
+        # for this common use case rather than waste performance for the
+        # odd one.
+        pattern = re.compile(r"<@!?%s>" % user.id)
+        return pattern.sub("@%s" % user.display_name.replace('\\', r'\\'), self.context.prefix)
 
     @property
     def cog(self):

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -54,10 +54,6 @@ class Context(discord.abc.Messageable):
         :func:`on_command_error` event then this dict could be incomplete.
     prefix: :class:`str`
         The prefix that was used to invoke the command.
-    clean_prefix: :class:`str`
-        The cleaned up invoke prefix. i.e. mentions are ``@name`` instead of ``<@id>``.
-        
-        .. versionadded:: 2.0
     command: :class:`Command`
         The command that is being invoked currently.
     invoked_with: :class:`str`
@@ -219,7 +215,7 @@ class Context(discord.abc.Messageable):
         # for this common use case rather than waste performance for the
         # odd one.
         pattern = re.compile(r"<@!?%s>" % user.id)
-        return pattern.sub("@%s" % user.display_name.replace('\\', r'\\'), self.context.prefix)
+        return pattern.sub("@%s" % user.display_name.replace('\\', r'\\'), self.prefix)
 
     @property
     def cog(self):

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -208,7 +208,10 @@ class Context(discord.abc.Messageable):
 
     @property
     def clean_prefix(self):
-        """:class:`str`The cleaned up invoke prefix. i.e. mentions are ``@name`` instead of ``<@id>``."""
+        """:class:`str`: The cleaned up invoke prefix. i.e. mentions are ``@name`` instead of ``<@id>``.
+
+        .. versionadded:: 2.0
+        """
         user = self.guild.me if self.guild else self.bot.user
         # this breaks if the prefix mention is not the bot itself but I
         # consider this to be an *incredibly* strange use case. I'd rather go


### PR DESCRIPTION
## Summary

Adds the `clean_prefix` attribute to commands.Context.

Reviews welcome

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
