### PR TITLE
Convert NoneType to EmptyEmbed in embeds.py

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -186,11 +186,12 @@ class Embed:
         timestamp: datetime.datetime = None,
     ):
 
-        self.colour = colour if colour is not EmptyEmbed else color
-        self.title = title
+        color = color if color is not None else EmptyEmbed
+        self.colour = colour if colour is not EmptyEmbed and colour is not None else color
+        self.title = title if title is not None else EmptyEmbed
         self.type = type
-        self.url = url
-        self.description = description
+        self.url = url if url is not None else EmptyEmbed
+        self.description = description if description is not None else EmptyEmbed
 
         if self.title is not EmptyEmbed:
             self.title = str(self.title)
@@ -357,6 +358,9 @@ class Embed:
         icon_url: :class:`str`
             The URL of the footer icon. Only HTTP(S) is supported.
         """
+        
+        text = text if text is not None else EmptyEmbed
+        icon_url = icon_url if icon_url is not None else EmptyEmbed
 
         self._footer = {}
         if text is not EmptyEmbed:
@@ -411,6 +415,8 @@ class Embed:
         url: :class:`str`
             The source URL for the image. Only HTTP(S) is supported.
         """
+        
+        url = url if url is not None else EmptyEmbed
 
         if url is EmptyEmbed:
             try:
@@ -453,6 +459,8 @@ class Embed:
         url: :class:`str`
             The source URL for the thumbnail. Only HTTP(S) is supported.
         """
+        
+        url = url if url is not None else EmptyEmbed
 
         if url is EmptyEmbed:
             try:
@@ -515,6 +523,9 @@ class Embed:
         icon_url: :class:`str`
             The URL of the author icon. Only HTTP(S) is supported.
         """
+        
+        url = url if url is not None else EmptyEmbed
+        icon_url = icon_url if icon_url is not None else EmptyEmbed
 
         self._author = {
             'name': str(name),


### PR DESCRIPTION
## Summary

Can use None instead of discord.Embed.Empty in embeds

## Checklist


- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
