### PR TITLE
Fix NSFW check within threads under NSFW channels

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1902,7 +1902,7 @@ def is_nsfw():
     """
     def pred(ctx):
         ch = ctx.channel
-        if ctx.guild is None or ((isinstance(ch, discord.TextChannel) or isinstance(ch, discord.Thread)) and ch.is_nsfw()):
+        if ctx.guild is None or (isinstance(ch, (discord.TextChannel, discord.Thread)) and ch.is_nsfw()):
             return True
         raise NSFWChannelRequired(ch)
     return check(pred)

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1902,7 +1902,7 @@ def is_nsfw():
     """
     def pred(ctx):
         ch = ctx.channel
-        if ctx.guild is None or (isinstance(ch, discord.TextChannel) and ch.is_nsfw()):
+        if ctx.guild is None or ((isinstance(ch, discord.TextChannel) or isinstance(ch, discord.Thread)) and ch.is_nsfw()):
             return True
         raise NSFWChannelRequired(ch)
     return check(pred)


### PR DESCRIPTION
## Summary

This PR aims to fix the `discord.ext.commands.is_nsfw()` decorator so that the check provides accurate results for threads under NSFW channels

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
