### PR TITLE
use premium_subscriber_role over premium_since for boosters

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -555,7 +555,8 @@ class Guild(Hashable):
     @property
     def premium_subscribers(self):
         """List[:class:`Member`]: A list of members who have "boosted" this guild."""
-        return [member for member in self.members if member.premium_since is not None]
+        role = self.premium_subscriber_role
+        return [member for member in self.members if member._roles.has(role.id)]
 
     @property
     def roles(self):


### PR DESCRIPTION
## Summary

Since [`premium_since` is documented as both optional and nullable](https://discord.com/developers/docs/resources/guild#guild-member-object), it seems more appropriate to check if they have the premium subscriber role.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
