### PR TITLE
Remove outdated note

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -326,10 +326,6 @@ Quick example: ::
     embed.set_image(url="attachment://image.png")
     await channel.send(file=file, embed=embed)
 
-.. note ::
-
-    Due to a Discord limitation, filenames may not include underscores.
-
 Is there an event for audit log entries being created?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary
Underscores can be used in filenames for embed attachments.

```python
embed = discord.Embed().set_image(url="attachment://long_name.png")
file = discord.File(..., filename="long_name.png")
```
![image](https://user-images.githubusercontent.com/78228142/157369030-d7e82d88-3dff-42c4-ba22-9e25fd843762.png)

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
