### PR TITLE
Fix missing User import in reaction.py

### DIFF
--- a/discord/reaction.py
+++ b/discord/reaction.py
@@ -25,6 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 from typing import Any, TYPE_CHECKING, AsyncIterator, Union, Optional
 
+from .user import User
 from .object import Object
 
 # fmt: off
@@ -34,7 +35,6 @@ __all__ = (
 # fmt: on
 
 if TYPE_CHECKING:
-    from .user import User
     from .member import Member
     from .types.message import Reaction as ReactionPayload
     from .message import Message


### PR DESCRIPTION
## Summary

If `TYPE_CHECKING` is not on, `User` will be undefined in <https://github.com/Rapptz/discord.py/blob/master/discord/reaction.py#L243> and <https://github.com/Rapptz/discord.py/blob/master/discord/reaction.py#L251>. Always importing `User` fixes this.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
