### PR TITLE
`activities` is no longer nullable

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -225,7 +225,7 @@ class Member(discord.abc.Messageable, _BaseUser):
         self._client_status = {
             None: 'offline'
         }
-        self.activities = tuple(map(create_activity, data.get('activities', [])))
+        self.activities = []
         self.nick = data.get('nick', None)
         self.pending = data.get('pending', False)
 
@@ -312,7 +312,7 @@ class Member(discord.abc.Messageable, _BaseUser):
         self._update_roles(data)
 
     def _presence_update(self, data, user):
-        self.activities = tuple(map(create_activity, data.get('activities', [])))
+        self.activities = tuple(map(create_activity, data['activities']))
         self._client_status = {
             sys.intern(key): sys.intern(value)
             for key, value in data.get('client_status', {}).items()


### PR DESCRIPTION
## Summary

discord/discord-api-docs@5c4aa52

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
