### PR TITLE
Add new on_thread_create event

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -552,6 +552,10 @@ class Intents(BaseFlags):
         - :func:`on_guild_channel_create`
         - :func:`on_guild_channel_delete`
         - :func:`on_guild_channel_pins_update`
+        - :func:`on_thread_create`
+        - :func:`on_thread_join`
+        - :func:`on_thread_update`
+        - :func:`on_thread_delete`
 
         This also corresponds to the following attributes and classes in terms of cache:
 
@@ -574,6 +578,8 @@ class Intents(BaseFlags):
         - :func:`on_member_remove`
         - :func:`on_member_update`
         - :func:`on_user_update`
+        - :func:`on_thread_member_join`
+        - :func:`on_thread_member_remove`
 
         This also corresponds to the following attributes and classes in terms of cache:
 

--- a/discord/state.py
+++ b/discord/state.py
@@ -850,7 +850,10 @@ class ConnectionState:
         has_thread = guild.get_thread(thread.id)
         guild._add_thread(thread)
         if not has_thread:
-            self.dispatch('thread_join', thread)
+            if data.get('newly_created'):
+                self.dispatch('thread_create', thread)
+            else:
+                self.dispatch('thread_join', thread)
 
     def parse_thread_update(self, data: gw.ThreadUpdateEvent) -> None:
         guild_id = int(data['guild_id'])

--- a/discord/types/threads.py
+++ b/discord/types/threads.py
@@ -64,6 +64,7 @@ class Thread(TypedDict):
     member: NotRequired[ThreadMember]
     last_message_id: NotRequired[Optional[Snowflake]]
     last_pin_timestamp: NotRequired[Optional[Snowflake]]
+    newly_created: NotRequired[bool]
 
 
 class ThreadPaginationPayload(TypedDict):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1096,11 +1096,22 @@ Stages
 Threads
 ~~~~~~~~
 
+.. function:: on_thread_create(thread)
+
+    Called whenever a thread is created.
+
+    Note that you can get the guild from :attr:`Thread.guild`.
+
+    This requires :attr:`Intents.guilds` to be enabled.
+
+    .. versionadded:: 2.0
+
+    :param thread: The thread that was created.
+    :type thread: :class:`Thread`
 
 .. function:: on_thread_join(thread)
 
-    Called whenever a thread is joined or created. Note that from the API's perspective there is no way to
-    differentiate between a thread being created or the bot joining a thread.
+    Called whenever a thread is joined.
 
     Note that you can get the guild from :attr:`Thread.guild`.
 


### PR DESCRIPTION
## Summary

Adds a new on_thread_create event

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
