### PR TITLE
Fix minor typo in typing() docs

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1315,7 +1315,7 @@ class Messageable(Protocol):
 
         Example Usage: ::
             async with channel.typing(): 
-                # stimulate something heavy 
+                # simulate something heavy 
                 await asyncio.sleep(10)
 
             await channel.send('done!')


### PR DESCRIPTION
## Summary

Fixes a typo accidentally introduced in #6919.

## Checklist
- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
