### PR TITLE
Typehint opus.py

### DIFF
--- a/discord/opus.py
+++ b/discord/opus.py
@@ -320,18 +320,18 @@ class Encoder(_OpusStruct):
 
     def __del__(self) -> None:
         if hasattr(self, '_state'):
-            _lib.opus_encoder_destroy(self._state) # type: ignore
+            _lib.opus_encoder_destroy(self._state)
             # This is a destructor, so it's okay to assign None
             self._state = None # type: ignore
 
     def _create_state(self) -> EncoderStruct:
         ret = ctypes.c_int()
-        return _lib.opus_encoder_create(self.SAMPLING_RATE, self.CHANNELS, self.application, ctypes.byref(ret)) # type: ignore
+        return _lib.opus_encoder_create(self.SAMPLING_RATE, self.CHANNELS, self.application, ctypes.byref(ret))
 
     def set_bitrate(self, kbps: int) -> int:
         kbps = min(512, max(16, int(kbps)))
 
-        _lib.opus_encoder_ctl(self._state, CTL_SET_BITRATE, kbps * 1024) # type: ignore
+        _lib.opus_encoder_ctl(self._state, CTL_SET_BITRATE, kbps * 1024)
         return kbps
 
     def set_bandwidth(self, req: BAND_CTL) -> None:
@@ -339,17 +339,17 @@ class Encoder(_OpusStruct):
             raise KeyError(f'{req!r} is not a valid bandwidth setting. Try one of: {",".join(band_ctl)}')
 
         k = band_ctl[req]
-        _lib.opus_encoder_ctl(self._state, CTL_SET_BANDWIDTH, k) # type: ignore
+        _lib.opus_encoder_ctl(self._state, CTL_SET_BANDWIDTH, k)
 
     def set_signal_type(self, req: SIGNAL_CTL) -> None:
         if req not in signal_ctl:
             raise KeyError(f'{req!r} is not a valid bandwidth setting. Try one of: {",".join(signal_ctl)}')
 
         k = signal_ctl[req]
-        _lib.opus_encoder_ctl(self._state, CTL_SET_SIGNAL, k) # type: ignore
+        _lib.opus_encoder_ctl(self._state, CTL_SET_SIGNAL, k)
 
     def set_fec(self, enabled: bool = True) -> None:
-        _lib.opus_encoder_ctl(self._state, CTL_SET_FEC, 1 if enabled else 0) # type: ignore
+        _lib.opus_encoder_ctl(self._state, CTL_SET_FEC, 1 if enabled else 0)
 
     def set_expected_packet_loss_percent(self, percentage: float) -> None:
         _lib.opus_encoder_ctl(self._state, CTL_SET_PLP, min(100, max(0, int(percentage * 100)))) # type: ignore
@@ -360,7 +360,7 @@ class Encoder(_OpusStruct):
         pcm_ptr = ctypes.cast(pcm, c_int16_ptr) # type: ignore
         data = (ctypes.c_char * max_data_bytes)()
 
-        ret = _lib.opus_encode(self._state, pcm_ptr, frame_size, data, max_data_bytes) # type: ignore
+        ret = _lib.opus_encode(self._state, pcm_ptr, frame_size, data, max_data_bytes)
 
         # array can be initialized with bytes but mypy doesn't know
         return array.array('b', data[:ret]).tobytes() # type: ignore
@@ -373,28 +373,28 @@ class Decoder(_OpusStruct):
 
     def __del__(self) -> None:
         if hasattr(self, '_state'):
-            _lib.opus_decoder_destroy(self._state) # type: ignore
+            _lib.opus_decoder_destroy(self._state)
             # This is a destructor, so it's okay to assign None
             self._state = None # type: ignore
 
     def _create_state(self) -> DecoderStruct:
         ret = ctypes.c_int()
-        return _lib.opus_decoder_create(self.SAMPLING_RATE, self.CHANNELS, ctypes.byref(ret)) # type: ignore
+        return _lib.opus_decoder_create(self.SAMPLING_RATE, self.CHANNELS, ctypes.byref(ret))
 
     @staticmethod
     def packet_get_nb_frames(data: bytes) -> int:
         """Gets the number of frames in an Opus packet"""
-        return _lib.opus_packet_get_nb_frames(data, len(data)) # type: ignore
+        return _lib.opus_packet_get_nb_frames(data, len(data))
 
     @staticmethod
     def packet_get_nb_channels(data: bytes) -> int:
         """Gets the number of channels in an Opus packet"""
-        return _lib.opus_packet_get_nb_channels(data) # type: ignore
+        return _lib.opus_packet_get_nb_channels(data)
 
     @classmethod
     def packet_get_samples_per_frame(cls, data: bytes) -> int:
         """Gets the number of samples per frame from an Opus packet"""
-        return _lib.opus_packet_get_samples_per_frame(data, cls.SAMPLING_RATE) # type: ignore
+        return _lib.opus_packet_get_samples_per_frame(data, cls.SAMPLING_RATE)
 
     def _set_gain(self, adjustment: int) -> int:
         """Configures decoder gain adjustment.
@@ -406,7 +406,7 @@ class Decoder(_OpusStruct):
         gain = 10**x/(20.0*256)
         (from opus_defines.h)
         """
-        return _lib.opus_decoder_ctl(self._state, CTL_SET_GAIN, adjustment) # type: ignore
+        return _lib.opus_decoder_ctl(self._state, CTL_SET_GAIN, adjustment)
 
     def set_gain(self, dB: float) -> int:
         """Sets the decoder gain in dB, from -128 to 128."""
@@ -422,7 +422,7 @@ class Decoder(_OpusStruct):
         """Gets the duration (in samples) of the last packet successfully decoded or concealed."""
 
         ret = ctypes.c_int32()
-        _lib.opus_decoder_ctl(self._state, CTL_LAST_PACKET_DURATION, ctypes.byref(ret)) # type: ignore
+        _lib.opus_decoder_ctl(self._state, CTL_LAST_PACKET_DURATION, ctypes.byref(ret))
         return ret.value
 
     @overload
@@ -449,6 +449,6 @@ class Decoder(_OpusStruct):
         pcm = (ctypes.c_int16 * (frame_size * channel_count))()
         pcm_ptr = ctypes.cast(pcm, c_int16_ptr)
 
-        ret = _lib.opus_decode(self._state, data, len(data) if data else 0, pcm_ptr, frame_size, fec) # type: ignore
+        ret = _lib.opus_decode(self._state, data, len(data) if data else 0, pcm_ptr, frame_size, fec)
 
         return array.array('h', pcm[:ret * channel_count]).tobytes()

--- a/discord/opus.py
+++ b/discord/opus.py
@@ -22,7 +22,9 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-from typing import List, Tuple, TypedDict, Any
+from __future__ import annotations
+
+from typing import List, Tuple, TypedDict, Any, TYPE_CHECKING, Callable, TypeVar, Literal, Optional, overload
 
 import array
 import ctypes
@@ -33,7 +35,12 @@ import os.path
 import struct
 import sys
 
-from .errors import DiscordException
+from .errors import DiscordException, InvalidArgument
+
+if TYPE_CHECKING:
+    T = TypeVar('T')
+    BAND_CTL = Literal['narrow', 'medium', 'wide', 'superwide', 'full']
+    SIGNAL_CTL = Literal['auto', 'voice', 'music']
 
 class BandCtl(TypedDict):
     narrow: int
@@ -104,13 +111,13 @@ signal_ctl: SignalCtl = {
     'music': 3002,
 }
 
-def _err_lt(result, func, args):
+def _err_lt(result: int, func: Callable, args: List) -> int:
     if result < OK:
         _log.info('error has happened in %s', func.__name__)
         raise OpusError(result)
     return result
 
-def _err_ne(result, func, args):
+def _err_ne(result: T, func: Callable, args: List) -> T:
     ret = args[-1]._obj
     if ret.value != OK:
         _log.info('error has happened in %s', func.__name__)
@@ -172,7 +179,7 @@ exported_functions: List[Tuple[Any, ...]] = [
         [ctypes.c_char_p, ctypes.c_int], ctypes.c_int, _err_lt),
 ]
 
-def libopus_loader(name):
+def libopus_loader(name: str) -> ctypes.CDLL:
     # create the library...
     lib = ctypes.cdll.LoadLibrary(name)
 
@@ -196,7 +203,7 @@ def libopus_loader(name):
 
     return lib
 
-def _load_default():
+def _load_default() -> bool:
     global _lib
     try:
         if sys.platform == 'win32':
@@ -212,7 +219,7 @@ def _load_default():
 
     return _lib is not None
 
-def load_opus(name):
+def load_opus(name: str) -> None:
     """Loads the libopus shared library for use with voice.
 
     If this function is not called then the library uses the function
@@ -250,7 +257,7 @@ def load_opus(name):
     global _lib
     _lib = libopus_loader(name)
 
-def is_loaded():
+def is_loaded() -> bool:
     """Function to check if opus lib is successfully loaded either
     via the :func:`ctypes.util.find_library` call of :func:`load_opus`.
 
@@ -273,8 +280,8 @@ class OpusError(DiscordException):
         The error code returned.
     """
 
-    def __init__(self, code):
-        self.code = code
+    def __init__(self, code: int) -> None:
+        self.code: int = code
         msg = _lib.opus_strerror(self.code).decode('utf-8')
         _log.info('"%s" has happened', msg)
         super().__init__(msg)
@@ -300,92 +307,96 @@ class _OpusStruct:
         return _lib.opus_get_version_string().decode('utf-8')
 
 class Encoder(_OpusStruct):
-    def __init__(self, application=APPLICATION_AUDIO):
+    def __init__(self, application: int=APPLICATION_AUDIO) -> None:
         _OpusStruct.get_opus_version()
 
-        self.application = application
-        self._state = self._create_state()
+        self.application: int = application
+        self._state: EncoderStruct = self._create_state()
         self.set_bitrate(128)
         self.set_fec(True)
         self.set_expected_packet_loss_percent(0.15)
         self.set_bandwidth('full')
         self.set_signal_type('auto')
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '_state'):
-            _lib.opus_encoder_destroy(self._state)
-            self._state = None
+            _lib.opus_encoder_destroy(self._state) # type: ignore
+            # This is a destructor, so it's okay to assign None
+            self._state = None # type: ignore
 
-    def _create_state(self):
+    def _create_state(self) -> EncoderStruct:
         ret = ctypes.c_int()
-        return _lib.opus_encoder_create(self.SAMPLING_RATE, self.CHANNELS, self.application, ctypes.byref(ret))
+        return _lib.opus_encoder_create(self.SAMPLING_RATE, self.CHANNELS, self.application, ctypes.byref(ret)) # type: ignore
 
-    def set_bitrate(self, kbps):
+    def set_bitrate(self, kbps: int) -> int:
         kbps = min(512, max(16, int(kbps)))
 
-        _lib.opus_encoder_ctl(self._state, CTL_SET_BITRATE, kbps * 1024)
+        _lib.opus_encoder_ctl(self._state, CTL_SET_BITRATE, kbps * 1024) # type: ignore
         return kbps
 
-    def set_bandwidth(self, req):
+    def set_bandwidth(self, req: BAND_CTL) -> None:
         if req not in band_ctl:
             raise KeyError(f'{req!r} is not a valid bandwidth setting. Try one of: {",".join(band_ctl)}')
 
         k = band_ctl[req]
-        _lib.opus_encoder_ctl(self._state, CTL_SET_BANDWIDTH, k)
+        _lib.opus_encoder_ctl(self._state, CTL_SET_BANDWIDTH, k) # type: ignore
 
-    def set_signal_type(self, req):
+    def set_signal_type(self, req: SIGNAL_CTL) -> None:
         if req not in signal_ctl:
             raise KeyError(f'{req!r} is not a valid bandwidth setting. Try one of: {",".join(signal_ctl)}')
 
         k = signal_ctl[req]
-        _lib.opus_encoder_ctl(self._state, CTL_SET_SIGNAL, k)
+        _lib.opus_encoder_ctl(self._state, CTL_SET_SIGNAL, k) # type: ignore
 
-    def set_fec(self, enabled=True):
-        _lib.opus_encoder_ctl(self._state, CTL_SET_FEC, 1 if enabled else 0)
+    def set_fec(self, enabled: bool = True) -> None:
+        _lib.opus_encoder_ctl(self._state, CTL_SET_FEC, 1 if enabled else 0) # type: ignore
 
-    def set_expected_packet_loss_percent(self, percentage):
-        _lib.opus_encoder_ctl(self._state, CTL_SET_PLP, min(100, max(0, int(percentage * 100))))
+    def set_expected_packet_loss_percent(self, percentage: float) -> None:
+        _lib.opus_encoder_ctl(self._state, CTL_SET_PLP, min(100, max(0, int(percentage * 100)))) # type: ignore
 
-    def encode(self, pcm, frame_size):
+    def encode(self, pcm: bytes, frame_size: int) -> bytes:
         max_data_bytes = len(pcm)
-        pcm = ctypes.cast(pcm, c_int16_ptr)
+        # bytes can be used to reference pointer
+        pcm_ptr = ctypes.cast(pcm, c_int16_ptr) # type: ignore
         data = (ctypes.c_char * max_data_bytes)()
 
-        ret = _lib.opus_encode(self._state, pcm, frame_size, data, max_data_bytes)
+        ret = _lib.opus_encode(self._state, pcm_ptr, frame_size, data, max_data_bytes) # type: ignore
 
-        return array.array('b', data[:ret]).tobytes()
+        # array can be initialized with bytes but mypy doesn't know
+        return array.array('b', data[:ret]).tobytes() # type: ignore
 
 class Decoder(_OpusStruct):
-    def __init__(self):
+    def __init__(self) -> None:
         _OpusStruct.get_opus_version()
 
-        self._state = self._create_state()
+        self._state: DecoderStruct = self._create_state()
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '_state'):
-            _lib.opus_decoder_destroy(self._state)
-            self._state = None
+            _lib.opus_decoder_destroy(self._state) # type: ignore
+            # This is a destructor, so it's okay to assign None
+            self._state = None # type: ignore
 
-    def _create_state(self):
+    def _create_state(self) -> DecoderStruct:
         ret = ctypes.c_int()
-        return _lib.opus_decoder_create(self.SAMPLING_RATE, self.CHANNELS, ctypes.byref(ret))
+        return _lib.opus_decoder_create(self.SAMPLING_RATE, self.CHANNELS, ctypes.byref(ret)) # type: ignore
 
     @staticmethod
-    def packet_get_nb_frames(data):
+    def packet_get_nb_frames(data: bytes) -> int:
         """Gets the number of frames in an Opus packet"""
-        return _lib.opus_packet_get_nb_frames(data, len(data))
+        return _lib.opus_packet_get_nb_frames(data, len(data)) # type: ignore
 
     @staticmethod
-    def packet_get_nb_channels(data):
+    def packet_get_nb_channels(data: bytes) -> int:
         """Gets the number of channels in an Opus packet"""
-        return _lib.opus_packet_get_nb_channels(data)
+        return _lib.opus_packet_get_nb_channels(data) # type: ignore
 
     @classmethod
-    def packet_get_samples_per_frame(cls, data):
+    def packet_get_samples_per_frame(cls, data: bytes) -> int:
         """Gets the number of samples per frame from an Opus packet"""
-        return _lib.opus_packet_get_samples_per_frame(data, cls.SAMPLING_RATE)
+        return _lib.opus_packet_get_samples_per_frame(data, cls.SAMPLING_RATE) # type: ignore
 
-    def _set_gain(self, adjustment):
+    def _set_gain(self, adjustment: int) -> int:
         """Configures decoder gain adjustment.
 
         Scales the decoded output by a factor specified in Q8 dB units.
@@ -395,28 +406,36 @@ class Decoder(_OpusStruct):
         gain = 10**x/(20.0*256)
         (from opus_defines.h)
         """
-        return _lib.opus_decoder_ctl(self._state, CTL_SET_GAIN, adjustment)
+        return _lib.opus_decoder_ctl(self._state, CTL_SET_GAIN, adjustment) # type: ignore
 
-    def set_gain(self, dB):
+    def set_gain(self, dB: float) -> int:
         """Sets the decoder gain in dB, from -128 to 128."""
 
         dB_Q8 = max(-32768, min(32767, round(dB * 256))) # dB * 2^n where n is 8 (Q8)
         return self._set_gain(dB_Q8)
 
-    def set_volume(self, mult):
+    def set_volume(self, mult: float) -> int:
         """Sets the output volume as a float percent, i.e. 0.5 for 50%, 1.75 for 175%, etc."""
         return self.set_gain(20 * math.log10(mult)) # amplitude ratio
 
-    def _get_last_packet_duration(self):
+    def _get_last_packet_duration(self) -> int:
         """Gets the duration (in samples) of the last packet successfully decoded or concealed."""
 
         ret = ctypes.c_int32()
-        _lib.opus_decoder_ctl(self._state, CTL_LAST_PACKET_DURATION, ctypes.byref(ret))
+        _lib.opus_decoder_ctl(self._state, CTL_LAST_PACKET_DURATION, ctypes.byref(ret)) # type: ignore
         return ret.value
 
-    def decode(self, data, *, fec=False):
+    @overload
+    def decode(self, data: bytes, *, fec: bool) -> bytes:
+        ...
+    
+    @overload
+    def decode(self, data: Literal[None], *, fec: Literal[False]) -> bytes:
+        ...
+
+    def decode(self, data: Optional[bytes], *, fec: bool = False) -> bytes:
         if data is None and fec:
-            raise OpusError("Invalid arguments: FEC cannot be used with null data")
+            raise InvalidArgument("Invalid arguments: FEC cannot be used with null data")
 
         if data is None:
             frame_size = self._get_last_packet_duration() or self.SAMPLES_PER_FRAME
@@ -430,6 +449,6 @@ class Decoder(_OpusStruct):
         pcm = (ctypes.c_int16 * (frame_size * channel_count))()
         pcm_ptr = ctypes.cast(pcm, c_int16_ptr)
 
-        ret = _lib.opus_decode(self._state, data, len(data) if data else 0, pcm_ptr, frame_size, fec)
+        ret = _lib.opus_decode(self._state, data, len(data) if data else 0, pcm_ptr, frame_size, fec) # type: ignore
 
         return array.array('h', pcm[:ret * channel_count]).tobytes()

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -153,10 +153,10 @@ class Shard:
                 return
             if e.code != 1000:
                 self._queue_put(EventItem(EventType.close, self, e))
-        _log     return
+                return
 
         retry = self._backoff.delay()
-        log.error('Attempting a reconnect for shard ID %s in %.2fs', self.id, retry, exc_info=e)
+        _log.error('Attempting a reconnect for shard ID %s in %.2fs', self.id, retry, exc_info=e)
         await asyncio.sleep(retry)
         self._queue_put(EventItem(EventType.reconnect, self, e))
 
@@ -178,10 +178,10 @@ class Shard:
                 break
 
     async def reidentify(self, exc: ReconnectWebSocket) -> None:
-        _logf._cancel_task()
+        self._cancel_task()
         self._dispatch('disconnect')
         self._dispatch('shard_disconnect', self.id)
-        log.info('Got a request to %s the websocket at Shard ID %s.', exc.op, self.id)
+        _log.info('Got a request to %s the websocket at Shard ID %s.', exc.op, self.id)
         try:
             coro = DiscordWebSocket.from_client(
                 self._client,
@@ -377,7 +377,7 @@ class AutoShardedClient(Client):
     def get_shard(self, shard_id: int) -> Optional[ShardInfo]:
         """Optional[:class:`ShardInfo`]: Gets the shard information at a given shard ID or ``None`` if not found."""
         try:
-            _logent = self.__shards[shard_id]
+            parent = self.__shards[shard_id]
         except KeyError:
             return None
         else:
@@ -393,7 +393,7 @@ class AutoShardedClient(Client):
             coro = DiscordWebSocket.from_client(self, initial=initial, gateway=gateway, shard_id=shard_id)
             ws = await asyncio.wait_for(coro, timeout=180.0)
         except Exception:
-            log.exception('Failed to connect for shard_id: %s. Retrying...', shard_id)
+            _log.exception('Failed to connect for shard_id: %s. Retrying...', shard_id)
             await asyncio.sleep(5.0)
             return await self.launch_shard(gateway, shard_id)
 


### PR DESCRIPTION
## Summary
Typehints opus.py. Checked on mypy.

- All native function calls are `#type: ignore`'d.
- `None` assignment inside destructors are `#type: ignore`'d.
- `Decoder.decode` now raises `InvalidArgument` instead of `OpusError` because `OpusError` cannot take a string as the error code. This is not technically breaking change, since it is unused and never documented.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
