### PR TITLE
Add a __str__ to EmptyEmbed so that __repr__ is not used

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -39,6 +39,9 @@ class _EmptyEmbed:
     def __bool__(self) -> bool:
         return False
 
+    def __str__(self) -> str:
+        return ''
+
     def __repr__(self) -> str:
         return 'Embed.Empty'
 


### PR DESCRIPTION
## Summary

Doing `str()` on EmptyEmbed would give `Empty.Embed` instead of an empty string as could be expected.