### PR TITLE
Fix `Guild.fetch_channel` does not work for threads

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2036,3 +2036,10 @@ def _threaded_channel_factory(channel_type: int):
     if value in (ChannelType.private_thread, ChannelType.public_thread, ChannelType.news_thread):
         return Thread, value
     return cls, value
+
+
+def _threaded_guild_channel_factory(channel_type: int):
+    cls, value = _guild_channel_factory(channel_type)
+    if value in (ChannelType.private_thread, ChannelType.public_thread, ChannelType.news_thread):
+        return Thread, value
+    return cls, value

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -52,6 +52,7 @@ from .colour import Colour
 from .errors import InvalidArgument, ClientException
 from .channel import *
 from .channel import _guild_channel_factory
+from .channel import _threaded_guild_channel_factory
 from .enums import (
     AuditLogAction,
     VideoQualityMode,
@@ -1703,7 +1704,7 @@ class Guild(Hashable):
         data: BanPayload = await self._state.http.get_ban(user.id, self.id)
         return BanEntry(user=User(state=self._state, data=data['user']), reason=data['reason'])
 
-    async def fetch_channel(self, channel_id: int, /) -> GuildChannel:
+    async def fetch_channel(self, channel_id: int, /) -> Union[GuildChannel, Thread]:
         """|coro|
 
         Retrieves a :class:`.abc.GuildChannel` with the specified ID.
@@ -1734,7 +1735,7 @@ class Guild(Hashable):
         """
         data = await self._state.http.get_channel(channel_id)
 
-        factory, ch_type = _guild_channel_factory(data['type'])
+        factory, ch_type = _threaded_guild_channel_factory(data['type'])
         if factory is None:
             raise InvalidData('Unknown channel type {type} for channel ID {id}.'.format_map(data))
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1707,11 +1707,11 @@ class Guild(Hashable):
     async def fetch_channel(self, channel_id: int, /) -> Union[GuildChannel, Thread]:
         """|coro|
 
-        Retrieves a :class:`.abc.GuildChannel` with the specified ID.
+        Retrieves a :class:`.abc.GuildChannel` or :class:`.Thread` with the specified ID.
 
         .. note::
 
-            This method is an API call. For general usage, consider :meth:`get_channel` instead.
+            This method is an API call. For general usage, consider :meth:`get_channel_or_thread` instead.
 
         .. versionadded:: 2.0
 
@@ -1730,7 +1730,7 @@ class Guild(Hashable):
 
         Returns
         --------
-        :class:`.abc.GuildChannel`
+        Union[:class:`.abc.GuildChannel`, :class:`.Thread`]
             The channel from the ID.
         """
         data = await self._state.http.get_channel(channel_id)


### PR DESCRIPTION
## Summary
Guild.fetch_channel did not work when the target was a thread.
I created a new function `_threaded_guild_channel_factory` and fixed `Guild.fetch_channle` to support Thread.

Followed the changes in `Client.fetch_channel`.  #7156

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
