### PR TITLE
[commands] Set constructible FlagConverter flags to not be required by default.

### DIFF
--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -184,6 +184,9 @@ def get_flags(namespace: Dict[str, Any], globals: Dict[str, Any], locals: Dict[s
 
         annotation = flag.annotation = resolve_annotation(flag.annotation, globals, locals, cache)
 
+        if flag.default is MISSING and issubclass(annotation, FlagConverter) and annotation._can_be_constructible():
+            flag.default = annotation._construct_default
+
         if flag.aliases is MISSING:
             flag.aliases = []
 


### PR DESCRIPTION
## Summary

This PR sets Flags of type FlagConverter which are constructible to be optional.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested. (By NC)
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
