### PR TITLE
Stop _edit_webhook_helper from passing an array with None to request

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -1189,7 +1189,9 @@ class HTTPClient:
             }
         ]
 
-        if file:
+        if file is None:
+            return self.request(route, form=form)
+        else:
             form.append(
                 {
                     'name': 'file',
@@ -1198,8 +1200,7 @@ class HTTPClient:
                     'content_type': 'application/octet-stream',
                 }
             )
-
-        return self.request(route, form=form, files=[file])
+            return self.request(route, form=form, files=[file])
 
     def create_interaction_response(self, interaction_id, token):
         r = Route(


### PR DESCRIPTION
## Summary

Fixes an error that occurs when a method that uses _edit_webhook_helper does not include a file

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
