### PR TITLE
Fix Grammar for `Intents` Docstring

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -395,7 +395,7 @@ class PublicUserFlags(BaseFlags):
 class Intents(BaseFlags):
     r"""Wraps up a Discord gateway intent flag.
 
-    Similar to :class:`Permissions`\, the properties provided are two way.
+    Similar to :class:`Permissions`\, the properties provided are two ways.
     You can set and retrieve individual bits using the properties as if they
     were regular bools.
 


### PR DESCRIPTION
## Summary

This fixes a minor grammar mistake in the intents docstring. It was “two way”,  now I corrected it to “two ways”.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
