### PR TITLE
Change GitHub Actions PR trigger to use `synchronize` instead of `edited`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
   pull_request:
-    types: [ opened, edited ]
+    types: [ opened, synchronize ]
 
 jobs:
   dists-and-docs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: lint
 on:
   push:
   pull_request:
-    types: [ opened, edited ]
+    types: [ opened, synchronize ]
 
 jobs:
   check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   push:
   pull_request:
-    types: [ opened, edited ]
+    types: [ opened, synchronize ]
 
 jobs:
   pytest:


### PR DESCRIPTION
## Summary

This makes it so that PR checks re-run when it receives new commits as opposed to the PR details being edited (this was the original intention, but was the wrong event for it).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
