### PR TITLE
Add reason kwarg to more methods.

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -637,6 +637,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         name: str,
         message: Optional[Snowflake] = None,
         auto_archive_duration: ThreadArchiveDuration = 1440,
+        reason: Optional[str] = None
     ) -> Thread:
         """|coro|
 
@@ -650,6 +651,8 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         you must have :attr:`~discord.Permissions.send_messages` and
         :attr:`~discord.Permissions.use_threads` in order to start the thread.
 
+        .. versionadded:: 2.0
+
         Parameters
         -----------
         name: :class:`str`
@@ -661,6 +664,8 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         auto_archive_duration: :class:`int`
             The duration in minutes before a thread is automatically archived for inactivity.
             Defaults to ``1440`` or 24 hours.
+        reason: :class:`str`
+            The reason for starting a new thread. Shows up on the audit log.
 
         Raises
         -------
@@ -681,6 +686,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
                 name=name,
                 auto_archive_duration=auto_archive_duration,
                 type=ChannelType.private_thread.value,
+                reason=reason,
             )
         else:
             data = await self._state.http.start_public_thread(
@@ -689,6 +695,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
                 name=name,
                 auto_archive_duration=auto_archive_duration,
                 type=ChannelType.public_thread.value,
+                reason=reason,
             )
 
         return Thread(guild=self.guild, state=self._state, data=data)
@@ -705,6 +712,8 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
 
         You must have :attr:`~Permissions.read_message_history` to use this. If iterating over private threads
         then :attr:`~Permissions.manage_threads` is also required.
+
+        .. versionadded:: 2.0
 
         Parameters
         -----------
@@ -1119,7 +1128,7 @@ class StageChannel(VocalGuildChannel):
         """
         return utils.get(self.guild.stage_instances, channel_id=self.id)
 
-    async def create_instance(self, *, topic: str, privacy_level: StagePrivacyLevel = MISSING) -> StageInstance:
+    async def create_instance(self, *, topic: str, privacy_level: StagePrivacyLevel = MISSING, reason: Optional[str] = None) -> StageInstance:
         """|coro|
 
         Create a stage instance.
@@ -1135,6 +1144,8 @@ class StageChannel(VocalGuildChannel):
             The stage instance's topic.
         privacy_level: :class:`StagePrivacyLevel`
             The stage instance's privacy level. Defaults to :attr:`StagePrivacyLevel.guild_only`.
+        reason: :class:`str`
+            The reason the stage instance was created. Shows up on the audit log.
 
         Raises
         ------
@@ -1159,7 +1170,7 @@ class StageChannel(VocalGuildChannel):
 
             payload['privacy_level'] = privacy_level.value
 
-        data = await self._state.http.create_stage_instance(**payload)
+        data = await self._state.http.create_stage_instance(**payload, reason=reason)
         return StageInstance(guild=self.guild, state=self._state, data=data)
 
     async def fetch_instance(self) -> StageInstance:

--- a/discord/http.py
+++ b/discord/http.py
@@ -709,11 +709,11 @@ class HTTPClient:
         reason: Optional[str] = None,
     ) -> Response[None]:
         r = Route('PUT', '/guilds/{guild_id}/bans/{user_id}', guild_id=guild_id, user_id=user_id)
-        payload = {
+        params = {
             'delete_message_days': delete_message_days,
         }
 
-        return self.request(r, json=payload, reason=reason)
+        return self.request(r, params=params, reason=reason)
 
     def unban(self, user_id: Snowflake, guild_id: Snowflake, *, reason: Optional[str] = None) -> Response[None]:
         r = Route('DELETE', '/guilds/{guild_id}/bans/{user_id}', guild_id=guild_id, user_id=user_id)
@@ -1141,10 +1141,10 @@ class HTTPClient:
     ) -> Response[guild.GuildPrune]:
         payload: Dict[str, Any] = {
             'days': days,
-            'compute_prune_count': compute_prune_count,
+            'compute_prune_count': 'true' if compute_prune_count else 'false',
         }
         if roles:
-            payload['include_roles'] = roles
+            payload['include_roles'] = ', '.join(roles)
 
         return self.request(Route('POST', '/guilds/{guild_id}/prune', guild_id=guild_id), json=payload, reason=reason)
 
@@ -1158,7 +1158,7 @@ class HTTPClient:
             'days': days,
         }
         if roles:
-            params['include_roles'] = roles
+            params['include_roles'] = ', '.join(roles)
 
         return self.request(Route('GET', '/guilds/{guild_id}/prune', guild_id=guild_id), params=params)
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -1144,7 +1144,7 @@ class HTTPClient:
             'compute_prune_count': compute_prune_count,
         }
         if roles:
-            payload['include_roles'] = ', '.join(roles)
+            payload['include_roles'] = roles
 
         return self.request(Route('POST', '/guilds/{guild_id}/prune', guild_id=guild_id), json=payload, reason=reason)
 
@@ -1158,7 +1158,7 @@ class HTTPClient:
             'days': days,
         }
         if roles:
-            params['include_roles'] = ', '.join(roles)
+            params['include_roles'] = roles
 
         return self.request(Route('GET', '/guilds/{guild_id}/prune', guild_id=guild_id), params=params)
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -436,7 +436,7 @@ class HTTPClient:
 
         if embed:
             payload['embeds'] = [embed]
-        
+
         if embeds:
             payload['embeds'] = embeds
 
@@ -709,15 +709,11 @@ class HTTPClient:
         reason: Optional[str] = None,
     ) -> Response[None]:
         r = Route('PUT', '/guilds/{guild_id}/bans/{user_id}', guild_id=guild_id, user_id=user_id)
-        params = {
+        payload = {
             'delete_message_days': delete_message_days,
         }
 
-        if reason:
-            # thanks aiohttp
-            r.url = f'{r.url}?reason={_uriquote(reason)}'
-
-        return self.request(r, params=params)
+        return self.request(r, json=payload, reason=reason)
 
     def unban(self, user_id: Snowflake, guild_id: Snowflake, *, reason: Optional[str] = None) -> Response[None]:
         r = Route('DELETE', '/guilds/{guild_id}/bans/{user_id}', guild_id=guild_id, user_id=user_id)
@@ -879,6 +875,7 @@ class HTTPClient:
         name: str,
         auto_archive_duration: threads.ThreadArchiveDuration,
         type: threads.ThreadType,
+        reason: Optional[str] = None,
     ) -> Response[threads.Thread]:
         payload = {
             'name': name,
@@ -889,7 +886,7 @@ class HTTPClient:
         route = Route(
             'POST', '/channels/{channel_id}/messages/{message_id}/threads', channel_id=channel_id, message_id=message_id
         )
-        return self.request(route, json=payload)
+        return self.request(route, json=payload, reason=reason)
 
     def start_private_thread(
         self,
@@ -898,6 +895,7 @@ class HTTPClient:
         name: str,
         auto_archive_duration: threads.ThreadArchiveDuration,
         type: threads.ThreadType,
+        reason: Optional[str] = None,
     ) -> Response[threads.Thread]:
         payload = {
             'name': name,
@@ -906,7 +904,7 @@ class HTTPClient:
         }
 
         route = Route('POST', '/channels/{channel_id}/threads', channel_id=channel_id)
-        return self.request(route, json=payload)
+        return self.request(route, json=payload, reason=reason)
 
     def join_thread(self, channel_id: Snowflake) -> Response[None]:
         return self.request(Route('POST', '/channels/{channel_id}/thread-members/@me', channel_id=channel_id))
@@ -1143,7 +1141,7 @@ class HTTPClient:
     ) -> Response[guild.GuildPrune]:
         payload: Dict[str, Any] = {
             'days': days,
-            'compute_prune_count': 'true' if compute_prune_count else 'false',
+            'compute_prune_count': compute_prune_count,
         }
         if roles:
             payload['include_roles'] = ', '.join(roles)
@@ -1237,12 +1235,12 @@ class HTTPClient:
 
         return self.request(r)
 
-    def delete_integration(self, guild_id: Snowflake, integration_id: Snowflake) -> Response[None]:
+    def delete_integration(self, guild_id: Snowflake, integration_id: Snowflake, *, reason: Optional[str] = None) -> Response[None]:
         r = Route(
             'DELETE', '/guilds/{guild_id}/integrations/{integration_id}', guild_id=guild_id, integration_id=integration_id
         )
 
-        return self.request(r)
+        return self.request(r, reason=reason)
 
     def get_audit_logs(
         self,
@@ -1422,7 +1420,7 @@ class HTTPClient:
     def get_stage_instance(self, channel_id: Snowflake) -> Response[channel.StageInstance]:
         return self.request(Route('GET', '/stage-instances/{channel_id}', channel_id=channel_id))
 
-    def create_stage_instance(self, **payload) -> Response[channel.StageInstance]:
+    def create_stage_instance(self, *, reason: Optional[str], **payload: Any) -> Response[channel.StageInstance]:
         valid_keys = (
             'channel_id',
             'topic',
@@ -1430,19 +1428,19 @@ class HTTPClient:
         )
         payload = {k: v for k, v in payload.items() if k in valid_keys}
 
-        return self.request(Route('POST', '/stage-instances'), json=payload)
+        return self.request(Route('POST', '/stage-instances'), json=payload, reason=reason)
 
-    def edit_stage_instance(self, channel_id: Snowflake, **payload) -> Response[None]:
+    def edit_stage_instance(self, channel_id: Snowflake, *, reason: Optional[str] = None, **payload: Any) -> Response[None]:
         valid_keys = (
             'topic',
             'privacy_level',
         )
         payload = {k: v for k, v in payload.items() if k in valid_keys}
 
-        return self.request(Route('PATCH', '/stage-instances/{channel_id}', channel_id=channel_id), json=payload)
+        return self.request(Route('PATCH', '/stage-instances/{channel_id}', channel_id=channel_id), json=payload, reason=reason)
 
-    def delete_stage_instance(self, channel_id: Snowflake) -> Response[None]:
-        return self.request(Route('DELETE', '/stage-instances/{channel_id}', channel_id=channel_id))
+    def delete_stage_instance(self, channel_id: Snowflake, *, reason: Optional[str] = None) -> Response[None]:
+        return self.request(Route('DELETE', '/stage-instances/{channel_id}', channel_id=channel_id), reason=reason)
 
     # Application commands (global)
 
@@ -1571,9 +1569,9 @@ class HTTPClient:
         return self.request(r)
 
     def bulk_upsert_guild_commands(
-        self, 
+        self,
         application_id: Snowflake,
-        guild_id: Snowflake, 
+        guild_id: Snowflake,
         payload: List[interactions.EditApplicationCommand],
     ) -> Response[List[interactions.ApplicationCommand]]:
         r = Route(

--- a/discord/integrations.py
+++ b/discord/integrations.py
@@ -127,13 +127,20 @@ class Integration:
         self.user = User(state=self._state, data=user) if user else None
         self.enabled: bool = data['enabled']
 
-    async def delete(self) -> None:
+    async def delete(self, *, reason: Optional[str] = None) -> None:
         """|coro|
 
         Deletes the integration.
 
         You must have the :attr:`~Permissions.manage_guild` permission to
         do this.
+
+        Parameters
+        -----------
+        reason: :class:`str`
+            The reason the integration was deleted. Shows up on the audit log.
+
+            .. versionadded:: 2.0
 
         Raises
         -------
@@ -142,7 +149,7 @@ class Integration:
         HTTPException
             Deleting the integration failed.
         """
-        await self._state.http.delete_integration(self.guild.id, self.id)
+        await self._state.http.delete_integration(self.guild.id, self.id, reason=reason)
 
 
 class StreamIntegration(Integration):

--- a/discord/stage_instance.py
+++ b/discord/stage_instance.py
@@ -111,7 +111,7 @@ class StageInstance(Hashable):
     def is_public(self) -> bool:
         return self.privacy_level is StagePrivacyLevel.public
 
-    async def edit(self, *, topic: str = MISSING, privacy_level: StagePrivacyLevel = MISSING) -> None:
+    async def edit(self, *, topic: str = MISSING, privacy_level: StagePrivacyLevel = MISSING, reason: Optional[str] = None) -> None:
         """|coro|
 
         Edits the stage instance.
@@ -125,6 +125,8 @@ class StageInstance(Hashable):
             The stage instance's new topic.
         privacy_level: :class:`StagePrivacyLevel`
             The stage instance's new privacy level.
+        reason: :class:`str`
+            The reason the stage instance was edited. Shows up on the audit log.
 
         Raises
         ------
@@ -148,15 +150,20 @@ class StageInstance(Hashable):
             payload['privacy_level'] = privacy_level.value
 
         if payload:
-            await self._state.http.edit_stage_instance(self.channel_id, **payload)
+            await self._state.http.edit_stage_instance(self.channel_id, **payload, reason=reason)
 
-    async def delete(self) -> None:
+    async def delete(self, *, reason: Optional[str] = None) -> None:
         """|coro|
 
         Deletes the stage instance.
 
         You must have the :attr:`~Permissions.manage_channels` permission to
         use this.
+
+        Parameters
+        -----------
+        reason: :class:`str`
+            The reason the stage instance was deleted. Shows up on the audit log.
 
         Raises
         ------
@@ -165,4 +172,4 @@ class StageInstance(Hashable):
         HTTPException
             Deleting the stage instance failed.
         """
-        await self._state.http.delete_stage_instance(self.channel_id)
+        await self._state.http.delete_stage_instance(self.channel_id, reason=reason)


### PR DESCRIPTION
## Summary

Add reason kwarg to more methods.
Reference: discord/discord-api-docs@ab9e385

Also made bans send a JSON payload rather than use query parameters.
Also does not format `roles` for `include_roles` in prune/estimate_pruned_members as a comma separated string, which seemed to work for me.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
