### PR TITLE
Also check the global scope when dispatching commands

### DIFF
--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -672,7 +672,7 @@ class CommandTree(Generic[ClientT]):
     async def _call_context_menu(self, interaction: Interaction, data: ApplicationCommandInteractionData, type: int):
         name = data['name']
         guild_id = interaction.guild_id
-        ctx_menu = self._context_menus.get((name, guild_id, type))
+        ctx_menu = self._context_menus.get((name, guild_id, type)) or self._context_menus.get((name, None, type))
         if ctx_menu is None:
             raise CommandNotFound(name, [], AppCommandType(type))
 


### PR DESCRIPTION
## Summary

This PR fixes the `discord.app_commands.errors.CommandNotFound: Application command 'Whatever' not found` that is raised when trying to dispatch global application commands in a guild context.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
