### PR TITLE
Change Client status & activity behavior

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -144,10 +144,12 @@ class Client:
         A status to start your presence with upon logging on to Discord.
 
         .. versionchanged:: 2.0
+            Renamed from `status` to `start_up_status`
     start_up_activity: Optional[:class:`.BaseActivity`]
         An activity to start your presence with upon logging on to Discord.
 
         .. versionchanged:: 2.0
+            Renamed from `activity` to `start_up_activity`
     allowed_mentions: Optional[:class:`AllowedMentions`]
         Control how the client handles mentions by default on every message sent.
 
@@ -631,14 +633,17 @@ class Client:
         return self._closed
 
     @property
-    def activity(self):
+    def start_up_activity(self):
         """Optional[:class:`.BaseActivity`]: The activity being used upon
         logging in.
+
+        .. versionchanged: 2.0
+            Renamed from `activity` to `start_up_activity`
         """
         return create_activity(self._connection._activity)
 
-    @activity.setter
-    def activity(self, value):
+    @start_up_activity.setter
+    def start_up_activity(self, value):
         if value is None:
             self._connection._activity = None
         elif isinstance(value, BaseActivity):
@@ -647,16 +652,16 @@ class Client:
             raise TypeError('activity must derive from BaseActivity.')
     
     @property
-    def status(self):
-        """Optional[:class:`.Status`]
-        A status to start your presence with upon logging on to Discord.
+    def start_up_status(self):
+        """:class:`.Status`:
+        The status being used upon logging on to Discord.
 
         .. versionadded: 2.0
         """
         return Status(self._connection._status)
 
-    @status.setter
-    def status(self, value):
+    @start_up_status.setter
+    def start_up_status(self, value):
         if value is Status.offline:
             self._connection._status = 'invisible'
         elif isinstance(value, Status):

--- a/discord/client.py
+++ b/discord/client.py
@@ -658,7 +658,9 @@ class Client:
 
         .. versionadded: 2.0
         """
-        return Status(self._connection._status)
+        if self._connection._status in set(state.value for state in Status):
+            return Status(self._connection._status)
+        return Status.online
 
     @start_up_status.setter
     def start_up_status(self, value):

--- a/discord/client.py
+++ b/discord/client.py
@@ -140,10 +140,14 @@ class Client:
         is ``True``.
 
         .. versionadded:: 1.5
-    status: Optional[:class:`.Status`]
+    start_up_status: Optional[:class:`.Status`]
         A status to start your presence with upon logging on to Discord.
-    activity: Optional[:class:`.BaseActivity`]
+
+        .. versionchanged:: 2.0
+    start_up_activity: Optional[:class:`.BaseActivity`]
         An activity to start your presence with upon logging on to Discord.
+
+        .. versionchanged:: 2.0
     allowed_mentions: Optional[:class:`AllowedMentions`]
         Control how the client handles mentions by default on every message sent.
 
@@ -641,6 +645,24 @@ class Client:
             self._connection._activity = value.to_dict()
         else:
             raise TypeError('activity must derive from BaseActivity.')
+    
+    @property
+    def status(self):
+        """Optional[:class:`.Status`]
+        A status to start your presence with upon logging on to Discord.
+
+        .. versionadded: 2.0
+        """
+        return Status(self._connection._status)
+
+    @status.setter
+    def status(self, value):
+        if value is Status.offline:
+            self._connection._status = 'invisible'
+        elif isinstance(value, Status):
+            self._connection._status = str(value)
+        else:
+            raise TypeError('status must derive from Status.')
 
     @property
     def allowed_mentions(self):

--- a/discord/state.py
+++ b/discord/state.py
@@ -128,14 +128,14 @@ class ConnectionState:
         self.allowed_mentions = allowed_mentions
         self._chunk_requests = {} # Dict[Union[int, str], ChunkRequest]
 
-        activity = options.get('activity', None)
+        activity = options.get('start_up_activity', None)
         if activity:
             if not isinstance(activity, BaseActivity):
                 raise TypeError('activity parameter must derive from BaseActivity.')
 
             activity = activity.to_dict()
 
-        status = options.get('status', None)
+        status = options.get('start_up_status', None)
         if status:
             if status is Status.offline:
                 status = 'invisible'


### PR DESCRIPTION
## Summary

This PR addresses #6868. `Client.(activity|status)` have been renamed to `Client.start_up_(activity|status)` and both are accessible as properties.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
