### PR TITLE
Fix incorrect wording in Message.edit docstring

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -1220,7 +1220,7 @@ class Message(Hashable):
             The ``suppress`` keyword-only parameter was added.
 
         .. versionchanged:: 2.0
-            Edits are no longer in-place, the newly edited role is returned instead.
+            Edits are no longer in-place, the newly edited message is returned instead.
 
         .. versionchanged:: 2.0
             This function no-longer raises ``InvalidArgument`` instead raising


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This fixes incorrect wording in the docs for `Message.edit` and `PartialMessage.edit`; specifically, "role" was changed to "message" in the versionchanged directive specifying that the edited message is now returned.

I have checked all the other edit methods with this change, and no other errors were found.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
