### PR TITLE
Use channel's default_auto_archive_duration for new threads

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -662,7 +662,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         *,
         name: str,
         message: Optional[Snowflake] = None,
-        auto_archive_duration: ThreadArchiveDuration = 1440,
+        auto_archive_duration: ThreadArchiveDuration = MISSING,
         type: Optional[ChannelType] = None,
         reason: Optional[str] = None,
     ) -> Thread:
@@ -692,7 +692,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             Defaults to ``None``.
         auto_archive_duration: :class:`int`
             The duration in minutes before a thread is automatically archived for inactivity.
-            Defaults to ``1440`` or 24 hours.
+            If not provided, the channel's default auto archive duration is used.
         type: Optional[:class:`ChannelType`]
             The type of thread to create. If a ``message`` is passed then this parameter
             is ignored, as a thread created with a message is always a public thread.
@@ -720,7 +720,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             data = await self._state.http.start_thread_without_message(
                 self.id,
                 name=name,
-                auto_archive_duration=auto_archive_duration,
+                auto_archive_duration=auto_archive_duration or self.default_auto_archive_duration,
                 type=type.value,
                 reason=reason,
             )
@@ -729,7 +729,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
                 self.id,
                 message.id,
                 name=name,
-                auto_archive_duration=auto_archive_duration,
+                auto_archive_duration=auto_archive_duration or self.default_auto_archive_duration,
                 reason=reason,
             )
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -1484,7 +1484,7 @@ class Message(Hashable):
         """
         await self._state.http.clear_reactions(self.channel.id, self.id)
 
-    async def create_thread(self, *, name: str, auto_archive_duration: ThreadArchiveDuration = 1440) -> Thread:
+    async def create_thread(self, *, name: str, auto_archive_duration: ThreadArchiveDuration = MISSING) -> Thread:
         """|coro|
 
         Creates a public thread from this message.
@@ -1502,7 +1502,7 @@ class Message(Hashable):
             The name of the thread.
         auto_archive_duration: :class:`int`
             The duration in minutes before a thread is automatically archived for inactivity.
-            Defaults to ``1440`` or 24 hours.
+            If not provided, the channel's default auto archive duration is used.
 
         Raises
         -------
@@ -1525,7 +1525,7 @@ class Message(Hashable):
             self.channel.id,
             self.id,
             name=name,
-            auto_archive_duration=auto_archive_duration,
+            auto_archive_duration=auto_archive_duration or self.channel.default_auto_archive_duration,
         )
         return Thread(guild=self.guild, state=self._state, data=data)  # type: ignore
 


### PR DESCRIPTION
## Summary

Currently creating a new thread uses a default auto archive duration of
1440 minutes, or 1 day.

Rather than prescribing our own default, we can use the default auto
archive duration that is set on the channel. This ensures that newly
created threads will respect the default auto archive duration as
prescribed by the user.

My initial approach was to simply omit the `auto_archive_duration` from
the request, but when doing so, the thread is always created with an
auto archive duration of 1440 minutes, regardless of the channel's
default setting.

See the following PR for more discussion on the matter:

  https://github.com/discord/discord-api-docs/pull/3567

It's unclear if this is intended behaviour or not, but we might as well
work with it for the time being

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
