### PR TITLE
Set Message.guild from guild_id if unavailable through Message.channel 

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -657,7 +657,11 @@ class Message(Hashable):
         self.nonce = data.get('nonce')
         self.stickers = [Sticker(data=d, state=state) for d in data.get('stickers', [])]
         self.components = [_component_factory(d) for d in data.get('components', [])]
-        self.guild = state._get_guild(utils._get_as_snowflake(data, 'guild_id'))
+
+        try:
+            self.guild = channel.guild
+        except AttributeError:
+            self.guild = state._get_guild(utils._get_as_snowflake(data, 'guild_id'))
 
         try:
             ref = data['message_reference']

--- a/discord/message.py
+++ b/discord/message.py
@@ -590,6 +590,8 @@ class Message(Hashable):
         A list of components in the message.
 
         .. versionadded:: 2.0
+    guild: Optional[:class:`Guild`]
+        The guild that the message belongs to, if applicable.
     """
 
     __slots__ = (
@@ -601,7 +603,6 @@ class Message(Hashable):
         '_cs_raw_channel_mentions',
         '_cs_raw_role_mentions',
         '_cs_system_content',
-        '_cs_guild',
         'tts',
         'content',
         'channel',
@@ -623,6 +624,7 @@ class Message(Hashable):
         'activity',
         'stickers',
         'components',
+        'guild',
     )
 
     if TYPE_CHECKING:
@@ -655,6 +657,7 @@ class Message(Hashable):
         self.nonce = data.get('nonce')
         self.stickers = [Sticker(data=d, state=state) for d in data.get('stickers', [])]
         self.components = [_component_factory(d) for d in data.get('components', [])]
+        self.guild = state._get_guild(utils._get_as_snowflake(data, 'guild_id'))
 
         try:
             ref = data['message_reference']
@@ -858,11 +861,6 @@ class Message(Hashable):
             del self._cs_guild  # type: ignore
         except AttributeError:
             pass
-
-    @utils.cached_slot_property('_cs_guild')
-    def guild(self) -> Optional[Guild]:
-        """Optional[:class:`Guild`]: The guild that the message belongs to, if applicable."""
-        return getattr(self.channel, 'guild', None)
 
     @utils.cached_slot_property('_cs_raw_mentions')
     def raw_mentions(self) -> List[int]:

--- a/discord/message.py
+++ b/discord/message.py
@@ -858,13 +858,9 @@ class Message(Hashable):
     def _handle_components(self, components: List[ComponentPayload]):
         self.components = [_component_factory(d) for d in components]
 
-    def _rebind_channel_reference(self, new_channel: Union[TextChannel, Thread, DMChannel, GroupChannel]) -> None:
+    def _rebind_cached_references(self, new_guild: Optional[Guild], new_channel: Union[TextChannel, Thread, DMChannel, GroupChannel]) -> None:
+        self.guild = new_guild
         self.channel = new_channel
-
-        try:
-            del self._cs_guild  # type: ignore
-        except AttributeError:
-            pass
 
     @utils.cached_slot_property('_cs_raw_mentions')
     def raw_mentions(self) -> List[int]:

--- a/discord/message.py
+++ b/discord/message.py
@@ -858,7 +858,7 @@ class Message(Hashable):
     def _handle_components(self, components: List[ComponentPayload]):
         self.components = [_component_factory(d) for d in components]
 
-    def _rebind_cached_references(self, new_guild: Optional[Guild], new_channel: Union[TextChannel, Thread, DMChannel, GroupChannel]) -> None:
+    def _rebind_cached_references(self, new_guild: Guild, new_channel: Union[TextChannel, Thread]) -> None:
         self.guild = new_guild
         self.channel = new_channel
 

--- a/discord/state.py
+++ b/discord/state.py
@@ -1273,7 +1273,7 @@ class AutoShardedConnectionState(ConnectionState):
             if new_guild is not None and new_guild is not msg.guild:
                 channel_id = msg.channel.id
                 channel = new_guild.get_channel(channel_id) or new_guild.get_thread(channel_id) or Object(id=channel_id)
-                msg._rebind_channel_reference(channel)
+                msg._rebind_cached_references(new_guild, channel)
 
     async def chunker(self, guild_id, query='', limit=0, presences=False, *, shard_id=None, nonce=None):
         ws = self._get_websocket(guild_id, shard_id=shard_id)


### PR DESCRIPTION
## Summary

Fixes `Message.guild` being `None` when `Message.channel` is `None` or is only an `Object`.

I ran into this a bunch due to the current issues with unarchiving threads, but it should also be useful in case there are new text channel types.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
