### PR TITLE
Fix typo in FlagConverter docs

### DIFF
--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -663,7 +663,7 @@ In order to customise the flag syntax we also have a few options that can be pas
         make: str
 
     # TOPIC: not allowed nsfw: yes Slowmode: 100
-    class Settings(commands.FlagConverter, case_insentitive=True):
+    class Settings(commands.FlagConverter, case_insensitive=True):
         topic: Optional[str]
         nsfw: Optional[bool]
         slowmode: Optional[int]


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes a typo in the FlagConverter documentation. 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
