### PR TITLE
[activity] add discord.Spotify.elapsed

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -679,6 +679,11 @@ class Spotify:
     def start(self):
         """:class:`datetime.datetime`: When the user started playing this song in UTC."""
         return datetime.datetime.utcfromtimestamp(self._timestamps['start'] / 1000)
+    
+    @property
+    def elapsed(self):
+        """:class:`datetime.timedelta`: The elapsed time of the song being played.."""
+        return datetime.datetime.utcnow() - self.start
 
     @property
     def end(self):


### PR DESCRIPTION
## Summary

Add a new property to discord.Spotify that reflects the elapsed time of the currently playing song.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
