### PR TITLE
Add support for discord.ui.Select.disabled

### DIFF
--- a/discord/components.py
+++ b/discord/components.py
@@ -226,6 +226,8 @@ class SelectMenu(Component):
         Defaults to 1 and must be between 1 and 25.
     options: List[:class:`SelectOption`]
         A list of options that can be selected in this menu.
+    disabled: :class:`bool`
+        Whether the select is disabled or not.
     """
 
     __slots__: Tuple[str, ...] = (
@@ -234,6 +236,7 @@ class SelectMenu(Component):
         'min_values',
         'max_values',
         'options',
+        'disabled',
     )
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
@@ -245,6 +248,7 @@ class SelectMenu(Component):
         self.min_values: int = data.get('min_values', 1)
         self.max_values: int = data.get('max_values', 1)
         self.options: List[SelectOption] = [SelectOption.from_dict(option) for option in data.get('options', [])]
+        self.disabled: bool = data.get('disabled', False)
 
     def to_dict(self) -> SelectMenuPayload:
         payload: SelectMenuPayload = {
@@ -253,6 +257,7 @@ class SelectMenu(Component):
             'min_values': self.min_values,
             'max_values': self.max_values,
             'options': [op.to_dict() for op in self.options],
+            'disabled': self.disabled,
         }
 
         if self.placeholder:

--- a/discord/types/components.py
+++ b/discord/types/components.py
@@ -53,6 +53,7 @@ class _SelectMenuOptional(TypedDict, total=False):
     placeholder: str
     min_values: int
     max_values: int
+    disabled: bool
 
 
 class _SelectOptionsOptional(TypedDict, total=False):

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -93,7 +93,7 @@ class Select(Item[V]):
         'min_values',
         'max_values',
         'options',
-        'disabled'
+        'disabled',
     )
 
     def __init__(

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -275,14 +275,14 @@ class Select(Item[V]):
         self._selected_values = data.get('values', [])
 
     @classmethod
-    def from_component(cls: Type[S], select: SelectMenu) -> S:
+    def from_component(cls: Type[S], component: SelectMenu) -> S:
         return cls(
-            custom_id=select.custom_id,
-            placeholder=select.placeholder,
-            min_values=select.min_values,
-            max_values=select.max_values,
-            options=select.options,
-            disabled=select.disabled,
+            custom_id=component.custom_id,
+            placeholder=component.placeholder,
+            min_values=component.min_values,
+            max_values=component.max_values,
+            options=component.options,
+            disabled=component.disabled,
             row=None,
         )
 

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -78,6 +78,8 @@ class Select(Item[V]):
         Defaults to 1 and must be between 1 and 25.
     options: List[:class:`discord.SelectOption`]
         A list of options that can be selected in this menu.
+    disabled: :class:`bool`
+        Whether the select is disabled or not.
     row: Optional[:class:`int`]
         The relative row this select menu belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -91,6 +93,7 @@ class Select(Item[V]):
         'min_values',
         'max_values',
         'options',
+        'disabled'
     )
 
     def __init__(
@@ -101,8 +104,10 @@ class Select(Item[V]):
         min_values: int = 1,
         max_values: int = 1,
         options: List[SelectOption] = MISSING,
+        disabled: bool = False,
         row: Optional[int] = None,
     ) -> None:
+        super().__init__()
         self._selected_values: List[str] = []
         self._provided_custom_id = custom_id is not MISSING
         custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
@@ -114,6 +119,7 @@ class Select(Item[V]):
             min_values=min_values,
             max_values=max_values,
             options=options,
+            disabled=disabled,
         )
         self.row = row
 
@@ -241,6 +247,15 @@ class Select(Item[V]):
         self._underlying.options.append(option)
 
     @property
+    def disabled(self) -> bool:
+        """:class:`bool`: Whether the select is disabled or not."""
+        return self._underlying.disabled
+
+    @disabled.setter
+    def disabled(self, value: bool):
+        self._underlying.disabled = bool(value)
+
+    @property
     def values(self) -> List[str]:
         """List[:class:`str`]: A list of values that have been selected by the user."""
         return self._selected_values
@@ -260,13 +275,14 @@ class Select(Item[V]):
         self._selected_values = data.get('values', [])
 
     @classmethod
-    def from_component(cls: Type[S], component: SelectMenu) -> S:
+    def from_component(cls: Type[S], select: SelectMenu) -> S:
         return cls(
-            custom_id=component.custom_id,
-            placeholder=component.placeholder,
-            min_values=component.min_values,
-            max_values=component.max_values,
-            options=component.options,
+            custom_id=select.custom_id,
+            placeholder=select.placeholder,
+            min_values=select.min_values,
+            max_values=select.max_values,
+            options=select.options,
+            disabled=select.disabled,
             row=None,
         )
 
@@ -285,6 +301,7 @@ def select(
     min_values: int = 1,
     max_values: int = 1,
     options: List[SelectOption] = MISSING,
+    disabled: bool = False,
     row: Optional[int] = None,
 ) -> Callable[[ItemCallbackType], ItemCallbackType]:
     """A decorator that attaches a select menu to a component.
@@ -317,11 +334,13 @@ def select(
         Defaults to 1 and must be between 1 and 25.
     options: List[:class:`discord.SelectOption`]
         A list of options that can be selected in this menu.
+    disabled: :class:`bool`
+        Whether the select is disabled or not. Defaults to ``False``.
     """
 
     def decorator(func: ItemCallbackType) -> ItemCallbackType:
         if not inspect.iscoroutinefunction(func):
-            raise TypeError('button function must be a coroutine function')
+            raise TypeError('select function must be a coroutine function')
 
         func.__discord_ui_model_type__ = Select
         func.__discord_ui_model_kwargs__ = {
@@ -331,6 +350,7 @@ def select(
             'min_values': min_values,
             'max_values': max_values,
             'options': options,
+            'disabled': disabled,
         }
         return func
 


### PR DESCRIPTION
Fix typo in the select decorator TypeError

Took 16 minutes

## Summary

- Add support for discord.ui.Select.disabled
- Fixed typo in discord.ui.select decorator TypeError
- ~~Solved #7231~~
- Add missing `super().__init__()` for `discord.ui.Select` 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
