### PR TITLE
Typing issues with abc.User and commands.Bot.is_owner

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -155,7 +155,6 @@ class User(Snowflake, Protocol):
 
     name: str
     discriminator: str
-    avatar: Optional[Asset]
     bot: bool
 
     @property
@@ -167,6 +166,10 @@ class User(Snowflake, Protocol):
     def mention(self) -> str:
         """:class:`str`: Returns a string that allows you to mention the given user."""
         raise NotImplementedError
+
+    @property
+    def avatar(self) -> Optional[Asset]:
+        """Optional[:class:`~Asset`]: Returns an Asset that represents the user's avatar, if present."""
 
 
 @runtime_checkable

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -145,8 +145,6 @@ class User(Snowflake, Protocol):
         The user's username.
     discriminator: :class:`str`
         The user's discriminator.
-    avatar: :class:`~discord.Asset`
-        The avatar asset the user has.
     bot: :class:`bool`
         If the user is a bot account.
     """
@@ -169,7 +167,8 @@ class User(Snowflake, Protocol):
 
     @property
     def avatar(self) -> Optional[Asset]:
-        """Optional[:class:`~Asset`]: Returns an Asset that represents the user's avatar, if present."""
+        """Optional[:class:`~discord.Asset`]: Returns an Asset that represents the user's avatar, if present."""
+        raise NotImplementedError
 
 
 @runtime_checkable

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -155,7 +155,7 @@ class User(Snowflake, Protocol):
 
     name: str
     discriminator: str
-    avatar: Asset
+    avatar: Optional[Asset]
     bot: bool
 
     @property

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
     import importlib.machinery
 
     from discord.message import Message
-    from discord import abc
+    from discord.abc import User
     from ._types import (
         Check,
         CoroFunc,
@@ -334,7 +334,7 @@ class BotBase(GroupMixin):
         # type-checker doesn't distinguish between functions and methods
         return await discord.utils.async_all(f(ctx) for f in data)  # type: ignore
 
-    async def is_owner(self, user: abc.User) -> bool:
+    async def is_owner(self, user: User) -> bool:
         """|coro|
 
         Checks if a :class:`~discord.User` or :class:`~discord.Member` is the owner of
@@ -349,7 +349,7 @@ class BotBase(GroupMixin):
 
         Parameters
         -----------
-        user: :class:`.abc.Snowflake`
+        user: :class:`.abc.User`
             The user to check for.
 
         Returns

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
     import importlib.machinery
 
     from discord.message import Message
-    from discord.abc import User
+    from discord import abc
     from ._types import (
         Check,
         CoroFunc,
@@ -334,7 +334,7 @@ class BotBase(GroupMixin):
         # type-checker doesn't distinguish between functions and methods
         return await discord.utils.async_all(f(ctx) for f in data)  # type: ignore
 
-    async def is_owner(self, user: User) -> bool:
+    async def is_owner(self, user: abc.User) -> bool:
         """|coro|
 
         Checks if a :class:`~discord.User` or :class:`~discord.Member` is the owner of
@@ -349,7 +349,7 @@ class BotBase(GroupMixin):
 
         Parameters
         -----------
-        user: :class:`.abc.User`
+        user: :class:`.abc.Snowflake`
             The user to check for.
 
         Returns


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
3rd time lucky!

This PR fixes typing issues with abc.User and subsequently Bot.is_owner, to allow a stricter type that is correct.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
