### PR TITLE
Add raw thread delete event

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Set, List, Tuple, Union
 
+from .enums import ChannelType, try_enum
+
 if TYPE_CHECKING:
     from .types.gateway import (
         MessageDeleteEvent,
@@ -36,10 +38,12 @@ if TYPE_CHECKING:
         MessageReactionRemoveEmojiEvent as ReactionClearEmojiEvent,
         MessageUpdateEvent,
         IntegrationDeleteEvent,
+        ThreadDeleteEvent,
     )
     from .message import Message
     from .partial_emoji import PartialEmoji
     from .member import Member
+    from .threads import Thread
 
     ReactionActionEvent = Union[MessageReactionAddEvent, MessageReactionRemoveEvent]
 
@@ -52,6 +56,7 @@ __all__ = (
     'RawReactionClearEvent',
     'RawReactionClearEmojiEvent',
     'RawIntegrationDeleteEvent',
+    'RawThreadDeleteEvent',
 )
 
 
@@ -280,3 +285,30 @@ class RawIntegrationDeleteEvent(_RawReprMixin):
             self.application_id: Optional[int] = int(data['application_id'])
         except KeyError:
             self.application_id: Optional[int] = None
+
+
+class RawThreadDeleteEvent(_RawReprMixin):
+    """Represents the payload for a :func:`on_raw_thread_delete` event.
+    .. versionadded:: 2.0
+    Attributes
+    ----------
+    thread_id: :class:`int`
+        The ID of the thread that was deleted.
+    thread_type: :class:`discord.ChannelType`
+        The channel type of the deleted thread.
+    guild_id: :class:`int`
+        The ID of the guild the thread was deleted in.
+    parent_id: :class:`int`
+        The ID of the channel the thread was belonged to.
+    thread: Optional[:class:`discord.Thread`]
+        The thread, if it could be found in the internal cache.
+    """
+
+    __slots__ = ('thread_id', 'thread_type', 'parent_id', 'guild_id', 'thread')
+
+    def __init__(self, data: ThreadDeleteEvent) -> None:
+        self.thread_id: int = int(data['id'])
+        self.thread_type: ChannelType = try_enum(ChannelType, data['type'])
+        self.guild_id: int = int(data['guild_id'])
+        self.parent_id: int = int(data['parent_id'])
+        self.thread: Optional[Thread] = None

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -289,7 +289,9 @@ class RawIntegrationDeleteEvent(_RawReprMixin):
 
 class RawThreadDeleteEvent(_RawReprMixin):
     """Represents the payload for a :func:`on_raw_thread_delete` event.
+
     .. versionadded:: 2.0
+
     Attributes
     ----------
     thread_id: :class:`int`

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -301,7 +301,7 @@ class RawThreadDeleteEvent(_RawReprMixin):
     guild_id: :class:`int`
         The ID of the guild the thread was deleted in.
     parent_id: :class:`int`
-        The ID of the channel the thread was belonged to.
+        The ID of the channel the thread belonged to.
     thread: Optional[:class:`discord.Thread`]
         The thread, if it could be found in the internal cache.
     """

--- a/discord/state.py
+++ b/discord/state.py
@@ -886,8 +886,10 @@ class ConnectionState:
             _log.debug('THREAD_DELETE referencing an unknown guild ID: %s. Discarding', guild_id)
             return
 
-        thread_id = int(data['id'])
-        thread = guild.get_thread(thread_id)
+        raw = RawThreadDeleteEvent(data)
+        raw.thread = thread = guild.get_thread(raw.thread_id)
+        self.dispatch('raw_thread_delete', raw)
+
         if thread is not None:
             guild._remove_thread(thread)
             self.dispatch('thread_delete', thread)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4004,7 +4004,7 @@ RawIntegrationDeleteEvent
     :members:
 
 RawThreadDeleteEvent
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: RawThreadDeleteEvent
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1157,7 +1157,11 @@ Threads
 
 .. function:: on_thread_delete(thread)
 
-    Called whenever a thread is deleted.
+    Called whenever a thread is deleted. If the thread could
+    not be found in the internal cache this event will not be called.
+    Threads will not be in the cache if they are archived.
+
+    If you need this information use :func:`on_raw_thread_delete` instead.
 
     Note that you can get the guild from :attr:`Thread.guild`.
 
@@ -1167,6 +1171,18 @@ Threads
 
     :param thread: The thread that got deleted.
     :type thread: :class:`Thread`
+
+.. function:: on_raw_thread_delete(payload)
+
+    Called whenever a thread is deleted. Unlike :func:`on_thread_delete` this
+    is called regardless of the thread being in the internal thread cache or not.
+
+    This requires :attr:`Intents.guilds` to be enabled.
+
+    .. versionadded:: 2.0
+
+    :param payload: The raw event payload data.
+    :type payload: :class:`RawThreadDeleteEvent`
 
 .. function:: on_thread_member_join(member)
               on_thread_member_remove(member)
@@ -3985,6 +4001,14 @@ RawIntegrationDeleteEvent
 .. attributetable:: RawIntegrationDeleteEvent
 
 .. autoclass:: RawIntegrationDeleteEvent()
+    :members:
+
+RawThreadDeleteEvent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: RawThreadDeleteEvent
+
+.. autoclass:: RawThreadDeleteEvent()
     :members:
 
 PartialWebhookGuild


### PR DESCRIPTION
## Summary

Allows receiving information when archived threads are deleted, currently no event is dispatched as they are not cached.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
