### PR TITLE
Add a note to users that they must have the message content intent

### DIFF
--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -11,6 +11,8 @@ how you can arbitrarily nest groups and commands to have a rich sub-command syst
 Commands are defined by attaching it to a regular Python function. The command is then invoked by the user using a similar
 signature to the Python function.
 
+Note that you must have access to the ``message_content`` intent for the commands extension to function.
+
 For example, in the given command definition:
 
 .. code-block:: python3

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -11,7 +11,12 @@ how you can arbitrarily nest groups and commands to have a rich sub-command syst
 Commands are defined by attaching it to a regular Python function. The command is then invoked by the user using a similar
 signature to the Python function.
 
-Note that you must have access to the ``message_content`` intent for the commands extension to function.
+.. warning::
+
+    You must have access to the :attr:`~discord.Intents.message_content` intent for the commands extension
+    to function. This must be set both in the developer portal and within your code.
+
+    Failure to do this will result in your bot not responding to any of your commands.
 
 For example, in the given command definition:
 


### PR DESCRIPTION
## Summary

This PR adds a note within the documentation that they must have access to the message content intent for the commands extension to function.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
