### PR TITLE
Add: add utils.to_timestamp_format

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -509,6 +509,7 @@ class NSFWLevel(Enum):
     age_restricted = 3
 
 class TimeMentionType(Enum):
+    default         = "f"
     short_date_time = "f"
     long_date_time  = "F"
     short_date      = "d"

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -508,6 +508,15 @@ class NSFWLevel(Enum):
     safe = 2
     age_restricted = 3
 
+class TimeMentionType(Enum):
+    short_date_time = "f"
+    long_date_time  = "F"
+    short_date      = "d"
+    long_date       = "D"
+    short_time      = "t"
+    long_time       = "T"
+    relative        = "R"
+
 T = TypeVar('T')
 
 def create_unknown_value(cls: Type[T], val: Any) -> T:

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -508,7 +508,7 @@ class NSFWLevel(Enum):
     safe = 2
     age_restricted = 3
 
-class TimeMentionType(Enum):
+class TimestampFormat(Enum):
     default         = "f"
     short_date_time = "f"
     long_date_time  = "F"

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -569,7 +569,7 @@ def to_time_mention(time: datetime.datetime) -> str:
     :class:`str`
         A datetime mention for given datetime.
     """
-    return "<t:{}>".format(int(time.timestamp()))
+    return f"<t:{int(time.timestamp())}>"
 
 
 def valid_icon_size(size: int) -> bool:

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -561,8 +561,13 @@ def to_time_mention(time: datetime.datetime) -> str:
 
     Parameters
     -----------
-    when: :class:`datetime.datetime`
+    time: :class:`datetime.datetime`
         The ``datetime`` to make mention.
+
+    Returns
+    --------
+    :class:`str`
+        A datetime mention for given datetime.
     """
     return "<t:{}>".format(int(time.timestamp()))
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -572,7 +572,7 @@ def to_time_mention(time: datetime.datetime, mention_type: Optional[TimeMentionT
     :class:`str`
         A datetime mention for given datetime.
     """
-    if mention_type is None:
+    if mention_type is None or mention_type is TimeMentionType.default:
         return f"<t:{int(time.timestamp())}>"
     else:
         return f"<t:{int(time.timestamp())}:{mention_type.value}>"

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -555,7 +555,7 @@ def utcnow() -> datetime.datetime:
     return datetime.datetime.now(datetime.timezone.utc)
 
 
-def to_time_mention(time: datetime.datetime, mention_type: Optional[TimeMentionType] = None) -> str:
+def to_timestamp_format(time: datetime.datetime, mention_type: Optional[TimeMentionType] = None) -> str:
     """A helper function to make a time mention from ``datetime.datetime``.
 
     .. versionadded:: 2.0

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -61,6 +61,7 @@ import sys
 import types
 import warnings
 
+from .enums import TimeMentionType
 from .errors import InvalidArgument
 
 __all__ = (
@@ -554,7 +555,7 @@ def utcnow() -> datetime.datetime:
     return datetime.datetime.now(datetime.timezone.utc)
 
 
-def to_time_mention(time: datetime.datetime) -> str:
+def to_time_mention(time: datetime.datetime, mention_type: Optional[TimeMentionType] = None) -> str:
     """A helper function to make a time mention from ``datetime.datetime``.
 
     .. versionadded:: 2.0
@@ -569,7 +570,10 @@ def to_time_mention(time: datetime.datetime) -> str:
     :class:`str`
         A datetime mention for given datetime.
     """
-    return f"<t:{int(time.timestamp())}>"
+    if mention_type is None:
+        return f"<t:{int(time.timestamp())}>"
+    else:
+        return f"<t:{int(time.timestamp())}:{mention_type.value}>"
 
 
 def valid_icon_size(size: int) -> bool:

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -572,10 +572,10 @@ def to_timestamp_format(time: datetime.datetime, format_type: Optional[Timestamp
     :class:`str`
         A datetime mention for given datetime.
     """
-    if mention_type is None or mention_type is TimeMentionType.default:
+    if format_type is None or format_type is TimestampFormat.default:
         return f"<t:{int(time.timestamp())}>"
     else:
-        return f"<t:{int(time.timestamp())}:{mention_type.value}>"
+        return f"<t:{int(time.timestamp())}:{format_type.value}>"
 
 
 def valid_icon_size(size: int) -> bool:

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -556,7 +556,7 @@ def utcnow() -> datetime.datetime:
 
 
 def to_timestamp_format(time: datetime.datetime, format_type: Optional[TimestampFormat] = None) -> str:
-    """A helper function to make a time mention from ``datetime.datetime``.
+    """A helper function to format ``datetime.datetime``.
 
     .. versionadded:: 2.0
 
@@ -565,7 +565,7 @@ def to_timestamp_format(time: datetime.datetime, format_type: Optional[Timestamp
     time: :class:`datetime.datetime`
         The ``datetime`` to make mention.
     format_type: :class:`TimestampFormat`
-        Type of the mention.
+        Type of format.
 
     Returns
     --------

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -564,6 +564,8 @@ def to_time_mention(time: datetime.datetime, mention_type: Optional[TimeMentionT
     -----------
     time: :class:`datetime.datetime`
         The ``datetime`` to make mention.
+    mention_type: :class:`TimeMentionType`
+        Type of the mention.
 
     Returns
     --------

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -554,6 +554,19 @@ def utcnow() -> datetime.datetime:
     return datetime.datetime.now(datetime.timezone.utc)
 
 
+def to_time_mention(time: datetime.datetime) -> str:
+    """A helper function to make a time mention from ``datetime.datetime``.
+
+    .. versionadded:: 2.0
+
+    Parameters
+    -----------
+    when: :class:`datetime.datetime`
+        The ``datetime`` to make mention.
+    """
+    return "<t:{}>".format(int(time.timestamp()))
+
+
 def valid_icon_size(size: int) -> bool:
     """Icons must be power of 2 within [16, 4096]."""
     return not size & (size - 1) and 4096 >= size >= 16

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -61,7 +61,7 @@ import sys
 import types
 import warnings
 
-from .enums import TimeMentionType
+from .enums import TimestampFormat
 from .errors import InvalidArgument
 
 __all__ = (
@@ -555,7 +555,7 @@ def utcnow() -> datetime.datetime:
     return datetime.datetime.now(datetime.timezone.utc)
 
 
-def to_timestamp_format(time: datetime.datetime, mention_type: Optional[TimeMentionType] = None) -> str:
+def to_timestamp_format(time: datetime.datetime, format_type: Optional[TimestampFormat] = None) -> str:
     """A helper function to make a time mention from ``datetime.datetime``.
 
     .. versionadded:: 2.0
@@ -564,7 +564,7 @@ def to_timestamp_format(time: datetime.datetime, mention_type: Optional[TimeMent
     -----------
     time: :class:`datetime.datetime`
         The ``datetime`` to make mention.
-    mention_type: :class:`TimeMentionType`
+    format_type: :class:`TimestampFormat`
         Type of the mention.
 
     Returns

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2360,6 +2360,48 @@ of :class:`enum.Enum`.
 
         The guild may contain NSFW content.
 
+.. class:: TimeMentionType
+
+    Represents the type of time mention.
+
+    .. versionadded:: 2.0
+    
+    .. attribute:: default
+
+        Short date and time, like ``June 1, 2021 8:17 AM``.
+    
+    .. attribute:: short_date_time
+
+        Same as ``default``.
+    
+    .. attribute:: long_date_time
+
+        Long date and time, like ``Saturday, June 19, 2021 8:18 AM``.
+    
+    .. attribute:: short_date
+
+        Short date, like ``06/19/2021``.
+    
+    .. attribute:: long_date
+
+        Long date, like ``June 19, 2021``.
+    
+    .. attribute:: short_time
+
+        Short time, like ``8:18 AM``.
+    
+    .. attribute:: long_time
+
+        Long time, like ``8:18:09 AM``.
+    
+    .. attribute:: relative
+
+        Relative time from now, like ``10 hours ago``.
+
+    .. note::
+
+        Format changes by language setting of client.
+
 Async Iterator
 ----------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1065,7 +1065,7 @@ Utility Functions
 
 .. autofunction:: discord.utils.as_chunks
 
-.. autofunction:: discord.utils.to_time_mention
+.. autofunction:: discord.utils.to_timestamp_format
 
 .. _discord-api-enums:
 
@@ -2360,9 +2360,9 @@ of :class:`enum.Enum`.
 
         The guild may contain NSFW content.
 
-.. class:: TimeMentionType
+.. class:: TimestampFormat
 
-    Represents the type of time mention.
+    Represents the format of :func:`utils.to_timestamp_format`.
 
     .. versionadded:: 2.0
     

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1065,6 +1065,8 @@ Utility Functions
 
 .. autofunction:: discord.utils.as_chunks
 
+.. autofunction:: discord.utils.to_time_mention
+
 .. _discord-api-enums:
 
 Enumerations


### PR DESCRIPTION
## Summary

I added a function that makes time mention (Like: `<t:1624048212>`) from datetime.
Note: It only works in Canary, but I think it will work in stable when 2.0 is released.
![image](https://user-images.githubusercontent.com/59691627/122613415-c8bb9680-d0bf-11eb-816f-24d09d2d75ef.png)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
