### PR TITLE
Add views on every on_ready in persistent example

### DIFF
--- a/examples/views/persistent.py
+++ b/examples/views/persistent.py
@@ -30,17 +30,14 @@ class PersistentView(discord.ui.View):
 class PersistentViewBot(commands.Bot):
     def __init__(self):
         super().__init__(command_prefix=commands.when_mentioned_or('$'))
-        self.persistent_views_added = False
 
     async def on_ready(self):
-        if not self.persistent_views_added:
             # Register the persistent view for listening here.
             # Note that this does not send the view to any message.
             # In order to do this you need to first send a message with the View, which is shown below.
             # If you have the message_id you can also pass it as a keyword argument, but for this example
             # we don't have one.
             self.add_view(PersistentView())
-            self.persistent_views_added = True
 
         print(f'Logged in as {self.user} (ID: {self.user.id})')
         print('------')

--- a/examples/views/persistent.py
+++ b/examples/views/persistent.py
@@ -32,13 +32,12 @@ class PersistentViewBot(commands.Bot):
         super().__init__(command_prefix=commands.when_mentioned_or('$'))
 
     async def on_ready(self):
-            # Register the persistent view for listening here.
-            # Note that this does not send the view to any message.
-            # In order to do this you need to first send a message with the View, which is shown below.
-            # If you have the message_id you can also pass it as a keyword argument, but for this example
-            # we don't have one.
-            self.add_view(PersistentView())
-
+        # Register the persistent view for listening here.
+        # Note that this does not send the view to any message.
+        # In order to do this you need to first send a message with the View, which is shown below.
+        # If you have the message_id you can also pass it as a keyword argument, but for this example
+        # we don't have one.
+        self.add_view(PersistentView())
         print(f'Logged in as {self.user} (ID: {self.user.id})')
         print('------')
 


### PR DESCRIPTION
## Summary

This is an attempt at clarifying the persistent view example and adding the views back on every `on_ready` as `READY` clears the state of said views, breaking them. (See #7437) This ensures that the views keep working after a disconnect for example. I have not tested this, but it shouldn't cause any issues.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
