### PR TITLE
make description parameter of Guild.create_sticker non-Optional

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2403,7 +2403,7 @@ class Guild(Hashable):
         name: :class:`str`
             The sticker name. Must be at least 2 characters.
         description: :class:`str`
-            The sticker's description. Can be ``None``.
+            The sticker's description.
         emoji: :class:`str`
             The name of a unicode emoji that represents the sticker's expression.
         file: :class:`File`

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2384,7 +2384,7 @@ class Guild(Hashable):
         self,
         *,
         name: str,
-        description: Optional[str] = None,
+        description: str,
         emoji: str,
         file: File,
         reason: Optional[str] = None,
@@ -2402,7 +2402,7 @@ class Guild(Hashable):
         -----------
         name: :class:`str`
             The sticker name. Must be at least 2 characters.
-        description: Optional[:class:`str`]
+        description: :class:`str`
             The sticker's description. Can be ``None``.
         emoji: :class:`str`
             The name of a unicode emoji that represents the sticker's expression.
@@ -2427,8 +2427,7 @@ class Guild(Hashable):
             'name': name,
         }
 
-        if description:
-            payload['description'] = description
+        payload['description'] = description
 
         try:
             emoji = unicodedata.name(emoji)


### PR DESCRIPTION
## Summary

Resolves #7311 by making the `description` parameter of `Guild.create_sticker` required instead of Optional.
The documentation at https://discord.com/developers/docs/resources/sticker#create-guild-sticker marks description as non-optional

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
