### PR TITLE
Fix `role.is_assignable()`

### DIFF
--- a/discord/role.py
+++ b/discord/role.py
@@ -263,7 +263,7 @@ class Role(Hashable):
 
         .. versionadded:: 2.0
         """
-        return not self.is_default() and not self.managed and self.guild.me.top_role > self
+        return not self.is_default() and not self.managed and (self.guild.me.top_role > self or self.guild.owner == self.guild.me)
 
     @property
     def permissions(self):

--- a/discord/role.py
+++ b/discord/role.py
@@ -263,7 +263,7 @@ class Role(Hashable):
 
         .. versionadded:: 2.0
         """
-        return not self.is_default() and not self.managed and (self.guild.me.top_role > self or self.guild.owner == self.guild.me)
+        return not self.is_default() and not self.managed and (self.guild.me.top_role > self or self.guild.me == self.guild.owner)
 
     @property
     def permissions(self):


### PR DESCRIPTION
## Summary

Since a discord client can be the owner of a maximum of 10 guilds, `role.is_assignable()` should take care of this case. This PR fixes this issue.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
