### PR TITLE
Add missing fields to (Partial)AppInfo

### DIFF
--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -108,6 +108,8 @@ class AppInfo:
         The application's privacy policy URL, if set.
 
         .. versionadded:: 2.0
+    custom_install_url: Optional[:class:`str`]
+        The application's custom install URL, if set.
     """
 
     __slots__ = (
@@ -129,6 +131,7 @@ class AppInfo:
         '_flags',
         'terms_of_service_url',
         'privacy_policy_url',
+        'custom_install_url',
     )
 
     def __init__(self, state: ConnectionState, data: AppInfoPayload):
@@ -157,6 +160,7 @@ class AppInfo:
         self._cover_image: Optional[str] = data.get('cover_image')
         self.terms_of_service_url: Optional[str] = data.get('terms_of_service_url')
         self.privacy_policy_url: Optional[str] = data.get('privacy_policy_url')
+        self.custom_install_url: Optional[str] = data.get('custom_install_url')
 
     def __repr__(self) -> str:
         return (
@@ -222,6 +226,8 @@ class PartialAppInfo:
         The application's terms of service URL, if set.
     privacy_policy_url: Optional[:class:`str`]
         The application's privacy policy URL, if set.
+    custom_install_url: Optional[:class:`str`]
+        The application's custom install URL, if set.
     """
 
     __slots__ = (
@@ -233,6 +239,7 @@ class PartialAppInfo:
         'verify_key',
         'terms_of_service_url',
         'privacy_policy_url',
+        'custom_install_url',
         '_icon',
         '_flags',
     )
@@ -248,6 +255,7 @@ class PartialAppInfo:
         self.verify_key: str = data['verify_key']
         self.terms_of_service_url: Optional[str] = data.get('terms_of_service_url')
         self.privacy_policy_url: Optional[str] = data.get('privacy_policy_url')
+        self.custom_install_url: Optional[str] = data.get('custom_install_url')
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} id={self.id} name={self.name!r} description={self.description!r}>'

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -108,10 +108,6 @@ class AppInfo:
         The application's privacy policy URL, if set.
 
         .. versionadded:: 2.0
-    custom_install_url: Optional[:class:`str`]
-        The application's custom install URL, if set.
-
-        .. versionadded:: 2.0
     category_ids: Optional[List[:class:`int`]]
         The application's categories in the App Directory, if any.
 

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -112,6 +112,18 @@ class AppInfo:
         The application's custom install URL, if set.
 
         .. versionadded:: 2.0
+    category_ids: Optional[List[:class:`int`]]
+        The application's categories in the App Directory, if any.
+
+        .. versionadded:: 2.0
+    custom_install_url: Optional[:class:`str`]
+        The application's custom install URL, if set.
+
+        .. versionadded:: 2.0
+    tags: Optional[List[:class:`str`]]
+        The application's tags for the App Directory, if any.
+
+        .. versionadded:: 2.0
     """
 
     __slots__ = (
@@ -134,6 +146,8 @@ class AppInfo:
         'terms_of_service_url',
         'privacy_policy_url',
         'custom_install_url',
+        'tags',
+        'category_ids',
     )
 
     def __init__(self, state: ConnectionState, data: AppInfoPayload):
@@ -163,6 +177,8 @@ class AppInfo:
         self.terms_of_service_url: Optional[str] = data.get('terms_of_service_url')
         self.privacy_policy_url: Optional[str] = data.get('privacy_policy_url')
         self.custom_install_url: Optional[str] = data.get('custom_install_url')
+        self.tags: List[str] = data.get("tags", [])
+        self.category_ids: List[int] = data.get("category_ids", [])
 
     def __repr__(self) -> str:
         return (
@@ -228,8 +244,12 @@ class PartialAppInfo:
         The application's terms of service URL, if set.
     privacy_policy_url: Optional[:class:`str`]
         The application's privacy policy URL, if set.
+    category_ids: Optional[List[:class:`str`]]
+        The application's categories in the App Directory, if any.
     custom_install_url: Optional[:class:`str`]
         The application's custom install URL, if set.
+    tags: Optional[List[:class:`str`]]
+        The application's tags for the App Directory, if any.
     """
 
     __slots__ = (
@@ -242,6 +262,8 @@ class PartialAppInfo:
         'terms_of_service_url',
         'privacy_policy_url',
         'custom_install_url',
+        'tags',
+        'category_ids',
         '_icon',
         '_flags',
     )
@@ -258,6 +280,8 @@ class PartialAppInfo:
         self.terms_of_service_url: Optional[str] = data.get('terms_of_service_url')
         self.privacy_policy_url: Optional[str] = data.get('privacy_policy_url')
         self.custom_install_url: Optional[str] = data.get('custom_install_url')
+        self.tags: List[str] = data.get("tags", [])
+        self.category_ids: List[int] = data.get("category_ids", [])
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} id={self.id} name={self.name!r} description={self.description!r}>'

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -110,6 +110,8 @@ class AppInfo:
         .. versionadded:: 2.0
     custom_install_url: Optional[:class:`str`]
         The application's custom install URL, if set.
+
+        .. versionadded:: 2.0
     """
 
     __slots__ = (

--- a/discord/types/appinfo.py
+++ b/discord/types/appinfo.py
@@ -50,6 +50,8 @@ class _AppInfoOptional(TypedDict, total=False):
     hook: bool
     max_participants: int
     custom_install_url: str
+    tags: List[str]
+    category_ids: List[int]
 
 
 class AppInfo(BaseAppInfo, _AppInfoOptional):
@@ -68,6 +70,8 @@ class _PartialAppInfoOptional(TypedDict, total=False):
     max_participants: int
     flags: int
     custom_install_url: str
+    tags: List[str]
+    category_ids: List[int]
 
 
 class PartialAppInfo(_PartialAppInfoOptional, BaseAppInfo):

--- a/discord/types/appinfo.py
+++ b/discord/types/appinfo.py
@@ -49,6 +49,7 @@ class _AppInfoOptional(TypedDict, total=False):
     privacy_policy_url: str
     hook: bool
     max_participants: int
+    custom_install_url: str
 
 
 class AppInfo(BaseAppInfo, _AppInfoOptional):
@@ -66,6 +67,7 @@ class _PartialAppInfoOptional(TypedDict, total=False):
     privacy_policy_url: str
     max_participants: int
     flags: int
+    custom_install_url: str
 
 
 class PartialAppInfo(_PartialAppInfoOptional, BaseAppInfo):


### PR DESCRIPTION
## Summary

This PR adds the following fields to `(Partial)AppInfo`: `custom_install_url, tags, category_ids`. Found these keys in the payload of `https://discord.com/api/v10/applications/:id/rpc`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
