### PR TITLE
default to 0 instead of 15 for Guild.sticker_limit

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -717,7 +717,7 @@ class Guild(Hashable):
 
         .. versionadded:: 2.0
         """
-        more_stickers = 60 if 'MORE_STICKERS' in self.features else 15
+        more_stickers = 60 if 'MORE_STICKERS' in self.features else 0
         return max(more_stickers, self._PREMIUM_GUILD_LIMITS[self.premium_tier].stickers)
 
     @property


### PR DESCRIPTION
## Summary

should be 0 because level 0 doesn't offer stickers.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
