### PR TITLE
Make GuildChannel inherit Snowflake

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -179,7 +179,7 @@ class _Overwrites:
         return self.type == 1
 
 
-class GuildChannel(Protocol):
+class GuildChannel(Snowflake, Protocol):
     """An ABC that details the common operations on a Discord guild channel.
 
     The following implement this ABC:


### PR DESCRIPTION
## Summary

Makes GuildChannel inherit Snowflake as intersection types don't exist.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
