### PR TITLE
Add category_id shortcut to Thread

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -220,6 +220,26 @@ class Thread(Messageable, Hashable):
         """
         return self._state._get_message(self.last_message_id) if self.last_message_id else None
 
+    @property
+    def category_id(self) -> Optional[int]:
+        """The category channel ID the parent channel belongs to, if applicable.
+
+        Raises
+        -------
+        ClientException
+            The parent channel was not cached and returned ``None``.
+
+        Returns
+        -------
+        Optional[:class:`int`]
+            The parent channel's category ID.
+        """
+
+        parent = self.parent
+        if parent is None:
+            raise ClientException('Parent channel not found')
+        return parent.category_id
+
     def is_private(self) -> bool:
         """:class:`bool`: Whether the thread is a private thread.
 


### PR DESCRIPTION
## Summary

Adds a shortcut to retrieve the category ID of a thread/its parent channel.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
