### PR TITLE
fix errors in ScheduledEvent and add url property 

### DIFF
--- a/discord/scheduled_event.py
+++ b/discord/scheduled_event.py
@@ -132,7 +132,7 @@ class ScheduledEvent(Hashable):
         self.name: str = data['name']
         self.description: str = data.get('description', '')
         self.entity_type = try_enum(EntityType, data['entity_type'])
-        self.entity_id: Optional[int] = _get_as_snowflake(data['entity_id'])
+        self.entity_id: Optional[int] = _get_as_snowflake(data, 'entity_id')
         self.start_time: datetime = parse_time(data['scheduled_start_time'])
         self.privacy_level: PrivacyLevel = try_enum(PrivacyLevel, data['status'])
         self.status: EventStatus = try_enum(EventStatus, data['status'])

--- a/discord/scheduled_event.py
+++ b/discord/scheduled_event.py
@@ -430,14 +430,14 @@ class ScheduledEvent(Hashable):
             if end_time is MISSING or end_time is None:
                 raise TypeError('end_time must be set when entity_type is external')
 
-        if end_time is None:
+        if end_time is not MISSING:
+            if end_time is not None:
+                if end_time.tzinfo is None:
+                    raise ValueError(
+                        'end_time must be an aware datetime. Consider using discord.utils.utcnow() or datetime.datetime.now().astimezone() for local time.'
+                    )
+                end_time = end_time.isoformat()
             payload['scheduled_end_time'] = end_time
-        else:
-            if end_time.tzinfo is None:
-                raise ValueError(
-                    'end_time must be an aware datetime. Consider using discord.utils.utcnow() or datetime.datetime.now().astimezone() for local time.'
-                )
-            payload['scheduled_end_time'] = end_time.isoformat()
 
         if metadata:
             payload['entity_metadata'] = metadata

--- a/discord/scheduled_event.py
+++ b/discord/scheduled_event.py
@@ -321,7 +321,7 @@ class ScheduledEvent(Hashable):
 
             Required if the entity type is either :attr:`EntityType.voice` or
             :attr:`EntityType.stage_instance`.
-        start_time: Optional[:class:`datetime.datetime`]
+        start_time: :class:`datetime.datetime`
             The time that the scheduled event will start. This must be a timezone-aware
             datetime object. Consider using :func:`utils.utcnow`.
         end_time: Optional[:class:`datetime.datetime`]

--- a/discord/scheduled_event.py
+++ b/discord/scheduled_event.py
@@ -464,7 +464,7 @@ class ScheduledEvent(Hashable):
     ) -> AsyncIterator[User]:
         """|coro|
 
-        Retrieves all :class:`User` that are in this thread.
+        Retrieves all :class:`User` that are subscribed to this event.
 
         This requires :attr:`Intents.members` to get information about members
         other than yourself.

--- a/discord/scheduled_event.py
+++ b/discord/scheduled_event.py
@@ -83,8 +83,8 @@ class ScheduledEvent(Hashable):
         The description of the scheduled event.
     entity_type: :class:`EntityType`
         The type of entity this event is for.
-    entity_id: :class:`int`
-        The ID of the entity this event is for.
+    entity_id: Optional[:class:`int`]
+        The ID of the entity this event is for if available.
     start_time: :class:`datetime.datetime`
         The time that the scheduled event will start in UTC.
     end_time: :class:`datetime.datetime`
@@ -132,7 +132,7 @@ class ScheduledEvent(Hashable):
         self.name: str = data['name']
         self.description: str = data.get('description', '')
         self.entity_type = try_enum(EntityType, data['entity_type'])
-        self.entity_id: int = int(data['id'])
+        self.entity_id: Optional[int] = _get_as_snowflake(data['entity_id'])
         self.start_time: datetime = parse_time(data['scheduled_start_time'])
         self.privacy_level: PrivacyLevel = try_enum(PrivacyLevel, data['status'])
         self.status: EventStatus = try_enum(EventStatus, data['status'])
@@ -173,6 +173,11 @@ class ScheduledEvent(Hashable):
     def channel(self) -> Optional[Union[VoiceChannel, StageChannel]]:
         """Optional[Union[:class:`VoiceChannel`, :class:`StageChannel`]]: The channel this scheduled event is in."""
         return self.guild.get_channel(self.channel_id)  # type: ignore
+
+    @property
+    def url(self):
+        """:class:`str`: The url for the scheduled event."""
+        return f'https://discord.com/events/{self.guild_id}/{self.id}'
 
     async def start(self, *, reason: Optional[str] = None) -> ScheduledEvent:
         """|coro|


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds `ScheduledEvent.url` since they behave like invite urls where even a partial url creates a special embed.

add ability to remove cover_image with `image=None`.
add ability to remove end_time with `end_time=None` for voice/stage entity types.
fix `event.channel` attribute error by adding `event.guild` property
fix `data['entity_metadata']` key and attribute error for `location` if `entity_metadata` was missing.
fix `entity_id` using `data['id']` instead of `data['entity_id']`.
fix `invalid channel type for event` error when switching from entity type voice/stage to external by setting channel to `None`.
fix events having both location and channel attributes by setting location to `None` when changing `entity_type` from external to voice/stage.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
