### PR TITLE
Fix documentation note for interaction_check

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -303,9 +303,8 @@ class View:
 
         .. note::
 
-            If an exception occurs within the body then the interaction
-            check then :meth:`on_error` is called and it is considered
-            a failure.
+            If an exception occurs within the body then the check
+            is considered a failure and :meth:`on_error` is called.
 
         Parameters
         -----------


### PR DESCRIPTION
## Summary

Fixes some weird phrasing in the documentation note for `interaction_check` that didn't really make much sense.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
