### PR TITLE
Replace `TypeError` with `ValueError`

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -261,7 +261,7 @@ class View:
         """
 
         if len(self.children) > 25:
-            raise ValueError('maximum number of children exceeded')
+            raise TypeError('maximum number of children exceeded')
 
         if not isinstance(item, Item):
             raise TypeError(f'expected Item not {item.__class__!r}')


### PR DESCRIPTION
## Summary

Replace `TypeError` with `ValueError`, as the type of `children` isn't the issue, but the inappropriate value is.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
