### PR TITLE
Replace uses of Ellipsis as sentinels with utils.MISSING

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -56,6 +56,8 @@ if TYPE_CHECKING:
     from .asset import Asset
 
 
+MISSING = utils.MISSING
+
 class _Undefined:
     def __repr__(self):
         return 'see-below'
@@ -829,8 +831,8 @@ class GuildChannel(Protocol):
             raise InvalidArgument('Only one of [before, after, end, beginning] can be used.')
 
         bucket = self._sorting_bucket
-        parent_id = kwargs.get('category', ...)
-        if parent_id not in (..., None):
+        parent_id = kwargs.get('category', MISSING)
+        if parent_id not in (MISSING, None):
             parent_id = parent_id.id
             channels = [
                 ch
@@ -874,7 +876,7 @@ class GuildChannel(Protocol):
         reason = kwargs.get('reason')
         for index, channel in enumerate(channels):
             d = {'id': channel.id, 'position': index}
-            if parent_id is not ... and channel.id == self.id:
+            if parent_id is not MISSING and channel.id == self.id:
                 d.update(parent_id=parent_id, lock_permissions=lock_permissions)
             payload.append(d)
 

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -45,6 +45,8 @@ VALID_STATIC_FORMATS = frozenset({"jpeg", "jpg", "webp", "png"})
 VALID_ASSET_FORMATS = VALID_STATIC_FORMATS | {"gif"}
 
 
+MISSING = utils.MISSING
+
 class AssetMixin:
     url: str
     _state: Optional[Any]
@@ -254,9 +256,9 @@ class Asset(AssetMixin):
 
     def replace(
         self,
-        size: int = ...,
-        format: ValidAssetFormatTypes = ...,
-        static_format: ValidStaticFormatTypes = ...,
+        size: int = MISSING,
+        format: ValidAssetFormatTypes = MISSING,
+        static_format: ValidStaticFormatTypes = MISSING,
     ) -> Asset:
         """Returns a new asset with the passed components replaced.
 
@@ -284,7 +286,7 @@ class Asset(AssetMixin):
         url = yarl.URL(self._url)
         path, _ = os.path.splitext(url.path)
 
-        if format is not ...:
+        if format is not MISSING:
             if self._animated:
                 if format not in VALID_ASSET_FORMATS:
                     raise InvalidArgument(f'format must be one of {VALID_ASSET_FORMATS}')
@@ -293,12 +295,12 @@ class Asset(AssetMixin):
                     raise InvalidArgument(f'format must be one of {VALID_STATIC_FORMATS}')
             url = url.with_path(f'{path}.{format}')
 
-        if static_format is not ... and not self._animated:
+        if static_format is not MISSING and not self._animated:
             if static_format not in VALID_STATIC_FORMATS:
                 raise InvalidArgument(f'static_format must be one of {VALID_STATIC_FORMATS}')
             url = url.with_path(f'{path}.{static_format}')
 
-        if size is not ...:
+        if size is not MISSING:
             if not utils.valid_icon_size(size):
                 raise InvalidArgument('size must be a power of 2 between 16 and 4096')
             url = url.with_query(size=size)

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1179,7 +1179,7 @@ class Webhook(BaseWebhook):
 
         previous_mentions: Optional[AllowedMentions] = getattr(self._state, 'allowed_mentions', None)
         if content is None:
-            content = ...  # type: ignore
+            content = MISSING
 
         params = handle_message_parameters(
             content=content,

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -853,7 +853,7 @@ class SyncWebhook(BaseWebhook):
 
         previous_mentions: Optional[AllowedMentions] = getattr(self._state, 'allowed_mentions', None)
         if content is None:
-            content = ...  # type: ignore
+            content = MISSING
 
         params = handle_message_parameters(
             content=content,


### PR DESCRIPTION
## Summary

Replaces uses of Ellipsis as sentinels with utils.MISSING

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
