### PR TITLE
Raise ClientException in Member#request_to_speak

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -40,6 +40,7 @@ from .user import BaseUser, User, _UserTag
 from .activity import create_activity, ActivityTypes
 from .permissions import Permissions
 from .enums import Status, try_enum
+from .errors import ClientException
 from .colour import Colour
 from .object import Object
 
@@ -869,13 +870,15 @@ class Member(discord.abc.Messageable, _UserTag):
 
         Raises
         -------
+        ClientException
+            You are not connected to a voice channel.
         Forbidden
             You do not have the proper permissions to the action requested.
         HTTPException
             The operation failed.
         """
         if self.voice is None or self.voice.channel is None:
-            raise RuntimeError('Cannot request to speak while not connected to a voice channel.')
+            raise ClientException('Cannot request to speak while not connected to a voice channel.')
 
         payload = {
             'channel_id': self.voice.channel.id,


### PR DESCRIPTION
## Summary
Raise ClientException in Member#request_to_speak. In 1.7.x this raised `AttributeError`. In 285069de0808215b6ff25847bbb6070036af8c30 this was changed to raise a `RuntimeError`, however this behavior is inconsistent with other methods.

Question: is this a breaking change?

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
