### PR TITLE
Add `utils.convert_timestamp`

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1150,7 +1150,7 @@ def format_dt(dt: datetime.datetime, /, style: Optional[TimestampStyle] = None) 
         return f'<t:{int(dt.timestamp())}>'
     return f'<t:{int(dt.timestamp())}:{style}>'
     
-def format_timestamp(timestamp: str, /, tz: datetime.timezone = MISSING) -> Optional[datetime.datetime]:
+def convert_timestamp(timestamp: str, /, tz: datetime.timezone = MISSING) -> Optional[datetime.datetime]:
     """A helper function to convert a Discord timestamp to a :class:`datetime.datetime` object.
 
     .. versionadded:: 2.0

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1160,12 +1160,12 @@ def format_timestamp(timestamp: str, /, tz: datetime.timezone = MISSING) -> Opti
     timestamp: :class:`str`
         The Discord timestamp to format.
     tz: :class:`datetime.timezone`
-        The style to format the datetime with. Defaults to UTC.
+        The timezone to convert the timestamp to. Defaults to UTC.
 
     Returns
     --------
     Optional[:class:`datetime.datetime`]
-        The converted datetime object or ``None`` if the paramater ``ts`` is invalid.
+        The converted datetime object or ``None`` if the paramater ``timestamp`` is invalid.
     """
     ts = timestamp.strip('<:tTdDfFR>')
     try:

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1149,3 +1149,26 @@ def format_dt(dt: datetime.datetime, /, style: Optional[TimestampStyle] = None) 
     if style is None:
         return f'<t:{int(dt.timestamp())}>'
     return f'<t:{int(dt.timestamp())}:{style}>'
+    
+def format_timestamp(timestamp: str, /, tz: datetime.timezone = MISSING) -> Optional[datetime.datetime]:
+    """A helper function to convert a Discord timestamp to a :class:`datetime.datetime` object.
+
+    .. versionadded:: 2.0
+
+    Parameters
+    -----------
+    timestamp: :class:`str`
+        The Discord timestamp to format.
+    tz: :class:`datetime.timezone`
+        The style to format the datetime with. Defaults to UTC.
+
+    Returns
+    --------
+    Optional[:class:`datetime.datetime`]
+        The converted datetime object or ``None`` if the paramater ``ts`` is invalid.
+    """
+    ts = timestamp.strip('<:tTdDfFR>')
+    try:
+        return datetime.datetime.fromtimestamp(int(ts), tz=tz if tz is not MISSING else datetime.timezone.utc)
+    except ValueError:
+        return None


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
#### New Feature
Add `utils.convert_timestamp(timestamp, tz=...)`.
Converts a discord timestamp (for example `<:9999999>`) to a datetime object using `datetime.fromtimestamp`. `tz` is the timezone to convert to.

Not sure if I should also make a Transformer/Converter.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
