### PR TITLE
Add Thread to the return type of Client.get_channel and add type: ignore where needed

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -206,6 +206,7 @@ class Client:
         loop: Optional[asyncio.AbstractEventLoop] = None,
         **options: Any,
     ):
+        # self.ws is set in the connect method
         self.ws: DiscordWebSocket = None  # type: ignore
         self.loop: asyncio.AbstractEventLoop = asyncio.get_event_loop() if loop is None else loop
         self._listeners: Dict[str, List[Tuple[asyncio.Future, Callable[..., bool]]]] = {}

--- a/discord/client.py
+++ b/discord/client.py
@@ -37,7 +37,7 @@ from .user import User, ClientUser
 from .invite import Invite
 from .template import Template
 from .widget import Widget
-from .guild import Guild, VocalGuildChannel
+from .guild import Guild
 from .emoji import Emoji
 from .channel import _threaded_channel_factory, PartialMessageable
 from .enums import ChannelType
@@ -717,7 +717,7 @@ class Client:
         """List[:class:`~discord.User`]: Returns a list of all the users the bot can see."""
         return list(self._connection._users.values())
 
-    def get_channel(self, id: int) -> Optional[Union[GuildChannel, VocalGuildChannel, PrivateChannel, PartialMessageable, Thread]]:
+    def get_channel(self, id: int) -> Optional[Union[GuildChannel, Thread, PrivateChannel]]:
         """Returns a channel with the given ID.
 
         Parameters

--- a/discord/client.py
+++ b/discord/client.py
@@ -29,7 +29,7 @@ import logging
 import signal
 import sys
 import traceback
-from typing import Any, Callable, Coroutine, Dict, Generator, Iterable, List, Optional, Sequence, TYPE_CHECKING, Tuple, TypeVar, Union
+from typing import Any, Callable, Coroutine, Dict, Generator, List, Optional, Sequence, TYPE_CHECKING, Tuple, TypeVar, Union
 
 import aiohttp
 
@@ -37,7 +37,7 @@ from .user import User, ClientUser
 from .invite import Invite
 from .template import Template
 from .widget import Widget
-from .guild import Guild
+from .guild import Guild, VocalGuildChannel
 from .emoji import Emoji
 from .channel import _threaded_channel_factory, PartialMessageable
 from .enums import ChannelType
@@ -682,7 +682,8 @@ class Client:
         if value is None:
             self._connection._activity = None
         elif isinstance(value, BaseActivity):
-            self._connection._activity = value.to_dict()
+            # ConnectionState._activity is typehinted as ActivityPayload, we're passing Dict[str, Any]
+            self._connection._activity = value.to_dict() # type: ignore
         else:
             raise TypeError('activity must derive from BaseActivity.')
 
@@ -716,7 +717,7 @@ class Client:
         """List[:class:`~discord.User`]: Returns a list of all the users the bot can see."""
         return list(self._connection._users.values())
 
-    def get_channel(self, id: int) -> Optional[Union[GuildChannel, PrivateChannel]]:
+    def get_channel(self, id: int) -> Optional[Union[GuildChannel, VocalGuildChannel, PrivateChannel, PartialMessageable, Thread]]:
         """Returns a channel with the given ID.
 
         Parameters
@@ -726,7 +727,7 @@ class Client:
 
         Returns
         --------
-        Optional[Union[:class:`.abc.GuildChannel`, :class:`.abc.PrivateChannel`]]
+        Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.abc.PrivateChannel`]]
             The returned channel or ``None`` if not found.
         """
         return self._connection.get_channel(id)
@@ -1473,11 +1474,14 @@ class Client:
             raise InvalidData('Unknown channel type {type} for channel ID {id}.'.format_map(data))
 
         if ch_type in (ChannelType.group, ChannelType.private):
-            channel = factory(me=self.user, data=data, state=self._connection)
+            # the factory will be a DMChannel or GroupChannel here
+            channel = factory(me=self.user, data=data, state=self._connection) # type: ignore
         else:
-            guild_id = int(data['guild_id'])
+            # the factory can't be a DMChannel or GroupChannel here
+            guild_id = int(data['guild_id']) # type: ignore
             guild = self.get_guild(guild_id) or Object(id=guild_id)
-            channel = factory(guild=guild, state=self._connection, data=data)
+            # GuildChannels expect a Guild, we may be passing an Object
+            channel = factory(guild=guild, state=self._connection, data=data) # type: ignore
 
         return channel
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -718,7 +718,7 @@ class Client:
         return list(self._connection._users.values())
 
     def get_channel(self, id: int) -> Optional[Union[GuildChannel, Thread, PrivateChannel]]:
-        """Returns a channel with the given ID.
+        """Returns a channel or thread with the given ID.
 
         Parameters
         -----------

--- a/docs/locale/ja/LC_MESSAGES/api.po
+++ b/docs/locale/ja/LC_MESSAGES/api.po
@@ -1313,8 +1313,8 @@ msgstr "戻り値の型"
 
 #: discord.Client.get_channel:7 of
 #, fuzzy
-msgid "Optional[Union[:class:`.abc.GuildChannel`, :class:`.abc.PrivateChannel`]]"
-msgstr "Union[:class:`.abc.GuildChannel`, :class:`.abc.PrivateChannel`]"
+msgid "Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.abc.PrivateChannel`]]"
+msgstr "Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.abc.PrivateChannel`]"
 
 #: discord.Client.get_guild:1 of
 #, fuzzy
@@ -16949,11 +16949,11 @@ msgstr ":class:`~discord.User`"
 #~ ":class:`.Streaming`]] -- ログイン時のアクティビティ。"
 
 #~ msgid ""
-#~ "Optional[Union[:class:`.abc.GuildChannel`, "
+#~ "Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, "
 #~ ":class:`.abc.PrivateChannel`]]: Returns a channel"
 #~ " with the given ID."
 #~ msgstr ""
-#~ "Optional[Union[:class:`.abc.GuildChannel`, "
+#~ "Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, "
 #~ ":class:`.abc.PrivateChannel`]]: 与えられたIDを持つチャンネルを返します。"
 
 #~ msgid "If not found, returns ``None``."

--- a/docs/locale/ja/LC_MESSAGES/ext/commands/api.po
+++ b/docs/locale/ja/LC_MESSAGES/ext/commands/api.po
@@ -1466,7 +1466,7 @@ msgid ":class:`.Member` -- A member the client can see."
 msgstr ""
 
 #: discord.ext.commands.Bot.get_channel:1 of
-msgid "Returns a channel with the given ID."
+msgid "Returns a channel or thread with the given ID."
 msgstr ""
 
 #: discord.ext.commands.Bot.get_channel:3 discord.ext.commands.Bot.get_emoji:3
@@ -1481,8 +1481,8 @@ msgstr ""
 
 #: discord.ext.commands.Bot.get_channel:7 of
 #, fuzzy
-msgid "Optional[Union[:class:`.abc.GuildChannel`, :class:`.abc.PrivateChannel`]]"
-msgstr "Union[ :class:`.abc.GuildChannel` , :class:`.abc.PrivateChannel` ]"
+msgid "Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.abc.PrivateChannel`]]"
+msgstr "Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.abc.PrivateChannel`]"
 
 #: discord.ext.commands.Bot.get_cog:1 of
 msgid "Gets the cog instance requested."
@@ -6008,7 +6008,7 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid ""
-#~ "Optional[Union[:class:`.abc.GuildChannel`, "
+#~ "Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, "
 #~ ":class:`.abc.PrivateChannel`]]: Returns a channel"
 #~ " with the given ID."
 #~ msgstr ""


### PR DESCRIPTION
## Summary
Lines 234, 235 and 303 were not `# type: ignore`'d because they will no longer error once #7414 is merged.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
