### PR TITLE
Remove GroupChannel functionalities

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -136,7 +136,6 @@ class PrivateChannel(Snowflake, Protocol):
     The following implement this ABC:
 
     - :class:`~discord.DMChannel`
-    - :class:`~discord.GroupChannel`
 
     This ABC must also implement :class:`~discord.abc.Snowflake`.
 
@@ -955,7 +954,6 @@ class Messageable(Protocol):
 
     - :class:`~discord.TextChannel`
     - :class:`~discord.DMChannel`
-    - :class:`~discord.GroupChannel`
     - :class:`~discord.User`
     - :class:`~discord.Member`
     - :class:`~discord.ext.commands.Context`

--- a/discord/client.py
+++ b/discord/client.py
@@ -1303,7 +1303,7 @@ class Client:
         if factory is None:
             raise InvalidData('Unknown channel type {type} for channel ID {id}.'.format_map(data))
 
-        if ch_type in (ChannelType.group, ChannelType.private):
+        if ch_type == ChannelType.private:
             channel = factory(me=self.user, data=data, state=self._connection)
         else:
             guild_id = int(data['guild_id'])

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -150,10 +150,9 @@ class ChannelType(Enum):
     text     = 0
     private  = 1
     voice    = 2
-    group    = 3
-    category = 4
-    news     = 5
-    store    = 6
+    category = 3
+    news     = 4
+    store    = 5
     stage_voice = 13
 
     def __str__(self):

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -160,25 +160,20 @@ class ChannelType(Enum):
 
 class MessageType(Enum):
     default                                      = 0
-    recipient_add                                = 1
-    recipient_remove                             = 2
-    call                                         = 3
-    channel_name_change                          = 4
-    channel_icon_change                          = 5
-    pins_add                                     = 6
-    new_member                                   = 7
-    premium_guild_subscription                   = 8
-    premium_guild_tier_1                         = 9
-    premium_guild_tier_2                         = 10
-    premium_guild_tier_3                         = 11
-    channel_follow_add                           = 12
-    guild_stream                                 = 13
-    guild_discovery_disqualified                 = 14
-    guild_discovery_requalified                  = 15
-    guild_discovery_grace_period_initial_warning = 16
-    guild_discovery_grace_period_final_warning   = 17
-    reply                                        = 19
-    application_command                          = 20
+    pins_add                                     = 1
+    new_member                                   = 2
+    premium_guild_subscription                   = 3
+    premium_guild_tier_1                         = 4
+    premium_guild_tier_2                         = 5
+    premium_guild_tier_3                         = 6
+    channel_follow_add                           = 7
+    guild_stream                                 = 8
+    guild_discovery_disqualified                 = 9
+    guild_discovery_requalified                  = 10
+    guild_discovery_grace_period_initial_warning = 11
+    guild_discovery_grace_period_final_warning   = 12
+    reply                                        = 13
+    application_command                          = 14
 
 class VoiceRegion(Enum):
     us_west       = 'us-west'

--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -62,7 +62,7 @@ class BucketType(Enum):
             # we return the channel id of a private-channel as there are only roles in guilds
             # and that yields the same result as for a guild with only the @everyone role
             # NOTE: PrivateChannel doesn't actually have an id attribute but we assume we are
-            # recieving a DMChannel or GroupChannel which inherit from PrivateChannel and do
+            # recieving a DMChannel which inherits from PrivateChannel and do
             return (msg.channel if isinstance(msg.channel, PrivateChannel) else msg.author.top_role).id
 
     def __call__(self, msg):

--- a/discord/message.py
+++ b/discord/message.py
@@ -452,7 +452,7 @@ class Message(Hashable):
         A list of embeds the message has.
     channel: Union[:class:`abc.Messageable`]
         The :class:`TextChannel` that the message was sent from.
-        Could be a :class:`DMChannel` or :class:`GroupChannel` if it's a private message.
+        Could be a :class:`DMChannel` if it's a private message.
     reference: Optional[:class:`~discord.MessageReference`]
         The message that this message references. This is only applicable to messages of
         type :attr:`MessageType.pins_add`, crossposted messages created by a

--- a/discord/state.py
+++ b/discord/state.py
@@ -626,12 +626,6 @@ class ConnectionState:
     def parse_channel_update(self, data):
         channel_type = try_enum(ChannelType, data.get('type'))
         channel_id = int(data['id'])
-        if channel_type is ChannelType.group:
-            channel = self._get_private_channel(channel_id)
-            old_channel = copy.copy(channel)
-            channel._update_group(data)
-            self.dispatch('private_channel_update', old_channel, channel)
-            return
 
         guild_id = utils._get_as_snowflake(data, 'guild_id')
         guild = self._get_guild(guild_id)

--- a/discord/state.py
+++ b/discord/state.py
@@ -992,9 +992,6 @@ class ConnectionState:
                     if member_data:
                         member = Member(data=member_data, state=self, guild=guild)
 
-            elif isinstance(channel, GroupChannel):
-                member = utils.find(lambda x: x.id == user_id, channel.recipients)
-
             if member is not None:
                 timestamp = datetime.datetime.utcfromtimestamp(data.get('timestamp'))
                 timestamp = timestamp.replace(tzinfo=datetime.timezone.utc)

--- a/discord/types/channel.py
+++ b/discord/types/channel.py
@@ -34,7 +34,7 @@ class PermissionOverwrite(TypedDict):
     deny: str
 
 
-ChannelType = Literal[0, 1, 2, 3, 4, 5, 6, 13]
+ChannelType = Literal[0, 1, 2, 3, 4, 5, 13]
 
 
 class PartialChannel(TypedDict):
@@ -84,8 +84,3 @@ class GuildChannel(
 class DMChannel(PartialChannel):
     last_message_id: Optional[Snowflake]
     recipients: List[PartialUser]
-
-
-class GroupDMChannel(DMChannel):
-    icon: Optional[str]
-    owner_id: Snowflake

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -328,7 +328,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     Called when someone begins typing a message.
 
     The ``channel`` parameter can be a :class:`abc.Messageable` instance.
-    Which could either be :class:`TextChannel`, :class:`GroupChannel`, or
+    Which could either be :class:`TextChannel` or
     :class:`DMChannel`.
 
     If the ``channel`` is a :class:`TextChannel` then the ``user`` parameter
@@ -595,17 +595,6 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
     :param interaction: The interaction data.
     :type interaction: :class:`Interaction`
-
-.. function:: on_private_channel_update(before, after)
-
-    Called whenever a private group DM is updated. e.g. changed name or topic.
-
-    This requires :attr:`Intents.messages` to be enabled.
-
-    :param before: The updated group channel's old info.
-    :type before: :class:`GroupChannel`
-    :param after: The updated group channel's new info.
-    :type after: :class:`GroupChannel`
 
 .. function:: on_private_channel_pins_update(channel, last_pin)
 


### PR DESCRIPTION
## Summary

Because version 2.0 will remove all user bot functionalities, I thought it was a good idea to remove group channels as well. A bot cannot create nor join a group channel so this is why.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
