### PR TITLE
Fix archived threads not getting evicted from cache.

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -857,10 +857,13 @@ class ConnectionState:
         if thread is not None:
             old = copy.copy(thread)
             thread._update(data)
+            if thread.archived:
+                guild._remove_thread(thread)
             self.dispatch('thread_update', old, thread)
         else:
             thread = Thread(guild=guild, state=guild._state, data=data)
-            guild._add_thread(thread)
+            if not thread.archived:
+                guild._add_thread(thread)
             self.dispatch('thread_join', thread)
 
     def parse_thread_delete(self, data: gw.ThreadDeleteEvent) -> None:


### PR DESCRIPTION
## Summary

Fixes #7541

This PR fixes threads not getting removed from cache after they have been archived.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
