### PR TITLE
Make `Invite.inviter` optional

### DIFF
--- a/discord/invite.py
+++ b/discord/invite.py
@@ -262,7 +262,7 @@ class Invite(Hashable):
     max_uses: :class:`int`
         How many times the invite can be used.
         A value of ``0`` indicates that it has unlimited uses.
-    inviter: :class:`User`
+    inviter: Optional[:class:`User`]
         The user who created the invite.
     approximate_member_count: Optional[:class:`int`]
         The approximate number of members in the guild.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2010,9 +2010,9 @@ of :class:`enum.Enum`.
     .. attribute:: stream
 
         The invite targets a stream.
-        
+
     .. attribute:: embedded_application
-    
+
         The invite targets an embedded application activity.
 
 .. class:: VideoQualityMode
@@ -2538,7 +2538,7 @@ AuditLogDiff
 
         See also :attr:`Invite.inviter`.
 
-        :type: :class:`User`
+        :type: Optional[:class:`User`]
 
     .. attribute:: max_uses
 


### PR DESCRIPTION
## Summary

When an invite is created by loading the guild widget (`https://discord.com/widget?id=<guild_id>`) it's inviter is None

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)