### PR TITLE
Fix message converter not inferring channel when missing

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -344,7 +344,7 @@ class PartialMessageConverter(Converter[discord.PartialMessage]):
         if not match:
             raise MessageNotFound(argument)
         data = match.groupdict()
-        channel_id = discord.utils._get_as_snowflake(data, 'channel_id')
+        channel_id = discord.utils._get_as_snowflake(data, 'channel_id') or ctx.channel.id
         message_id = int(data['message_id'])
         guild_id = data.get('guild_id')
         if guild_id is None:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
The docstring for both the MessageConverter and the PartialMessageConverter imply that they will infer the channel id from the context channel if one isn't given. However, as of [this commit](https://github.com/Rapptz/discord.py/commit/1a4e73d59932cdbe7bf2c281f25e32529fc7ae1f), it no longer does this.

Instead, passing just a messageID to either of the message converters will only return a Message object if the given message ID is in the bot's cached messages.

I am not familiar with contributing to this project, so please let me know if I need to document this fix somewhere.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
