### PR TITLE
Fix typo in Thread.remove_user

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -664,7 +664,7 @@ class Thread(Messageable, Hashable):
         Parameters
         -----------
         user: :class:`abc.Snowflake`
-            The user to add to the thread.
+            The user to remove from the thread.
 
         Raises
         -------


### PR DESCRIPTION
## Summary

Fixes a typo in the description of the `user` parameter in `Thread.remove_user`

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
