### PR TITLE
Rework help command to avoid a deepcopy on invoke

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -127,12 +127,14 @@ def unwrap_function(function: Callable[..., Any]) -> Callable[..., Any]:
 def get_signature_parameters(
     function: Callable[..., Any],
     globalns: Dict[str, Any],
+    *,
+    skip_parameters: Optional[int] = None,
 ) -> Dict[str, inspect.Parameter]:
     signature = inspect.signature(function)
     params = {}
     cache: Dict[str, Any] = {}
     eval_annotation = discord.utils.evaluate_annotation
-    required_params = discord.utils.is_inside_class(function) + 1
+    required_params = discord.utils.is_inside_class(function) + 1 if skip_parameters is None else skip_parameters
     if len(signature.parameters) < required_params:
         raise TypeError(f'Command signature requires at least {required_params - 1} parameter(s)')
 

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -127,14 +127,12 @@ def unwrap_function(function: Callable[..., Any]) -> Callable[..., Any]:
 def get_signature_parameters(
     function: Callable[..., Any],
     globalns: Dict[str, Any],
-    *,
-    skip_parameters: Optional[int] = None,
 ) -> Dict[str, inspect.Parameter]:
     signature = inspect.signature(function)
     params = {}
     cache: Dict[str, Any] = {}
     eval_annotation = discord.utils.evaluate_annotation
-    required_params = discord.utils.is_inside_class(function) + 1 if skip_parameters is None else skip_parameters
+    required_params = discord.utils.is_inside_class(function) + 1
     if len(signature.parameters) < required_params:
         raise TypeError(f'Command signature requires at least {required_params - 1} parameter(s)')
 

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -58,8 +58,6 @@ if TYPE_CHECKING:
     from .context import Context
     from .cog import Cog
 
-    from ._types import ContextT
-
 __all__ = (
     'Paginator',
     'HelpCommand',
@@ -73,8 +71,8 @@ if TYPE_CHECKING:
     P = ParamSpec('P')
 else:
     P = TypeVar('P')
-    ContextT = TypeVar('ContextT', bound='Context')
 
+ContextT = TypeVar('ContextT', bound='Context')
 FuncT = TypeVar('FuncT', bound=Callable[..., Any])
 
 MISSING: Any = discord.utils.MISSING

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -74,6 +74,7 @@ else:
 
 ContextT = TypeVar('ContextT', bound='Context')
 FuncT = TypeVar('FuncT', bound=Callable[..., Any])
+HelpCommandCommand = Command[Optional['Cog'], ... if TYPE_CHECKING else Any, Any]
 
 MISSING: Any = discord.utils.MISSING
 
@@ -221,8 +222,7 @@ def _not_overridden(f: FuncT) -> FuncT:
 
 _context: ContextVar[Optional[Context]] = ContextVar('context', default=None)
 
-
-class HelpCommand(Command[Optional['Cog'], ... if TYPE_CHECKING else Any, Any], Generic[ContextT]):
+class HelpCommand(HelpCommandCommand, Generic[ContextT]):
     r"""The base implementation for help command formatting.
 
     Attributes

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -222,6 +222,7 @@ def _not_overridden(f: FuncT) -> FuncT:
 
 _context: ContextVar[Optional[Context]] = ContextVar('context', default=None)
 
+
 class HelpCommand(HelpCommandCommand, Generic[ContextT]):
     r"""The base implementation for help command formatting.
 


### PR DESCRIPTION
## Summary

This PR is my first go-around at reworking help command to avoid a deepcopy.

I'm not 100% sure on the implementation here, but it's an option we can consider.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
