### PR TITLE
Fix type of Bot.is_owner, again

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
     import importlib.machinery
 
     from discord.message import Message
-    from discord.abc import User
+    from discord.abc import Snowflake
     from ._types import (
         Check,
         CoroFunc,
@@ -334,7 +334,7 @@ class BotBase(GroupMixin):
         # type-checker doesn't distinguish between functions and methods
         return await discord.utils.async_all(f(ctx) for f in data)  # type: ignore
 
-    async def is_owner(self, user: User) -> bool:
+    async def is_owner(self, user: Snowflake) -> bool:
         """|coro|
 
         Checks if a :class:`~discord.User` or :class:`~discord.Member` is the owner of
@@ -349,7 +349,7 @@ class BotBase(GroupMixin):
 
         Parameters
         -----------
-        user: :class:`.abc.User`
+        user: :class:`.abc.Snowflake`
             The user to check for.
 
         Returns


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR re-fixes the type used in `commands.Bot.is_owner` as my previous PR (#7492) was not correct.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
