### PR TITLE
Make case_insensitive default to true for both groups and the bot.

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -1041,7 +1041,7 @@ class Bot(BotBase, discord.Client):
             when passing an empty string, it should always be last as no prefix
             after it will be matched.
     case_insensitive: :class:`bool`
-        Whether the commands should be case insensitive. Defaults to ``False``. This
+        Whether the commands should be case insensitive. Defaults to ``True``. This
         attribute does not carry over to groups. You must set it to every group if
         you require group commands to be case insensitive as well.
     description: :class:`str`

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1066,10 +1066,10 @@ class GroupMixin:
         A mapping of command name to :class:`.Command`
         objects.
     case_insensitive: :class:`bool`
-        Whether the commands should be case insensitive. Defaults to ``False``.
+        Whether the commands should be case insensitive. Defaults to ``True``.
     """
     def __init__(self, *args, **kwargs):
-        case_insensitive = kwargs.get('case_insensitive', False)
+        case_insensitive = kwargs.get('case_insensitive', True)
         self.all_commands = _CaseInsensitiveDict() if case_insensitive else {}
         self.case_insensitive = case_insensitive
         super().__init__(*args, **kwargs)
@@ -1270,7 +1270,7 @@ class Group(GroupMixin, Command):
         will be executed. Defaults to ``False``.
     case_insensitive: :class:`bool`
         Indicates if the group's commands should be case insensitive.
-        Defaults to ``False``.
+        Defaults to ``True``.
     """
     def __init__(self, *args, **attrs):
         self.invoke_without_command = attrs.pop('invoke_without_command', False)


### PR DESCRIPTION
## Summary

This is a followup PR to https://discord.com/channels/336642139381301249/603069307286454290/871358364720963624. It makes the `case_insensitive` kwarg defaults to True, as this enhance user experience, especially on phones. 

The same gotchas as before apply, meaning that, to get the previous behavior, you'd need to specify case_insensitive on groups and the bot.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [X] This PR is a breaking change (e.g. methods or parameters removed/renamed) (Kindof: Just a defaults change)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
