### PR TITLE
Add audit log events for threads

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -58,7 +58,6 @@ if TYPE_CHECKING:
     from .types.snowflake import Snowflake
     from .user import User
     from .stage_instance import StageInstance
-    from .webhook import Webhook
     from .threads import Thread
 
 
@@ -347,12 +346,10 @@ class AuditLogEntry(Hashable):
         which actions have this field filled out.
     """
 
-    def __init__(self, *, users: Dict[int, User], webhooks: Dict[int, Webhook], threads: Dict[int, Thread], data: AuditLogEntryPayload, guild: Guild):
+    def __init__(self, *, users: Dict[int, User], data: AuditLogEntryPayload, guild: Guild):
         self._state = guild._state
         self.guild = guild
         self._users = users
-        self._webhooks = webhooks
-        self._threads = threads
         self._from_data(data)
 
     def _from_data(self, data: AuditLogEntryPayload) -> None:
@@ -441,7 +438,7 @@ class AuditLogEntry(Hashable):
         return utils.snowflake_time(self.id)
 
     @utils.cached_property
-    def target(self) -> Union[Guild, abc.GuildChannel, Member, User, Role, Invite, Emoji, Object, Webhook, Thread, None]:
+    def target(self) -> Union[Guild, abc.GuildChannel, Member, User, Role, Invite, Emoji, Object, Thread, None]:
         try:
             converter = getattr(self, '_convert_target_' + self.action.target_type)
         except AttributeError:
@@ -503,9 +500,6 @@ class AuditLogEntry(Hashable):
             pass
         return obj
 
-    def _convert_target_webhook(self, target_id: int) -> Optional[Webhook]:
-        return self._webhooks.get(target_id)
-
     def _convert_target_emoji(self, target_id: int) -> Union[Emoji, Object]:
         return self._state.get_emoji(target_id) or Object(id=target_id)
 
@@ -516,4 +510,4 @@ class AuditLogEntry(Hashable):
         return self.guild.get_stage_instance(target_id) or Object(id=target_id)
 
     def _convert_target_thread(self, target_id: int) -> Union[Thread, Object]:
-        return self.guild.get_thread(target_id) or self._threads.get(target_id) or Object(id=target_id)
+        return self.guild.get_thread(target_id) or Object(id=target_id)

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -512,8 +512,8 @@ class AuditLogEntry(Hashable):
     def _convert_target_message(self, target_id: int) -> Union[Member, User, None]:
         return self._get_member(target_id)
 
-    def _convert_target_stage_instance(self, target_id: int) -> Optional[StageInstance]:
-        return self.guild.get_stage_instance(target_id)
+    def _convert_target_stage_instance(self, target_id: int) -> Union[StageInstance, Object]:
+        return self.guild.get_stage_instance(target_id) or Object(id=target_id)
 
-    def _convert_target_thread(self, target_id: int) -> Optional[Thread]:
-        return self._threads.get(target_id)
+    def _convert_target_thread(self, target_id: int) -> Union[Thread, Object]:
+        return self.guild.get_thread(target_id) or self._threads.get(target_id) or Object(id=target_id)

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -69,7 +69,7 @@ def _transform_snowflake(entry: AuditLogEntry, data: Snowflake) -> int:
     return int(data)
 
 
-def _transform_channel(entry: AuditLogEntry, data: Optional[Snowflake]) -> Optional[Object]:
+def _transform_channel(entry: AuditLogEntry, data: Optional[Snowflake]) -> Optional[Union[abc.GuildChannel, Object]]:
     if data is None:
         return None
     return entry.guild.get_channel(int(data)) or Object(id=data)

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -49,8 +49,10 @@ if TYPE_CHECKING:
     from .guild import Guild
     from .member import Member
     from .role import Role
-    from .types.audit_log import AuditLogChange as AuditLogChangePayload
-    from .types.audit_log import AuditLogEntry as AuditLogEntryPayload
+    from .types.audit_log import (
+        AuditLogChange as AuditLogChangePayload,
+        AuditLogEntry as AuditLogEntryPayload,
+    )
     from .types.channel import PermissionOverwrite as PermissionOverwritePayload
     from .types.role import Role as RolePayload
     from .types.snowflake import Snowflake

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -346,6 +346,9 @@ class AuditLogAction(Enum):
     stage_instance_create    = 83
     stage_instance_update    = 84
     stage_instance_delete    = 85
+    thread_create            = 110
+    thread_update            = 111
+    thread_delete            = 112
     # fmt: on
 
     @property
@@ -390,6 +393,9 @@ class AuditLogAction(Enum):
             AuditLogAction.stage_instance_create: AuditLogActionCategory.create,
             AuditLogAction.stage_instance_update: AuditLogActionCategory.update,
             AuditLogAction.stage_instance_delete: AuditLogActionCategory.delete,
+            AuditLogAction.thread_create:         AuditLogActionCategory.create,
+            AuditLogAction.thread_update:         AuditLogActionCategory.update,
+            AuditLogAction.thread_delete:         AuditLogActionCategory.delete,
         }
         # fmt: on
         return lookup[self]
@@ -421,6 +427,8 @@ class AuditLogAction(Enum):
             return 'integration'
         elif v < 90:
             return 'stage_instance'
+        elif v < 113:
+            return 'thread'
 
 
 class UserFlags(Enum):

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -411,8 +411,6 @@ class AuditLogIterator(_AsyncIterator['AuditLogEntry']):
         self.action_type = action_type
         self.after = OLDEST_OBJECT
         self._users = {}
-        self._webhooks = {}
-        self._threads = {}
         self._state = guild._state
 
         self._filter = None  # entry dict -> bool
@@ -439,7 +437,7 @@ class AuditLogIterator(_AsyncIterator['AuditLogEntry']):
             if self.limit is not None:
                 self.limit -= retrieve
             self.before = Object(id=int(entries[-1]['id']))
-        return data.get('users', []), data.get('webhooks', []), data.get('threads', []), entries
+        return data.get('users', []), entries
 
     async def _after_strategy(self, retrieve):
         after = self.after.id if self.after else None
@@ -451,7 +449,7 @@ class AuditLogIterator(_AsyncIterator['AuditLogEntry']):
             if self.limit is not None:
                 self.limit -= retrieve
             self.after = Object(id=int(entries[0]['id']))
-        return data.get('users', []), data.get('webhooks', []), data.get('threads', []), entries
+        return data.get('users', []), entries
 
     async def next(self) -> AuditLogEntry:
         if self.entries.empty():
@@ -473,11 +471,9 @@ class AuditLogIterator(_AsyncIterator['AuditLogEntry']):
 
     async def _fill(self):
         from .user import User
-        from .webhook import Webhook
-        from .threads import Thread
 
         if self._get_retrieve():
-            users, webhooks, threads, data = await self._strategy(self.retrieve)
+            users, data = await self._strategy(self.retrieve)
             if len(data) < 100:
                 self.limit = 0  # terminate the infinite loop
 
@@ -490,20 +486,12 @@ class AuditLogIterator(_AsyncIterator['AuditLogEntry']):
                 u = User(data=user, state=self._state)
                 self._users[u.id] = u
 
-            for webhook in webhooks:
-                w = Webhook.from_state(webhook, self._state)
-                self._webhooks[w.id] = w
-
-            for thread in threads:
-                t = Thread(guild=self.guild, state=self._state, data=thread)
-                self._threads[t.id] = t
-
             for element in data:
                 # TODO: remove this if statement later
                 if element['action_type'] is None:
                     continue
 
-                await self.entries.put(AuditLogEntry(data=element, users=self._users, webhooks=self._webhooks, threads=self._threads, guild=self.guild))
+                await self.entries.put(AuditLogEntry(data=element, users=self._users, guild=self.guild))
 
 
 class GuildIterator(_AsyncIterator['Guild']):

--- a/discord/types/audit_log.py
+++ b/discord/types/audit_log.py
@@ -31,7 +31,7 @@ from .integration import IntegrationExpireBehavior, PartialIntegration
 from .user import User
 from .snowflake import Snowflake
 from .role import Role
-from .channel import ChannelType, VideoQualityMode, PermissionOverwrite
+from .channel import ChannelType, ThreadChannel, VideoQualityMode, PermissionOverwrite
 
 AuditLogEvent = Literal[
     1,
@@ -141,6 +141,7 @@ class _AuditLogChange_Int(TypedDict):
         'max_age',
         'user_limit',
         'auto_archive_duration',
+        'default_auto_archive_duration',
     ]
     new_value: int
     old_value: int
@@ -247,3 +248,4 @@ class AuditLog(TypedDict):
     users: List[User]
     audit_log_entries: List[AuditLogEntry]
     integrations: List[PartialIntegration]
+    threads: List[ThreadChannel]

--- a/discord/types/audit_log.py
+++ b/discord/types/audit_log.py
@@ -69,6 +69,12 @@ AuditLogEvent = Literal[
     80,
     81,
     82,
+    83,
+    84,
+    85,
+    110,
+    111,
+    112,
 ]
 
 
@@ -116,6 +122,8 @@ class _AuditLogChange_Bool(TypedDict):
         'enabled_emoticons',
         'region',
         'rtc_region',
+        'archived',
+        'locked',
     ]
     new_value: bool
     old_value: bool
@@ -132,6 +140,7 @@ class _AuditLogChange_Int(TypedDict):
         'max_uses',
         'max_age',
         'user_limit',
+        'auto_archive_duration',
     ]
     new_value: int
     old_value: int

--- a/discord/types/audit_log.py
+++ b/discord/types/audit_log.py
@@ -31,7 +31,8 @@ from .integration import IntegrationExpireBehavior, PartialIntegration
 from .user import User
 from .snowflake import Snowflake
 from .role import Role
-from .channel import ChannelType, ThreadChannel, VideoQualityMode, PermissionOverwrite
+from .channel import ChannelType, VideoQualityMode, PermissionOverwrite
+from .threads import Thread
 
 AuditLogEvent = Literal[
     1,
@@ -248,4 +249,4 @@ class AuditLog(TypedDict):
     users: List[User]
     audit_log_entries: List[AuditLogEntry]
     integrations: List[PartialIntegration]
-    threads: List[ThreadChannel]
+    threads: List[Thread]

--- a/discord/types/channel.py
+++ b/discord/types/channel.py
@@ -115,7 +115,7 @@ class _ThreadChannelOptional(TypedDict, total=False):
 
 
 class ThreadChannel(_BaseChannel, _ThreadChannelOptional):
-    type: Literal[11, 12]
+    type: Literal[10, 11, 12]
     guild_id: Snowflake
     parent_id: Snowflake
     owner_id: Snowflake

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2014,7 +2014,7 @@ of :class:`enum.Enum`.
         A webhook was created.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Webhook` or :class:`Object` with the webhook ID.
+        the :class:`Object` with the webhook ID.
 
         Possible attributes for :class:`AuditLogDiff`:
 
@@ -2030,7 +2030,7 @@ of :class:`enum.Enum`.
         - The webhook channel changed
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Webhook` or :class:`Object` with the webhook ID.
+        the :class:`Object` with the webhook ID.
 
         Possible attributes for :class:`AuditLogDiff`:
 
@@ -2043,7 +2043,7 @@ of :class:`enum.Enum`.
         A webhook was deleted.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Webhook` or :class:`Object` with the webhook ID.
+        the :class:`Object` with the webhook ID.
 
         Possible attributes for :class:`AuditLogDiff`:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1745,6 +1745,7 @@ of :class:`enum.Enum`.
         - :attr:`~AuditLogDiff.bitrate`
         - :attr:`~AuditLogDiff.rtc_region`
         - :attr:`~AuditLogDiff.video_quality_mode`
+        - :attr:`~AuditLogDiff.default_auto_archive_duration`
 
     .. attribute:: channel_delete
 
@@ -2013,7 +2014,7 @@ of :class:`enum.Enum`.
         A webhook was created.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Object` with the webhook ID.
+        the :class:`Webhook` or :class:`Object` with the webhook ID.
 
         Possible attributes for :class:`AuditLogDiff`:
 
@@ -2029,7 +2030,7 @@ of :class:`enum.Enum`.
         - The webhook channel changed
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Object` with the webhook ID.
+        the :class:`Webhook` or :class:`Object` with the webhook ID.
 
         Possible attributes for :class:`AuditLogDiff`:
 
@@ -2042,7 +2043,7 @@ of :class:`enum.Enum`.
         A webhook was deleted.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Object` with the webhook ID.
+        the :class:`Webhook` or :class:`Object` with the webhook ID.
 
         Possible attributes for :class:`AuditLogDiff`:
 
@@ -2173,8 +2174,8 @@ of :class:`enum.Enum`.
         A stage instance was started.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        either :class:`Object` with the stage instance ID of the stage instance
-        which was created.
+        the :class:`StageInstance` or :class:`Object` with the ID of the stage
+        instance which was created.
 
         Possible attributes for :class:`AuditLogDiff`:
 
@@ -2188,8 +2189,8 @@ of :class:`enum.Enum`.
         A stage instance was updated.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        either :class:`Object` with the stage instance ID of the stage instance
-        which was updated.
+        the :class:`StageInstance` or :class:`Object` with the ID of the stage
+        instance which was updated.
 
         Possible attributes for :class:`AuditLogDiff`:
 
@@ -2201,6 +2202,57 @@ of :class:`enum.Enum`.
     .. attribute:: stage_instance_delete
 
         A stage instance was ended.
+
+        .. versionadded:: 2.0
+
+    .. attribute:: thread_create
+
+        A thread was created.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.target` is
+        the :class:`Thread` or :class:`Object` with the ID of the thread which
+        was created.
+
+        Possible attributes for :class:`AuditLogDiff`:
+
+        - :attr:`~AuditLogDiff.name`
+        - :attr:`~AuditLogDiff.archived`
+        - :attr:`~AuditLogDiff.locked`
+        - :attr:`~AuditLogDiff.auto_archive_duration`
+
+        .. versionadded:: 2.0
+
+    .. attribute:: thread_update
+
+        A thread was updated.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.target` is
+        the :class:`Thread` or :class:`Object` with the ID of the thread which
+        was updated.
+
+        Possible attributes for :class:`AuditLogDiff`:
+
+        - :attr:`~AuditLogDiff.name`
+        - :attr:`~AuditLogDiff.archived`
+        - :attr:`~AuditLogDiff.locked`
+        - :attr:`~AuditLogDiff.auto_archive_duration`
+
+        .. versionadded:: 2.0
+
+    .. attribute:: thread_delete
+
+        A thread was deleted.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.target` is
+        the :class:`Thread` or :class:`Object` with the ID of the thread which
+        was deleted.
+
+        Possible attributes for :class:`AuditLogDiff`:
+
+        - :attr:`~AuditLogDiff.name`
+        - :attr:`~AuditLogDiff.archived`
+        - :attr:`~AuditLogDiff.locked`
+        - :attr:`~AuditLogDiff.auto_archive_duration`
 
         .. versionadded:: 2.0
 
@@ -2987,6 +3039,32 @@ AuditLogDiff
         See also :attr:`VoiceChannel.video_quality_mode`.
 
         :type: :class:`VideoQualityMode`
+
+    .. attribute:: archived
+
+        The thread is now archived.
+
+        :type: :class:`bool`
+
+    .. attribute:: locked
+
+        The thread is being locked or unlocked.
+
+        :type: :class:`bool`
+
+    .. attribute:: auto_archive_duration
+
+        The thread's auto archive duration being changed.
+
+        See also :attr:`Thread.auto_archive_duration`
+
+        :type: :class:`int`
+
+    .. attribute:: default_auto_archive_duration
+
+        The default auto archive duration for newly created threads being changed.
+
+        :type: :class:`int`
 
 .. this is currently missing the following keys: reason and application_id
    I'm not sure how to about porting these


### PR DESCRIPTION
## Summary

Audit log events from discord/discord-api-docs#3502

Also resolves stage instances correctly as they are now received/cached from gateway events.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
