### PR TITLE
Fixes for bpo 44732 (types.Union rename)

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -916,7 +916,7 @@ def evaluate_annotation(
         is_literal = False
         args = tp.__args__
         if not hasattr(tp, '__origin__'):
-            if PY_310 and tp.__class__ is types.Union:  # type: ignore
+            if PY_310 and tp.__class__ is types.UnionType:  # type: ignore
                 converted = Union[args]  # type: ignore
                 return evaluate_annotation(converted, globals, locals, cache)
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
`types.Union` has been renamed to `types.UnionType` see https://bugs.python.org/issue44732 for the reasoning behind this change.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
