### PR TITLE
Add a `custom_id` attribute to the `Interaction` object

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -84,6 +84,8 @@ class Interaction:
     token: :class:`str`
         The token to continue the interaction. These are valid
         for 15 minutes.
+    custom_id: Optional[:class:`str`]
+        The custom ID of the interaction. ``None`` if the interaction is not a Message Component.
     """
 
     __slots__: Tuple[str, ...] = (
@@ -97,6 +99,7 @@ class Interaction:
         'user',
         'token',
         'version',
+        'custom_id',
         '_state',
         '_session',
         '_cs_response',
@@ -116,6 +119,7 @@ class Interaction:
         self.channel_id = utils._get_as_snowflake(data, 'channel_id')
         self.guild_id = utils._get_as_snowflake(data, 'guild_id')
         self.application_id = utils._get_as_snowflake(data, 'application_id')
+        self.custom_id = self.data.get('custom_id')
 
         channel = self.channel or Object(id=self.channel_id)
         try:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -85,7 +85,8 @@ class Interaction:
         The token to continue the interaction. These are valid
         for 15 minutes.
     custom_id: Optional[:class:`str`]
-        The custom ID of the interaction. ``None`` if the interaction is not a Message Component.
+        The custom ID of the interaction. ``None`` if the 
+        interaction is not a Message Component.
     """
 
     __slots__: Tuple[str, ...] = (


### PR DESCRIPTION

## Summary

Add the `custom_id` attribute to the `discord.Interaction` object.
This attribute will be `None` unless the `Interaction` is a component.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)