### PR TITLE
Add documentation to user.mutual_guilds

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -340,6 +340,8 @@ class User(BaseUser, discord.abc.Messageable):
     @property
     def mutual_guilds(self):
         """List[:class:`Guild`]: The guilds that the user shares with the client.
+        
+        This requires :meth:`Intents.members` to be enabled.
 
         .. note::
 


### PR DESCRIPTION
## Summary

`user.mutual_guilds` requires `Intents.members` (privileged intent) to be enabled because it uses `guild.get_member()`, this is important for anyone who may want to use it to know.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
