### PR TITLE
[commands] re-order union for checks

### DIFF
--- a/discord/ext/commands/_types.py
+++ b/discord/ext/commands/_types.py
@@ -37,7 +37,7 @@ Coro = Coroutine[Any, Any, T]
 MaybeCoro = Union[T, Coro[T]]
 CoroFunc = Callable[..., Coro[Any]]
 
-Check = Union[Callable[["Cog", "Context[Any]"], MaybeCoro[bool]], Callable[["Context[Any]"], MaybeCoro[bool]]]
+Check = Union[Callable[["Context[Any]"], MaybeCoro[bool]], Callable[["Cog", "Context[Any]"], MaybeCoro[bool]]]
 Hook = Union[Callable[["Cog", "Context[Any]"], Coro[Any]], Callable[["Context[Any]"], Coro[Any]]]
 Error = Union[Callable[["Cog", "Context[Any]", "CommandError"], Coro[Any]], Callable[["Context[Any]", "CommandError"], Coro[Any]]]
 


### PR DESCRIPTION
## Summary

Seemingly, pyright complains with checks involving lambdas with the current order of the Union, inferring that the first argument is a Cog instance:
```py
@check(lambda ctx: ctx.author.id == 0)
@bot.command()
async def test(ctx: Context[Bot]):
    ...
```

```
Argument of type "(ctx: Cog) -> Unknown" cannot be assigned to parameter "predicate" of type "Check" in function "check"
  Type "(ctx: Cog) -> Unknown" cannot be assigned to type "Check"
    Type "(ctx: Cog) -> Unknown" cannot be assigned to type "(_p0: Cog, _p1: Context[Any]) -> MaybeCoro[bool]"
      Function accepts too many positional parameters; expected 1 but received 2
    Type "(ctx: Cog) -> Unknown" cannot be assigned to type "(_p0: Context[Any]) -> MaybeCoro[bool]"
      Parameter 1: type "Context[Any]" cannot be assigned to type "Cog"
        "Context[Any]" is incompatible with "Cog" Pylance(reportGeneralTypeIssues)
```

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
