### PR TITLE
add `discord.Message.interaction`

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -640,6 +640,8 @@ class Message(Hashable):
         .. versionadded:: 2.0
     guild: Optional[:class:`Guild`]
         The guild that the message belongs to, if applicable.
+    interaction: Optional[:class:`dict`]
+        The interaction associated with this message.
     """
 
     __slots__ = (
@@ -673,6 +675,7 @@ class Message(Hashable):
         'stickers',
         'components',
         'guild',
+        'interaction',
     )
 
     if TYPE_CHECKING:
@@ -710,6 +713,7 @@ class Message(Hashable):
         self.nonce: Optional[Union[int, str]] = data.get('nonce')
         self.stickers: List[StickerItem] = [StickerItem(data=d, state=state) for d in data.get('sticker_items', [])]
         self.components: List[Component] = [_component_factory(d) for d in data.get('components', [])]
+        self.interaction: Optional[dict] = data.get('interaction')
 
         try:
             # if the channel doesn't have a guild attribute, we handle that


### PR DESCRIPTION
## Summary
discord.Messageにinteractionの生データを取得できるようにします。


Allows raw data of interactions to be retrieved in discord.Message.
Translated with www.DeepL.com/Translator (free version)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
