### PR TITLE
Fix default hook signature

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -717,7 +717,7 @@ class DiscordVoiceWebSocket:
         if hook:
             self._hook = hook
 
-    async def _hook(self, msg):
+    async def _hook(self, *args):
         pass
     
     async def send_as_json(self, data):


### PR DESCRIPTION
Since the hook function can be both bound and unbound the bound signature needs to accept an extra argument