### PR TITLE
Embed inline default false

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -536,7 +536,7 @@ class Embed:
         """
         return [EmbedProxy(d) for d in getattr(self, '_fields', [])]  # type: ignore
 
-    def add_field(self: E, *, name: Any, value: Any, inline: bool = True) -> E:
+    def add_field(self: E, *, name: Any, value: Any, inline: bool = False) -> E:
         """Adds a field to the embed object.
 
         This function returns the class instance to allow for fluent-style
@@ -565,7 +565,7 @@ class Embed:
 
         return self
 
-    def insert_field_at(self: E, index: int, *, name: Any, value: Any, inline: bool = True) -> E:
+    def insert_field_at(self: E, index: int, *, name: Any, value: Any, inline: bool = False) -> E:
         """Inserts a field before a specified index to the embed.
 
         This function returns the class instance to allow for fluent-style
@@ -626,7 +626,7 @@ class Embed:
         except (AttributeError, IndexError):
             pass
 
-    def set_field_at(self: E, index: int, *, name: Any, value: Any, inline: bool = True) -> E:
+    def set_field_at(self: E, index: int, *, name: Any, value: Any, inline: bool = False) -> E:
         """Modifies a field to the embed object.
 
         The index must point to a valid pre-existing field.

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -550,6 +550,9 @@ class Embed:
             The value of the field.
         inline: :class:`bool`
             Whether the field should be displayed inline.
+
+            .. versionchanged:: 2.0
+                Changed the default value to ``False``.
         """
 
         field = {
@@ -583,6 +586,9 @@ class Embed:
             The value of the field.
         inline: :class:`bool`
             Whether the field should be displayed inline.
+
+            .. versionchanged:: 2.0
+                Changed the default value to ``False``.
         """
 
         field = {
@@ -644,6 +650,9 @@ class Embed:
             The value of the field.
         inline: :class:`bool`
             Whether the field should be displayed inline.
+
+            .. versionchanged:: 2.0
+                Changed the default value to ``False``.
 
         Raises
         -------


### PR DESCRIPTION
## Summary

Sets the default `inline` value to `False` on embed fields. This would make the behaviour consistent with Discord's API when the value is omitted.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
