### PR TITLE
Fix issues with imports causing NameErrors

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import copy
 import asyncio
+from datetime import datetime
 from typing import Any, Dict, List, Mapping, Optional, TYPE_CHECKING, Protocol, Type, TypeVar, Union, overload, runtime_checkable
 
 from .iterators import HistoryIterator
@@ -52,8 +53,6 @@ __all__ = (
 T = TypeVar('T', bound=VoiceProtocol)
 
 if TYPE_CHECKING:
-    from datetime import datetime
-
     from .user import ClientUser
     from .asset import Asset
     from .state import ConnectionState

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import copy
 import asyncio
-from datetime import datetime
 from typing import Any, Dict, List, Mapping, Optional, TYPE_CHECKING, Protocol, Type, TypeVar, Union, overload, runtime_checkable
 
 from .iterators import HistoryIterator
@@ -53,6 +52,8 @@ __all__ = (
 T = TypeVar('T', bound=VoiceProtocol)
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from .user import ClientUser
     from .asset import Asset
     from .state import ConnectionState
@@ -61,6 +62,8 @@ if TYPE_CHECKING:
     from .channel import CategoryChannel
     from .embeds import Embed
     from .message import Message, MessageReference
+
+    SnowflakeTime = Union["Snowflake", datetime]
 
 MISSING = utils.MISSING
 
@@ -96,8 +99,6 @@ class Snowflake(Protocol):
     def created_at(self) -> datetime:
         """:class:`datetime.datetime`: Returns the model's creation time as an aware datetime in UTC."""
         raise NotImplementedError
-
-SnowflakeTime = Union[Snowflake, datetime]
 
 @runtime_checkable
 class User(Snowflake, Protocol):

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -52,7 +52,7 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
-    from .abc import Snowflake
+    from .abc import SnowflakeTime
     from .types.guild import (
         Ban as BanPayload
     )

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -22,6 +22,8 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
+from __future__ import annotations
+
 import copy
 from collections import namedtuple
 from typing import Dict, List, Literal, Optional, TYPE_CHECKING, Union, overload

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -52,6 +52,7 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from .abc import Snowflake
     from .types.guild import (
         Ban as BanPayload
     )
@@ -1354,7 +1355,7 @@ class Guild(Hashable):
 
         return [convert(d) for d in data]
 
-    def fetch_members(self, *, limit: int = 1000, after: Optional[abc.SnowflakeTime] = None) -> List[Member]:
+    def fetch_members(self, *, limit: int = 1000, after: Optional[SnowflakeTime] = None) -> List[Member]:
         """Retrieves an :class:`.AsyncIterator` that enables receiving the guild's members. In order to use this,
         :meth:`Intents.members` must be enabled.
 
@@ -2223,8 +2224,8 @@ class Guild(Hashable):
         self,
         *,
         limit: int = 100,
-        before: Optional[abc.SnowflakeTime] = None,
-        after: Optional[abc.SnowflakeTime] = None,
+        before: Optional[SnowflakeTime] = None,
+        after: Optional[SnowflakeTime] = None,
         oldest_first: Optional[bool] = None,
         user: abc.Snowflake = None,
         action: AuditLogAction = None

--- a/discord/member.py
+++ b/discord/member.py
@@ -22,6 +22,8 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
+from __future__ import annotations
+
 import datetime
 import inspect
 import itertools


### PR DESCRIPTION
## Summary

Fixes NameErrors caused by lack of `from __future__ import annotations` directives in  #6813

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
