### PR TITLE
Fix for doc reference to python "raise" statement

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -267,7 +267,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
     If you want exception to propagate out of the :class:`Client` class
     you can define an ``on_error`` handler consisting of a single empty
-    :ref:`py:raise`.  Exceptions raised by ``on_error`` will not be
+    :ref:`raise statement <py:raise>`. Exceptions raised by ``on_error`` will not be
     handled in any way by :class:`Client`.
 
     .. note::


### PR DESCRIPTION
:ref:\`py:raise\` -> :ref:\`raise statement \<py:raise\>\`

Text currently reads: "...define an on_error handler consisting of a single empty The raise statement."
After fix it should read: "...define an on_error handler consisting of a single empty raise statement."

## Summary

Fixes a small issue with a reference to the python "raise" statement webpage in the API Reference documentation.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
