### PR TITLE
add raw thread create and update events

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -731,6 +731,7 @@ class ConnectionState:
         thread = Thread(guild=guild, state=guild._state, data=data)
         has_thread = guild.get_thread(thread.id)
         guild._add_thread(thread)
+        self.dispatch('raw_thread_create', thread)
         if not has_thread:
             self.dispatch('thread_join', thread)
 
@@ -743,6 +744,7 @@ class ConnectionState:
 
         thread_id = int(data['id'])
         thread = guild.get_thread(thread_id)
+        self.dispatch('raw_thread_update', thread)
         if thread is not None:
             old = copy.copy(thread)
             thread._update(data)

--- a/discord/state.py
+++ b/discord/state.py
@@ -744,14 +744,15 @@ class ConnectionState:
 
         thread_id = int(data['id'])
         thread = guild.get_thread(thread_id)
-        self.dispatch('raw_thread_update', thread)
         if thread is not None:
             old = copy.copy(thread)
             thread._update(data)
+            self.dispatch('raw_thread_update', thread)
             self.dispatch('thread_update', old, thread)
         else:
             thread = Thread(guild=guild, state=guild._state, data=data)
             guild._add_thread(thread)
+            self.dispatch('raw_thread_update', thread)
             self.dispatch('thread_join', thread)
 
     def parse_thread_delete(self, data):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -681,6 +681,18 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param thread: The thread that got joined.
     :type thread: :class:`Thread`
 
+.. function:: on_raw_thread_create(thread)
+
+    Called whenever a thread is created. Unlike :func:`on_thread_join` this
+    is only called when a thread is created.
+
+    This requires :attr:`Intents.guilds` to be enabled.
+
+    .. versionadded:: 2.0
+
+    :param thread: The thread that was created.
+    :type payload: :class:`Thread`
+
 .. function:: on_thread_remove(thread)
 
     Called whenever a thread is removed. This is different from a thread being deleted.
@@ -738,6 +750,18 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :type before: :class:`Thread`
     :param after: The updated thread's new info.
     :type after: :class:`Thread`
+
+
+.. function:: on_thread_update(thread)
+
+    Called whenever a thread is updated, regardless on if the previous state was cached or not.
+
+    This requires :attr:`Intents.guilds` to be enabled.
+
+    .. versionadded:: 2.0
+
+    :param thread: The current state of the thread that was updated.
+    :type before: :class:`Thread`
 
 .. function:: on_guild_integrations_update(guild)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -752,7 +752,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :type after: :class:`Thread`
 
 
-.. function:: on_thread_update(thread)
+.. function:: on_raw_thread_update(thread)
 
     Called whenever a thread is updated, regardless on if the previous state was cached or not.
 


### PR DESCRIPTION
## Summary

This adds events for the raw thread creation and updates. This allows to know when a thread was created vs when it was unarchived but not in the local cache.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
