### PR TITLE
Fix bug in ui.View __slot__

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -91,6 +91,8 @@ class View:
         'children',
         'id',
         '_cancel_callback',
+        '_timeout_handler',
+        '_stopped'
     )
 
     __discord_ui_view__: ClassVar[bool] = True


### PR DESCRIPTION
## Summary

There was an error because _stopped and _timeout_handler were not in __slots__.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
