### PR TITLE
Fix typing of ApplicationCommandInteractionDataOption

### DIFF
--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -93,16 +93,52 @@ class GuildApplicationCommandPermissions(PartialGuildApplicationCommandPermissio
 InteractionType = Literal[1, 2, 3]
 
 
-class _ApplicationCommandInteractionDataOptionOptional(TypedDict, total=False):
-    value: ApplicationCommandOptionType
+class _ApplicationCommandInteractionDataOption(TypedDict):
+    name: str
+
+
+class _ApplicationCommandInteractionDataOptionSubcommand(
+    _ApplicationCommandInteractionDataOption
+):
+    type: Literal[1, 2]
     options: List[ApplicationCommandInteractionDataOption]
 
 
-class ApplicationCommandInteractionDataOption(
-    _ApplicationCommandInteractionDataOptionOptional
+class _ApplicationCommandInteractionDataOptionString(
+    _ApplicationCommandInteractionDataOption
 ):
-    name: str
-    type: ApplicationCommandOptionType
+    type: Literal[3]
+    value: str
+
+
+class _ApplicationCommandInteractionDataOptionInteger(
+    _ApplicationCommandInteractionDataOption
+):
+    type: Literal[4]
+    value: int
+
+
+class _ApplicationCommandInteractionDataOptionBoolean(
+    _ApplicationCommandInteractionDataOption
+):
+    type: Literal[5]
+    value: bool
+
+
+class _ApplicationCommandInteractionDataOptionSnowflake(
+    _ApplicationCommandInteractionDataOption
+):
+    type: Literal[6, 7, 8, 9]
+    value: Snowflake
+
+
+ApplicationCommandInteractionDataOption = Union[
+    _ApplicationCommandInteractionDataOptionString,
+    _ApplicationCommandInteractionDataOptionInteger,
+    _ApplicationCommandInteractionDataOptionSubcommand,
+    _ApplicationCommandInteractionDataOptionBoolean,
+    _ApplicationCommandInteractionDataOptionSnowflake,
+]
 
 
 class ApplicationCommandResolvedPartialChannel(TypedDict):


### PR DESCRIPTION
## Summary

`ApplicationCommandInteractionDataOption`'s value type should be derived from the type key.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
