### PR TITLE
Fill in ConnectionState.user via HTTPClient.static_login

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -33,7 +33,7 @@ from typing import Any, Callable, Coroutine, Dict, Generator, Iterable, List, Op
 
 import aiohttp
 
-from .user import User
+from .user import User, ClientUser
 from .invite import Invite
 from .template import Template
 from .widget import Widget
@@ -65,7 +65,6 @@ from .sticker import GuildSticker, StandardSticker, StickerPack, _sticker_factor
 if TYPE_CHECKING:
     from .abc import SnowflakeTime, PrivateChannel, GuildChannel, Snowflake
     from .channel import DMChannel
-    from .user import ClientUser
     from .message import Message
     from .member import Member
     from .voice_client import VoiceProtocol
@@ -467,7 +466,9 @@ class Client:
         """
 
         log.info('logging in using static token')
-        await self.http.static_login(token.strip())
+
+        data = await self.http.static_login(token.strip())
+        self._connection.user = ClientUser(state=self._connection, data=data)
 
     async def connect(self, *, reconnect: bool = True) -> None:
         """|coro|


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Uses the data returned from `HTTPClient.static_login` to fill in `ConnectionState.user` (and in turn `discord.Client.user`) in `discord.Client.login`. This allows earlier access to the client's user object in the startup flow.
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
