### PR TITLE
Change button label field to a required field

### DIFF
--- a/discord/ui/button.py
+++ b/discord/ui/button.py
@@ -39,9 +39,22 @@ __all__ = (
     'button',
 )
 
+class _EmptyButton:
+    def __bool__(self) -> bool:
+        return False
+
+    def __repr__(self) -> str:
+        return 'Button.Empty'
+
+    def __len__(self) -> int:
+        return 0
+
 if TYPE_CHECKING:
     from .view import View
     from ..emoji import Emoji
+   
+    T = TypeVar('T')
+    MaybeEmpty = Union[T, _EmptyEmbed]
 
 B = TypeVar('B', bound='Button')
 V = TypeVar('V', bound='View', covariant=True)
@@ -63,8 +76,9 @@ class Button(Item[V]):
         The URL this button sends you to.
     disabled: :class:`bool`
         Whether the button is disabled or not.
-    label: Optional[:class:`str`]
+    label: :class:`str`
         The label of the button, if any.
+        This can be set during initialisation.
     emoji: Optional[Union[:class:`PartialEmoji`, :class:`Emoji`, :class:`str`]]
         The emoji of the button, if available.
     row: Optional[:class:`int`]
@@ -88,7 +102,7 @@ class Button(Item[V]):
         self,
         *,
         style: ButtonStyle,
-        label: Optional[str] = None,
+        label: MaybeEmpty[str] = _EmptyButton,
         disabled: bool = False,
         custom_id: Optional[str] = None,
         url: Optional[str] = None,


### PR DESCRIPTION
## Summary

As per Rapptz/discord.py#7113, adjust `label` field to be similar to the `description` field of an embed. This might not be the ideal way of doing it, I just tried to mimic the embed's way of doing it as closely as possible.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes. (**I believe the documentation should automatically update with a type change? If not, how do I change it?**)
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
