### PR TITLE
Add `ConnectionState.message_cache_filter`

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -218,8 +218,10 @@ class Client:
     message_cache_filter: Optional[Callable[[:class:`.Message`], :class:`bool`]]
         An optional function called on each message event to control whether to add it to cache.
 
-        This can be used for higher control over the message cache, in order to only cache messages with
-        certain attributes filled, for example. This does not bypass max_messages.
+        This gives greater control over the message cache. 
+        
+        .. note:: 
+            This does not bypass ``max_messages``.
 
         .. versionadded:: 2.0
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -215,6 +215,13 @@ class Client:
         To enable these events, this must be set to ``True``. Defaults to ``False``.
 
         .. versionadded:: 2.0
+    message_cache_filter: Optional[Callable[[:class:`.Message`], :class:`bool`]]
+        Am optional function called on each message event to control whether to add it to cache or discard it.
+
+        This can be used for higher control over the message cache, in order to only cache messages with
+        certain attributes filled, for example. This does not bypass max_messages.
+
+        .. versionadded:: 2.0
 
     Attributes
     -----------

--- a/discord/client.py
+++ b/discord/client.py
@@ -216,7 +216,7 @@ class Client:
 
         .. versionadded:: 2.0
     message_cache_filter: Optional[Callable[[:class:`.Message`], :class:`bool`]]
-        Am optional function called on each message event to control whether to add it to cache or discard it.
+        An optional function called on each message event to control whether to add it to cache.
 
         This can be used for higher control over the message cache, in order to only cache messages with
         certain attributes filled, for example. This does not bypass max_messages.

--- a/discord/client.py
+++ b/discord/client.py
@@ -218,9 +218,9 @@ class Client:
     message_cache_filter: Optional[Callable[[:class:`.Message`], :class:`bool`]]
         An optional function called on each message event to control whether to add it to cache.
 
-        This gives greater control over the message cache. 
-        
-        .. note:: 
+        This gives greater control over the message cache.
+
+        .. note::
             This does not bypass ``max_messages``.
 
         .. versionadded:: 2.0

--- a/discord/state.py
+++ b/discord/state.py
@@ -236,6 +236,7 @@ class ConnectionState:
 
             cache_flags._verify_intents(intents)
 
+        self.message_cache_filter: Optional[Callable[[Message], bool]] = options.get('message_cache_filter')
         self.member_cache_flags: MemberCacheFlags = cache_flags
         self._activity: Optional[ActivityPayload] = activity
         self._status: Optional[str] = status
@@ -585,7 +586,7 @@ class ConnectionState:
         # channel would be the correct type here
         message = Message(channel=channel, data=data, state=self)  # type: ignore
         self.dispatch('message', message)
-        if self._messages is not None:
+        if self._messages is not None and (self.message_cache_filter is None or self.message_cache_filter(message)):
             self._messages.append(message)
         # we ensure that the channel is either a TextChannel or Thread
         if channel and channel.__class__ in (TextChannel, Thread):


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This closes #7620, with a basic predicate function. This is one option which I believe allows the most control, other than a `MessageCacheFlags` or similar which wouldn't be able to account for all of a user's intentions.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
