### PR TITLE
Handle `role_id` possibly being `None` for `StreamIntegration`

### DIFF
--- a/discord/integrations.py
+++ b/discord/integrations.py
@@ -196,7 +196,7 @@ class StreamIntegration(Integration):
         self.expire_behaviour: ExpireBehaviour = try_enum(ExpireBehaviour, data['expire_behavior'])
         self.expire_grace_period: int = data['expire_grace_period']
         self.synced_at: datetime.datetime = parse_time(data['synced_at'])
-        self._role_id: int = int(data['role_id'])
+        self._role_id: Optional[int] = _get_as_snowflake(data, 'role_id')
         self.syncing: bool = data['syncing']
         self.enable_emoticons: bool = data['enable_emoticons']
         self.subscriber_count: int = data['subscriber_count']

--- a/discord/types/integration.py
+++ b/discord/types/integration.py
@@ -69,7 +69,7 @@ class BaseIntegration(PartialIntegration):
 
 
 class StreamIntegration(BaseIntegration):
-    role_id: Snowflake
+    role_id: Optional[Snowflake]
     enable_emoticons: bool
     subscriber_count: int
     revoked: bool


### PR DESCRIPTION
## Summary

Fixes:
```pytb
    client.loop.run_until_complete(client.start(token))
  File "C:\Program Files\Python39\lib\asyncio\base_events.py", line 642, in run_until_complete
    return future.result()
  File "C:\Program Files\Python39\lib\site-packages\discord\client.py", line 568, in start
    await self.connect(reconnect=reconnect)
  File "C:\Program Files\Python39\lib\site-packages\discord\client.py", line 474, in connect
    await self.ws.poll_event()
  File "C:\Program Files\Python39\lib\site-packages\discord\gateway.py", line 553, in poll_event
    await self.received_message(msg.data)
  File "C:\Program Files\Python39\lib\site-packages\discord\gateway.py", line 503, in received_message
    func(data)
  File "C:\Program Files\Python39\lib\site-packages\discord\state.py", line 1106, in parse_integration_update
    integration = cls(data=data, guild=guild)
  File "C:\Program Files\Python39\lib\site-packages\discord\integrations.py", line 115, in __init__
    self._from_data(data)
  File "C:\Program Files\Python39\lib\site-packages\discord\integrations.py", line 199, in _from_data
    self._role_id: int = int(data['role_id'])
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

## Checklist

- [X] If code changes were made then they have been tested.
    - [N/A] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [N/A] This PR adds something new (e.g. new method or parameters).
- [N/A] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [N/A] This PR is **not** a code change (e.g. documentation, README, ...)
