### PR TITLE
Fix for `_Bot` Context generic in converters.

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from discord.threads import Thread
     from .bot import Bot, AutoShardedBot
 
-    _Bot = Union[Bot, AutoShardedBot, Any]
+    _Bot = TypeVar('_Bot', bound=Union[Bot, AutoShardedBot])
 
 
 __all__ = (

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from discord.threads import Thread
     from .bot import Bot, AutoShardedBot
 
-    _Bot = Union[Bot, AutoShardedBot]
+    _Bot = TypeVar('_Bot', bound=Union[Bot, AutoShardedBot])
 
 
 __all__ = (

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from discord.threads import Thread
     from .bot import Bot, AutoShardedBot
 
-    _Bot = TypeVar('_Bot', bound=Union[Bot, AutoShardedBot])
+    _Bot = Union[Bot, AutoShardedBot, Any]
 
 
 __all__ = (


### PR DESCRIPTION
## Summary
Changes `_Bot` in `converter.py` to use a TypeVar which allows for subclasses to properly typecheck when setting `Context`'s generic.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)