### PR TITLE
Allow callables in abc.Connectable.Connect

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -28,6 +28,7 @@ import copy
 import asyncio
 from typing import (
     Any,
+    Callable,
     Dict,
     List,
     Mapping,
@@ -68,6 +69,7 @@ T = TypeVar('T', bound=VoiceProtocol)
 if TYPE_CHECKING:
     from datetime import datetime
 
+    from .client import Client
     from .user import ClientUser
     from .asset import Asset
     from .state import ConnectionState
@@ -1610,7 +1612,13 @@ class Connectable(Protocol):
     def _get_voice_state_pair(self) -> Tuple[int, int]:
         raise NotImplementedError
 
-    async def connect(self, *, timeout: float = 60.0, reconnect: bool = True, cls: Type[T] = VoiceClient) -> T:
+    async def connect(
+        self,
+        *,
+        timeout: float = 60.0,
+        reconnect: bool = True,
+        cls: Callable[[Client, Connectable], T] = VoiceClient,
+    ) -> T:
         """|coro|
 
         Connects to voice and creates a :class:`VoiceClient` to establish


### PR DESCRIPTION
## Summary

Allows callables which return an instance of `VoiceProtocol` to type-check in `abc.Connectable.connect`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
