### PR TITLE
[docs] Explicitly ignore legacy file reference errors in sphinx -n mode

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ extensions = [
     'exception_hierarchy',
     'attributetable',
     'resourcelinks',
+    'nitpick_file_ignorer',
 ]
 
 autodoc_member_order = 'bysource'
@@ -139,6 +140,13 @@ pygments_style = 'friendly'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 #keep_warnings = False
 
+
+# Nitpicky mode options
+nitpick_ignore_files = [
+  "migrating_to_async",
+  "migrating",
+  "whats_new",
+]
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/extensions/nitpick_file_ignorer.py
+++ b/docs/extensions/nitpick_file_ignorer.py
@@ -1,0 +1,22 @@
+import logging
+
+from sphinx.application import Sphinx
+from sphinx.util import logging as sphinx_logging
+
+
+class NitpickFileIgnorer(logging.Filter):
+    
+    def __init__(self, app: Sphinx) -> None:
+        self.app = app
+        super().__init__()
+
+    def filter(self, record: sphinx_logging.SphinxLogRecord) -> bool:
+        if getattr(record, 'type', None) == 'ref':
+            return record.location.get('refdoc') not in self.app.config.nitpick_ignore_files
+        return True
+
+
+def setup(app: Sphinx):
+    app.add_config_value('nitpick_ignore_files', [], '')
+    f = NitpickFileIgnorer(app)
+    sphinx_logging.getLogger('sphinx.transforms.post_transforms').logger.addFilter(f)


### PR DESCRIPTION
## Summary

Forces sphinx nitpicky `-n` mode to ignore reference issues in legacy files.
 
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
