### PR TITLE
Type BotBase.help_command as Optional

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -151,7 +151,7 @@ class BotBase(GroupMixin[None]):
     def __init__(
         self,
         command_prefix: PrefixType[BotT],
-        help_command: HelpCommand = _default,
+        help_command: Optional[HelpCommand] = _default,
         description: Optional[str] = None,
         **options: Any,
     ) -> None:


### PR DESCRIPTION
## Summary

`BotBase.__init__`'s `help_command` argument is incorrectly typed as `HelpCommand` and doesn't support passing `None`.

![image](https://user-images.githubusercontent.com/25802745/158224351-b7630fbc-2ff8-46f2-873a-f81dce13f329.png)

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
