### PR TITLE
Fixed audio delay when calling the after function

### DIFF
--- a/discord/player.py
+++ b/discord/player.py
@@ -694,8 +694,8 @@ class AudioPlayer(threading.Thread):
             self._current_error = exc
             self.stop()
         finally:
-            self.source.cleanup()
             self._call_after()
+            self.source.cleanup()
 
     def _call_after(self) -> None:
         error = self._current_error


### PR DESCRIPTION
## Summary
After the source has been exhausted or an error occurred, the `after` function is supposed to be called immediately. However, sometimes `source.cleanup()` may take several seconds to finish, which causes a noticeable delay when playing audio.

A possible solution is to call `self._call_after()` before `self.source.cleanup()` in `AudioPlayer.run()`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
