### PR TITLE
Fix broken ref in migrating guide

### DIFF
--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -915,7 +915,7 @@ Allowed types for the following parameters have been changed:
 - ``rtc_region`` in :meth:`Guild.create_voice_channel` is now of type Optional[:class:`str`].
 - ``rtc_region`` in :meth:`StageChannel.edit` is now of type Optional[:class:`str`].
 - ``rtc_region`` in :meth:`VoiceChannel.edit` is now of type Optional[:class:`str`].
-- ``preferred_locale`` in :meth`Guild.edit` is now of type :class:`Locale`. 
+- ``preferred_locale`` in :meth:`Guild.edit` is now of type :class:`Locale`. 
 
 Attribute Type Changes
 ------------------------


### PR DESCRIPTION
## Summary

Adds missing `:` :)

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
