### PR TITLE
Catch TypeError instead of AttributeError

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -973,20 +973,16 @@ class ConnectionState:
         if self.member_cache_flags.joined:
             guild._add_member(member)
 
-        try:
+        if guild._member_count is not None:
             guild._member_count += 1
-        except TypeError:
-            pass
 
         self.dispatch('member_join', member)
 
     def parse_guild_member_remove(self, data: gw.GuildMemberRemoveEvent) -> None:
         guild = self._get_guild(int(data['guild_id']))
         if guild is not None:
-            try:
+            if guild._member_count is not None:
                 guild._member_count -= 1
-            except TypeError:
-                pass
 
             user_id = int(data['user']['id'])
             member = guild.get_member(user_id)

--- a/discord/state.py
+++ b/discord/state.py
@@ -975,7 +975,7 @@ class ConnectionState:
 
         try:
             guild._member_count += 1
-        except AttributeError:
+        except TypeError:
             pass
 
         self.dispatch('member_join', member)
@@ -985,7 +985,7 @@ class ConnectionState:
         if guild is not None:
             try:
                 guild._member_count -= 1
-            except AttributeError:
+            except TypeError:
                 pass
 
             user_id = int(data['user']['id'])


### PR DESCRIPTION
In the past, the attribute is not set if the guild is unavailable but now `Guild._member_count` is `Optional[int]` 

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
