### PR TITLE
Add the suppress_embeds parameter to send methods

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1183,6 +1183,7 @@ class Messageable:
         reference: Union[Message, MessageReference, PartialMessage] = ...,
         mention_author: bool = ...,
         view: View = ...,
+        suppress_embeds: bool = ...,
     ) -> Message:
         ...
 
@@ -1201,6 +1202,7 @@ class Messageable:
         reference: Union[Message, MessageReference, PartialMessage] = ...,
         mention_author: bool = ...,
         view: View = ...,
+        suppress_embeds: bool = ...,
     ) -> Message:
         ...
 
@@ -1219,6 +1221,7 @@ class Messageable:
         reference: Union[Message, MessageReference, PartialMessage] = ...,
         mention_author: bool = ...,
         view: View = ...,
+        suppress_embeds: bool = ...,
     ) -> Message:
         ...
 
@@ -1237,6 +1240,7 @@ class Messageable:
         reference: Union[Message, MessageReference, PartialMessage] = ...,
         mention_author: bool = ...,
         view: View = ...,
+        suppress_embeds: bool = ...,
     ) -> Message:
         ...
 
@@ -1256,6 +1260,7 @@ class Messageable:
         reference=None,
         mention_author=None,
         view=None,
+        suppress_embeds=False,
     ):
         """|coro|
 
@@ -1330,6 +1335,10 @@ class Messageable:
             A list of stickers to upload. Must be a maximum of 3.
 
             .. versionadded:: 2.0
+        suppress_embeds: :class:`bool`
+            Whether to suppress embeds for the message. This sends the message without any embeds if set to ``True``.
+
+            .. versionadded:: 2.0
 
         Raises
         --------
@@ -1372,6 +1381,12 @@ class Messageable:
         if view and not hasattr(view, '__discord_ui_view__'):
             raise TypeError(f'view parameter must be View not {view.__class__!r}')
 
+        if suppress_embeds:
+            from .message import MessageFlags  # circualr import
+            flags = MessageFlags._from_value(4)
+        else:
+            flags = MISSING
+
         with handle_message_parameters(
             content=content,
             tts=tts,
@@ -1386,6 +1401,7 @@ class Messageable:
             mention_author=mention_author,
             stickers=stickers,
             view=view,
+            flags=flags,
         ) as params:
             data = await state.http.send_message(channel.id, params=params)
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -494,6 +494,7 @@ class InteractionResponse:
         tts: bool = False,
         ephemeral: bool = False,
         allowed_mentions: AllowedMentions = MISSING,
+        suppress_embeds: bool = False,
     ) -> None:
         """|coro|
 
@@ -524,6 +525,10 @@ class InteractionResponse:
         allowed_mentions: :class:`~discord.AllowedMentions`
             Controls the mentions being processed in this message. See :meth:`.abc.Messageable.send` for
             more information.
+        suppress_embeds: :class:`bool`
+            Whether to suppress embeds for the message. This sends the message without any embeds if set to ``True``.
+
+            .. versionadded:: 2.0
 
         Raises
         -------
@@ -539,8 +544,10 @@ class InteractionResponse:
         if self._responded:
             raise InteractionResponded(self._parent)
 
-        if ephemeral:
-            flags = MessageFlags._from_value(64)
+        if ephemeral or suppress_embeds:
+            flags = MessageFlags._from_value(0)
+            flags.ephemeral = ephemeral
+            flags.suppress_embeds = suppress_embeds
         else:
             flags = MISSING
 

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1310,6 +1310,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         thread: Snowflake = MISSING,
         wait: Literal[True],
+        suppress_embeds: bool = MISSING,
     ) -> WebhookMessage:
         ...
 
@@ -1330,6 +1331,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         thread: Snowflake = MISSING,
         wait: Literal[False] = ...,
+        suppress_embeds: bool = MISSING,
     ) -> None:
         ...
 
@@ -1349,6 +1351,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         thread: Snowflake = MISSING,
         wait: bool = False,
+        suppress_embeds: bool = False,
     ) -> Optional[WebhookMessage]:
         """|coro|
 
@@ -1418,6 +1421,10 @@ class Webhook(BaseWebhook):
             The thread to send this webhook to.
 
             .. versionadded:: 2.0
+        suppress_embeds: :class:`bool`
+            Whether to suppress embeds for the message. This sends the message without any embeds if set to ``True``.
+
+            .. versionadded:: 2.0
 
         Raises
         --------
@@ -1447,8 +1454,10 @@ class Webhook(BaseWebhook):
         previous_mentions: Optional[AllowedMentions] = getattr(self._state, 'allowed_mentions', None)
         if content is None:
             content = MISSING
-        if ephemeral:
-            flags = MessageFlags._from_value(64)
+        if ephemeral or suppress_embeds:
+            flags = MessageFlags._from_value(0)
+            flags.ephemeral = ephemeral
+            flags.suppress_embeds = suppress_embeds
         else:
             flags = MISSING
 

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -42,7 +42,7 @@ import weakref
 
 from .. import utils
 from ..errors import HTTPException, Forbidden, NotFound, DiscordServerError
-from ..message import Message
+from ..message import Message, MessageFlags
 from ..http import Route, handle_message_parameters
 from ..channel import PartialMessageable
 
@@ -833,6 +833,7 @@ class SyncWebhook(BaseWebhook):
         embeds: List[Embed] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
         wait: Literal[True],
+        suppress_embeds: bool = MISSING,
     ) -> SyncWebhookMessage:
         ...
 
@@ -850,6 +851,7 @@ class SyncWebhook(BaseWebhook):
         embeds: List[Embed] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
         wait: Literal[False] = ...,
+        suppress_embeds: bool = MISSING,
     ) -> None:
         ...
 
@@ -867,6 +869,7 @@ class SyncWebhook(BaseWebhook):
         allowed_mentions: AllowedMentions = MISSING,
         thread: Snowflake = MISSING,
         wait: bool = False,
+        suppress_embeds: bool = False,
     ) -> Optional[SyncWebhookMessage]:
         """Sends a message using the webhook.
 
@@ -915,6 +918,10 @@ class SyncWebhook(BaseWebhook):
             The thread to send this message to.
 
             .. versionadded:: 2.0
+        suppress_embeds: :class:`bool`
+            Whether to suppress embeds for the message. This sends the message without any embeds if set to ``True``.
+
+            .. versionadded:: 2.0
 
         Raises
         --------
@@ -943,6 +950,11 @@ class SyncWebhook(BaseWebhook):
         if content is None:
             content = MISSING
 
+        if suppress_embeds:
+            flags = MessageFlags._from_value(4)
+        else:
+            flags = MISSING
+
         params = handle_message_parameters(
             content=content,
             username=username,
@@ -954,6 +966,7 @@ class SyncWebhook(BaseWebhook):
             embeds=embeds,
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=previous_mentions,
+            flags=flags,
         )
         adapter: WebhookAdapter = _get_webhook_adapter()
         thread_id: Optional[int] = None


### PR DESCRIPTION
## Summary

This PR adds the ability to send messages with all embeds suppressed.

The following methods are modified:
- abc.Messageable.send
- Webhook.send
- SyncWebhook.send
- InteractionResponse.send_message

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
