### PR TITLE
Fixed AttributeError in PartialMessageable.trigger_typing

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2146,8 +2146,8 @@ class PartialMessageable(discord.abc.Messageable, Hashable):
         self.id: int = id
         self.type: Optional[ChannelType] = type
 
-    async def _get_channel(self) -> Object:
-        return self._channel
+    async def _get_channel(self) -> PartialMessageable:
+        return self
 
     def get_partial_message(self, message_id: int, /) -> PartialMessage:
         """Creates a :class:`PartialMessage` from the message ID.

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2142,7 +2142,6 @@ class PartialMessageable(discord.abc.Messageable, Hashable):
 
     def __init__(self, state: ConnectionState, id: int, type: Optional[ChannelType] = None):
         self._state: ConnectionState = state
-        self._channel: Object = Object(id=id)
         self.id: int = id
         self.type: Optional[ChannelType] = type
 


### PR DESCRIPTION
## Summary
The `PartialMessageable._get_channel` method returns a `discord.Object`, but `abc.Messageable.trigger_typing` tries to access the `_state` attribute of this object, causing an `AttributeError` to be raised.

Maybe making `PartialMessageable._get_channel` returns itself might help?

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
