### PR TITLE
Add Client.fetch_application

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -70,7 +70,7 @@ from .utils import MISSING, time_snowflake
 from .object import Object
 from .backoff import ExponentialBackoff
 from .webhook import Webhook
-from .appinfo import AppInfo
+from .appinfo import AppInfo, PartialAppInfo
 from .ui.view import View
 from .stage_instance import StageInstance
 from .threads import Thread
@@ -1541,6 +1541,31 @@ class Client:
         await self.http.delete_invite(resolved.code)
 
     # Miscellaneous stuff
+
+    async def fetch_application(self, application_id: int, /) -> PartialAppInfo:
+        """|coro|
+
+        Retrieves a :class:`.PartialAppInfo` from an application ID.
+
+        Parameters
+        -----------
+        application_id: :class:`int`
+            The application ID to retrieve information from.
+
+        Raises
+        -------
+        NotFound
+            An application with this ID does not exist.
+        HTTPException
+            Retrieving the application failed.
+
+        Returns
+        --------
+        :class:`.PartialAppInfo`
+            The application information.
+        """
+        data = await self.http.get_application(application_id)
+        return PartialAppInfo(state=self._connection, data=data)
 
     async def fetch_widget(self, guild_id: int, /) -> Widget:
         """|coro|

--- a/discord/http.py
+++ b/discord/http.py
@@ -1978,6 +1978,9 @@ class HTTPClient:
         return self.request(r, json=payload)
 
     # Misc
+    
+    def get_application(self, application_id: Snowflake, /) -> Response[appinfo.PartialAppInfo]:
+        return self.request(Route("GET", "/applications/{application_id}/rpc", application_id=application_id))
 
     def application_info(self) -> Response[appinfo.AppInfo]:
         return self.request(Route('GET', '/oauth2/applications/@me'))

--- a/discord/http.py
+++ b/discord/http.py
@@ -1980,7 +1980,7 @@ class HTTPClient:
     # Misc
 
     def get_application(self, application_id: Snowflake, /) -> Response[appinfo.PartialAppInfo]:
-        return self.request(Route("GET", "/applications/{application_id}/rpc", application_id=application_id))
+        return self.request(Route('GET', '/applications/{application_id}/rpc', application_id=application_id))
 
     def application_info(self) -> Response[appinfo.AppInfo]:
         return self.request(Route('GET', '/oauth2/applications/@me'))

--- a/discord/http.py
+++ b/discord/http.py
@@ -1978,7 +1978,7 @@ class HTTPClient:
         return self.request(r, json=payload)
 
     # Misc
-    
+
     def get_application(self, application_id: Snowflake, /) -> Response[appinfo.PartialAppInfo]:
         return self.request(Route("GET", "/applications/{application_id}/rpc", application_id=application_id))
 


### PR DESCRIPTION
## Summary

This PR adds a `fetch_application()` method to `Client` and a matching `get_application()` in http.py. This method allows users to get the a `PartialAppInfo` object with an application id. Uses the following path: `/applications/:id/rpc`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
