### PR TITLE
Check view is not None

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1508,7 +1508,7 @@ class Webhook(BaseWebhook):
         if wait:
             msg = self._create_message(data)
 
-        if view is not MISSING and not view.is_finished():
+        if view is not MISSING and view is not None and not view.is_finished():
             message_id = None if msg is None else msg.id
             self._state.store_view(view, message_id)
 


### PR DESCRIPTION
Same rationale as https://github.com/Rapptz/discord.py/pull/7039

Passing view=None into webhook.send raises an `AttributeError`.

## Summary
This fixes a bug where passing view=None to webhook.send caused an AttributeError:


```
  File "discord\webhook\async_.py", line 1511, in send
    if view is not MISSING and not view.is_finished():
AttributeError: 'NoneType' object has no attribute 'is_finished'
```


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
