### PR TITLE
Fix `on_scheduled_event_(user_)x` args

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -1317,7 +1317,7 @@ class ConnectionState:
         if guild is not None:
             scheduled_event = ScheduledEvent(state=self, data=data)
             guild._scheduled_events[scheduled_event.id] = scheduled_event
-            self.dispatch('scheduled_event_create', guild, scheduled_event)
+            self.dispatch('scheduled_event_create', scheduled_event)
         else:
             _log.debug('SCHEDULED_EVENT_CREATE referencing unknown guild ID: %s. Discarding.', data['guild_id'])
 
@@ -1328,7 +1328,7 @@ class ConnectionState:
             if scheduled_event is not None:
                 old_scheduled_event = copy.copy(scheduled_event)
                 scheduled_event._update(data)
-                self.dispatch('scheduled_event_update', guild, old_scheduled_event, scheduled_event)
+                self.dispatch('scheduled_event_update', old_scheduled_event, scheduled_event)
             else:
                 _log.debug('SCHEDULED_EVENT_UPDATE referencing unknown scheduled event ID: %s. Discarding.', data['id'])
         else:
@@ -1342,7 +1342,7 @@ class ConnectionState:
             except KeyError:
                 pass
             else:
-                self.dispatch('scheduled_event_delete', guild, scheduled_event)
+                self.dispatch('scheduled_event_delete', scheduled_event)
         else:
             _log.debug('SCHEDULED_EVENT_DELETE referencing unknown guild ID: %s. Discarding.', data['guild_id'])
 

--- a/discord/state.py
+++ b/discord/state.py
@@ -1354,10 +1354,9 @@ class ConnectionState:
                 user = self.get_user(int(data['user_id']))
                 if user is not None:
                     scheduled_event._add_user(user)
-                    self.dispatch('scheduled_event_user_add', guild, scheduled_event, user)
+                    self.dispatch('scheduled_event_user_add', scheduled_event, user)
                 else:
                     _log.debug('SCHEDULED_EVENT_USER_ADD referencing unknown user ID: %s. Discarding.', data['user_id'])
-                self.dispatch('scheduled_event_user_add', guild, scheduled_event, user)
             else:
                 _log.debug(
                     'SCHEDULED_EVENT_USER_ADD referencing unknown scheduled event ID: %s. Discarding.',
@@ -1377,7 +1376,6 @@ class ConnectionState:
                     self.dispatch('scheduled_event_user_remove', scheduled_event, user)
                 else:
                     _log.debug('SCHEDULED_EVENT_USER_REMOVE referencing unknown user ID: %s. Discarding.', data['user_id'])
-                self.dispatch('scheduled_event_user_remove', scheduled_event, user)
             else:
                 _log.debug(
                     'SCHEDULED_EVENT_USER_REMOVE referencing unknown scheduled event ID: %s. Discarding.',


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fix `on_scheduled_event_x`/`on_scheduled_event_user_x` events having guild in the args to match docs. Guild/id can be accessed with `event.guild`/`event.guild_id`
Fix `on_scheduled_event_user_x` dispatching `None` user
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
