### PR TITLE
Add message content to doc examples and change wording of Context's attributes

### DIFF
--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -178,9 +178,9 @@ As seen earlier, every command must take at least a single parameter, called the
 This parameter gives you access to something called the "invocation context". Essentially all the information you need to
 know how the command was executed. It contains a lot of useful information:
 
-- :attr:`.Context.guild` to fetch the :class:`Guild` of the command, if any.
-- :attr:`.Context.message` to fetch the :class:`Message` of the command.
-- :attr:`.Context.author` to fetch the :class:`Member` or :class:`User` that called the command.
+- :attr:`.Context.guild` returns the :class:`Guild` of the command, if any.
+- :attr:`.Context.message` returns the :class:`Message` of the command.
+- :attr:`.Context.author` returns the :class:`Member` or :class:`User` that called the command.
 - :meth:`.Context.send` to send a message to the channel the command was used in.
 
 The context implements the :class:`abc.Messageable` interface, so anything you can do on a :class:`abc.Messageable` you

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -18,6 +18,7 @@ Let's make a bot that responds to a specific message and walk you through it.
 It looks something like this:
 
 .. code-block:: python3
+
     # This example requires the 'message_content' intent.
 
     import discord

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -18,10 +18,14 @@ Let's make a bot that responds to a specific message and walk you through it.
 It looks something like this:
 
 .. code-block:: python3
+    # This example requires the 'message_content' intent.
 
     import discord
 
-    client = discord.Client()
+    intents = discord.Intents.default()
+    intents.message_content = True
+
+    client = discord.Client(intents=intents)
 
     @client.event
     async def on_ready():


### PR DESCRIPTION
## Summary

This PR adds message content to the example in the doc that requires it.
It also changes the wording of Context's attributes from fetch to returns since fetch is usually used to describe API calls.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
