### PR TITLE
Add thread attribute to discord.Message class.

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -988,6 +988,21 @@ class Message(Hashable):
             MessageType.application_command,
             MessageType.thread_starter_message,
         )
+    
+    @property
+    def thread(self) -> Optional[Thread]:
+        """Retrieves the thread the message has created ``None`` if no thread was created
+        with this message or if the channel is not a :class:`TextChannel`.
+        
+        Returns
+        --------
+        Optional[:class:`Thread`]
+            The thread this message has created.
+        """
+        try:
+            return self.channel.get_thread(self.id)
+        except AttributeError:
+            return None
 
     @utils.cached_slot_property('_cs_system_content')
     def system_content(self):


### PR DESCRIPTION
## Summary
Add an attribute which returns the thread the message created, None if it did not create any threads or if the channel is not a TextChannel.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
