### PR TITLE
Fix link buttons not being regarded as persistent

### DIFF
--- a/discord/ui/button.py
+++ b/discord/ui/button.py
@@ -218,7 +218,7 @@ class Button(Item[V]):
         return self.custom_id is not None
 
     def is_persistent(self) -> bool:
-        if self.style == ButtonStyle.link:
+        if self.style is ButtonStyle.link:
             return self.url is not None
         return super().is_persistent()
 

--- a/discord/ui/button.py
+++ b/discord/ui/button.py
@@ -217,6 +217,11 @@ class Button(Item[V]):
     def is_dispatchable(self) -> bool:
         return self.custom_id is not None
 
+    def is_persistent(self) -> bool:
+        if self.style == ButtonStyle.link:
+            return self.url is not None
+        return super().is_persistent()
+
     def refresh_component(self, button: ButtonComponent) -> None:
         self._underlying = button
 


### PR DESCRIPTION
## Summary

Currently add_view raises an error if link buttons are present in a view being added.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
