### PR TITLE
Crowdin Actions workflows

### DIFF
--- a/.github/workflows/crowdin_download.yml
+++ b/.github/workflows/crowdin_download.yml
@@ -1,0 +1,44 @@
+name: crowdin download
+
+on:
+  schedule:
+    - cron: '0 18 * * 1'
+  workflow_dispatch:
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    environment: Crowdin
+    name: download
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: master
+
+      - name: Install system dependencies
+        run: |
+          wget -qO - https://artifacts.crowdin.com/repo/GPG-KEY-crowdin | sudo apt-key add -
+          echo "deb https://artifacts.crowdin.com/repo/deb/ /" | sudo tee -a /etc/apt/sources.list.d/crowdin.list
+          sudo apt-get update -qq
+          sudo apt-get install -y crowdin3
+
+      - name: Download translations
+        shell: bash
+        run: |
+          cd docs
+          crowdin download --all
+        env:
+          CROWDIN_API_KEY: ${{ secrets.CROWDIN_API_KEY }}
+
+      - name: Create pull request
+        id: cpr_crowdin
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Crowdin translations download
+          title: "[Crowdin] Updated translation files"
+          body: |
+            Created by the [Crowdin download workflow](.github/workflows/crowdin_download.yml).
+          branch: "auto/crowdin"
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/crowdin_upload.yml
+++ b/.github/workflows/crowdin_upload.yml
@@ -1,0 +1,50 @@
+name: crowdin upload
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: crowdin-upload
+  cancel-in-progress: true
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    environment: Crowdin
+    name: upload
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up CPython 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: Install system dependencies
+        run: |
+          wget -qO - https://artifacts.crowdin.com/repo/GPG-KEY-crowdin | sudo apt-key add -
+          echo "deb https://artifacts.crowdin.com/repo/deb/ /" | sudo tee -a /etc/apt/sources.list.d/crowdin.list
+          sudo apt-get update -qq
+          sudo apt-get install -y crowdin3
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -e .[docs,speed,voice]
+
+      - name: Build gettext
+        run: |
+          cd docs
+          make gettext
+
+      - name: Upload sources
+        shell: bash
+        run: |
+          cd docs
+          crowdin upload
+        env:
+          CROWDIN_API_KEY: ${{ secrets.CROWDIN_API_KEY }}


### PR DESCRIPTION
## Summary

This adds a download and upload workflow for Crowdin translations.

Uploading is scheduled every commit on master, but is deployed to the 'Crowdin' environment, so the run is delayed by 30 minutes. If another commit hits master in that time, the old run will be cancelled in favor of the new run, so uploading actually occurs after 30 minutes of inactivity on master (but adjustable via Environment settings)

Downloading can be triggered by workflow dispatch, but otherwise, it gets triggered at 6pm UTC every Monday. This is because I figure weekends might be when a decent amount of translation work gets done, and 6pm UTC is usually after most Japanese people have gone to sleep, so this should result in a sync during relatively quiet Crowdin hours. The resulting download sync will be opened as a PR, updating the existing branch if it exists.

I also merged in the download sync I used for testing so we can have an up to date sync given it's already past the time this week.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
