### PR TITLE
colour.py: Make spelling of "colour" consistent in docs

### DIFF
--- a/discord/colour.py
+++ b/discord/colour.py
@@ -56,7 +56,7 @@ class Colour:
              
         .. describe:: int(x)
 
-             Returns the raw color value.
+             Returns the raw colour value.
 
     Attributes
     ------------


### PR DESCRIPTION
## Summary

The 4 operations above this use "colour", but this one uses "color". This changes the spelling of the `int` description to "colour" to make it consistent.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
