### PR TITLE
raise InvalidArgument when using overwrites

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -295,6 +295,13 @@ class GuildChannel(Protocol):
         if overwrites is not None:
             perms = []
             for target, perm in overwrites.items():
+                if isinstance(target, Role):
+                    payload_type = _Overwrites.ROLE
+                elif isinstance(target, Member):
+                    payload_type = _Overwrites.MEMBER
+                else:
+                    raise InvalidArgument(f'Expected Role or Member received {target.__class__.__name__}')
+
                 if not isinstance(perm, PermissionOverwrite):
                     raise InvalidArgument(f'Expected PermissionOverwrite received {perm.__class__.__name__}')
 
@@ -302,13 +309,9 @@ class GuildChannel(Protocol):
                 payload = {
                     'allow': allow.value,
                     'deny': deny.value,
-                    'id': target.id
+                    'id': target.id,
+                    'type': payload_type
                 }
-
-                if isinstance(target, Role):
-                    payload['type'] = _Overwrites.ROLE
-                else:
-                    payload['type'] = _Overwrites.MEMBER
 
                 perms.append(payload)
             options['permission_overwrites'] = perms

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -732,6 +732,13 @@ class Guild(Hashable):
 
         perms = []
         for target, perm in overwrites.items():
+            if isinstance(target, Role):
+                payload_type = abc._Overwrites.ROLE
+            elif isinstance(target, Member):
+                payload_type = abc._Overwrites.MEMBER
+            else:
+                raise InvalidArgument(f'Expected Role or Member received {target.__class__.__name__}')
+
             if not isinstance(perm, PermissionOverwrite):
                 raise InvalidArgument(f'Expected PermissionOverwrite received {perm.__class__.__name__}')
 
@@ -739,13 +746,9 @@ class Guild(Hashable):
             payload = {
                 'allow': allow.value,
                 'deny': deny.value,
-                'id': target.id
+                'id': target.id,
+                'type': payload_type
             }
-
-            if isinstance(target, Role):
-                payload['type'] = abc._Overwrites.ROLE
-            else:
-                payload['type'] = abc._Overwrites.MEMBER
 
             perms.append(payload)
 


### PR DESCRIPTION

## Summary
when creating a channel with the overwrites set but using the wrong type
for the keys a not so descriptive AttributeError was raised as the
assumed to be a Member target does not have an id attribute.

instead the target is checked and a clear InvalidArgument is raised when
the overwrites dict has the wrong class as a key.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.(change reflects documentation)
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
