### PR TITLE
Make enums comparable

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -62,10 +62,6 @@ def _create_value_cls(name):
     cls = namedtuple('_EnumValue_' + name, 'name value')
     cls.__repr__ = lambda self: f'<{name}.{self.name}: {self.value!r}>'
     cls.__str__ = lambda self: f'{name}.{self.name}'
-    cls.__le__ = lambda self, other: isinstance(other, self.__class__) and self.value <= other.value
-    cls.__ge__ = lambda self, other: isinstance(other, self.__class__) and self.value >= other.value
-    cls.__lt__ = lambda self, other: isinstance(other, self.__class__) and self.value < other.value
-    cls.__gt__ = lambda self, other: isinstance(other, self.__class__) and self.value > other.value
     return cls
 
 
@@ -80,12 +76,19 @@ class EnumMeta(type):
         _enum_member_map_: ClassVar[Dict[str, Any]]
         _enum_value_map_: ClassVar[Dict[Any, Any]]
 
-    def __new__(cls, name, bases, attrs):
+    def __new__(cls, name, bases, attrs, **kwargs):
         value_mapping = {}
         member_mapping = {}
         member_names = []
 
         value_cls = _create_value_cls(name)
+
+        if kwargs.get('comparable'):
+            value_cls.__le__ = lambda self, other: isinstance(other, self.__class__) and self.value <= other.value
+            value_cls.__ge__ = lambda self, other: isinstance(other, self.__class__) and self.value >= other.value
+            value_cls.__lt__ = lambda self, other: isinstance(other, self.__class__) and self.value < other.value
+            value_cls.__gt__ = lambda self, other: isinstance(other, self.__class__) and self.value > other.value
+
         for key, value in list(attrs.items()):
             is_descriptor = _is_descriptor(value)
             if key[0] == '_' and not is_descriptor:
@@ -256,7 +259,7 @@ class SpeakingState(Enum):
         return self.value
 
 
-class VerificationLevel(Enum):
+class VerificationLevel(Enum, comparable=True):
     none = 0
     low = 1
     medium = 2
@@ -267,7 +270,7 @@ class VerificationLevel(Enum):
         return self.name
 
 
-class ContentFilter(Enum):
+class ContentFilter(Enum, comparable=True):
     disabled = 0
     no_role = 1
     all_members = 2
@@ -300,7 +303,7 @@ class DefaultAvatar(Enum):
         return self.name
 
 
-class NotificationLevel(Enum):
+class NotificationLevel(Enum, comparable=True):
     all_messages = 0
     only_mentions = 1
 
@@ -582,7 +585,7 @@ class StagePrivacyLevel(Enum):
     guild_only = 2
 
 
-class NSFWLevel(Enum):
+class NSFWLevel(Enum, comparable=True):
     default = 0
     explicit = 1
     safe = 2

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -62,6 +62,10 @@ def _create_value_cls(name):
     cls = namedtuple('_EnumValue_' + name, 'name value')
     cls.__repr__ = lambda self: f'<{name}.{self.name}: {self.value!r}>'
     cls.__str__ = lambda self: f'{name}.{self.name}'
+    cls.__le__ = lambda self, other: isinstance(other, self.__class__) and self.value <= other.value
+    cls.__ge__ = lambda self, other: isinstance(other, self.__class__) and self.value >= other.value
+    cls.__lt__ = lambda self, other: isinstance(other, self.__class__) and self.value < other.value
+    cls.__gt__ = lambda self, other: isinstance(other, self.__class__) and self.value > other.value
     return cls
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1591,6 +1591,8 @@ of :class:`enum.Enum`.
 
     .. container:: operations
 
+        .. versionadded:: 2.0
+
         .. describe:: x == y
 
             Checks if two verification levels are equal.
@@ -1670,6 +1672,8 @@ of :class:`enum.Enum`.
     pornography or otherwise explicit content.
 
     .. container:: operations
+
+        .. versionadded:: 2.0
 
         .. describe:: x == y
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1633,6 +1633,29 @@ of :class:`enum.Enum`.
 
     Specifies whether a :class:`Guild` has notifications on for all messages or mentions only by default.
 
+    .. container:: operations
+
+        .. versionadded:: 2.0
+
+        .. describe:: x == y
+
+            Checks if two notification levels are equal.
+        .. describe:: x != y
+
+            Checks if two notification levels are not equal.
+        .. describe:: x > y
+
+            Checks if a notification level is higher than another.
+        .. describe:: x < y
+
+            Checks if a notification level is lower than another.
+        .. describe:: x >= y
+
+            Checks if a notification level is higher or equal to another.
+        .. describe:: x <= y
+
+            Checks if a notification level is lower or equal to another.
+
     .. attribute:: all_messages
 
         Members receive notifications for every message regardless of them being mentioned.
@@ -2531,6 +2554,27 @@ of :class:`enum.Enum`.
     Represents the NSFW level of a guild.
 
     .. versionadded:: 2.0
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two NSFW levels are equal.
+        .. describe:: x != y
+
+            Checks if two NSFW levels are not equal.
+        .. describe:: x > y
+
+            Checks if a NSFW level is higher than another.
+        .. describe:: x < y
+
+            Checks if a NSFW level is lower than another.
+        .. describe:: x >= y
+
+            Checks if a NSFW level is higher or equal to another.
+        .. describe:: x <= y
+
+            Checks if a NSFW level is lower or equal to another.
 
     .. attribute:: default
 


### PR DESCRIPTION
## Summary

Add comparison operations to Enum. Also added docs for supported operations on some enums where comparing values might be relevant. (NotificationLevel, NSFWLevel)

Not sure what to do about the supported operations containers on VerificationLevel and ContentFilter that were added in #688 and then broken in 0ddc6867e9e2c98d74a4ef85ac36a99fec5a1f03.

This PR closes #7250.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
