### PR TITLE
Remove VerificationLevel aliases

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -229,7 +229,7 @@ class VerificationLevel(Enum):
     low       = 1
     medium    = 2
     high      = 3
-    very_high = 4
+    highest = 4
 
     def __str__(self):
         return self.name

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -225,14 +225,11 @@ class SpeakingState(Enum):
         return self.value
 
 class VerificationLevel(Enum):
-    none              = 0
-    low               = 1
-    medium            = 2
-    high              = 3
-    table_flip        = 3
-    extreme           = 4
-    double_table_flip = 4
-    very_high         = 4
+    none      = 0
+    low       = 1
+    medium    = 2
+    high      = 3
+    very_high = 4
 
     def __str__(self):
         return self.name

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -225,10 +225,10 @@ class SpeakingState(Enum):
         return self.value
 
 class VerificationLevel(Enum):
-    none      = 0
-    low       = 1
-    medium    = 2
-    high      = 3
+    none    = 0
+    low     = 1
+    medium  = 2
+    high    = 3
     highest = 4
 
     def __str__(self):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1298,11 +1298,9 @@ of :class:`enum.Enum`.
         Member must have a verified email, be registered on Discord for more
         than five minutes, and be a member of the guild itself for more than
         ten minutes.
-    .. attribute:: very_high
+    .. attribute:: highest
 
         Member must have a verified phone on their Discord account.
-
-        .. versionadded:: 1.4
 
 .. class:: NotificationLevel
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1298,20 +1298,9 @@ of :class:`enum.Enum`.
         Member must have a verified email, be registered on Discord for more
         than five minutes, and be a member of the guild itself for more than
         ten minutes.
-    .. attribute:: table_flip
-
-        An alias for :attr:`high`.
-    .. attribute:: extreme
-
-        Member must have a verified phone on their Discord account.
-
-    .. attribute:: double_table_flip
-
-        An alias for :attr:`extreme`.
-
     .. attribute:: very_high
 
-        An alias for :attr:`extreme`.
+        Member must have a verified phone on their Discord account.
 
         .. versionadded:: 1.4
 


### PR DESCRIPTION
## Summary

This PR removes VerificationLevel aliases that are no longer used in the Discord client

## Checklist

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)