### PR TITLE
Add the Command.callback and ContextMenu.callback properties

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -328,6 +328,10 @@ class Command(Generic[GroupT, P, T]):
         self.on_error: Optional[Error[GroupT]] = None
         self._params: Dict[str, CommandParameter] = _extract_parameters_from_callback(callback, callback.__globals__)
 
+    @property
+    def callback(self) -> CommandCallback[GroupT, P, T]:
+        return self._callback
+
     def _copy_with_binding(self, binding: GroupT) -> Command:
         cls = self.__class__
         copy = cls.__new__(cls)
@@ -562,6 +566,10 @@ class ContextMenu:
             raise ValueError(f'context menu callback implies a type of {actual_type} but {type} was passed.')
         self._param_name = param
         self._annotation = annotation
+
+    @property
+    def callback(self) -> ContextMenuCallback:
+        return self._callback
 
     @classmethod
     def _from_decorator(cls, callback: ContextMenuCallback, *, name: str = MISSING) -> ContextMenu:

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -303,8 +303,6 @@ class Command(Generic[GroupT, P, T]):
     ------------
     name: :class:`str`
         The name of the application command.
-    callback: :ref:`coroutine <coroutine>`
-        The coroutine that is executed when the command is called.
     description: :class:`str`
         The description of the application command. This shows up in the UI to describe
         the application command.
@@ -330,6 +328,7 @@ class Command(Generic[GroupT, P, T]):
 
     @property
     def callback(self) -> CommandCallback[GroupT, P, T]:
+        """:ref:`coroutine <coroutine>`: The coroutine that is executed when the command is called."""
         return self._callback
 
     def _copy_with_binding(self, binding: GroupT) -> Command:
@@ -545,8 +544,6 @@ class ContextMenu:
     ------------
     name: :class:`str`
         The name of the context menu.
-    callback: :ref:`coroutine <coroutine>`
-        The coroutine that is executed when the context menu is called.
     type: :class:`.AppCommandType`
         The type of context menu application command.
     """
@@ -569,6 +566,7 @@ class ContextMenu:
 
     @property
     def callback(self) -> ContextMenuCallback:
+        """:ref:`coroutine <coroutine>`: The coroutine that is executed when the context menu is called."""
         return self._callback
 
     @classmethod


### PR DESCRIPTION
## Summary

This PR adds the missing `callback` property for `Command` and `ContextMenu`.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
