### PR TITLE
Document `NotFound` for `Interaction` original_message methods

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -255,9 +255,10 @@ class Interaction:
 
         Fetches the original interaction response message associated with the interaction.
 
-        If the interaction response was :meth:`InteractionResponse.send_message` then this would
-        return the message that was sent using that response. Otherwise, this would return
-        the message that triggered the interaction.
+        If the interaction response was a newly created message (i.e. through :meth:`InteractionResponse.send_message`
+        or :meth:`InteractionResponse.defer`, where `thinking` is `True`) then this returns the message that was sent
+        using that response. Otherwise, this returns the message that triggered the interaction (i.e.
+        through a component).
 
         Repeated calls to this will return a cached value.
 
@@ -267,6 +268,8 @@ class Interaction:
             Fetching the original response message failed.
         ClientException
             The channel for the message could not be resolved.
+        NotFound
+            The interaction response message does not exist.
 
         Returns
         --------
@@ -342,6 +345,8 @@ class Interaction:
         -------
         HTTPException
             Editing the message failed.
+        NotFound
+            The interaction response message does not exist.
         Forbidden
             Edited a message that is not yours.
         TypeError
@@ -393,6 +398,8 @@ class Interaction:
         -------
         HTTPException
             Deleting the message failed.
+        NotFound
+            The interaction response message does not exist or has already been deleted.
         Forbidden
             Deleted a message that is not yours.
         """

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -256,7 +256,7 @@ class Interaction:
         Fetches the original interaction response message associated with the interaction.
 
         If the interaction response was a newly created message (i.e. through :meth:`InteractionResponse.send_message`
-        or :meth:`InteractionResponse.defer`, where `thinking` is `True`) then this returns the message that was sent
+        or :meth:`InteractionResponse.defer`, where ``thinking`` is ``True``) then this returns the message that was sent
         using that response. Otherwise, this returns the message that triggered the interaction (i.e.
         through a component).
 


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? Does it fix any issues? -->
Resolves #7660 
* Documents possible `NotFound` exception for `Interaction.original_message`, `Interaction.edit_original message`, and `Interaction.delete_original_message`. The exception will occur when there is no associated response message (i.e. the interaction response has not been sent) or, in the case of the last method, the associated message has already been deleted.
* Minor documentation rewording for `Interaction.original_message` to improve clarity.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
