### PR TITLE
Fix PartialMessage rejecting Threads

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -1605,8 +1605,15 @@ class PartialMessage(Hashable):
     to_message_reference_dict = Message.to_message_reference_dict
 
     def __init__(self, *, channel: PartialMessageableChannel, id: int):
-        if channel.type not in (ChannelType.text, ChannelType.news, ChannelType.private):
-            raise TypeError(f'Expected TextChannel or DMChannel not {type(channel)!r}')
+        if channel.type not in (
+            ChannelType.text,
+            ChannelType.news,
+            ChannelType.private,
+            ChannelType.news_thread,
+            ChannelType.public_thread,
+            ChannelType.private_thread
+        ):
+            raise TypeError(f'Expected TextChannel, DMChannel or Thread not {type(channel)!r}')
 
         self.channel: PartialMessageableChannel = channel
         self._state: ConnectionState = channel._state


### PR DESCRIPTION
## Summary
Fixes `PartialMessage.__init__` such that `news_`, `public_`, and `private_thread` `ChannelType`s are accepted ([as documented](https://github.com/Rapptz/discord.py/blob/master/discord/message.py#L1586)).
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
