### PR TITLE
[Interactions] Create User only when in DMs

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -111,11 +111,7 @@ class Interaction:
         except KeyError:
             self.message = None
 
-        try:
-            self.user = User(state=self._state, data=data['user'])
-        except KeyError:
-            self.user = None
-
+        self.user = None
         # TODO: there's a potential data loss here
         if self.guild_id:
             guild = self.guild or Object(id=self.guild_id)
@@ -123,6 +119,12 @@ class Interaction:
                 self.user = Member(state=self._state, guild=guild, data=data['member'])
             except KeyError:
                 pass
+        else:
+            try:
+                self.user = User(state=self._state, data=data['user'])
+            except KeyError:
+                pass
+
 
     @property
     def guild(self) -> Optional[Guild]:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -111,7 +111,7 @@ class Interaction:
         except KeyError:
             self.message = None
 
-        self.user = None
+        self.user: Optional[Union[User, Member]] = None
         # TODO: there's a potential data loss here
         if self.guild_id:
             guild = self.guild or Object(id=self.guild_id)


### PR DESCRIPTION
## Summary
Makes it so that User object is created only when self.guild_id is not present
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
