### PR TITLE
Replace API-deprecated stickers with sticker_items

### DIFF
--- a/discord/asset.py
+++ b/discord/asset.py
@@ -215,15 +215,6 @@ class Asset(AssetMixin):
             animated=animated,
         )
 
-    @classmethod
-    def _from_sticker(cls, state, sticker_id: int, sticker_hash: str) -> Asset:
-        return cls(
-            state,
-            url=f'{cls.BASE}/stickers/{sticker_id}/{sticker_hash}.png?size=1024',
-            key=sticker_hash,
-            animated=False,
-        )
-
     def __str__(self) -> str:
         return self._url
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -45,7 +45,7 @@ from .file import File
 from .utils import escape_mentions, MISSING
 from .guild import Guild
 from .mixins import Hashable
-from .sticker import Sticker
+from .sticker import StickerItem
 from .threads import Thread
 
 if TYPE_CHECKING:
@@ -582,8 +582,8 @@ class Message(Hashable):
         - ``description``: A string representing the application's description.
         - ``icon``: A string representing the icon ID of the application.
         - ``cover_image``: A string representing the embed's image asset ID.
-    stickers: List[:class:`Sticker`]
-        A list of stickers given to the message.
+    sticker_items: List[:class:`StickerItem`]
+        A list of sticker items given to the message.
 
         .. versionadded:: 1.6
     components: List[:class:`Component`]
@@ -621,7 +621,7 @@ class Message(Hashable):
         'reference',
         'application',
         'activity',
-        'stickers',
+        'sticker_items',
         'components',
     )
 
@@ -653,7 +653,7 @@ class Message(Hashable):
         self.tts = data['tts']
         self.content = data['content']
         self.nonce = data.get('nonce')
-        self.stickers = [Sticker(data=d, state=state) for d in data.get('stickers', [])]
+        self.sticker_items = [StickerItem(data=d, state=state) for d in data.get('sticker_items', [])]
         self.components = [_component_factory(d) for d in data.get('components', [])]
 
         try:

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -89,19 +89,12 @@ class MessageReference(TypedDict, total=False):
     fail_if_not_exists: bool
 
 
-class _StickerOptional(TypedDict, total=False):
-    tags: str
-
-
 StickerFormatType = Literal[1, 2, 3]
 
 
-class Sticker(_StickerOptional):
+class StickerItem(TypedDict):
     id: Snowflake
-    pack_id: Snowflake
     name: str
-    description: str
-    asset: str
     format_type: StickerFormatType
 
 
@@ -117,7 +110,7 @@ class _MessageOptional(TypedDict, total=False):
     application_id: Snowflake
     message_reference: MessageReference
     flags: int
-    stickers: List[Sticker]
+    sticker_items: List[StickerItem]
     referenced_message: Optional[Message]
     interaction: MessageInteraction
     components: List[Component]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3508,12 +3508,12 @@ Widget
 .. autoclass:: Widget()
     :members:
 
-Sticker
+StickerItem
 ~~~~~~~~~~~~~~~
 
-.. attributetable:: Sticker
+.. attributetable:: StickerItem
 
-.. autoclass:: Sticker()
+.. autoclass:: StickerItem()
     :members:
 
 RawMessageDeleteEvent


### PR DESCRIPTION
## Summary
Replaces API-deprecated `Message.stickers` with `Message.sticker_items`. See also discord/discord-api-docs#3171

## Checklist

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
