### PR TITLE
[docs] Fix typo in tasks docs.

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -504,7 +504,7 @@ class Loop(Generic[LF]):
         return coro
 
     def after_loop(self, coro: FT) -> FT:
-        """A decorator that registers a coroutine to be called after the loop finished running.
+        """A decorator that registers a coroutine to be called after the loop finishes running.
 
         The coroutine must take no arguments (except ``self`` in a class context).
 

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -504,7 +504,7 @@ class Loop(Generic[LF]):
         return coro
 
     def after_loop(self, coro: FT) -> FT:
-        """A decorator that register a coroutine to be called after the loop finished running.
+        """A decorator that registers a coroutine to be called after the loop finished running.
 
         The coroutine must take no arguments (except ``self`` in a class context).
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
A typo was made in the after_loop decorator docs, I fixed it.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
