### PR TITLE
Rename activity and status to be less ambiguous

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -161,7 +161,7 @@ class Client:
         .. versionadded:: 1.5
     status: Optional[:class:`.Status`]
         A status to start your presence with upon logging on to Discord.
-    activity: Optional[:class:`.BaseActivity`]
+    start_up_activity: Optional[:class:`.BaseActivity`]
         An activity to start your presence with upon logging on to Discord.
     allowed_mentions: Optional[:class:`AllowedMentions`]
         Control how the client handles mentions by default on every message sent.
@@ -668,20 +668,20 @@ class Client:
         return self._closed
 
     @property
-    def activity(self) -> Optional[ActivityTypes]:
+    def start_up_activity(self) -> Optional[ActivityTypes]:
         """Optional[:class:`.BaseActivity`]: The activity being used upon
         logging in.
         """
-        return create_activity(self._connection._activity)
+        return create_activity(self._connection._start_up_activity)
 
-    @activity.setter
-    def activity(self, value: Optional[ActivityTypes]) -> None:
+    @start_up_activity.setter
+    def start_up_activity(self, value: Optional[ActivityTypes]) -> None:
         if value is None:
-            self._connection._activity = None
+            self._connection._start_up_activity = None
         elif isinstance(value, BaseActivity):
-            self._connection._activity = value.to_dict()
+            self._connection._start_up_activity = value.to_dict()
         else:
-            raise TypeError('activity must derive from BaseActivity.')
+            raise TypeError('start_up_activity must derive from BaseActivity.')
 
     @property
     def allowed_mentions(self) -> Optional[AllowedMentions]:

--- a/discord/client.py
+++ b/discord/client.py
@@ -159,7 +159,7 @@ class Client:
         is ``True``.
 
         .. versionadded:: 1.5
-    status: Optional[:class:`.Status`]
+    start_up_status: Optional[:class:`.Status`]
         A status to start your presence with upon logging on to Discord.
     start_up_activity: Optional[:class:`.BaseActivity`]
         An activity to start your presence with upon logging on to Discord.

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -390,10 +390,10 @@ class DiscordWebSocket:
             payload['d']['shard'] = [self.shard_id, self.shard_count]
 
         state = self._connection
-        if state._activity is not None or state._status is not None:
+        if state._start_up_activity is not None or state._status is not None:
             payload['d']['presence'] = {
                 'status': state._status,
-                'game': state._activity,
+                'game': state._start_up_activity,
                 'since': 0,
                 'afk': False
             }

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -390,9 +390,9 @@ class DiscordWebSocket:
             payload['d']['shard'] = [self.shard_id, self.shard_count]
 
         state = self._connection
-        if state._start_up_activity is not None or state._status is not None:
+        if state._start_up_activity is not None or state._start_up_status is not None:
             payload['d']['presence'] = {
-                'status': state._status,
+                'status': state._start_up_status,
                 'game': state._start_up_activity,
                 'since': 0,
                 'afk': False

--- a/discord/state.py
+++ b/discord/state.py
@@ -141,12 +141,12 @@ class ConnectionState:
 
             start_up_activity = start_up_activity.to_dict()
 
-        status = options.get('status', None)
-        if status:
-            if status is Status.offline:
-                status = 'invisible'
+        start_up_status = options.get('start_up_status', None)
+        if start_up_status:
+            if start_up_status is Status.offline:
+                start_up_status = 'invisible'
             else:
-                status = str(status)
+                start_up_status = str(start_up_status)
 
         intents = options.get('intents', None)
         if intents is not None:
@@ -175,7 +175,7 @@ class ConnectionState:
 
         self.member_cache_flags = cache_flags
         self._start_up_activity = start_up_activity
-        self._status = status
+        self._start_up_status = start_up_status
         self._intents = intents
 
         if not intents.members or cache_flags._empty:

--- a/discord/state.py
+++ b/discord/state.py
@@ -134,12 +134,12 @@ class ConnectionState:
         self.allowed_mentions = allowed_mentions
         self._chunk_requests = {} # Dict[Union[int, str], ChunkRequest]
 
-        activity = options.get('activity', None)
-        if activity:
-            if not isinstance(activity, BaseActivity):
-                raise TypeError('activity parameter must derive from BaseActivity.')
+        start_up_activity = options.get('start_up_activity', None)
+        if start_up_activity:
+            if not isinstance(start_up_activity, BaseActivity):
+                raise TypeError('start_up_activity parameter must derive from BaseActivity.')
 
-            activity = activity.to_dict()
+            start_up_activity = start_up_activity.to_dict()
 
         status = options.get('status', None)
         if status:
@@ -174,7 +174,7 @@ class ConnectionState:
             cache_flags._verify_intents(intents)
 
         self.member_cache_flags = cache_flags
-        self._activity = activity
+        self._start_up_activity = start_up_activity
         self._status = status
         self._intents = intents
 


### PR DESCRIPTION
## Summary

This PR renames the `activity` and `status` attributes to be less ambiguous, and is a pre-cursor to tackling #6868.

- `activity` -> `start_up_activity`
- `status` -> `start_up_status`

These attributes can be confused with the "current" activity or status, when in reality they're only used on the initial connection.

The inspiration for this change comes [from Danny](https://github.com/Rapptz/discord.py/issues/6868#issuecomment-834384186).

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
