### PR TITLE
Do not try to check length of None embeds

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -438,9 +438,12 @@ def handle_message_parameters(
 
     payload = {}
     if embeds is not MISSING:
-        if len(embeds) > 10:
+        if embed is None:
+            payload['embeds'] = []
+        elif len(embeds) > 10:
             raise InvalidArgument('embeds has a maximum of 10 elements.')
-        payload['embeds'] = [e.to_dict() for e in embeds]
+        else:
+            payload['embeds'] = [e.to_dict() for e in embeds]
 
     if embed is not MISSING:
         if embed is None:


### PR DESCRIPTION
## Summary

When passing `None` in the `embeds` parameter of `Webhook.send`, a `TypeError` is raised due to attempting to check the length of `None`.

Unlike other parameters, like `content` and `embed` and `view`, `embeds` doesn't consider `None` as an empty value.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
