### PR TITLE
`'image'` key is now optional for scheduled events

### DIFF
--- a/discord/scheduled_event.py
+++ b/discord/scheduled_event.py
@@ -136,7 +136,7 @@ class ScheduledEvent(Hashable):
         self.start_time: datetime = parse_time(data['scheduled_start_time'])
         self.privacy_level: PrivacyLevel = try_enum(PrivacyLevel, data['status'])
         self.status: EventStatus = try_enum(EventStatus, data['status'])
-        self._cover_image: Optional[str] = data['image']
+        self._cover_image: Optional[str] = data.get('image', None)
         self.user_count: int = data.get('user_count', 0)
 
         creator = data.get('creator')

--- a/discord/types/scheduled_event.py
+++ b/discord/types/scheduled_event.py
@@ -38,6 +38,7 @@ class _BaseGuildScheduledEventOptional(TypedDict, total=False):
     description: str
     creator: User
     user_count: int
+    image: Optional[str]
 
 
 class _BaseGuildScheduledEvent(_BaseGuildScheduledEventOptional):
@@ -48,7 +49,6 @@ class _BaseGuildScheduledEvent(_BaseGuildScheduledEventOptional):
     scheduled_start_time: str
     privacy_level: PrivacyLevel
     status: EventStatus
-    image: Optional[str]
 
 
 class _VoiceChannelScheduledEventOptional(_BaseGuildScheduledEvent, total=False):


### PR DESCRIPTION
## Summary

Seems like Discord decided to randomly make 'image' optional since the last time I tested it.

Closes #7501

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
