### PR TITLE
tests for regression of 19ad64a

### DIFF
--- a/tests/test_ext_tasks.py
+++ b/tests/test_ext_tasks.py
@@ -23,7 +23,7 @@ async def test_explicit_initial_runs_tomorrow_single():
         await asyncio.sleep(5 * 60)  # sleep for 5 minutes
 
     now = utils.utcnow()
-    
+
     has_run = False
 
     async def inner():

--- a/tests/test_ext_tasks.py
+++ b/tests/test_ext_tasks.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+"""
+
+Tests for discord.ext.tasks
+
+"""
+
+import asyncio
+import datetime
+
+import pytest
+
+from discord import utils
+from discord.ext import tasks
+
+
+@pytest.mark.asyncio
+async def test_explicit_initial_runs_tomorrow_single():
+    now = utils.utcnow()
+
+    if not ((0, 4) < (now.hour, now.minute) < (23, 59)):
+        await asyncio.sleep(5 * 60)  # sleep for 5 minutes
+
+    now = utils.utcnow()
+    
+    has_run = False
+
+    async def inner():
+        nonlocal has_run
+        has_run = True
+
+    # a loop that should have an initial run tomorrow
+    loop = tasks.loop(time=datetime.time(hour=now.hour, minute=now.minute - 1))(inner)
+
+    loop.start()
+    await asyncio.sleep(1)
+
+    try:
+        assert not has_run
+    finally:
+        loop.cancel()
+
+
+@pytest.mark.asyncio
+async def test_explicit_initial_runs_tomorrow_multi():
+    now = utils.utcnow()
+
+    if not ((0, 4) < (now.hour, now.minute) < (23, 59)):
+        await asyncio.sleep(5 * 60)  # sleep for 5 minutes
+
+    now = utils.utcnow()
+
+    # multiple times that are in the past for today
+    times = [
+        datetime.time(hour=now.hour, minute=now.minute - 1),
+        datetime.time(hour=now.hour, minute=now.minute - 2),
+        datetime.time(hour=now.hour, minute=now.minute - 3),
+    ]
+
+    has_run = False
+
+    async def inner():
+        nonlocal has_run
+        has_run = True
+
+    # a loop that should have an initial run tomorrow
+    loop = tasks.loop(time=times)(inner)
+
+    loop.start()
+    await asyncio.sleep(1)
+
+    try:
+        assert not has_run
+    finally:
+        loop.cancel()

--- a/tests/test_ext_tasks.py
+++ b/tests/test_ext_tasks.py
@@ -30,8 +30,10 @@ async def test_explicit_initial_runs_tomorrow_single():
         nonlocal has_run
         has_run = True
 
+    time = utils.utcnow() - datetime.timedelta(minutes=1)
+
     # a loop that should have an initial run tomorrow
-    loop = tasks.loop(time=datetime.time(hour=now.hour, minute=now.minute - 1))(inner)
+    loop = tasks.loop(time=datetime.time(hour=time.hour, minute=time.minute))(inner)
 
     loop.start()
     await asyncio.sleep(1)
@@ -52,11 +54,10 @@ async def test_explicit_initial_runs_tomorrow_multi():
     now = utils.utcnow()
 
     # multiple times that are in the past for today
-    times = [
-        datetime.time(hour=now.hour, minute=now.minute - 1),
-        datetime.time(hour=now.hour, minute=now.minute - 2),
-        datetime.time(hour=now.hour, minute=now.minute - 3),
-    ]
+    times = []
+    for _ in range(3):
+        now -= datetime.timedelta(minutes=1)
+        times.append(datetime.time(hour=now.hour, minute=now.minute))
 
     has_run = False
 


### PR DESCRIPTION
## Summary

Initial creation of test file for ext.tasks

- Tests for testing regression of 19ad64a in ext.tasks

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [N/A] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
