### PR TITLE
[commands] Add Case-Insensitive to BotBase.get_cog()

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -518,7 +518,7 @@ class BotBase(GroupMixin):
             raise TypeError('cogs must derive from Cog')
 
         cog_name = cog.__cog_name__
-        existing = self.__cogs.get(cog_name)
+        existing = self.get_cog(cog_name)
 
         if existing is not None:
             if not override:
@@ -545,6 +545,12 @@ class BotBase(GroupMixin):
         Optional[:class:`Cog`]
             The cog that was requested. If not found, returns ``None``.
         """
+
+        if self.case_insensitive:
+            for k in self.__cogs.keys():
+                if k.casefold() == name.casefold():
+                    return self.__cogs[k]
+            
         return self.__cogs.get(name)
 
     def remove_cog(self, name):


### PR DESCRIPTION
## Summary

Add Case-Insensitive to cog lookup func ( .get_cog() )
I did it because the '[p]help Cog' is case-sensitive
also please take note that i changed .add_cog() to use .get_cog() instead of self.__cogs.get(cog_name), I dont know supposed to be case-senstive

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
