### PR TITLE
Fix Member.ban typing to include 0-day message deletes

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -530,7 +530,7 @@ class Member(discord.abc.Messageable, _BaseUser):
         self,
         *,
         reason: Optional[str] = ...,
-        delete_message_days: Literal[1, 2, 3, 4, 5, 6, 7] = ...,
+        delete_message_days: Literal[0, 1, 2, 3, 4, 5, 6, 7] = ...,
     ) -> None:
         ...
 


### PR DESCRIPTION
## Summary

To match `Guild.ban` https://github.com/Rapptz/discord.py/blob/d30fea5b0dcba9cd130026b56ec01e78bd788aff/discord/guild.py#L2354