### PR TITLE
Add Member.get_role

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -830,3 +830,20 @@ class Member(discord.abc.Messageable, _BaseUser):
             user_id = self.id
             for role in roles:
                 await req(guild_id, user_id, role.id, reason=reason)
+
+    def get_role(self, role_id: int) -> Optional[discord.Role]:
+        """Returns a role with the given ID from roles which the member has.
+
+        .. versionadded:: 2.0
+
+        Parameters
+        -----------
+        role_id: :class:`int`
+            The ID to search for.
+
+        Returns
+        --------
+        Optional[:class:`Role`]
+            The role or ``None`` if not found in the member's roles.
+        """
+        return self.guild.get_role(role_id) if self._roles.has(role_id) else None


### PR DESCRIPTION
## Summary

  - Adds an efficient way to check if a member has a role by ID.

     This is done in a way consistent with the existing user API of the
     library.

     The more debated Member.has_role_id/has_role is intentionally not
     included for review at this time given the heavy bikeshedding of it.
 
If this is not something to be included yet or needs further discussion first, I have no issues with this being closed or delayed, but I figured getting the part that wasn't as controversial and was beneficial to those currently directly using the internals started was worth it.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
