### PR TITLE
Add disable_guild_select to utils.oauth_url()

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -257,7 +257,7 @@ def oauth_url(
     guild: Snowflake = MISSING,
     redirect_uri: str = MISSING,
     scopes: Iterable[str] = MISSING,
-    disable_guild_select: bool = MISSING,
+    disable_guild_select: bool = False,
 ):
     """A helper function that returns the OAuth2 URL for inviting the bot
     into guilds.
@@ -288,7 +288,7 @@ def oauth_url(
         The OAuth2 URL for inviting the bot into guilds.
     """
     url = f'https://discord.com/oauth2/authorize?client_id={client_id}'
-    url += '&scope=' + '+'.join(scopes if scopes is not MISSING else ('bot',))
+    url += '&scope=' + '+'.join(scopes or ('bot',))
     if permissions is not MISSING:
         url += f'&permissions={permissions.value}'
     if guild is not MISSING:
@@ -297,9 +297,8 @@ def oauth_url(
         from urllib.parse import urlencode
 
         url += '&response_type=code&' + urlencode({'redirect_uri': redirect_uri})
-    if disable_guild_select is not MISSING:
-        url += '&disable_guild_select='
-        url += 'true' if disable_guild_select else 'false'
+    if disable_guild_select:
+        url += '&disable_guild_select=true'
     return url
 
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -251,18 +251,20 @@ def deprecated(instead: Optional[str] = None) -> Callable[[Callable[..., T]], Ca
 
 
 def oauth_url(
-    client_id: str,
-    permissions: Optional[Permissions] = None,
-    guild: Optional[Snowflake] = None,
-    redirect_uri: Optional[str] = None,
-    scopes: Optional[Iterable[str]] = None,
+    client_id: Union[int, str],
+    *,
+    permissions: Permissions = MISSING,
+    guild: Snowflake = MISSING,
+    redirect_uri: str = MISSING,
+    scopes: Iterable[str] = MISSING,
+    disable_guild_select: bool = MISSING,
 ):
     """A helper function that returns the OAuth2 URL for inviting the bot
     into guilds.
 
     Parameters
     -----------
-    client_id: :class:`str`
+    client_id: Union[:class:`int`, :class:`str`]
         The client ID for your bot.
     permissions: :class:`~discord.Permissions`
         The permissions you're requesting. If not given then you won't be requesting any
@@ -275,6 +277,10 @@ def oauth_url(
         An optional valid list of scopes. Defaults to ``('bot',)``.
 
         .. versionadded:: 1.7
+    disable_guild_select: :class:`bool`
+        Whether to disallow the user from changing the guild dropdown.
+
+        .. versionadded:: 2.0
 
     Returns
     --------
@@ -282,15 +288,18 @@ def oauth_url(
         The OAuth2 URL for inviting the bot into guilds.
     """
     url = f'https://discord.com/oauth2/authorize?client_id={client_id}'
-    url = url + '&scope=' + '+'.join(scopes or ('bot',))
-    if permissions is not None:
-        url = url + '&permissions=' + str(permissions.value)
-    if guild is not None:
-        url = url + "&guild_id=" + str(guild.id)
-    if redirect_uri is not None:
+    url += '&scope=' + '+'.join(scopes if scopes is not MISSING else ('bot',))
+    if permissions is not MISSING:
+        url += f'&permissions={permissions.value}'
+    if guild is not MISSING:
+        url += f'&guild_id={guild.id}'
+    if redirect_uri is not MISSING:
         from urllib.parse import urlencode
 
-        url = url + "&response_type=code&" + urlencode({'redirect_uri': redirect_uri})
+        url += '&response_type=code&' + urlencode({'redirect_uri': redirect_uri})
+    if disable_guild_select is not MISSING:
+        url += '&disable_guild_select='
+        url += 'true' if disable_guild_select else 'false'
     return url
 
 


### PR DESCRIPTION
## Summary

This PR makes everything after `client_id` a keyword argument for `discord.utils.oauth_url()` and adds `disable_guild_select`  to disable the guilds dropdown when used. And now uses f-strings, `MISSING` and `client_id` is now typed to take an integer or string.

*Thanks to NCPlayz#7941 for literally all the code and letting me have this PR, only had to write this text*

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
