### PR TITLE
Fix Webhook example

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -740,7 +740,7 @@ class Webhook(BaseWebhook):
 
     .. code-block:: python3
 
-        from discord import Webhook, AsyncWebhookAdapter
+        from discord import Webhook
         import aiohttp
 
         async def foo():


### PR DESCRIPTION
## Summary
Fixes Webhook example in docstring, where it imported `AsyncWebhookAdapter`.

## Checklist
- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
