### PR TITLE
Add `.is_nsfw()` to Thread.

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -275,6 +275,8 @@ class Thread(Messageable, Hashable):
         i.e. :meth:`.TextChannel.is_nsfw` is ``True``.
         """
         parent = self.parent
+        if parent is None:
+            raise ClientException('Parent channel not found')
         return parent.is_nsfw()
 
     def permissions_for(self, obj: Union[Member, Role], /) -> Permissions:

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -275,9 +275,7 @@ class Thread(Messageable, Hashable):
         i.e. :meth:`.TextChannel.is_nsfw` is ``True``.
         """
         parent = self.parent
-        if parent is None:
-            raise ClientException('Parent channel not found')
-        return parent.is_nsfw()
+        return parent is not None and parent.is_nsfw()
 
     def permissions_for(self, obj: Union[Member, Role], /) -> Permissions:
         """Handles permission resolution for the :class:`~discord.Member`

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -268,6 +268,15 @@ class Thread(Messageable, Hashable):
         """
         return self._type is ChannelType.news_thread
 
+    def is_nsfw(self) -> bool:
+        """:class:`bool`: Whether the thread is NSFW or not.
+
+        An NSFW thread is a thread that has a parent that is an NSFW channel,
+        i.e. :meth:`.TextChannel.is_nsfw` is ``True``.
+        """
+        parent = self.parent
+        return parent.is_nsfw()
+
     def permissions_for(self, obj: Union[Member, Role], /) -> Permissions:
         """Handles permission resolution for the :class:`~discord.Member`
         or :class:`~discord.Role`.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR adds `Thread.is_nsfw()` for end user convenience. 
As Threads cannot be inherently NSFW themselves, this is read from the parent channel instead.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
