### PR TITLE
style(__init__): more strict type hint in releaselevel

### DIFF
--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -18,7 +18,7 @@ __version__ = '2.0.0a'
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
 import logging
-from typing import NamedTuple
+from typing import NamedTuple, Literal
 
 from .client import *
 from .appinfo import *
@@ -64,7 +64,7 @@ class VersionInfo(NamedTuple):
 	major: int
 	minor: int
 	micro: int
-	releaselevel: str
+	releaselevel: Literal["alpha", "beta", "candidate", "final"]
 	serial: int
 
 version_info = VersionInfo(major=2, minor=0, micro=0, releaselevel='alpha', serial=0)


### PR DESCRIPTION
## Summary

In the releaselevel argument of VersionInfo added Literal type hint.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
