### PR TITLE
Add Interaction.locale

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -103,9 +103,8 @@ class Interaction:
         for 15 minutes.
     data: :class:`dict`
         The raw interaction data.
-    locale: Optional[:class:`Locale`]
-        The locale of the user invoking the interaction. This field
-        is not available on `InteractionType.ping` interactions.
+    locale: :class:`Locale`
+        The locale of the user invoking the interaction.
     guild_locale: Optional[:class:`Locale`]
         The preferred locale of the guild the interaction was sent from, if any.
     """
@@ -150,12 +149,6 @@ class Interaction:
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, 'guild_id')
         self.application_id: int = int(data['application_id'])
 
-        self.locale: Optional[Locale]
-        try:
-            self.locale = try_enum(Locale, data['locale'])
-        except KeyError:
-            self.locale = None
-
         self.message: Optional[Message]
         try:
             # The channel and message payloads are mismatched yet handled properly at runtime
@@ -166,6 +159,7 @@ class Interaction:
         self.user: Union[User, Member] = MISSING
         self._permissions: int = 0
 
+        self.locale: Locale = try_enum(Locale, data.get('locale', 'en-US'))
         self.guild_locale: Optional[Locale]
 
         # TODO: there's a potential data loss here

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -159,7 +159,7 @@ class Interaction:
         self.user: Union[User, Member] = MISSING
         self._permissions: int = 0
 
-        self.locale: Locale = try_enum(Locale, data.get('locale'))
+        self.locale: Locale = try_enum(Locale, data.get('locale', 'en_US'))
         self.guild_locale: Optional[Locale]
 
         # TODO: there's a potential data loss here
@@ -174,7 +174,7 @@ class Interaction:
                 self.user = Member(state=self._state, guild=guild, data=member)  # type: ignore
                 self._permissions = self.user._permissions or 0
 
-            self.guild_locale = try_enum(Locale, data.get('guild_locale'))
+            self.guild_locale = try_enum(Locale, data.get('guild_locale', 'en_US'))
         else:
             try:
                 self.user = User(state=self._state, data=data['user'])  # type: ignore - The key is optional and handled

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -159,7 +159,7 @@ class Interaction:
         self.user: Union[User, Member] = MISSING
         self._permissions: int = 0
 
-        self.locale: Locale = try_enum(Locale, data.get('locale', 'en_US'))
+        self.locale: Locale = try_enum(Locale, data.get('locale'))
         self.guild_locale: Optional[Locale]
 
         # TODO: there's a potential data loss here
@@ -174,7 +174,7 @@ class Interaction:
                 self.user = Member(state=self._state, guild=guild, data=member)  # type: ignore
                 self._permissions = self.user._permissions or 0
 
-            self.guild_locale = try_enum(Locale, data.get('guild_locale', 'en_US'))
+            self.guild_locale = try_enum(Locale, data.get('guild_locale'))
         else:
             try:
                 self.user = User(state=self._state, data=data['user'])  # type: ignore - The key is optional and handled

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -177,8 +177,6 @@ class Interaction:
                 # The fallback to Object for guild causes a type check error but is explicitly allowed here
                 self.user = Member(state=self._state, guild=guild, data=member)  # type: ignore
                 self._permissions = self.user._permissions or 0
-
-            self.guild_locale = try_enum(Locale, data.get('guild_locale', 'en-US'))
         else:
             try:
                 self.user = User(state=self._state, data=data['user'])  # type: ignore - The key is optional and handled

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -183,8 +183,6 @@ class Interaction:
             except KeyError:
                 pass
 
-            self.guild_locale = None
-
     @property
     def client(self) -> Client:
         """:class:`Client`: The client that is handling this interaction."""

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -41,6 +41,7 @@ from .message import Message, Attachment
 from .object import Object
 from .permissions import Permissions
 from .http import handle_message_parameters
+from .enums import try_enum, Locale
 from .webhook.async_ import async_context, Webhook, interaction_response_params, interaction_message_response_params
 
 __all__ = (
@@ -103,7 +104,7 @@ class Interaction:
         for 15 minutes.
     data: :class:`dict`
         The raw interaction data.
-    locale: Optional[:class:`str`]
+    locale: Optional[:class:`Locale`]
         The locale of the interaction.
     """
 
@@ -145,7 +146,6 @@ class Interaction:
         self.channel_id: Optional[int] = utils._get_as_snowflake(data, 'channel_id')
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, 'guild_id')
         self.application_id: int = int(data['application_id'])
-        self.locale: Optional[str] = data.get('locale')
 
         self.message: Optional[Message]
         try:
@@ -156,6 +156,12 @@ class Interaction:
 
         self.user: Union[User, Member] = MISSING
         self._permissions: int = 0
+
+        self.locale: Optional[Locale]
+        try:
+            self.locale = try_enum(Locale, data['locale'])
+        except KeyError:
+            self.locale = None
 
         # TODO: there's a potential data loss here
         if self.guild_id:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -159,6 +159,7 @@ class Interaction:
 
         self.locale: Optional[Locale]
         try:
+            # PING interactions don't have a locale
             self.locale = try_enum(Locale, data['locale'])
         except KeyError:
             self.locale = None

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -103,8 +103,9 @@ class Interaction:
         for 15 minutes.
     data: :class:`dict`
         The raw interaction data.
-    locale: :class:`Locale`
-        The locale of the user invoking the interaction.
+    locale: Optional[:class:`Locale`]
+        The locale of the user invoking the interaction. This field
+        is not available on `InteractionType.ping` interactions.
     guild_locale: Optional[:class:`Locale`]
         The preferred locale of the guild the interaction was sent from, if any.
     """
@@ -149,6 +150,12 @@ class Interaction:
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, 'guild_id')
         self.application_id: int = int(data['application_id'])
 
+        self.locale: Optional[Locale]
+        try:
+            self.locale = try_enum(Locale, data['locale'])
+        except KeyError:
+            self.locale = None
+
         self.message: Optional[Message]
         try:
             # The channel and message payloads are mismatched yet handled properly at runtime
@@ -159,7 +166,6 @@ class Interaction:
         self.user: Union[User, Member] = MISSING
         self._permissions: int = 0
 
-        self.locale: Locale = try_enum(Locale, data.get('locale', 'en-US'))
         self.guild_locale: Optional[Locale]
 
         # TODO: there's a potential data loss here

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -103,6 +103,8 @@ class Interaction:
         for 15 minutes.
     data: :class:`dict`
         The raw interaction data.
+    locale: Optional[:class:`str`]
+        The locale of the interaction.
     """
 
     __slots__: Tuple[str, ...] = (
@@ -116,6 +118,7 @@ class Interaction:
         'user',
         'token',
         'version',
+        'locale',
         '_permissions',
         '_state',
         '_client',
@@ -142,6 +145,7 @@ class Interaction:
         self.channel_id: Optional[int] = utils._get_as_snowflake(data, 'channel_id')
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, 'guild_id')
         self.application_id: int = int(data['application_id'])
+        self.locale: Optional[str] = data.get('locale')
 
         self.message: Optional[Message]
         try:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -149,6 +149,13 @@ class Interaction:
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, 'guild_id')
         self.application_id: int = int(data['application_id'])
 
+        self.locale: Locale = try_enum(Locale, data.get('locale', 'en-US'))
+        self.guild_locale: Optional[Locale]
+        try:
+            self.guild_locale = try_enum(Locale, data.get['guild_locale'])
+        except KeyError:
+            self.guild_locale = None
+
         self.message: Optional[Message]
         try:
             # The channel and message payloads are mismatched yet handled properly at runtime
@@ -158,9 +165,6 @@ class Interaction:
 
         self.user: Union[User, Member] = MISSING
         self._permissions: int = 0
-
-        self.locale: Locale = try_enum(Locale, data.get('locale', 'en-US'))
-        self.guild_locale: Optional[Locale]
 
         # TODO: there's a potential data loss here
         if self.guild_id:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -159,7 +159,7 @@ class Interaction:
         self.user: Union[User, Member] = MISSING
         self._permissions: int = 0
 
-        self.locale: Locale = try_enum(Locale, data.get('locale', 'en_US'))
+        self.locale: Locale = try_enum(Locale, data.get('locale', 'en-US'))
         self.guild_locale: Optional[Locale]
 
         # TODO: there's a potential data loss here
@@ -174,7 +174,7 @@ class Interaction:
                 self.user = Member(state=self._state, guild=guild, data=member)  # type: ignore
                 self._permissions = self.user._permissions or 0
 
-            self.guild_locale = try_enum(Locale, data.get('guild_locale', 'en_US'))
+            self.guild_locale = try_enum(Locale, data.get('guild_locale', 'en-US'))
         else:
             try:
                 self.user = User(state=self._state, data=data['user'])  # type: ignore - The key is optional and handled

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -202,6 +202,7 @@ class _BaseInteractionOptional(TypedDict, total=False):
     guild_id: Snowflake
     channel_id: Snowflake
     locale: str
+    guild_locale: str
 
 
 class _BaseInteraction(_BaseInteractionOptional):

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -201,6 +201,7 @@ InteractionData = Union[
 class _BaseInteractionOptional(TypedDict, total=False):
     guild_id: Snowflake
     channel_id: Snowflake
+    locale: str
 
 
 class _BaseInteraction(_BaseInteractionOptional):


### PR DESCRIPTION
## Summary
Added `Interaction.locale`, being an optional Locale enum, to the Interaction class, as discord now [provides this data](https://discord.com/developers/docs/interactions/receiving-and-responding#:~:text=locale%3F***,the%20invoking%20user).
It's optional as it's [not available on ping interactions](https://discord.com/developers/docs/interactions/receiving-and-responding#:~:text=***%20This%20is%20available%20on%20all%20interaction%20types%20except%20PING).

## Note
*Not sure if the changes in `types/interactions.py` are in the right place.*
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
