### PR TITLE
[docs] fix refs to abc.Connectable.connect

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1693,7 +1693,7 @@ class Connectable(Protocol):
         Connects to voice and creates a :class:`~discord.VoiceClient` to establish
         your connection to the voice server.
 
-        This requires :attr:`Intents.voice_states`.
+        This requires :attr:`~discord.Intents.voice_states`.
 
         Parameters
         -----------

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1686,11 +1686,11 @@ class Connectable(Protocol):
         *,
         timeout: float = 60.0,
         reconnect: bool = True,
-        cls: Callable[[Client, Connectable], T] = VoiceClient,
+        cls: Callable[[Client, Connectable], T] = MISSING,
     ) -> T:
         """|coro|
 
-        Connects to voice and creates a :class:`VoiceClient` to establish
+        Connects to voice and creates a :class:`~discord.VoiceClient` to establish
         your connection to the voice server.
 
         This requires :attr:`Intents.voice_states`.
@@ -1703,7 +1703,7 @@ class Connectable(Protocol):
             Whether the bot should automatically attempt
             a reconnect if a part of the handshake fails
             or the gateway goes down.
-        cls: Type[:class:`VoiceProtocol`]
+        cls: Type[:class:`~discord.VoiceProtocol`]
             A type that subclasses :class:`~discord.VoiceProtocol` to connect with.
             Defaults to :class:`~discord.VoiceClient`.
 
@@ -1729,6 +1729,10 @@ class Connectable(Protocol):
             raise ClientException('Already connected to a voice channel.')
 
         client = state._get_client()
+
+        if cls is MISSING:
+            cls = VoiceClient
+
         voice = cls(client, self)
 
         if not isinstance(voice, VoiceProtocol):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3368,6 +3368,7 @@ Connectable
 .. attributetable:: discord.abc.Connectable
 
 .. autoclass:: discord.abc.Connectable()
+    :members:
 
 .. _discord_api_models:
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -72,7 +72,7 @@ New Features
 - Add :attr:`MessageReference.jump_url` (:issue:`6318`)
 - Add :attr:`File.spoiler` (:issue:`6317`)
 - Add support for passing ``roles`` to :meth:`Guild.estimate_pruned_members` (:issue:`6538`)
-- Allow callable class factories to be used in :meth:`abc.Connectable.play` (:issue:`6478`)
+- Allow callable class factories to be used in :meth:`abc.Connectable.connect` (:issue:`6478`)
 - Add a way to get mutual guilds from the client's cache via :attr:`User.mutual_guilds` (:issue:`2539`, :issue:`6444`)
 - :meth:`PartialMessage.edit` now returns a full :class:`Message` upon success (:issue:`6309`)
 - Add :attr:`RawMessageUpdateEvent.guild_id` (:issue:`6489`)


### PR DESCRIPTION
## Summary

Resolves #7535 

- Fixes the typo in the whats_new section
- Adds `:members:` to make sphinx doc `abc.Connectable.connect`
- Change the method signature of `connect()` to default to MISSING to have Ellipsis in the method signature in the docs

I did **NOT** test the code changes to this PR, only the sphinx builds.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
