### PR TITLE
Remove extra http.send_typing call in async context manager

### DIFF
--- a/discord/context_managers.py
+++ b/discord/context_managers.py
@@ -61,8 +61,7 @@ class Typing:
         self.task.cancel()
 
     async def __aenter__(self):
-        self._channel = channel = await self.messageable._get_channel()
-        await channel._state.http.send_typing(channel.id)
+        self._channel = await self.messageable._get_channel()
         return self.__enter__()
 
     async def __aexit__(self, exc_type, exc, tb):

--- a/discord/context_managers.py
+++ b/discord/context_managers.py
@@ -61,7 +61,6 @@ class Typing:
         self.task.cancel()
 
     async def __aenter__(self):
-        self._channel = await self.messageable._get_channel()
         return self.__enter__()
 
     async def __aexit__(self, exc_type, exc, tb):


### PR DESCRIPTION
## Summary

Removes an unneeded second immediate call to http.send_typing. 

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
