### PR TITLE
Re-try requests on 504 error and raise correct 5xx error

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -321,8 +321,8 @@ class HTTPClient:
 
                             continue
 
-                        # we've received a 500 or 502, unconditional retry
-                        if response.status in {500, 502}:
+                        # we've received a 500, 502, or 504, unconditional retry
+                        if response.status in {500, 502, 504}:
                             await asyncio.sleep(1 + tries * 2)
                             continue
 
@@ -331,7 +331,7 @@ class HTTPClient:
                             raise Forbidden(response, data)
                         elif response.status == 404:
                             raise NotFound(response, data)
-                        elif response.status == 503:
+                        elif response.status >= 500:
                             raise DiscordServerError(response, data)
                         else:
                             raise HTTPException(response, data)


### PR DESCRIPTION
## Summary

Re-tries requests that timed out instead of simply raising `HTTPException` and ensures all 5xx responses raise `DiscordServerError` instead of `HTTPException`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
