### PR TITLE
Adding `on_check_failure` to `View` 

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -301,7 +301,7 @@ class View:
         This is useful to override if, for example, you want to ensure that the
         interaction author is a given user.
 
-        When this returns ``False`` :meth:`InteractionResponse.defer` is automatically called
+        When this returns ``False`` :meth:`InteractionResponse.defer` is automatically called if the interaction hasn't been responded to
 
         The default implementation of this returns ``True``.
 
@@ -356,7 +356,8 @@ class View:
 
             allow = await self.interaction_check(interaction)
             if not allow:
-                await interaction.response.defer()
+                if not interaction.response.is_done():
+                    await interaction.response.defer()
                 return
 
             await item.callback(interaction)

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -354,6 +354,7 @@ class View:
 
             allow = await self.interaction_check(interaction)
             if not allow:
+                await interaction.response.defer()
                 return
 
             await item.callback(interaction)

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -301,6 +301,8 @@ class View:
         This is useful to override if, for example, you want to ensure that the
         interaction author is a given user.
 
+        When this returns ``False`` :meth:`InteractionResponse.defer` is automatically called
+
         The default implementation of this returns ``True``.
 
         .. note::

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -343,7 +343,7 @@ class View:
         interaction: :class:`~discord.Interaction`
             The interaction that occurred.
         """
-        if not interaction.response._responded:
+        if not interaction.response.is_done():
             await interaction.response.defer()
 
     async def on_error(self, error: Exception, item: Item, interaction: Interaction) -> None:


### PR DESCRIPTION
## Summary

This pull request adds the Coro `on_check_failure` to the `View` class which is called when `interaction_check` returns `False` and defers the interaction, if not previously responded to, per default.

Why this is needed:
`interaction_check`'s purpose is to check if the interaction should go through, not really to handle the case of it not going through. A separate method handling what to do when the check fails seems more clean and useful to deal with that.
So thing code which would previously look like
```py
async def interaction_check(self, interaction: discord.Interaction) -> bool:
    if not some_check():
        await interaction.response.defer()
        return False
    return True
```
looks now like
```py
async def on_check_failure(self, interaction: discord.Interaction) -> None:
    await interaction.response.defer()

async def interaction_check(self, interaction: discord.Interaction) -> bool:
    return some_check():
```

## Checklist

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
