### PR TITLE
Update Permissions.stage_moderator to include the proper permissions

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -231,12 +231,19 @@ class Permissions(BaseFlags):
 
     @classmethod
     def stage_moderator(cls) -> Self:
-        """A factory method that creates a :class:`Permissions` with all
-        "Stage Moderator" permissions from the official Discord UI set to ``True``.
+        """A factory method that creates a :class:`Permissions` with all permissions
+        for stage moderators set to ``True``. These permissions are currently:
+
+        - :attr:`manage_channels`
+        - :attr:`mute_members`
+        - :attr:`move_members`
 
         .. versionadded:: 1.7
+
+        .. versionchanged:: 2.0
+            Added :attr:`manage_channels` permission and removed :attr:`request_to_speak` permission.
         """
-        return cls(0b100000001010000000000000000000000)
+        return cls(0b1010000000000000000010000)
 
     @classmethod
     def advanced(cls) -> Self:

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -1156,6 +1156,8 @@ The following changes have been made:
 - :meth:`Message.edit` now merges object passed in ``allowed_mentions`` parameter with :attr:`Client.allowed_mentions`.
   If the parameter isn't provided, the defaults given by :attr:`Client.allowed_mentions` are used instead.
 
+- :meth:`Permissions.stage_moderator` now includes the :attr:`Permissions.manage_channels` permission and the :attr:`Permissions.request_to_speak` permission is no longer included.
+
 .. _migrating_2_0_commands:
 
 Command Extension Changes


### PR DESCRIPTION
## Summary

This PR removes the `request_to_speak` permission from `Permissions.stage_moderator` and adds the `manage_channels` permission to accurately represent the permissions required for stage moderators.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
