### PR TITLE
[docs] Fix typo within `HelpCommand.verify_checks` documentation

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -281,7 +281,7 @@ class HelpCommand:
         If ``None``, only calls :attr:`.Commands.checks` in a guild setting.
         If ``False``, never calls :attr:`.Commands.checks`. Defaults to ``True``.
 
-        ..versionchanged:: 1.7
+        .. versionchanged:: 1.7
     command_attrs: :class:`dict`
         A dictionary of options to pass in for the construction of the help command.
         This allows you to change the command behaviour without actually changing


### PR DESCRIPTION
## Summary
`versionchanged` is incorrectly implemented inside `HelpCommand.verify_checks` documentation.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
