### PR TITLE
Change GuildChannel.overwrites to not require member intents

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -53,6 +53,7 @@ from .invite import Invite
 from .file import File
 from .voice_client import VoiceClient, VoiceProtocol
 from .sticker import GuildSticker, StickerItem
+from .object import Object
 from . import utils
 
 __all__ = (
@@ -475,16 +476,18 @@ class GuildChannel:
         return PermissionOverwrite()
 
     @property
-    def overwrites(self) -> Dict[Union[Role, Member], PermissionOverwrite]:
+    def overwrites(self) -> Dict[Union[Role, Member, Object], PermissionOverwrite]:
         """Returns all of the channel's overwrites.
 
         This is returned as a dictionary where the key contains the target which
-        can be either a :class:`~discord.Role` or a :class:`~discord.Member` and the value is the
-        overwrite as a :class:`~discord.PermissionOverwrite`.
+        can be either a :class:`~discord.Role`, :class:`~discord.Member` or a
+        :class:`~discord.Object` and the value is the overwrite as a
+        :class:`~discord.PermissionOverwrite`. If the target is a :class:`~discord.Object`,
+        the guild isn't chunked or member intents are not enabled.
 
         Returns
         --------
-        Dict[Union[:class:`~discord.Role`, :class:`~discord.Member`], :class:`~discord.PermissionOverwrite`]
+        Dict[Union[:class:`~discord.Role`, :class:`~discord.Member`, :class:`~discord.Object`], :class:`~discord.PermissionOverwrite`]
             The channel's permission overwrites.
         """
         ret = {}
@@ -499,13 +502,10 @@ class GuildChannel:
             elif ow.is_member():
                 target = self.guild.get_member(ow.id)
 
-            # TODO: There is potential data loss here in the non-chunked
-            # case, i.e. target is None because get_member returned nothing.
-            # This can be fixed with a slight breaking change to the return type,
-            # i.e. adding discord.Object to the list of it
-            # However, for now this is an acceptable compromise.
             if target is not None:
                 ret[target] = overwrite
+            else:
+                ret[Object(ow.id)] = overwrite
         return ret
 
     @property

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -500,12 +500,9 @@ class GuildChannel:
             if ow.is_role():
                 target = self.guild.get_role(ow.id)
             elif ow.is_member():
-                target = self.guild.get_member(ow.id)
+                target = self.guild.get_member(ow.id) or Object(ow.id)
 
-            if target is not None:
-                ret[target] = overwrite
-            else:
-                ret[Object(ow.id)] = overwrite
+            ret[target] = overwrite
         return ret
 
     @property

--- a/docs/locale/ja/LC_MESSAGES/api.po
+++ b/docs/locale/ja/LC_MESSAGES/api.po
@@ -7504,9 +7504,11 @@ msgstr ""
 #: discord.CategoryChannel.overwrites:3 discord.TextChannel.overwrites:3
 #: discord.VoiceChannel.overwrites:3 discord.abc.GuildChannel.overwrites:3 of
 msgid ""
-"This is returned as a dictionary where the key contains the target which "
-"can be either a :class:`~discord.Role` or a :class:`~discord.Member` and "
-"the value is the overwrite as a :class:`~discord.PermissionOverwrite`."
+"This is returned as a dictionary where the key contains the target which"
+"can be either a :class:`~discord.Role`, :class:`~discord.Member` or a"
+":class:`~discord.Object` and the value is the overwrite as a"
+":class:`~discord.PermissionOverwrite`. If the target is a :class:`~discord.Object`,"
+"the guild isn't chunked or member intents are not enabled."
 msgstr ""
 
 #: discord.CategoryChannel.overwrites:7 discord.TextChannel.overwrites:7
@@ -17365,11 +17367,12 @@ msgstr ":class:`~discord.User`"
 
 #~ msgid ""
 #~ "This is returned as a dictionary "
-#~ "where the key contains the target "
-#~ "which can be either a "
-#~ ":class:`~discord.Role` or a :class:`~discord.Member`"
-#~ " and the key is the overwrite "
-#~ "as a :class:`~discord.PermissionOverwrite`."
+#~ "where the key contains the target which"
+#~ "can be either a :class:`~discord.Role`, :class:`~discord.Member` or a"
+#~ ":class:`~discord.Object` and the value is the overwrite as a"
+#~ ":class:`~discord.PermissionOverwrite`.
+#~ "If the target is a :class:`~discord.Object`, "
+#~ "the guild isn't chunked or member intents are not enabled."
 #~ msgstr ""
 
 #~ msgid ""

--- a/docs/locale/ja/LC_MESSAGES/api.po
+++ b/docs/locale/ja/LC_MESSAGES/api.po
@@ -7504,11 +7504,9 @@ msgstr ""
 #: discord.CategoryChannel.overwrites:3 discord.TextChannel.overwrites:3
 #: discord.VoiceChannel.overwrites:3 discord.abc.GuildChannel.overwrites:3 of
 msgid ""
-"This is returned as a dictionary where the key contains the target which"
-"can be either a :class:`~discord.Role`, :class:`~discord.Member` or a"
-":class:`~discord.Object` and the value is the overwrite as a"
-":class:`~discord.PermissionOverwrite`. If the target is a :class:`~discord.Object`,"
-"the guild isn't chunked or member intents are not enabled."
+"This is returned as a dictionary where the key contains the target which "
+"can be either a :class:`~discord.Role` or a :class:`~discord.Member` and "
+"the value is the overwrite as a :class:`~discord.PermissionOverwrite`."
 msgstr ""
 
 #: discord.CategoryChannel.overwrites:7 discord.TextChannel.overwrites:7
@@ -17367,12 +17365,11 @@ msgstr ":class:`~discord.User`"
 
 #~ msgid ""
 #~ "This is returned as a dictionary "
-#~ "where the key contains the target which"
-#~ "can be either a :class:`~discord.Role`, :class:`~discord.Member` or a"
-#~ ":class:`~discord.Object` and the value is the overwrite as a"
-#~ ":class:`~discord.PermissionOverwrite`.
-#~ "If the target is a :class:`~discord.Object`, "
-#~ "the guild isn't chunked or member intents are not enabled."
+#~ "where the key contains the target "
+#~ "which can be either a "
+#~ ":class:`~discord.Role` or a :class:`~discord.Member`"
+#~ " and the key is the overwrite "
+#~ "as a :class:`~discord.PermissionOverwrite`."
 #~ msgstr ""
 
 #~ msgid ""


### PR DESCRIPTION
## Summary
This PR is a somewhat breaking change that sets the target in `GuildChannel.overwrites` to an `Object` if `get_member` returned None.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
