### PR TITLE
Fix state parameter in Interaction.edit_original_message

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -376,7 +376,8 @@ class Interaction:
         )
 
         # The message channel types should always match
-        message = InteractionMessage(state=self._state, channel=self.channel, data=data)  # type: ignore
+        state = _InteractionMessageState(self, self._state)
+        message = InteractionMessage(state=state, channel=self.channel, data=data)  # type: ignore
         if view and not view.is_finished():
             self._state.store_view(view, message.id)
         return message


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Edited `Interaction.edit_original_message` so that it passes a `_InteractionMessageState` to the `InteractionMessage`, instead of `ConnectionState`. This is how it's done in `Interaction.original_message`.

This fixes a bug causing messages returned by `Interaction.edit_original_message` not being editable:
```
Traceback (most recent call last):
  File "/home/x/.local/lib/python3.9/site-packages/discord/ext/tasks/__init__.py", line 175, in _loop
    await self.coro(*args, **kwargs)
  File "/irrelevant/file/path", line 106, in update
    await msg.edit(embed=e)
  File "/home/x/.local/lib/python3.9/site-packages/discord/interactions.py", line 867, in edit
    return await self._state._interaction.edit_original_message(
AttributeError: 'ConnectionState' object has no attribute '_interaction'
```
Code to reproduce bug:
```py
# in an interaction callback function
await interaction.response.send_message("this")
msg = await interaction.edit_original_message(content="will")
await msg.edit(content="raise")
```
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
