### PR TITLE
Fix documentation for `RoleConverter`

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -592,8 +592,7 @@ ColorConverter = ColourConverter
 class RoleConverter(IDConverter[discord.Role]):
     """Converts to a :class:`~discord.Role`.
 
-    All lookups are via the local guild. If in a DM context, then the lookup
-    is done by the global cache.
+    All lookups are via the local guild.
 
     The lookup strategy is as follows (in order):
 

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -592,7 +592,8 @@ ColorConverter = ColourConverter
 class RoleConverter(IDConverter[discord.Role]):
     """Converts to a :class:`~discord.Role`.
 
-    All lookups are via the local guild.
+    All lookups are via the local guild. If in a DM context, the converter raises
+    :exc:`.NoPrivateMessage` exception.
 
     The lookup strategy is as follows (in order):
 


### PR DESCRIPTION
## Summary

I've noticed that the docstring says that the lookup in RoleConverter is done in DM context but it actually just raises a `NoPrivateMessage` exception.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
