### PR TITLE
Adjust quickstart to not show commands example

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -32,7 +32,7 @@ It looks something like this:
         if message.author == client.user:
             return
 
-        if message.content == 'Hello World!':
+        if message.content.startswith('hello'):
             await message.channel.send('Hello!')
 
     client.run('your token here')
@@ -54,8 +54,9 @@ There's a lot going on here, so let's walk you through it step by step.
 4. Since the :func:`on_message` event triggers for *every* message received, we have to make
    sure that we ignore messages from ourselves. We do this by checking if the :attr:`Message.author`
    is the same as the :attr:`Client.user`.
-5. Afterwards, we check if the :class:`Message.content` is ``'Hello World!'``. If it is,
-   then we send a message in the channel it was used in with ``'Hello!'``. 
+5. Afterwards, we check if the :class:`Message.content` starts with ``'hello'``. If it does,
+   then we send a message in the channel it was used in with ``'Hello!'``. This is a basic way of 
+   handling commands, which can be later automated with the :ref:`ext.commands` framework.
 6. Finally, we run the bot with our login token. If you need help getting your token or creating a bot,
    look in the :ref:`discord-intro` section.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -56,7 +56,7 @@ There's a lot going on here, so let's walk you through it step by step.
    is the same as the :attr:`Client.user`.
 5. Afterwards, we check if the :class:`Message.content` is ``'Hello World!'``. If it is,
    then we send a message in the channel it was used in with ``'Hello!'``. This is a basic way of 
-   handling commands, which can be later automated with the `ext.commands`_ framework.
+   handling commands, which can be later automated with the :ref:`ext.commands` framework.
 6. Finally, we run the bot with our login token. If you need help getting your token or creating a bot,
    look in the :ref:`discord-intro` section.
 
@@ -77,4 +77,3 @@ On other systems:
     $ python3 example_bot.py
 
 Now you can try playing around with your basic bot.
-.. _ext.commands: https://discordpy.readthedocs.io/en/stable/ext/commands/commands.html

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -32,7 +32,7 @@ It looks something like this:
         if message.author == client.user:
             return
 
-        if message.content == ('Hello World!'):
+        if message.content == 'Hello World!':
             await message.channel.send('Hello!')
 
     client.run('your token here')

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -56,7 +56,7 @@ There's a lot going on here, so let's walk you through it step by step.
    is the same as the :attr:`Client.user`.
 5. Afterwards, we check if the :class:`Message.content` is ``'Hello World!'``. If it is,
    then we send a message in the channel it was used in with ``'Hello!'``. This is a basic way of 
-   handling commands, which can be later automated with the 'ext.commands'_ framework.
+   handling commands, which can be later automated with the `ext.commands`_ framework.
 6. Finally, we run the bot with our login token. If you need help getting your token or creating a bot,
    look in the :ref:`discord-intro` section.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -55,8 +55,7 @@ There's a lot going on here, so let's walk you through it step by step.
    sure that we ignore messages from ourselves. We do this by checking if the :attr:`Message.author`
    is the same as the :attr:`Client.user`.
 5. Afterwards, we check if the :class:`Message.content` is ``'Hello World!'``. If it is,
-   then we send a message in the channel it was used in with ``'Hello!'``. This is a basic way of 
-   handling commands, which can be later automated with the :ref:`ext.commands` framework.
+   then we send a message in the channel it was used in with ``'Hello!'``. 
 6. Finally, we run the bot with our login token. If you need help getting your token or creating a bot,
    look in the :ref:`discord-intro` section.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -54,7 +54,7 @@ There's a lot going on here, so let's walk you through it step by step.
 4. Since the :func:`on_message` event triggers for *every* message received, we have to make
    sure that we ignore messages from ourselves. We do this by checking if the :attr:`Message.author`
    is the same as the :attr:`Client.user`.
-5. Afterwards, we check if the :class:`Message.content` starts with ``'hello'``. If it does,
+5. Afterwards, we check if the :class:`Message.content` starts with ``'$hello'``. If it does,
    then we send a message in the channel it was used in with ``'Hello!'``. This is a basic way of 
    handling commands, which can be later automated with the :ref:`ext.commands` framework.
 6. Finally, we run the bot with our login token. If you need help getting your token or creating a bot,

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -32,7 +32,7 @@ It looks something like this:
         if message.author == client.user:
             return
 
-        if message.content.startswith('$hello'):
+        if message.content == ('Hello World!'):
             await message.channel.send('Hello!')
 
     client.run('your token here')
@@ -54,8 +54,9 @@ There's a lot going on here, so let's walk you through it step by step.
 4. Since the :func:`on_message` event triggers for *every* message received, we have to make
    sure that we ignore messages from ourselves. We do this by checking if the :attr:`Message.author`
    is the same as the :attr:`Client.user`.
-5. Afterwards, we check if the :class:`Message.content` starts with ``'$hello'``. If it is,
-   then we send a message in the channel it was used in with ``'Hello!'``.
+5. Afterwards, we check if the :class:`Message.content` is ``'Hello World!'``. If it is,
+   then we send a message in the channel it was used in with ``'Hello!'``. This is a basic way of 
+   handling commands, which can be later automated with the 'ext.commands'_ framework.
 6. Finally, we run the bot with our login token. If you need help getting your token or creating a bot,
    look in the :ref:`discord-intro` section.
 
@@ -76,3 +77,4 @@ On other systems:
     $ python3 example_bot.py
 
 Now you can try playing around with your basic bot.
+.. _ext.commands: https://discordpy.readthedocs.io/en/stable/ext/commands/commands.html

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -32,7 +32,7 @@ It looks something like this:
         if message.author == client.user:
             return
 
-        if message.content.startswith('hello'):
+        if message.content.startswith('$hello'):
             await message.channel.send('Hello!')
 
     client.run('your token here')


### PR DESCRIPTION
## Summary

I thought this could be changed because new users might get the wrong impression that this is the intended
way to create commands, instead of using ext.commands. I also added a reference to ext.commands in the steps below.
P.S.: I am about 99% certain the way I did that reference is wrong, so if someone more experienced could take a look, it would
be greatly appreciated! Thanks!

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
