### PR TITLE
Add fetch_creation_message method to threads.

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -684,6 +684,26 @@ class Thread(Messageable, Hashable):
             Deleting the thread failed.
         """
         await self._state.http.delete_channel(self.id)
+        
+    async def fetch_creation_message(self) -> Message:
+        """|coro|
+        Retrieves the message that was used to create this thread from the parent channel.
+        
+        Raises
+        --------
+        ~discord.NotFound
+            The message was not found.
+        ~discord.Forbidden
+            You do not have the permissions required to get the message.
+        ~discord.HTTPException
+            Retrieving the message failed.
+           
+        Returns
+        --------
+        :class:`~discord.Message`
+            The message that was used to create this thread from the parent channel.
+        """
+        return await self.parent.fetch_message(self.id)
 
     def get_partial_message(self, message_id: int, /) -> PartialMessage:
         """Creates a :class:`PartialMessage` from the message ID.


### PR DESCRIPTION
Add a method to the discord.Thread class which allows you to fetch the message which created the thread from the parent channel.

## Summary
This pull request is for adding a method to the discord.Thread class, the method allows you to fetch the message which created the thread from the parent channel. 

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
