### PR TITLE
remove modal on stop

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -503,13 +503,13 @@ class ViewStore:
             del self._views[k]
 
     def add_view(self, view: View, message_id: Optional[int] = None):
+        view._start_listening_from_store(self)
         if view.__discord_ui_modal__:
             self._modals[view.custom_id] = view  # type: ignore
             return
 
         self.__verify_integrity()
 
-        view._start_listening_from_store(self)
         for item in view.children:
             if item.is_dispatchable():
                 self._views[(item.type.value, message_id, item.custom_id)] = (view, item)  # type: ignore


### PR DESCRIPTION
## Summary
Found an issue where `Modal.stop` method does not remove modal from the `ViewStore._modals` because it does not assign the `__cancel_callback` attribute, This makes callback still triggers after the timeout has reached.

So I move the `view._start_listening_from_store(self)` above the modal if statement instead.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
