### PR TITLE
Fix guild.chunk() creating a hanging waiter

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2218,7 +2218,8 @@ class Guild(Hashable):
         if not self._state._intents.members:
             raise ClientException('Intents.members must be enabled to use this.')
 
-        return await self._state.chunk_guild(self, cache=cache)
+        if not self._state.is_guild_evicted(self):
+            return await self._state.chunk_guild(self, cache=cache)
 
     async def query_members(self, query=None, *, limit=5, user_ids=None, presences=False, cache=True):
         """|coro|

--- a/discord/state.py
+++ b/discord/state.py
@@ -776,6 +776,9 @@ class ConnectionState:
 
         return self._add_guild_from_data(data)
 
+    def is_guild_evicted(self, guild) -> bool:
+        return guild.id not in self._guilds
+
     async def chunk_guild(self, guild, *, wait=True, cache=None):
         cache = cache or self.member_cache_flags.joined
         request = self._chunk_requests.get(guild.id)


### PR DESCRIPTION
## Summary

If you're trying to chunk a guild that the bot is not in, it'll just hang on the chunk coro forever. It's weird that one would even encounter this, I know.

I'm not 100% sure if this fix should be returning a coro here or not. As-is, seems to work.

In the meantime, if you're affected by this, the smallest fix for this would be putting `guild.chunk()` under an `if bot.get_guild(guild.id):`

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
