### PR TITLE
Adds Shorthand methods for Locking & Archiving threads

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -560,6 +560,38 @@ class Thread(Messageable, Hashable):
 
         await self._state.http.edit_channel(self.id, **payload)
 
+    async def lock(self):
+        """|coro|
+
+        Shorthand alias for thread.edit(locked=True)
+
+        Locking the thread requires :attr:`.Permissions.manage_threads`.
+
+        Raises
+        -------
+        Forbidden
+            You do not have permissions to archive the thread.
+        HTTPException
+            Archiving the thread failed.
+        """
+        await self._state.http.edit_channel(self.id, locked=True)
+
+    async def archive(self):
+        """|coro|
+
+        Shorthand alias for thread.edit(archived=True)
+
+        Archiving the thread requires :attr:`.Permissions.manage_threads`.
+
+        Raises
+        -------
+        Forbidden
+            You do not have permissions to archive the thread.
+        HTTPException
+            Archiving the thread failed.
+        """
+        await self._state.http.edit_channel(self.id, archived=True)
+
     async def join(self):
         """|coro|
 

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -563,7 +563,7 @@ class Thread(Messageable, Hashable):
     async def lock(self):
         """|coro|
 
-        Shorthand alias for thread.edit(locked=True)
+        Shorthand alias for :meth:`edit` with `locked=True`.
 
         Locking the thread requires :attr:`.Permissions.manage_threads`.
 
@@ -579,7 +579,7 @@ class Thread(Messageable, Hashable):
     async def archive(self):
         """|coro|
 
-        Shorthand alias for thread.edit(archived=True)
+        Shorthand alias for :meth:`edit` with `archived=True`.
 
         Archiving the thread requires :attr:`.Permissions.manage_threads`.
 


### PR DESCRIPTION
## Summary

Adds `thread.lock()` and `thread.archive()` which serve as quick aliases for `thread.edit` with archive/locked=True.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
