### PR TITLE
Fix (Sync)Webhook.send() overloads

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1155,7 +1155,7 @@ class Webhook(BaseWebhook):
         embed: Embed = MISSING,
         embeds: List[Embed] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
-        wait: Literal[False],
+        wait: Literal[False] = False,
     ) -> None:
         ...
 

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -734,7 +734,7 @@ class SyncWebhook(BaseWebhook):
         embed: Embed = MISSING,
         embeds: List[Embed] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
-        wait: Literal[False],
+        wait: Literal[False] = False,
     ) -> None:
         ...
 


### PR DESCRIPTION
## Summary

This ensures that there's an overload satisfying for any valid call to these methods.
Alternatively, the overload could use `= ...` if you think that looks better as both should work fine.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
