### PR TITLE
allow label to be none

### DIFF
--- a/discord/components.py
+++ b/discord/components.py
@@ -106,8 +106,8 @@ class Button(Component):
         The URL this button sends you to.
     disabled: :class:`bool`
         Whether the button is disabled or not.
-    label: :class:`str`
-        The label of the button.
+    label: Optional[:class:`str`]
+        The label of the button, if any.
     emoji: Optional[:class:`PartialEmoji`]
         The emoji of the button, if available.
     """
@@ -127,7 +127,7 @@ class Button(Component):
         self.custom_id: Optional[str] = data.get('custom_id')
         self.url: Optional[str] = data.get('url')
         self.disabled: bool = data.get('disabled', False)
-        self.label: str = data['label']
+        self.label: Optional[str] = data.get('label')
         self.emoji: Optional[PartialEmoji]
         try:
             self.emoji = PartialEmoji.from_dict(data['emoji'])

--- a/discord/types/components.py
+++ b/discord/types/components.py
@@ -41,12 +41,11 @@ class _ButtonComponentOptional(TypedDict, total=False):
     url: str
     disabled: bool
     emoji: PartialEmoji
-
+    label: str
 
 class ButtonComponent(_ButtonComponentOptional):
     type: Literal[2]
     style: ButtonStyle
-    label: str
 
 
 Component = Union[ComponentContainer, ButtonComponent]

--- a/discord/ui/button.py
+++ b/discord/ui/button.py
@@ -82,8 +82,8 @@ class Button(Item[V]):
         The URL this button sends you to.
     disabled: :class:`bool`
         Whether the button is disabled or not.
-    label: :class:`str`
-        The label of the button.
+    label: Optional[:class:`str`]
+        The label of the button, if any.
     emoji: Optional[:class:`PartialEmoji`]
         The emoji of the button, if available.
     """
@@ -101,7 +101,7 @@ class Button(Item[V]):
         self,
         *,
         style: ButtonStyle,
-        label: str,
+        label: Optional[str] = None,
         disabled: bool = False,
         custom_id: Optional[str] = None,
         url: Optional[str] = None,
@@ -174,13 +174,13 @@ class Button(Item[V]):
         self._underlying.disabled = bool(value)
 
     @property
-    def label(self) -> str:
-        """:class:`str`: The label of the button."""
+    def label(self) -> Optional[str]:
+        """Optional[:class:`str`]: The label of the button, if available."""
         return self._underlying.label
 
     @label.setter
-    def label(self, value: str):
-        self._underlying.label = str(value)
+    def label(self, value: Optional[str]):
+        self._underlying.label = str(value) if value is not None else value
 
     @property
     def emoji(self) -> Optional[PartialEmoji]:
@@ -221,8 +221,8 @@ class Button(Item[V]):
 
 
 def button(
-    label: str,
     *,
+    label: Optional[str] = None,
     custom_id: Optional[str] = None,
     disabled: bool = False,
     style: ButtonStyle = ButtonStyle.secondary,
@@ -245,8 +245,8 @@ def button(
 
     Parameters
     ------------
-    label: :class:`str`
-        The label of the button.
+    label: Optional[:class:`str`]
+        The label of the button, if any.
     custom_id: Optional[:class:`str`]
         The ID of the button that gets received during an interaction.
         It is recommended not to set this parameter to prevent conflicts.


### PR DESCRIPTION
## Summary

label is optional and the lib will error if its not passed. also makes label optional in parameters.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
