### PR TITLE
Clarify where abc.Messageable.fetch_message finds its messages from

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1155,7 +1155,8 @@ class Messageable(Protocol):
     async def fetch_message(self, id):
         """|coro|
 
-        Retrieves a single :class:`~discord.Message` from the destination.
+        Retrieves a single :class:`~discord.Message` from the destination, which is the channel that this
+        object refers to.
 
         This can only be used by bot accounts.
 


### PR DESCRIPTION
Clarify the "destination" that messages are fetched from. Fetch_message only finds a message with message_id from the channel that Messageable wraps, and not from other channels in (for example) the guild.

## Summary

Clarify what where fetch_message for abc.Messageable finds messages from.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
