### PR TITLE
Add per-guild member avatar support

### DIFF
--- a/discord/asset.py
+++ b/discord/asset.py
@@ -178,6 +178,17 @@ class Asset(AssetMixin):
         )
 
     @classmethod
+    def _from_guild_avatar(cls, state, guild_id: int, member_id: int, avatar: str) -> Asset:
+        animated = avatar.startswith('a_')
+        format = 'gif' if animated else 'png'
+        return cls(
+            state,
+            url=f"{cls.BASE}/guilds/{guild_id}/users/{member_id}/avatars/{avatar}.{format}?size=1024",
+            key=avatar,
+            animated=animated,
+        )
+
+    @classmethod
     def _from_icon(cls, state, object_id: int, icon_hash: str, path: str) -> Asset:
         return cls(
             state,

--- a/discord/member.py
+++ b/discord/member.py
@@ -502,16 +502,26 @@ class Member(discord.abc.Messageable, _UserTag):
         return self.nick or self.name
 
     @property
-    def guild_avatar(self) -> Asset:
-        """:class:`Asset`: Returns an :class:`Asset` for the guild avatar the member has.
+    def display_avatar(self) -> Asset:
+        """:class:`Asset`: Returns the member's display avatar.
 
-        If the member does not have a guild avatar, :meth:`Member.avatar`
-        will be called instead.
+        For regular members this is just their avatar, but
+        if they have a guild specific avatar then that
+        is returned instead.
+
+        .. versionadded:: 2.0
+        """
+        return self.guild_avatar or self.avatar
+
+    @property
+    def guild_avatar(self) -> Optional[Asset]:
+        """Optional[:class:`Asset`:] Returns an :class:`Asset` for the guild avatar
+        the member has if available.
 
         .. versionadded:: 2.0
         """
         if self._avatar is None:
-            return self.avatar
+            return None
         return Asset._from_guild_avatar(self._state, self.guild.id, self.id, self._avatar)
 
     @property

--- a/discord/member.py
+++ b/discord/member.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, List, Literal, Optional, TYPE_CHECKING, Tuple, Typ
 import discord.abc
 
 from . import utils
+from .asset import Asset
 from .utils import MISSING
 from .user import BaseUser, User, _UserTag
 from .activity import create_activity, ActivityTypes
@@ -261,6 +262,7 @@ class Member(discord.abc.Messageable, _UserTag):
         '_client_status',
         '_user',
         '_state',
+        '_avatar',
     )
 
     if TYPE_CHECKING:
@@ -288,6 +290,7 @@ class Member(discord.abc.Messageable, _UserTag):
         self.activities: Tuple[ActivityTypes, ...] = tuple()
         self.nick: Optional[str] = data.get('nick', None)
         self.pending: bool = data.get('pending', False)
+        self._avatar: Optional[str] = data.get("avatar", None)
 
     def __str__(self) -> str:
         return str(self._user)
@@ -492,6 +495,19 @@ class Member(discord.abc.Messageable, _UserTag):
         is returned instead.
         """
         return self.nick or self.name
+
+    @property
+    def guild_avatar(self) -> Asset:
+        """:class:`Asset`: Returns an :class:`Asset` for the guild avatar the member has.
+
+        If the member does not have a guild avatar, :meth:`Member.avatar`
+        will be called instead.
+
+        .. versionadded:: 2.0
+        """
+        if self._avatar is None:
+            return self.avatar
+        return Asset._from_guild_avatar(self._state, self.guild.id, self.id, self._avatar)
 
     @property
     def activity(self) -> Optional[ActivityTypes]:

--- a/discord/user.py
+++ b/discord/user.py
@@ -238,6 +238,18 @@ class BaseUser(_UserTag):
         """
         return self.name
 
+    @property
+    def display_avatar(self) -> Asset:
+        """:class:`Asset`: Returns the user's display avatar.
+
+        For regular users this is just their avatar, but
+        if they have a guild specific avatar then that
+        is returned instead.
+
+        .. versionadded:: 2.0
+        """
+        return self.avatar
+
     def mentioned_in(self, message: Message) -> bool:
         """Checks if the user is mentioned in the specified message.
 


### PR DESCRIPTION
## Summary

This pull request addresses the #7054 by adding support for per-guild member avatars. To put simply, this PR adds a ``Member.guild_avatar`` property to get member guild avatar. If the guild-specific avatar is unavailable, it just calls ``Member.avatar``.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
