### PR TITLE
None check in InteractionResponse.edit_message

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -422,7 +422,7 @@ class InteractionResponse:
             data=payload,
         )
 
-        if view is not MISSING and view is not None and not view.is_finished():
+        if view and not view.is_finished():
             state.store_view(view, message_id)
 
         self._responded = True

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -422,7 +422,7 @@ class InteractionResponse:
             data=payload,
         )
 
-        if view is not MISSING and not view.is_finished():
+        if view is not MISSING and view is not None and not view.is_finished():
             state.store_view(view, message_id)
 
         self._responded = True


### PR DESCRIPTION
## Summary

This fixes a bug where removing a view in `InteractionResponse.edit_message` using `edit_message(view=None)` caused an AttributeError:
```bash
  File "discord/interactions.py", line 425, in edit_message
    if view is not MISSING and not view.is_finished():
AttributeError: 'NoneType' object has no attribute 'is_finished'
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
