### PR TITLE
Localize Embed.timestamp during assignment

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -202,8 +202,6 @@ class Embed:
             self.url = str(self.url)
 
         if timestamp:
-            if timestamp.tzinfo is None:
-                timestamp = timestamp.astimezone()
             self.timestamp = timestamp
 
     @classmethod
@@ -327,7 +325,11 @@ class Embed:
 
     @timestamp.setter
     def timestamp(self, value: MaybeEmpty[datetime.datetime]):
-        if isinstance(value, (datetime.datetime, _EmptyEmbed)):
+        if isinstance(value, datetime.datetime):
+            if value.tzinfo is None:
+                value = value.astimezone()
+            self._timestamp = value
+        elif isinstance(value, _EmptyEmbed):
             self._timestamp = value
         else:
             raise TypeError(f"Expected datetime.datetime or Embed.Empty received {value.__class__.__name__} instead")


### PR DESCRIPTION
## Summary

This provides consistency between setting the timestamp through the constructor and through assignment, since originally it would interpret naive datetimes in constructor as local time but interpret the same datetime during `.timestamp =` assignment as UTC.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
