### PR TITLE
Added type: ignore for StageInstance.channel

### DIFF
--- a/discord/stage_instance.py
+++ b/discord/stage_instance.py
@@ -106,7 +106,8 @@ class StageInstance(Hashable):
     @cached_slot_property('_cs_channel')
     def channel(self) -> Optional[StageChannel]:
         """Optional[:class:`StageChannel`]: The channel that stage instance is running in."""
-        return self._state.get_channel(self.channel_id)
+        # the returned channel will always be a StageChannel or None
+        return self._state.get_channel(self.channel_id) # type: ignore
 
     def is_public(self) -> bool:
         return self.privacy_level is StagePrivacyLevel.public


### PR DESCRIPTION
## Summary
#7414 adds the return type of `ConnectionState.get_channel`, and once that is merged this would need to be `# type: ignore`'d

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
