### PR TITLE
[commands] Change: Allow nickname that prefixed with @

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -187,6 +187,9 @@ class MemberConverter(IDConverter[discord.Member]):
     .. versionchanged:: 1.5.1
         This converter now lazily fetches members from the gateway and HTTP APIs,
         optionally caching the result if :attr:`.MemberCacheFlags.joined` is enabled.
+    
+    .. versionchanged:: 2.0
+        Added support for nickname that starts with an at sign.
     """
 
     async def query_member_named(self, guild, argument):

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -187,7 +187,7 @@ class MemberConverter(IDConverter[discord.Member]):
     .. versionchanged:: 1.5.1
         This converter now lazily fetches members from the gateway and HTTP APIs,
         optionally caching the result if :attr:`.MemberCacheFlags.joined` is enabled.
-    
+
     .. versionchanged:: 2.0
         Added support for nickname that starts with an at sign.
     """
@@ -233,8 +233,6 @@ class MemberConverter(IDConverter[discord.Member]):
             # not a mention...
             if guild:
                 result = guild.get_member_named(argument)
-                if result is None and argument.startswith("@"):
-                    result = guild.get_member_named(argument[1:])
             else:
                 result = _get_from_guilds(bot, 'get_member_named', argument)
         else:
@@ -252,6 +250,8 @@ class MemberConverter(IDConverter[discord.Member]):
                 result = await self.query_member_by_id(bot, guild, user_id)
             else:
                 result = await self.query_member_named(guild, argument)
+                if result is None and argument.startswith('@'):
+                    result = await self.query_member_named(guild, argument[1:])
 
             if not result:
                 raise MemberNotFound(argument)

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -179,6 +179,7 @@ class MemberConverter(IDConverter[discord.Member]):
     3. Lookup by name#discrim
     4. Lookup by name
     5. Lookup by nickname
+    6. Lookup by nickname without first at sign
 
     .. versionchanged:: 1.5
          Raise :exc:`.MemberNotFound` instead of generic :exc:`.BadArgument`
@@ -229,6 +230,8 @@ class MemberConverter(IDConverter[discord.Member]):
             # not a mention...
             if guild:
                 result = guild.get_member_named(argument)
+                if result is None and argument.startswith("@"):
+                    result = guild.get_member_named(argument[1:])
             else:
                 result = _get_from_guilds(bot, 'get_member_named', argument)
         else:


### PR DESCRIPTION
## Summary

I made MemberConverter to be able to convert nickname that prefixed with `@`.
On Desktop client, mention doesn't be copied correctly(It'll be `@Nickname` as string).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
