### PR TITLE
Fix Guild.audit_logs order being reversed without oldest_first and after

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3282,7 +3282,7 @@ class Guild(Hashable):
             after = Object(id=utils.time_snowflake(after, high=True))
 
         if oldest_first is MISSING:
-            reverse = after is not None
+            reverse = after is not MISSING
         else:
             reverse = oldest_first
 


### PR DESCRIPTION
## Summary

Fixes `audit_logs()` returning older entries first without having set `oldest_first` or `after`, which contradicts the documentation.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
