### PR TITLE
Fix `Message` typing

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -29,7 +29,7 @@ import datetime
 import re
 import io
 from os import PathLike
-from typing import Dict, TYPE_CHECKING, Union, List, Optional, Any, Callable, Tuple, ClassVar, Optional, overload
+from typing import Dict, TYPE_CHECKING, Union, List, Optional, Any, Callable, Tuple, ClassVar, Optional, Type, TypeVar, overload
 
 from . import utils
 from .reaction import Reaction
@@ -86,8 +86,10 @@ __all__ = (
     'DeletedReferencedMessage',
 )
 
+C = TypeVar('C', bound='Type[Any]')
 
-def convert_emoji_reaction(emoji):
+
+def convert_emoji_reaction(emoji: Union[EmojiInputType, Reaction]) -> str:
     if isinstance(emoji, Reaction):
         emoji = emoji.emoji
 
@@ -468,7 +470,7 @@ class MessageReference:
     to_message_reference_dict = to_dict
 
 
-def flatten_handlers(cls):
+def flatten_handlers(cls: C) -> C:
     prefix = len('_handle_')
     handlers = [
         (key[prefix:], value)
@@ -1367,7 +1369,7 @@ class Message(Hashable):
         await self._state.http.unpin_message(self.channel.id, self.id, reason=reason)
         self.pinned = False
 
-    async def add_reaction(self, emoji: EmojiInputType) -> None:
+    async def add_reaction(self, emoji: Union[EmojiInputType, Reaction]) -> None:
         """|coro|
 
         Add a reaction to the message.


### PR DESCRIPTION
## Summary

Currently, the following code fails type checking:

```python
from typing import Iterable, List, cast

import discord

channel = cast(discord.TextChannel, {})
message = cast(discord.Message, {})

channel.delete_messages(message)  # Error 1

other_message = cast(discord.Message, {})

message.add_reaction(other_message.reactions[0])  # Error 2
```

"Error 1" is the result of `flatten_handlers()` being untyped and losing type information. "Error 2" is caused by `add_reaction()` not having `Reaction` in its accepted type union. This PR fixes both problems.


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
