### PR TITLE
Fix webhook attribute error on send file=None

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -478,7 +478,7 @@ def handle_message_parameters(
 
     multipart = []
     if file is not MISSING:
-        files = [file]
+        files = [file] if file is not None else []
 
     if files:
         multipart.append({'name': 'payload_json', 'value': utils.to_json(payload)})


### PR DESCRIPTION
## Summary

When sending an async webhook message, setting the file attribute to None an attribute error would occur. This fixes that.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
