### PR TITLE
[docs] remove mentions of bot only usability

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1157,8 +1157,6 @@ class Messageable(Protocol):
 
         Retrieves a single :class:`~discord.Message` from the destination.
 
-        This can only be used by bot accounts.
-
         Parameters
         ------------
         id: :class:`int`

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -269,8 +269,6 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         You must have the :attr:`~Permissions.manage_messages` permission to
         use this.
 
-        Usable only by bot accounts.
-
         Parameters
         -----------
         messages: Iterable[:class:`abc.Snowflake`]
@@ -281,8 +279,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         ClientException
             The number of messages to delete was more than 100.
         Forbidden
-            You do not have proper permissions to delete the messages or
-            you're not using a bot account.
+            You do not have proper permissions to delete the messages.
         NotFound
             If single delete, then the message was already deleted.
         HTTPException

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -310,8 +310,8 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         without discrimination.
 
         You must have the :attr:`~Permissions.manage_messages` permission to
-        delete messages even if they are your own (unless you are a user
-        account). The :attr:`~Permissions.read_message_history` permission is
+        delete messages even if they are your own.
+        The :attr:`~Permissions.read_message_history` permission is
         also needed to retrieve message history.
 
         Examples

--- a/discord/client.py
+++ b/discord/client.py
@@ -1255,10 +1255,9 @@ class Client:
     async def fetch_user(self, user_id):
         """|coro|
 
-        Retrieves a :class:`~discord.User` based on their ID. This can only
-        be used by bot accounts. You do not have to share any guilds
-        with the user to get this information, however many operations
-        do require that you do.
+        Retrieves a :class:`~discord.User` based on their ID. 
+        You do not have to share any guilds with the user to get this information,
+        however many operations do require that you do.
 
         .. note::
 


### PR DESCRIPTION
## Summary

Removes mentions of bot-only usability from the docs, since non-bot accounts are no longer supported.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
