### PR TITLE
Added the new blurple

### DIFF
--- a/discord/colour.py
+++ b/discord/colour.py
@@ -270,9 +270,14 @@ class Colour:
     darker_gray = darker_grey
 
     @classmethod
-    def blurple(cls: Type[CT]) -> CT:
+    def og_blurple(cls: Type[CT]) -> CT:
         """A factory method that returns a :class:`Colour` with a value of ``0x7289da``."""
         return cls(0x7289da)
+
+    @classmethod
+    def blurple(cls: Type[CT]) -> CT:
+        """A factory method that returns a :class:`Colour` with a value of ``0x5865F2``."""
+        return cls(0x5865F2)
 
     @classmethod
     def greyple(cls: Type[CT]) -> CT:


### PR DESCRIPTION
## Summary

Changed `discord.Colour.blurple` since Discord released the new colour set and set the old colour to `discord.Colour.og_blurple` as how Discord calls it.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
