### PR TITLE
Add missing reprs to WidgetMember + BaseUser + DeletedReferencedMessage

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -273,6 +273,9 @@ class DeletedReferencedMessage:
     def __init__(self, parent):
         self._parent = parent
 
+    def __repr__(self):
+        return f"<DeletedReferencedMessage id={self.id} channel_id={self.channel_id} guild_id={self.guild_id!r}>"
+
     @property
     def id(self):
         """:class:`int`: The message ID of the deleted referenced message."""

--- a/discord/user.py
+++ b/discord/user.py
@@ -44,6 +44,12 @@ class BaseUser(_BaseUser):
         self._state = state
         self._update(data)
 
+    def __repr__(self):
+        return (
+            f"<BaseUser id={self.id} name={self.name!r} discriminator={self.discriminator!r}"
+            f" bot={self.bot} system={self.system}>"
+        )
+
     def __str__(self):
         return f'{self.name}#{self.discriminator}'
 

--- a/discord/widget.py
+++ b/discord/widget.py
@@ -157,6 +157,12 @@ class WidgetMember(BaseUser):
 
         self.connected_channel = connected_channel
 
+    def __repr__(self):
+        return (
+            f"<WidgetMember name={self.name!r} discriminator={self.discriminator!r}"
+            f" bot={self.bot} nick={self.nick!r}>"
+        )
+
     @property
     def display_name(self):
         """:class:`str`: Returns the member's display name."""


### PR DESCRIPTION
## Summary

BaseUser until very recently was not exposed as something that can be returned, but now it is, so let's repr it!

WidgetMember and DeletedReferencedMessage... well, they had no reprs.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
