### PR TITLE
Rename `slowmode_delay` to `slowmode`

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -296,7 +296,7 @@ class GuildChannel:
             parent_id = parent and parent.id
 
         try:
-            options['rate_limit_per_user'] = options.pop('slowmode_delay')
+            options['rate_limit_per_user'] = options.pop('slowmode')
         except KeyError:
             pass
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -101,7 +101,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
     last_message_id: Optional[:class:`int`]
         The last message ID of the message sent to this channel. It may
         *not* point to an existing or valid message.
-    slowmode_delay: :class:`int`
+    slowmode: :class:`int`
         The number of seconds a member must wait between sending messages
         in this channel. A value of `0` denotes that it is disabled.
         Bots and users with :attr:`~Permissions.manage_channels` or
@@ -115,7 +115,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
     """
 
     __slots__ = ('name', 'id', 'guild', 'topic', '_state', 'nsfw',
-                 'category_id', 'position', 'slowmode_delay', '_overwrites',
+                 'category_id', 'position', 'slowmode', '_overwrites',
                  '_type', 'last_message_id')
 
     def __init__(self, *, state, guild, data):
@@ -144,7 +144,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         self.position = data['position']
         self.nsfw = data.get('nsfw', False)
         # Does this need coercion into `int`? No idea yet.
-        self.slowmode_delay = data.get('rate_limit_per_user', 0)
+        self.slowmode = data.get('rate_limit_per_user', 0)
         self._type = data.get('type', self._type)
         self.last_message_id = utils._get_as_snowflake(data, 'last_message_id')
         self._fill_overwrites(data)
@@ -223,7 +223,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         nsfw: bool = ...,
         sync_permissions: bool = ...,
         category: Optional[CategoryChannel] = ...,
-        slowmode_delay: int = ...,
+        slowmode: int = ...,
         type: ChannelType = ...,
         overwrites: Dict[Union[Role, Member, Snowflake], PermissionOverwrite] = ...,
     ) -> None:
@@ -263,7 +263,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         category: Optional[:class:`CategoryChannel`]
             The new category for this channel. Can be ``None`` to remove the
             category.
-        slowmode_delay: :class:`int`
+        slowmode: :class:`int`
             Specifies the slowmode rate limit for user in this channel, in seconds.
             A value of `0` disables slowmode. The maximum value possible is `21600`.
         type: :class:`ChannelType`
@@ -293,7 +293,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         return await self._clone_impl({
             'topic': self.topic,
             'nsfw': self.nsfw,
-            'rate_limit_per_user': self.slowmode_delay
+            'rate_limit_per_user': self.slowmode
         }, name=name, reason=reason)
 
     async def delete_messages(self, messages):


### PR DESCRIPTION
## Summary

This is a breaking change, and since development of 2.0 is going on right now, I feel like this would be the time to make this PR.

This has been discussed [before](https://discord.com/channels/336642139381301249/603069307286454290/834256491362910239) but not added.

I feel like `slowmode_delay` is a bit too verbose for me. For newcomers to discord.py, it is not obvious what the slowmode attribute is and would usually require a documentation lookup.

`slowmode_delay` was not to be consistent with the API anyways, as it is officially `rate_limit_per_user`  
If consistency with the API is preferred over this, renaming to `rate_limit_per_user` would be fine with me, too.  

I chose `slowmode` over `rate_limit_per_user` as I felt "slowmode" is what everyone calls it and would take less time to get used to

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
