### PR TITLE
[docs] document inherited members on `Asset`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2688,6 +2688,7 @@ Asset
 
 .. autoclass:: Asset()
     :members:
+    :inherited-members:
 
 Message
 ~~~~~~~


### PR DESCRIPTION
## Summary

`Asset.read` and `Asset.save` became undocumented when they were moved to `AssetMixin`.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
