### PR TITLE
Add Command.extras

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -215,6 +215,10 @@ class Command(_BaseCommand):
         If ``True``\, cooldown processing is done after argument parsing,
         which calls converters. If ``False`` then cooldown processing is done
         first and then the converters are called second. Defaults to ``False``.
+    extras: :class:`dict`
+        A dict of user provided extras to attach to the Command.
+
+        .. versionadded:: 2.0
     """
 
     def __new__(cls, *args, **kwargs):
@@ -258,6 +262,7 @@ class Command(_BaseCommand):
         self.usage = kwargs.get('usage')
         self.rest_is_raw = kwargs.get('rest_is_raw', False)
         self.aliases = kwargs.get('aliases', [])
+        self.extras = kwargs.get('extras', {})
 
         if not isinstance(self.aliases, (list, tuple)):
             raise TypeError("Aliases of a command must be a list or a tuple of strings.")
@@ -393,6 +398,8 @@ class Command(_BaseCommand):
             other._buckets = self._buckets.copy()
         if self._max_concurrency != other._max_concurrency:
             other._max_concurrency = self._max_concurrency.copy()
+        if self.extras != other.extras:
+            other.extras = self.extras.copy()
 
         try:
             other.on_error = self.on_error

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -216,7 +216,11 @@ class Command(_BaseCommand):
         which calls converters. If ``False`` then cooldown processing is done
         first and then the converters are called second. Defaults to ``False``.
     extras: :class:`dict`
-        A dict of user provided extras to attach to the Command.
+        A dict of user provided extras to attach to the Command. 
+        
+        .. note::
+            This object may be copied by the library.
+
 
         .. versionadded:: 2.0
     """
@@ -398,8 +402,6 @@ class Command(_BaseCommand):
             other._buckets = self._buckets.copy()
         if self._max_concurrency != other._max_concurrency:
             other._max_concurrency = self._max_concurrency.copy()
-        if self.extras != other.extras:
-            other.extras = self.extras.copy()
 
         try:
             other.on_error = self.on_error


### PR DESCRIPTION
## Summary

Adds Command.extras as per discussion in discord.

I'm not sure if this should be marked as breaking or not, I went with yes since this is a class designed to be subclassable and this is adding a kwarg.

I went with a copy at _ensure_assignment_on_copy but there may be a reason to use a deep copy instead:

This may also benefit from examples of use at some point (I can add them to this PR if needed/preferable)

I have done a small bit of testing of this, but given the original issue that led to command objects being copying, I'm leaving this as a draft until I get a moment to set up a minimal test that it is suitable in that case as well.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [X] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
