### PR TITLE
Fix attribute error when building docs

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -41,6 +41,7 @@ from .webhook.async_ import async_context, Webhook, handle_message_parameters
 
 __all__ = (
     'Interaction',
+    'InteractionMessage',
     'InteractionResponse',
 )
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes an attribute error during docs build due to `InteractionMessage` not being included in `__all__`.
Probably has more effects elsewhere.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
