### PR TITLE
Keep before/after comments consistent with other before/after comments

### DIFF
--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -851,12 +851,11 @@ Therefore, ``Embed.Empty`` has been removed in favour of ``None``.
 
 .. code-block:: python
 
-    # Before
-
+    # before
     embed = discord.Embed(title='foo')
     embed.title = discord.Embed.Empty
 
-    # After
+    # after
     embed = discord.Embed(title='foo')
     embed.title = None
 
@@ -1186,7 +1185,7 @@ Quick example of an extension setup function:
     def setup(bot):
         bot.add_cog(MyCog(bot))
 
-    #after
+    # after
     async def setup(bot):
         await bot.add_cog(MyCog(bot))
 
@@ -1194,10 +1193,10 @@ Quick example of loading an extension:
 
 .. code:: python
 
-    #before
+    # before
     bot.load_extension('my_extension')
 
-    #after using setup_hook
+    # after using setup_hook
     class MyBot(commands.Bot):
         async def setup_hook(self):
             await self.load_extension('my_extension')


### PR DESCRIPTION
## Summary

This PR just keeps the before/after comments in the migration guide consistent with the others

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
