### PR TITLE
[commands] Add BadColorArgument to __all__

### DIFF
--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -49,7 +49,7 @@ __all__ = (
     'ChannelNotFound',
     'ChannelNotReadable',
     'BadColourArgument',
-    'BadColorArgument'
+    'BadColorArgument',
     'RoleNotFound',
     'BadInviteArgument',
     'EmojiNotFound',

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -49,6 +49,7 @@ __all__ = (
     'ChannelNotFound',
     'ChannelNotReadable',
     'BadColourArgument',
+    'BadColorArgument'
     'RoleNotFound',
     'BadInviteArgument',
     'EmojiNotFound',


### PR DESCRIPTION
This PR adds BadColorArgument to __all__ . BadColorArgument is an alias of BadColourArgument.
```py
Traceback (most recent call last):
  File "/home/ubuntu/.local/lib/python3.9/site-packages/discord/ext/commands/bot.py", line 939, in invoke
    await ctx.command.invoke(ctx)
  File "/home/ubuntu/.local/lib/python3.9/site-packages/discord/ext/commands/core.py", line 863, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/home/ubuntu/.local/lib/python3.9/site-packages/discord/ext/commands/core.py", line 94, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: AttributeError: module 'discord.ext.commands' has no attribute 'BadColorArgument'
```

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
