### PR TITLE
Add missing annotation for ThreadMember.id

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -818,6 +818,7 @@ class ThreadMember(Hashable):
         return f'<ThreadMember id={self.id} thread_id={self.thread_id} joined_at={self.joined_at!r}>'
 
     def _from_data(self, data: ThreadMemberPayload) -> None:
+        self.id: int
         try:
             self.id = int(data['user_id'])
         except KeyError:


### PR DESCRIPTION
## Summary

This PR adds a missing annotation for `ThreadMember.id`. Its type was previously inferred as `int | None` instead of `int`.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
