### PR TITLE
Consistent on event loop's description.

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -177,7 +177,7 @@ class Client:
     ws
         The websocket gateway the client is currently connected to. Could be ``None``.
     loop: :class:`asyncio.AbstractEventLoop`
-        The event loop that the client uses for HTTP requests and websocket operations.
+        The event loop that the client uses for asynchronous operations.
     """
     def __init__(self, *, loop=None, **options):
         self.ws = None


### PR DESCRIPTION
## Summary

Changed the event loop's description because in the parameters, it said the loop is `to use for asynchronous operations.` But then in the attribute it said `The event loop that the client uses for HTTP requests and websocket operations.` Nothing is really wrong with it but just to be consistent to the parameter's description.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
