### PR TITLE
Create ClientStatus type to improve Member memory usage

### DIFF
--- a/discord/types/activity.py
+++ b/discord/types/activity.py
@@ -41,9 +41,9 @@ class PartialPresenceUpdate(TypedDict):
 
 
 class ClientStatus(TypedDict, total=False):
-    desktop: str
-    mobile: str
-    web: str
+    desktop: StatusType
+    mobile: StatusType
+    web: StatusType
 
 
 class ActivityTimestamps(TypedDict, total=False):


### PR DESCRIPTION
## Summary

Replaces the `_client_status` dict with a slotted class to reduce Member's memory footprint.
From some simple testing this reduces memory usage in my bot to ~960MiB from ~1125MiB.

I typed the attributes as `str` instead of `StatusType` so the `status.setter` in Member works typing wise, please let me know if I should reverse this and put an ignore there instead.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
