### PR TITLE
Fix bug in Embed.__len__ caused by footer without text

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -181,11 +181,11 @@ class Embed:
             total += len(field['name']) + len(field['value'])
 
         try:
-            footer = self._footer
-        except AttributeError:
+            footer_text = self._footer['text']
+        except (AttributeError, KeyError):
             pass
         else:
-            total += len(footer['text'])
+            total += len(footer_text)
 
         try:
             author = self._author


### PR DESCRIPTION
## Summary

`Embed.__len__` didn't account for a footer with only an `icon_url` set.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
