### PR TITLE
Add Role.is_assignable

### DIFF
--- a/discord/role.py
+++ b/discord/role.py
@@ -258,6 +258,13 @@ class Role(Hashable):
         """
         return self.tags is not None and self.tags.is_integration()
 
+    def is_assignable(self):
+        """:class:`bool`: Whether the role is able to be assigned by the logged in user.
+
+        .. versionadded:: 2.0
+        """
+        return not self.is_default() and not self.managed and self.guild.me.top_role > self
+
     @property
     def permissions(self):
         """:class:`Permissions`: Returns the role's permissions."""

--- a/discord/role.py
+++ b/discord/role.py
@@ -259,7 +259,7 @@ class Role(Hashable):
         return self.tags is not None and self.tags.is_integration()
 
     def is_assignable(self):
-        """:class:`bool`: Whether the role is able to be assigned by the logged in user.
+        """:class:`bool`: Whether the role is able to be assigned or removed by the bot.
 
         .. versionadded:: 2.0
         """


### PR DESCRIPTION
## Summary

Adds the ability for bots to quickly and efficiently check whether or not a `Role` is assignable to members by the logged in user.

Pros:

* Solves an issue that is commonly brought up in the help channels (Role hierarchy management/checking)
* Precedence with this type of method in the library (`Emoji.is_usable`)
* In case of future updates by Discord, this new method allows for the library to update the check rather than having library users update their own implementation of the check.

Bikeshed discussion: https://discord.com/channels/336642139381301249/603069307286454290/847640778485268520

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
