### PR TITLE
Update description of auto_archive_duration kwarg of Thread.edit

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -513,7 +513,7 @@ class Thread(Messageable, Hashable):
         locked: :class:`bool`
             Whether to lock the thread or not.
         auto_archive_duration: :class:`int`
-            The duration in minutes before a thread is automatically archived for inactivity.
+            The new duration in minutes before a thread is automatically archived for inactivity.
             Must be one of ``60``, ``1440``, ``4320``, or ``10080``.
         slowmode_delay: :class:`int`
             Specifies the slowmode rate limit for user in this thread, in seconds.

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -513,7 +513,7 @@ class Thread(Messageable, Hashable):
         locked: :class:`bool`
             Whether to lock the thread or not.
         auto_archive_duration: :class:`int`
-            The new duration to auto archive threads for inactivity.
+            The duration in minutes before a thread is automatically archived for inactivity.
             Must be one of ``60``, ``1440``, ``4320``, or ``10080``.
         slowmode_delay: :class:`int`
             Specifies the slowmode rate limit for user in this thread, in seconds.


### PR DESCRIPTION

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Update description of auto_archive_duration kwarg of Thread.edit to be consistent with the kwarg in start_thread. Also, documents that the time provided is in minutes which was missing previously.


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
