### PR TITLE
Fix docs for stickers

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1311,7 +1311,7 @@ class Messageable:
             A list of embeds to upload. Must be a maximum of 10.
 
             .. versionadded:: 2.0
-        stickers: Sequence[Union[:class:`GuildSticker`, :class:`StickerItem`]]
+        stickers: Sequence[Union[:class:`~discord.GuildSticker`, :class:`~discord.StickerItem`]]
             A list of stickers to upload. Must be a maximum of 3.
 
             .. versionadded:: 2.0

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3124,7 +3124,7 @@ AuditLogDiff
 
         The format type of a sticker being changed.
 
-        See also :attr:`GuildSticker.format_type`
+        See also :attr:`GuildSticker.format`
 
         :type: :class:`StickerFormatType`
 


### PR DESCRIPTION
## Summary

- Fixes GuildSticker & StickerItem not being linked in the docs for abc.Messageable.send.
- Fixes AuditLogDiff docs for format_type attribute

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
