### PR TITLE
[docs] add "new in version" missing in webhook documentation

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -654,15 +654,21 @@ class WebhookMessage(Message):
             This should not be mixed with the ``embeds`` parameter.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
+
+            .. versionadded:: 2.0
         files: List[:class:`File`]
             A list of files to send with the content. This cannot be mixed with the
             ``file`` parameter.
+
+            .. versionadded:: 2.0
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.
         view: Optional[:class:`~discord.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed.
+
+            .. versionadded:: 2.0
 
         Raises
         -------
@@ -774,11 +780,16 @@ class BaseWebhook(Hashable):
         self.source_guild: Optional[PartialWebhookGuild] = source_guild
 
     def is_partial(self) -> bool:
-        """:class:`bool`: Whether the webhook is a "partial" webhook."""
+        """:class:`bool`: Whether the webhook is a "partial" webhook.
+
+        .. versionadded:: 2.0"""
         return self.channel_id is None
 
     def is_authenticated(self) -> bool:
-        """:class:`bool`: Whether the webhook is authenticated with a bot token."""
+        """:class:`bool`: Whether the webhook is authenticated with a bot token.
+
+        .. versionadded:: 2.0
+        """
         return self.auth_token is not None
 
     @property
@@ -923,9 +934,13 @@ class Webhook(BaseWebhook):
             The session to use to send requests with. Note
             that the library does not manage the session and
             will not close it.
+
+            .. versionadded:: 2.0
         bot_token: Optional[:class:`str`]
             The bot authentication token for authenticated requests
             involving the webhook.
+
+            .. versionadded:: 2.0
 
         Returns
         --------
@@ -953,9 +968,13 @@ class Webhook(BaseWebhook):
             The session to use to send requests with. Note
             that the library does not manage the session and
             will not close it.
+
+            .. versionadded:: 2.0
         bot_token: Optional[:class:`str`]
             The bot authentication token for authenticated requests
             involving the webhook.
+
+            .. versionadded:: 2.0
 
         Raises
         -------
@@ -1003,6 +1022,8 @@ class Webhook(BaseWebhook):
         Fetches the current webhook.
 
         This could be used to get a full webhook from a partial webhook.
+
+        .. versionadded:: 2.0
 
         .. note::
 
@@ -1056,6 +1077,8 @@ class Webhook(BaseWebhook):
             Whether to use the bot token over the webhook token
             if available. Defaults to ``True``.
 
+            .. versionadded:: 2.0
+
         Raises
         -------
         HTTPException
@@ -1098,6 +1121,8 @@ class Webhook(BaseWebhook):
             A :term:`py:bytes-like object` representing the webhook's new default avatar.
         channel: Optional[:class:`abc.Snowflake`]
             The webhook's new channel. This requires an authenticated webhook.
+
+            .. versionadded:: 2.0
         reason: Optional[:class:`str`]
             The reason for editing this webhook. Shows up on the audit log.
 
@@ -1105,6 +1130,8 @@ class Webhook(BaseWebhook):
         prefer_auth: :class:`bool`
             Whether to use the bot token over the webhook token
             if available. Defaults to ``True``.
+
+            .. versionadded:: 2.0
 
         Raises
         -------
@@ -1244,6 +1271,8 @@ class Webhook(BaseWebhook):
             This is only available to :attr:`WebhookType.application` webhooks.
             If a view is sent with an ephemeral message and it has no timeout set
             then the timeout is set to 15 minutes.
+
+            .. versionadded:: 2.0
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
         files: List[:class:`File`]
@@ -1429,9 +1458,13 @@ class Webhook(BaseWebhook):
             This should not be mixed with the ``embeds`` parameter.
         file: :class:`File`
             The file to upload. This cannot be mixed with ``files`` parameter.
+
+            .. versionadded:: 2.0
         files: List[:class:`File`]
             A list of files to send with the content. This cannot be mixed with the
             ``file`` parameter.
+
+            .. versionadded:: 2.0
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.
@@ -1439,6 +1472,8 @@ class Webhook(BaseWebhook):
             The updated view to update this message with. If ``None`` is passed then
             the view is removed. The webhook must have state attached, similar to
             :meth:`send`.
+
+            .. versionadded:: 2.0
 
         Raises
         -------


### PR DESCRIPTION
## Summary

Add some "added in version" that was missing from the webhook documentation.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
