### PR TITLE
fix _HelpCommandImpl.clean_params popitem

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -216,8 +216,8 @@ class _HelpCommandImpl(Command):
     def clean_params(self):
         result = self.params.copy()
         try:
-            result.pop("ctx")
-        except KeyError:
+            del result[next(iter(result))]
+        except StopIteration:
             raise ValueError('Missing context parameter') from None
         else:
             return result

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -216,8 +216,8 @@ class _HelpCommandImpl(Command):
     def clean_params(self):
         result = self.params.copy()
         try:
-            result.popitem(last=False)
-        except Exception:
+            result.pop("ctx")
+        except KeyError:
             raise ValueError('Missing context parameter') from None
         else:
             return result


### PR DESCRIPTION
## Summary
This code produces `TypeError: dict.popitem() takes no keyword arguments` since it's not an OrderedDict but was silenced by `Exception` which raises `ValueError`.
```py
try:
    result.popitem(last=False)
except Exception:
    raise ValueError('Missing context parameter') from None
else:
    return result
```
So I changed from `popitem(last=False)` to `del result[next(iter(result))]` and catches `StopIteration` instead if that's okay.

Here's the traceback upon removing the Exception try-except
```py
Ignoring exception in command help:
Traceback (most recent call last):
  File "C:\Users\sarah\AppData\Local\Programs\Python\Python39-32\lib\site-packages\discord\ext\commands\core.py", line 204, in wrapped
    ret = await coro(*args, **kwargs)
  File "C:\Users\sarah\AppData\Local\Programs\Python\Python39-32\lib\site-packages\discord\ext\commands\help.py", line 829, in command_callback
    return await self.send_bot_help(mapping)
  File "C:\Users\sarah\PycharmProjects\stella_bot\cogs\helpful.py", line 194, in send_bot_help
    command_data.append((cog, [CommandHelp(*get_info(command)) for command in chunks]))
  File "C:\Users\sarah\PycharmProjects\stella_bot\cogs\helpful.py", line 194, in <listcomp>
    command_data.append((cog, [CommandHelp(*get_info(command)) for command in chunks]))
  File "C:\Users\sarah\PycharmProjects\stella_bot\cogs\helpful.py", line 188, in <genexpr>
    return (getattr(self, f"get_{x}")(com) for x in ("command_signature", "help"))
  File "C:\Users\sarah\PycharmProjects\stella_bot\cogs\helpful.py", line 139, in get_command_signature
    if not command.signature and not command.parent:
  File "C:\Users\sarah\AppData\Local\Programs\Python\Python39-32\lib\site-packages\discord\ext\commands\core.py", line 1020, in signature
    params = self.clean_params
  File "C:\Users\sarah\AppData\Local\Programs\Python\Python39-32\lib\site-packages\discord\ext\commands\help.py", line 219, in clean_params
    result.popitem(last=False)
TypeError: dict.popitem() takes no keyword arguments
```
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
