### PR TITLE
[docs] fix typos

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3215,7 +3215,7 @@ AuditLogDiff
 
     .. attribute:: invitable
 
-        Whetheer non-moderators can add users to this private thread.
+        Whether non-moderators can add users to this private thread.
 
         :type: :class:`bool`
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -106,7 +106,7 @@ A quick example to showcase how events work:
             print(f'Logged on as {self.user}!')
 
         async def on_message(self, message):
-            print(f'Message from {messsage.author}: {message.content}')
+            print(f'Message from {message.author}: {message.content}')
 
     client = MyClient()
     client.run('my token goes here')

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -1029,7 +1029,7 @@ The following have been removed:
 
     - Consider using the newer documented :func:`on_socket_event_type` event instead.
 
-Miscellanous Changes
+Miscellaneous Changes
 ----------------------
 
 The following changes have been made:


### PR DESCRIPTION
## Summary
Fix typos in docs. I found two more typos (in an internal function's docstring and in other file), but I did not fix them here.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
