### PR TITLE
fix Message.is_system

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -979,7 +979,7 @@ class Message(Hashable):
 
         .. versionadded:: 1.3
         """
-        return self.type is not MessageType.default
+        return self.type not in (MessageType.default, MessageType.reply, MessageType.application_command, MessageType.thread_starter_message)
 
     @utils.cached_slot_property('_cs_system_content')
     def system_content(self):


### PR DESCRIPTION
## Summary

Message.is_system was checking if the type is MessageType.default but now there are other MessageTypes that are not system messages, this PR fixes this

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
