### PR TITLE
Add client.setup_hook

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -649,7 +649,7 @@ class Client:
         await self.login(token)
         await self.connect(reconnect=reconnect)
 
-    async def setup_hook(self) -> Any:
+    async def setup_hook(self) -> None:
         """|coro|
 
         A coroutine to be called to setup the bot, by default this is blank.

--- a/discord/client.py
+++ b/discord/client.py
@@ -488,7 +488,8 @@ class Client:
     async def login(self, token: str) -> None:
         """|coro|
 
-        Logs in the client with the specified credentials.
+        Logs in the client with the specified credentials and
+        calls the :meth:`setup_hook`.
 
 
         Parameters
@@ -511,6 +512,8 @@ class Client:
 
         data = await self.http.static_login(token.strip())
         self._connection.user = ClientUser(state=self._connection, data=data)
+
+        await self.setup_hook()
 
     async def connect(self, *, reconnect: bool = True) -> None:
         """|coro|
@@ -645,6 +648,22 @@ class Client:
         """
         await self.login(token)
         await self.connect(reconnect=reconnect)
+
+    async def setup_hook(self) -> Any:
+        """|coro|
+
+        A coroutine to be called to setup the bot, by default this is blank.
+
+        To perform asynchronous setup after the bot is logged in but before
+        it has connected to the Websocket, overwrite this coroutine.
+
+        This is only called once, in :meth:`login`, and will be called before
+        any events are dispatched, making it a better solution than doing such
+        setup in the :func:`~discord.on_ready` event.
+
+        .. versionadded:: 2.0
+        """
+        pass
 
     def run(self, *args: Any, **kwargs: Any) -> None:
         """A blocking call that abstracts away the event loop


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This adds `discord.Client.setup_hook`, a simple method to be overwritten by the user to provide an asynchronous startup point. This has been in [enhanced-discord.py](https://github.com/iDevision/enhanced-discord.py/blob/03c51210a54c529fd26011d0ca6dcab878fee2b7/discord/client.py#L635-L648) for a while and we have received quite a lot of praise for it. It solves the issue of many new users doing asynchronous setup on_ready, which may be called multiple times, or after other events are received and can even be overwritten without subclassing due to how `@client.event` blindly overwrites methods on the client instance. 
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
