### PR TITLE
Added the Guild.delete_custom_emoji method

### DIFF
--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -188,10 +188,25 @@ class Emoji(_EmojiTag, AssetMixin):
 
     async def delete(self, *, reason: Optional[str] = None) -> None:
         """|coro|
-
-        Deletes this emoji. Equivalent to :meth:`Guild.delete_custom_emoji`.
+        
+        Deletes the custom emoji.
+        
+        You must have :attr:`~Permissions.manage_emojis` permission to
+        do this.
+        
+        Parameters
+        -----------
+        reason: Optional[:class:`str`]
+            The reason for deleting this emoji. Shows up on the audit log.
+        Raises
+        -------
+        Forbidden
+            You are not allowed to delete emojis.
+        HTTPException
+            An error occurred deleting the emoji.
         """
-        await self.guild.delete_custom_emoji(self, reason=reason)
+
+        await self._state.http.delete_custom_emoji(self.guild.id, self.id, reason=reason)
 
     async def edit(self, *, name: str = MISSING, roles: List[Snowflake] = MISSING, reason: Optional[str] = None) -> None:
         r"""|coro|

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -27,7 +27,7 @@ from typing import Any, Iterator, List, Optional, TYPE_CHECKING, Tuple
 
 from .asset import Asset, AssetMixin
 from .utils import SnowflakeList, snowflake_time, MISSING
-from .partial_emoji import _EmojiTag
+from .partial_emoji import _EmojiTag, PartialEmoji
 from .user import User
 
 __all__ = (
@@ -107,20 +107,23 @@ class Emoji(_EmojiTag, AssetMixin):
     )
 
     def __init__(self, *, guild: Guild, state: ConnectionState, data: EmojiPayload):
-        self.guild_id = guild.id
-        self._state = state
+        self.guild_id: int = guild.id
+        self._state: ConnectionState = state
         self._from_data(data)
 
     def _from_data(self, emoji: EmojiPayload):
-        self.require_colons = emoji.get('require_colons', False)
-        self.managed = emoji.get('managed', False)
-        self.id = int(emoji['id'])  # type: ignore
-        self.name = emoji['name']
-        self.animated = emoji.get('animated', False)
-        self.available = emoji.get('available', True)
-        self._roles = SnowflakeList(map(int, emoji.get('roles', [])))
+        self.require_colons: bool = emoji.get('require_colons', False)
+        self.managed: bool = emoji.get('managed', False)
+        self.id: int = int(emoji['id'])  # type: ignore
+        self.name: str = emoji['name']  # type: ignore
+        self.animated: bool = emoji.get('animated', False)
+        self.available: bool = emoji.get('available', True)
+        self._roles: SnowflakeList = SnowflakeList(map(int, emoji.get('roles', [])))
         user = emoji.get('user')
-        self.user = User(state=self._state, data=user) if user else None
+        self.user: Optional[User] = User(state=self._state, data=user) if user else None
+
+    def _to_partial(self) -> PartialEmoji:
+        return PartialEmoji(name=self.name, animated=self.animated, id=self.id)
 
     def __iter__(self) -> Iterator[Tuple[str, Any]]:
         for attr in self.__slots__:
@@ -188,16 +191,17 @@ class Emoji(_EmojiTag, AssetMixin):
 
     async def delete(self, *, reason: Optional[str] = None) -> None:
         """|coro|
-        
+
         Deletes the custom emoji.
-        
+
         You must have :attr:`~Permissions.manage_emojis` permission to
         do this.
-        
+
         Parameters
         -----------
         reason: Optional[:class:`str`]
             The reason for deleting this emoji. Shows up on the audit log.
+
         Raises
         -------
         Forbidden

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -189,25 +189,9 @@ class Emoji(_EmojiTag, AssetMixin):
     async def delete(self, *, reason: Optional[str] = None) -> None:
         """|coro|
 
-        Deletes the custom emoji.
-
-        You must have :attr:`~Permissions.manage_emojis` permission to
-        do this.
-
-        Parameters
-        -----------
-        reason: Optional[:class:`str`]
-            The reason for deleting this emoji. Shows up on the audit log.
-
-        Raises
-        -------
-        Forbidden
-            You are not allowed to delete emojis.
-        HTTPException
-            An error occurred deleting the emoji.
+        Deletes this emoji. Equivalent to :meth:`Guild.delete_custom_emoji`.
         """
-
-        await self._state.http.delete_custom_emoji(self.guild.id, self.id, reason=reason)
+        await self.guild.delete_custom_emoji(self, reason=reason)
 
     async def edit(self, *, name: str = MISSING, roles: List[Snowflake] = MISSING, reason: Optional[str] = None) -> None:
         r"""|coro|

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1911,6 +1911,36 @@ class Guild(Hashable):
         data = await self._state.http.create_custom_emoji(self.id, name, img, roles=roles, reason=reason)
         return self._state.store_emoji(self, data)
 
+    async def delete_custom_emoji(
+        self,
+        emoji: abc.Snowflake,
+        *,
+        reason: Optional[str] = None
+    ) -> None:
+        """|coro|
+
+        Deletes the custom :class:`Emoji` from the guild.
+
+        You must have :attr:`~Permissions.manage_emojis` permission to
+        do this.
+
+        Parameters
+        -----------
+        emoji: :class:`abc.Snowflake`
+            The emoji you are deleting.
+        reason: Optional[:class:`str`]
+            The reason for deleting this emoji. Shows up on the audit log.
+
+        Raises
+        -------
+        Forbidden
+            You are not allowed to delete emojis.
+        HTTPException
+            An error occurred deleting the emoji.
+        """
+
+        await self._state.http.delete_custom_emoji(self.id, emoji.id, reason=reason)
+
     async def fetch_roles(self):
         """|coro|
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1911,12 +1911,7 @@ class Guild(Hashable):
         data = await self._state.http.create_custom_emoji(self.id, name, img, roles=roles, reason=reason)
         return self._state.store_emoji(self, data)
 
-    async def delete_custom_emoji(
-        self,
-        emoji: abc.Snowflake,
-        *,
-        reason: Optional[str] = None
-    ) -> None:
+    async def delete_emoji(self, emoji: abc.Snowflake, *, reason: Optional[str] = None) -> None:
         """|coro|
 
         Deletes the custom :class:`Emoji` from the guild.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Allows an emoji to removed with it's ID (a snowflake) to avoid having to get or fetch the emoji.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
