### PR TITLE
Re-define Member properties inferred from User to support type-checking

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -272,28 +272,12 @@ class Member(discord.abc.Messageable, _UserTag):
         bot: bool
         system: bool
         created_at: datetime.datetime
-
-        @property
-        def default_avatar(self) -> Asset:
-            ...
-
-        @property
-        def avatar(self) -> Asset:
-            ...
-
-        @property
-        def dm_channel(self) -> Optional[DMChannel]:
-            ...
-
+        default_avatar: Asset
+        avatar: Asset
+        dm_channel: Optional[DMChannel]
         create_dm = User.create_dm
-
-        @property
-        def mutual_guilds(self) -> List[Guild]:
-            ...
-
-        @property
-        def public_flags(self) -> PublicUserFlags:
-            ...
+        mutual_guilds: List[Guild]
+        public_flags: PublicUserFlags
 
     def __init__(self, *, data: GatewayMemberPayload, guild: Guild, state: ConnectionState):
         self._state: ConnectionState = state

--- a/discord/member.py
+++ b/discord/member.py
@@ -48,7 +48,9 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
-    from .channel import VoiceChannel, StageChannel
+    from .asset import Asset
+    from .channel import DMChannel, VoiceChannel, StageChannel
+    from .flags import PublicUserFlags
     from .guild import Guild
     from .types.activity import PartialPresenceUpdate
     from .types.member import (
@@ -270,12 +272,28 @@ class Member(discord.abc.Messageable, _UserTag):
         bot: bool
         system: bool
         created_at: datetime.datetime
-        default_avatar = User.default_avatar
-        avatar = User.avatar
-        dm_channel = User.dm_channel
+
+        @property
+        def default_avatar(self) -> Asset:
+            ...
+
+        @property
+        def avatar(self) -> Asset:
+            ...
+
+        @property
+        def dm_channel(self) -> Optional[DMChannel]:
+            ...
+
         create_dm = User.create_dm
-        mutual_guilds = User.mutual_guilds
-        public_flags = User.public_flags
+
+        @property
+        def mutual_guilds(self) -> List[Guild]:
+            ...
+
+        @property
+        def public_flags(self) -> PublicUserFlags:
+            ...
 
     def __init__(self, *, data: GatewayMemberPayload, guild: Guild, state: ConnectionState):
         self._state: ConnectionState = state


### PR DESCRIPTION
## Summary

This pr re-defines all properties of `Member` derived from `User` as assignment leaves the type as `property`

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
