### PR TITLE
fix RuntimeWarning

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -356,9 +356,8 @@ class Client:
                 pass
 
     def _schedule_event(self, coro: Callable[..., Coroutine[Any, Any, Any]], event_name: str, *args: Any, **kwargs: Any) -> asyncio.Task:
-        wrapped = self._run_event(coro, event_name, *args, **kwargs)
         # Schedules the task
-        return asyncio.create_task(wrapped, name=f'discord.py: {event_name}')
+        return asyncio.create_task(self._run_event(coro, event_name, *args, **kwargs), name=f'discord.py: {event_name}')
 
     def dispatch(self, event: str, *args: Any, **kwargs: Any) -> None:
         log.debug('Dispatching event %s', event)


### PR DESCRIPTION
Fixing `RuntimeWarning: coroutine client._run_event was never awaited` which sometimes doesn't dispatchs to events

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [x] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
