### PR TITLE
Fix how to check if the adapter is async

### DIFF
--- a/discord/webhook.py
+++ b/discord/webhook.py
@@ -509,7 +509,7 @@ class WebhookMessage(Message):
         """
 
         if delay is not None:
-            if self._state.parent._adapter.is_async():
+            if self._state._webhook._adapter.is_async():
                 return self._delete_delay_async(delay)
             else:
                 return self._delete_delay_sync(delay)


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes an issue where webhook delay checking was looking incorrectly for the adapter. The main state had no adapter to it, the webhook does. Before:

```
Traceback (most recent call last):
  File "/home/bonfire/Bonfire/cogs/owner.py", line 179, in debug
    ret = await func()
  File "<string>", line 11, in func
  File "/home/bonfire/Bonfire/lib/python3.8/site-packages/discord/webhook.py", line 511, in delete
    if self._state.parent._adapter.is_async():
AttributeError: 'AutoShardedConnectionState' object has no attribute '_adapter'
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
