### PR TITLE
Add missing _ in the refresh method

### DIFF
--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -174,7 +174,7 @@ class Modal(View):
     def _refresh(self, components: Sequence[ModalSubmitComponentInteractionDataPayload]) -> None:
         for component in components:
             if component['type'] == 1:
-                self.refresh(component['components'])
+                self._refresh(component['components'])
             else:
                 item = find(lambda i: i.custom_id == component['custom_id'], self.children)  # type: ignore
                 if item is None:


### PR DESCRIPTION
Because of making this method private, this was rasing an error

## Summary

Fixes that modals would raise an error as soon as they were submitted because the _refresh method was failing. 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue. 
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
