### PR TITLE
Fix message.py typehints

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -1529,16 +1529,14 @@ class Message(Hashable):
         if self.guild is None:
             raise InvalidArgument('This message does not have guild info attached.')
 
-        if not isinstance(self.channel, TextChannel):
-            raise TypeError('This message\'s channel must be a TextChannel.')
-
         data = await self._state.http.start_thread_with_message(
             self.channel.id,
             self.id,
             name=name,
-            auto_archive_duration=auto_archive_duration or self.channel.default_auto_archive_duration,
+            # if the channel isn't a TextChannel, this will raise AttributeError 
+            auto_archive_duration=auto_archive_duration or self.channel.default_auto_archive_duration,  # type: ignore
         )
-        return Thread(guild=self.guild, state=self._state, data=data)  # type: ignore
+        return Thread(guild=self.guild, state=self._state, data=data)
 
     async def reply(self, content: Optional[str] = None, **kwargs) -> Message:
         """|coro|

--- a/discord/message.py
+++ b/discord/message.py
@@ -1785,8 +1785,7 @@ class PartialMessage(Hashable):
             pass
         else:
             flags = MessageFlags._from_value(0)
-            # pyright bug
-            flags.suppress_embeds = suppress # type: ignore
+            flags.suppress_embeds = suppress
             fields['flags'] = flags.value
 
         delete_after = fields.pop('delete_after', None)

--- a/discord/message.py
+++ b/discord/message.py
@@ -1518,8 +1518,6 @@ class Message(Hashable):
             Creating the thread failed.
         InvalidArgument
             This message does not have guild info attached.
-        TypeError
-            This message's channel is not a TextChannel.
 
         Returns
         --------

--- a/discord/message.py
+++ b/discord/message.py
@@ -639,7 +639,7 @@ class Message(Hashable):
         _HANDLERS: ClassVar[List[Tuple[str, Callable[..., None]]]]
         _CACHED_SLOTS: ClassVar[List[str]]
         guild: Optional[Guild]
-        ref: Optional[MessageReference]
+        reference: Optional[MessageReference]
         mentions: List[Union[User, Member]]
         author: Union[User, Member]
         role_mentions: List[Role]

--- a/discord/message.py
+++ b/discord/message.py
@@ -1531,8 +1531,7 @@ class Message(Hashable):
             self.channel.id,
             self.id,
             name=name,
-            # if the channel isn't a TextChannel, this will raise AttributeError 
-            auto_archive_duration=auto_archive_duration or self.channel.default_auto_archive_duration,  # type: ignore
+            auto_archive_duration=auto_archive_duration or self.channel.default_auto_archive_duration,
         )
         return Thread(guild=self.guild, state=self._state, data=data)
 


### PR DESCRIPTION
## Summary
Fix typehints in `message.py` and raise `TypeError` if the message's channel is not a `TextChannel` in `Message.create_thread`

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
