### PR TITLE
Add missing return type to `utils.oauth_url`

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -267,7 +267,7 @@ def oauth_url(
     redirect_uri: str = MISSING,
     scopes: Iterable[str] = MISSING,
     disable_guild_select: bool = False,
-):
+) -> str:
     """A helper function that returns the OAuth2 URL for inviting the bot
     into guilds.
 


### PR DESCRIPTION
## Summary

This PR fixes the missing return type for `utils.oauth_url`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
