### PR TITLE
Fix grammar for the `guild.edit` docstring

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1010,8 +1010,8 @@ class Guild(Hashable):
             The new description of the guild. This is only available to guilds that
             contain ``PUBLIC`` in :attr:`Guild.features`.
         icon: :class:`bytes`
-            A :term:`py:bytes-like object` representing the icon. Only PNG/JPEG supported
-            and GIF This is only available to guilds that contain ``ANIMATED_ICON`` in :attr:`Guild.features`.
+            A :term:`py:bytes-like object` representing the icon. Only PNG/JPEG is supported.
+            GIF is only available to guilds that contain ``ANIMATED_ICON`` in :attr:`Guild.features`.
             Could be ``None`` to denote removal of the icon.
         banner: :class:`bytes`
             A :term:`py:bytes-like object` representing the banner.


### PR DESCRIPTION
## Summary

Fixes a minor grammar mistake with the docstring for `guild.edit`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
