### PR TITLE
Fix type hinting on discord.utils.cached_property

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -72,7 +72,7 @@ __all__ = (
 DISCORD_EPOCH = 1420070400000
 
 
-class cached_property:
+class _cached_property:
     def __init__(self, function):
         self.function = function
         self.__doc__ = getattr(function, '__doc__')
@@ -88,7 +88,7 @@ class cached_property:
 
 
 if TYPE_CHECKING:
-    from functools import cached_property
+    from functools import cached_property as cached_property
     from .permissions import Permissions
     from .abc import Snowflake
     from .invite import Invite
@@ -96,6 +96,9 @@ if TYPE_CHECKING:
 
     class _RequestLike(Protocol):
         headers: Dict[str, Any]
+
+else:
+    cached_property = _cached_property
 
 
 T = TypeVar('T')


### PR DESCRIPTION
## Summary

PR Fixes type hinting on discord.utils.cached_property

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
