### PR TITLE
Fix default options not present in Select.values

### DIFF
--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -103,10 +103,10 @@ class Select(Item[V]):
         options: List[SelectOption] = MISSING,
         row: Optional[int] = None,
     ) -> None:
-        self._selected_values: List[str] = []
         self._provided_custom_id = custom_id is not MISSING
         custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
         options = [] if options is MISSING else options
+        self._selected_values: List[str] = [i.value for i in options if i.default]
         self._underlying = SelectMenu._raw_construct(
             custom_id=custom_id,
             type=ComponentType.select,


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This fixes the issue #7284 
Default values are not present in `_selected_values` during initialisation, and only gets updated after state gets refreshed.
So we can put those (default) values manually.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
