### PR TITLE
fix Guild.fetch_channel does not work for threads

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2017,6 +2017,8 @@ def _guild_channel_factory(channel_type: int):
         return StoreChannel, value
     elif value is ChannelType.stage_voice:
         return StageChannel, value
+    elif value in (ChannelType.news_thread, ChannelType.public_thread, ChannelType.private_thread):
+        return Thread, value
     else:
         return None, value
 


### PR DESCRIPTION
## Summary
Guild.fetch_channel did not work when the target was a thread.
I will solve this problem by adding threads to the target of _guild_channel_factory.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
