### PR TITLE
`flag_value` should not be a generic class

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -41,7 +41,7 @@ FV = TypeVar('FV', bound='flag_value')
 BF = TypeVar('BF', bound='BaseFlags')
 
 
-class flag_value(Generic[BF]):
+class flag_value:
     def __init__(self, func: Callable[[Any], int]):
         self.flag = func(None)
         self.__doc__ = func.__doc__


### PR DESCRIPTION
## Summary

Since there is no generic information in `flag_value.__init__()`, `flag_value` descriptors get stored as `flag_value[<nothing>]` in mypy strict mode and then the `__get__` overloads never match. This leads to errors when using things like `permissions_instance.embed_links` since `<nothing>` never matches `Permissions`. The generic inheritance isn't needed at all since the type information we care about comes from the call site of `__get__` and not the instantiation of the descriptor.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
