### PR TITLE
Add persistent view in a task instead of on_ready

### DIFF
--- a/examples/views/persistent.py
+++ b/examples/views/persistent.py
@@ -2,6 +2,15 @@ from discord.ext import commands
 import discord
 
 
+class PersistentViewBot(commands.Bot):
+    def __init__(self):
+        super().__init__(command_prefix=commands.when_mentioned_or('$'))
+
+    async def on_ready(self):
+        print(f'Logged in as {self.user} (ID: {self.user.id})')
+        print('------')
+
+
 # Define a simple View that persists between bot restarts
 # In order a view to persist between restarts it needs to meet the following conditions:
 # 1) The timeout of the View has to be set to None
@@ -27,27 +36,18 @@ class PersistentView(discord.ui.View):
         await interaction.response.send_message('This is grey.', ephemeral=True)
 
 
-class PersistentViewBot(commands.Bot):
-    def __init__(self):
-        super().__init__(command_prefix=commands.when_mentioned_or('$'))
-        self.persistent_views_added = False
-
-    async def on_ready(self):
-        if not self.persistent_views_added:
-            # Register the persistent view for listening here.
-            # Note that this does not send the view to any message.
-            # In order to do this you need to first send a message with the View, which is shown below.
-            # If you have the message_id you can also pass it as a keyword argument, but for this example
-            # we don't have one.
-            self.add_view(PersistentView())
-            self.persistent_views_added = True
-
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
-
-
 bot = PersistentViewBot()
 
+async def add_persistent_view():
+    # Register the persistent view for listening
+    # Note that this does not send the view to any message.
+    # In order to do this you need to first send a message with the View, which is shown below.
+    # If you have the message_id you can also pass it as a keyword argument, but for this example
+    # we don't have one.
+    # Add the view in a startup task to prevent loop issues.
+    bot.add_view(PersistentView())
+
+bot.loop.create_task(add_persistent_view())
 
 @bot.command()
 @commands.is_owner()


### PR DESCRIPTION
## Summary
There's no need to use on_ready for adding a persistent view, a startup task can be created instead.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
