### PR TITLE
Make `Guild.member_count` Optional

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -972,6 +972,10 @@ class Guild(Hashable):
             Due to a Discord limitation, in order for this attribute to remain up-to-date and
             accurate, it requires :attr:`Intents.members` to be specified.
 
+        .. versionchanged:: 2.0
+
+            Now returns an ``Optional[int]``.
+
         """
         return self._member_count
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -512,7 +512,7 @@ class Guild(Hashable):
                 self._add_member(member)
 
         self._sync(guild)
-        self._large: Optional[bool] = None if member_count is None else self._member_count >= 250
+        self._large: Optional[bool] = None if self._member_count is None else self._member_count >= 250
 
         self.owner_id: Optional[int] = utils._get_as_snowflake(guild, 'owner_id')
         self.afk_channel: Optional[VocalGuildChannel] = self.get_channel(utils._get_as_snowflake(guild, 'afk_channel_id'))  # type: ignore

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -975,7 +975,6 @@ class Guild(Hashable):
         .. versionchanged:: 2.0
 
             Now returns an ``Optional[int]``.
-
         """
         return self._member_count
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -450,9 +450,7 @@ class Guild(Hashable):
     def _from_data(self, guild: GuildPayload) -> None:
         # according to Stan, this is always available even if the guild is unavailable
         # I don't have this guarantee when someone updates the guild.
-        member_count = guild.get('member_count', None)
-        if member_count is not None:
-            self._member_count: int = member_count
+        self._member_count: Optional[int] = guild.get('member_count', None)
 
         self.name: str = guild.get('name', '')
         self.verification_level: VerificationLevel = try_enum(VerificationLevel, guild.get('verification_level'))
@@ -966,8 +964,8 @@ class Guild(Hashable):
         return Asset._from_guild_image(self._state, self.id, self._discovery_splash, path='discovery-splashes')
 
     @property
-    def member_count(self) -> int:
-        """:class:`int`: Returns the true member count regardless of it being loaded fully or not.
+    def member_count(self) -> Optional[int]:
+        """Optional[:class:`int`]: Returns the member count if available.
 
         .. warning::
 

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -791,7 +791,7 @@ The return type of the following methods has been changed to an :term:`asynchron
 - :meth:`Guild.fetch_members`
 - :meth:`Reaction.users`
 
-The ``NoMoreItems`` exception was removed as calling :func:`anext` or :meth:`~object.__anext__` on an 
+The ``NoMoreItems`` exception was removed as calling :func:`anext` or :meth:`~object.__anext__` on an
 :term:`asynchronous iterator` will now raise :class:`StopAsyncIteration`.
 
 Removal of ``InvalidArgument`` Exception
@@ -918,7 +918,7 @@ Allowed types for the following parameters have been changed:
 - ``rtc_region`` in :meth:`Guild.create_voice_channel` is now of type Optional[:class:`str`].
 - ``rtc_region`` in :meth:`StageChannel.edit` is now of type Optional[:class:`str`].
 - ``rtc_region`` in :meth:`VoiceChannel.edit` is now of type Optional[:class:`str`].
-- ``preferred_locale`` in :meth:`Guild.edit` is now of type :class:`Locale`. 
+- ``preferred_locale`` in :meth:`Guild.edit` is now of type :class:`Locale`.
 
 Attribute Type Changes
 ------------------------
@@ -929,6 +929,7 @@ The following changes have been made:
 - :meth:`Guild.vanity_invite` may now be ``None``. This has been done to fix an issue with the method returning a broken :class:`Invite` object.
 - :attr:`Guild.shard_id` is now ``0`` instead of ``None`` if :class:`AutoShardedClient` is not used.
 - :attr:`Guild.mfa_level` is now of type :class:`MFALevel`.
+- :attr:`Guild.member_count` is now of type Optional[:class:`int`].
 - :attr:`AuditLogDiff.mfa_level` is now of type :class:`MFALevel`.
 - :attr:`AuditLogDiff.rtc_region` is now of type :class:`str`.
 - :attr:`StageChannel.rtc_region` is now of type :class:`str`.
@@ -1171,7 +1172,7 @@ The following attributes have been removed:
     - Use :attr:`ext.commands.CommandOnCooldown.type` instead.
 
 - ``clean_prefix`` from the :class:`~ext.commands.HelpCommand`
-    
+
     - Use :attr:`ext.commands.Context.clean_prefix` instead.
 
 Miscellanous Changes


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
According to multiple reports, this key is not always present in a guild payload. Currently the library only sets this attribute if it is not `None` resulting in a rare error during startup or when retrieving guilds.
Potentially a fix for #6652?

I have made this attribute and property `Optional` as a result, to avoid an `AttributeError`.

Sadly I cannot test this, due to potentially requiring an "unavailable" guild.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->


- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
