### PR TITLE
Show decorator usage instead of signature in docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -40,7 +40,10 @@ Client
 
 .. autoclass:: Client
     :members:
-    :exclude-members: fetch_guilds
+    :exclude-members: fetch_guilds, event
+
+    .. automethod:: Client.event()
+        :decorator:
 
     .. automethod:: Client.fetch_guilds
         :async-for:

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -18,6 +18,31 @@ Bot
 .. autoclass:: discord.ext.commands.Bot
     :members:
     :inherited-members:
+    :exclude-members: after_invoke, before_invoke, check, check_once, command, event, group, listen
+
+    .. automethod:: Bot.after_invoke()
+        :decorator:
+
+    .. automethod:: Bot.before_invoke()
+        :decorator:
+
+    .. automethod:: Bot.check()
+        :decorator:
+
+    .. automethod:: Bot.check_once()
+        :decorator:
+
+    .. automethod:: Bot.command(*args, **kwargs)
+        :decorator:
+    
+    .. automethod:: Bot.event()
+        :decorator:
+
+    .. automethod:: Bot.group(*args, **kwargs)
+        :decorator:
+
+    .. automethod:: Bot.listen(name=None)
+        :decorator:
 
 AutoShardedBot
 ~~~~~~~~~~~~~~~~
@@ -84,8 +109,10 @@ Decorators
 ~~~~~~~~~~~~
 
 .. autofunction:: discord.ext.commands.command
+    :decorator:
 
 .. autofunction:: discord.ext.commands.group
+    :decorator:
 
 Command
 ~~~~~~~~~
@@ -95,6 +122,16 @@ Command
 .. autoclass:: discord.ext.commands.Command
     :members:
     :special-members: __call__
+    :exclude-members: after_invoke, before_invoke, error
+
+    .. automethod:: Command.after_invoke()
+        :decorator:
+
+    .. automethod:: Command.before_invoke()
+        :decorator:
+
+    .. automethod:: Command.error()
+        :decorator:
 
 Group
 ~~~~~~
@@ -104,6 +141,22 @@ Group
 .. autoclass:: discord.ext.commands.Group
     :members:
     :inherited-members:
+    :exclude-members: after_invoke, before_invoke, command, error, group
+
+    .. automethod:: Group.after_invoke()
+        :decorator:
+
+    .. automethod:: Group.before_invoke()
+        :decorator:
+
+    .. automethod:: Group.command(*args, **kwargs)
+        :decorator:
+
+    .. automethod:: Group.error()
+        :decorator:
+
+    .. automethod:: Group.group(*args, **kwargs)
+        :decorator:
 
 GroupMixin
 ~~~~~~~~~~~
@@ -112,6 +165,13 @@ GroupMixin
 
 .. autoclass:: discord.ext.commands.GroupMixin
     :members:
+    :exclude-members: command, group
+
+    .. automethod:: GroupMixin.command(*args, **kwargs)
+        :decorator:
+
+    .. automethod:: GroupMixin.group(*args, **kwargs)
+        :decorator:
 
 .. _ext_commands_api_cogs:
 
@@ -211,41 +271,59 @@ Enums
 Checks
 -------
 
-.. autofunction:: discord.ext.commands.check
+.. autofunction:: discord.ext.commands.check(predicate)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.check_any
+.. autofunction:: discord.ext.commands.check_any(*checks)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.has_role
+.. autofunction:: discord.ext.commands.has_role(item)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.has_permissions
+.. autofunction:: discord.ext.commands.has_permissions(**perms)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.has_guild_permissions
+.. autofunction:: discord.ext.commands.has_guild_permissions(**perms)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.has_any_role
+.. autofunction:: discord.ext.commands.has_any_role(*items)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.bot_has_role
+.. autofunction:: discord.ext.commands.bot_has_role(item)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.bot_has_permissions
+.. autofunction:: discord.ext.commands.bot_has_permissions(**perms)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.bot_has_guild_permissions
+.. autofunction:: discord.ext.commands.bot_has_guild_permissions(**perms)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.bot_has_any_role
+.. autofunction:: discord.ext.commands.bot_has_any_role(*items)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.cooldown
+.. autofunction:: discord.ext.commands.cooldown(rate, per, type=discord.BucketType.default)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.max_concurrency
+.. autofunction:: discord.ext.commands.max_concurrency(number, per=discord.BucketType.default, *, wait=False)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.before_invoke
+.. autofunction:: discord.ext.commands.before_invoke(coro)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.after_invoke
+.. autofunction:: discord.ext.commands.after_invoke(coro)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.guild_only
+.. autofunction:: discord.ext.commands.guild_only(,)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.dm_only
+.. autofunction:: discord.ext.commands.dm_only(,)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.is_owner
+.. autofunction:: discord.ext.commands.is_owner(,)
+    :decorator:
 
-.. autofunction:: discord.ext.commands.is_nsfw
+.. autofunction:: discord.ext.commands.is_nsfw(,)
+    :decorator:
 
 .. _ext_commands_api_context:
 

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -301,10 +301,10 @@ Checks
 .. autofunction:: discord.ext.commands.bot_has_any_role(*items)
     :decorator:
 
-.. autofunction:: discord.ext.commands.cooldown(rate, per, type=discord.BucketType.default)
+.. autofunction:: discord.ext.commands.cooldown(rate, per, type=discord.ext.commands.BucketType.default)
     :decorator:
 
-.. autofunction:: discord.ext.commands.max_concurrency(number, per=discord.BucketType.default, *, wait=False)
+.. autofunction:: discord.ext.commands.max_concurrency(number, per=discord.ext.commands.BucketType.default, *, wait=False)
     :decorator:
 
 .. autofunction:: discord.ext.commands.before_invoke(coro)

--- a/docs/ext/tasks/index.rst
+++ b/docs/ext/tasks/index.rst
@@ -140,5 +140,15 @@ API Reference
 .. autoclass:: discord.ext.tasks.Loop()
     :members:
     :special-members: __call__
+    :exclude-members: after_loop, before_loop, error
+
+    .. automethod:: Loop.after_loop()
+        :decorator:
+
+    .. automethod:: Loop.before_loop()
+        :decorator:
+
+    .. automethod:: Loop.error()
+        :decorator:
 
 .. autofunction:: discord.ext.tasks.loop


### PR DESCRIPTION
## Summary

This change makes decorators show their usage instead of their signature, which helps avoid confusing situations where the intended usage of a decorator is not entirely clear.

Before:
![image](https://user-images.githubusercontent.com/8049998/121802262-681efa80-cc76-11eb-8e67-17bcef6604e3.png)
![image](https://user-images.githubusercontent.com/8049998/121802313-9997c600-cc76-11eb-9f34-25296a12dc8c.png)
![image](https://user-images.githubusercontent.com/8049998/121802295-7ff67e80-cc76-11eb-8d9f-9f312cc9fd7a.png)
![image](https://user-images.githubusercontent.com/8049998/121802316-9ef51080-cc76-11eb-9f4a-f7016b915f13.png)


After:
![image](https://user-images.githubusercontent.com/8049998/121802177-2a21d680-cc76-11eb-943a-30138e9bcd2f.png)
![image](https://user-images.githubusercontent.com/8049998/121802351-c64bdd80-cc76-11eb-9df2-d716828f4fe3.png)
![image](https://user-images.githubusercontent.com/8049998/121802200-402f9700-cc76-11eb-9163-58a8bf3a4a22.png)
![image](https://user-images.githubusercontent.com/8049998/121802223-4aea2c00-cc76-11eb-9c73-d73581f30de1.png)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
