### PR TITLE
Add Thread.category

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -249,8 +249,8 @@ class Thread(Messageable, Hashable):
 
         Returns
         -------
-        Optional[:class:`int`]
-            The parent channel's category ID.
+        Optional[:class:`CategoryChannel`]
+            The parent channel's category.
         """
 
         parent = self.parent

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
         ThreadArchiveDuration,
     )
     from .guild import Guild
-    from .channel import TextChannel
+    from .channel import TextChannel, CategoryChannel
     from .member import Member
     from .message import Message, PartialMessage
     from .abc import Snowflake, SnowflakeTime
@@ -238,6 +238,26 @@ class Thread(Messageable, Hashable):
         """
         return self._state._get_message(self.last_message_id) if self.last_message_id else None
 
+    @property
+    def category(self) -> Optional[CategoryChannel]:
+        """The category channel the parent channel belongs to, if applicable.
+
+        Raises
+        -------
+        ClientException
+            The parent channel was not cached and returned ``None``.
+
+        Returns
+        -------
+        Optional[:class:`int`]
+            The parent channel's category ID.
+        """
+
+        parent = self.parent
+        if parent is None:
+            raise ClientException('Parent channel not found')
+        return parent.category
+    
     @property
     def category_id(self) -> Optional[int]:
         """The category channel ID the parent channel belongs to, if applicable.


### PR DESCRIPTION
Untested, but should work just fine.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR adds support for `ThreadChannel.category` to get the category of the parent channel from a Thread object.

This is used for compatibility with regular TextChannel, especially in on_message, when checking for a specific category.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
