### PR TITLE
[docs] Clarify connect() requires Intents.voice_states

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1636,6 +1636,8 @@ class Connectable(Protocol):
         Connects to voice and creates a :class:`VoiceClient` to establish
         your connection to the voice server.
 
+        This requires :attr:`Intents.voice_states`.
+
         Parameters
         -----------
         timeout: :class:`float`

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -650,6 +650,10 @@ class Intents(BaseFlags):
         - :attr:`VoiceChannel.members`
         - :attr:`VoiceChannel.voice_states`
         - :attr:`Member.voice`
+
+        .. note::
+
+            This intent is required to connect to voice.
         """
         return 1 << 7
 


### PR DESCRIPTION
## Summary

Despite perhaps being obvious in retrospect, the voice_states intent being needed for the voice connection flow to complete is undocumented.  Since the internals of the connection flow are generally not known to the average use, this is now clarified in the docs in the intent and on `connect()`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
