### PR TITLE
Fix link referencing the wrong document.

### DIFF
--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -5,7 +5,7 @@ Interactions API Reference
 
 The following section outlines the API of interactions, as implemented by the library.
 
-For documentation about the rest of the library, check :doc:`api`.
+For documentation about the rest of the library, check :doc:`/api`.
 
 Models
 --------


### PR DESCRIPTION
## Summary

That link referenced the `interactions/api.rst` instead of the main API reference.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
