### PR TITLE
[activity] add discord.Spotify.track_url

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -676,7 +676,7 @@ class Spotify:
         return self._sync_id
     
     @property
-    def track_url(self):
+    def track_url(self) -> str:
         """:class:`str`: The track URL to listen on Spotify.
         
         .. versionadded:: 2.0

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -677,7 +677,10 @@ class Spotify:
     
     @property
     def track_url(self):
-        """:class:`str`: The track URL to listen on Spotify."""
+        """:class:`str`: The track URL to listen on Spotify.
+        
+        .. versionadded:: 2.0
+        """
         return 'https://open.spotify.com/track/' + self.track_id
 
     @property

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -674,6 +674,11 @@ class Spotify:
     def track_id(self):
         """:class:`str`: The track ID used by Spotify to identify this song."""
         return self._sync_id
+    
+    @property
+    def track_url(self)
+        """:class:`str`: The track URL to listen on Spotify."""
+        return 'https://open.spotify.com/track/' + self.track_id
 
     @property
     def start(self):

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -676,7 +676,7 @@ class Spotify:
         return self._sync_id
     
     @property
-    def track_url(self)
+    def track_url(self):
         """:class:`str`: The track URL to listen on Spotify."""
         return 'https://open.spotify.com/track/' + self.track_id
 

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -681,7 +681,7 @@ class Spotify:
         
         .. versionadded:: 2.0
         """
-        return 'https://open.spotify.com/track/' + self.track_id
+        return f'https://open.spotify.com/track/{self.track_id}'
 
     @property
     def start(self):


### PR DESCRIPTION
## Summary

Add a new property to discord.Spotify that reflects the track URL of the currently playing song.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
