### PR TITLE
Fix a typo in member_role_update

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1934,7 +1934,7 @@ of :class:`enum.Enum`.
     .. attribute:: member_role_update
 
         A member's role has been updated. This triggers when a member
-        either gains a role or losses a role.
+        either gains a role or loses a role.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
         the :class:`Member` or :class:`User` who got the role.


### PR DESCRIPTION
## Summary

"losses a role" -> "loses a role"

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
