### PR TITLE
Fix extraneous colons in the documentation for `ButtonStyle`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1243,7 +1243,7 @@ of :class:`enum.Enum`.
     .. attribute:: danger
 
         Represents a red button for a dangerous action.
-    .. attribute:: link::
+    .. attribute:: link
 
         Represents a link button.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1231,16 +1231,16 @@ of :class:`enum.Enum`.
 
     .. versionadded:: 2.0
 
-    .. attribute:: primary::
+    .. attribute:: primary
 
         Represents a blurple button for the primary action.
-    .. attribute:: secondary::
+    .. attribute:: secondary
 
         Represents a grey button for the secondary action.
-    .. attribute:: success::
+    .. attribute:: success
 
         Represents a green button for a successful action.
-    .. attribute:: danger::
+    .. attribute:: danger
 
         Represents a red button for a dangerous action.
     .. attribute:: link::


### PR DESCRIPTION
## Summary

There were some extraneous colons in the docs for the enum ButtonStyle, this PR fixes this.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
