### PR TITLE
Fix EqualityComparable.__eq__ typing

### DIFF
--- a/discord/mixins.py
+++ b/discord/mixins.py
@@ -22,24 +22,20 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-from typing import TypeVar
-
 __all__ = (
     'EqualityComparable',
     'Hashable',
 )
-
-E = TypeVar('E', bound='EqualityComparable')
 
 class EqualityComparable:
     __slots__ = ()
 
     id: int
 
-    def __eq__(self: E, other: E) -> bool:
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, self.__class__) and other.id == self.id
 
-    def __ne__(self: E, other: E) -> bool:
+    def __ne__(self, other: object) -> bool:
         if isinstance(other, self.__class__):
             return other.id != self.id
         return True


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes typing for checking equality on two different EqualityComparable subclasses, or an EqualityComparable and other type.
 
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
