### PR TITLE
Add `Command.cooldown`

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -659,8 +659,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
     @property
     def cooldown(self) -> Optional[Cooldown]:
-        """Optional[:class:`Cooldown`]:
-        The cooldown of a command when invoked or ``None`` if the command
+        """Optional[:class:`Cooldown`]: The cooldown of a command when invoked or ``None`` if the command
         doesn't have a registered cooldown.
         
         .. versionadded:: 2.0

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -284,9 +284,6 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         requirements are met (e.g. ``?foo a b c`` when only expecting ``a``
         and ``b``). Otherwise :func:`.on_command_error` and local error handlers
         are called with :exc:`.TooManyArguments`. Defaults to ``True``.
-    cooldown: Optional[:class:`Cooldown`]
-        The cooldown of a command when invoked or ``None`` if the command
-        doesn't have a registered cooldown.
     cooldown_after_parsing: :class:`bool`
         If ``True``\, cooldown processing is done after argument parsing,
         which calls converters. If ``False`` then cooldown processing is done
@@ -662,6 +659,12 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
     @property
     def cooldown(self) -> Optional[Cooldown]:
+        """Optional[:class:`Cooldown`]:
+        The cooldown of a command when invoked or ``None`` if the command
+        doesn't have a registered cooldown.
+        
+        .. versionadded:: 2.0
+        """
         return self._buckets._cooldown
     
     @property

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -126,11 +126,7 @@ def unwrap_function(function: Callable[..., Any], /) -> Callable[..., Any]:
 
 
 def get_signature_parameters(
-    function: Callable[..., Any],
-    globalns: Dict[str, Any],
-    /,
-    *,
-    skip_parameters: Optional[int] = None,
+    function: Callable[..., Any], globalns: Dict[str, Any], /, *, skip_parameters: Optional[int] = None,
 ) -> Dict[str, inspect.Parameter]:
     signature = inspect.signature(function)
     params = {}
@@ -319,10 +315,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
     def __init__(
         self,
-        func: Union[
-            Callable[Concatenate[CogT, ContextT, P], Coro[T]],
-            Callable[Concatenate[ContextT, P], Coro[T]],
-        ],
+        func: Union[Callable[Concatenate[CogT, ContextT, P], Coro[T]], Callable[Concatenate[ContextT, P], Coro[T]],],
         /,
         **kwargs: Any,
     ) -> None:
@@ -415,16 +408,14 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
     @property
     def callback(
         self,
-    ) -> Union[Callable[Concatenate[CogT, Context, P], Coro[T]], Callable[Concatenate[Context, P], Coro[T]],]:
+    ) -> Union[
+        Callable[Concatenate[CogT, Context, P], Coro[T]], Callable[Concatenate[Context, P], Coro[T]],
+    ]:
         return self._callback
 
     @callback.setter
     def callback(
-        self,
-        function: Union[
-            Callable[Concatenate[CogT, Context, P], Coro[T]],
-            Callable[Concatenate[Context, P], Coro[T]],
-        ],
+        self, function: Union[Callable[Concatenate[CogT, Context, P], Coro[T]], Callable[Concatenate[Context, P], Coro[T]],],
     ) -> None:
         self._callback = function
         unwrap = unwrap_function(function)
@@ -672,7 +663,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         .. versionadded:: 2.0
         """
         return self._buckets._cooldown
-    
+
     @property
     def full_parent_name(self) -> str:
         """:class:`str`: Retrieves the fully qualified parent command name.
@@ -1354,46 +1345,22 @@ class GroupMixin(Generic[CogT]):
 
     @overload
     def command(
-        self: GroupMixin[CogT],
-        name: str = ...,
-        *args: Any,
-        **kwargs: Any,
+        self: GroupMixin[CogT], name: str = ..., *args: Any, **kwargs: Any,
     ) -> Callable[
-        [
-            Union[
-                Callable[Concatenate[CogT, ContextT, P], Coro[T]],
-                Callable[Concatenate[ContextT, P], Coro[T]],
-            ]
-        ],
+        [Union[Callable[Concatenate[CogT, ContextT, P], Coro[T]], Callable[Concatenate[ContextT, P], Coro[T]],]],
         Command[CogT, P, T],
     ]:
         ...
 
     @overload
     def command(
-        self: GroupMixin[CogT],
-        name: str = ...,
-        cls: Type[CommandT] = ...,
-        *args: Any,
-        **kwargs: Any,
+        self: GroupMixin[CogT], name: str = ..., cls: Type[CommandT] = ..., *args: Any, **kwargs: Any,
     ) -> Callable[
-        [
-            Union[
-                Callable[Concatenate[CogT, ContextT, P], Coro[T]],
-                Callable[Concatenate[ContextT, P], Coro[T]],
-            ]
-        ],
-        CommandT,
+        [Union[Callable[Concatenate[CogT, ContextT, P], Coro[T]], Callable[Concatenate[ContextT, P], Coro[T]],]], CommandT,
     ]:
         ...
 
-    def command(
-        self,
-        name: str = MISSING,
-        cls: Type[Command[Any, ..., Any]] = MISSING,
-        *args: Any,
-        **kwargs: Any,
-    ) -> Any:
+    def command(self, name: str = MISSING, cls: Type[Command[Any, ..., Any]] = MISSING, *args: Any, **kwargs: Any,) -> Any:
         """A shortcut decorator that invokes :func:`~discord.ext.commands.command` and adds it to
         the internal command list via :meth:`~.GroupMixin.add_command`.
 
@@ -1414,46 +1381,22 @@ class GroupMixin(Generic[CogT]):
 
     @overload
     def group(
-        self: GroupMixin[CogT],
-        name: str = ...,
-        *args: Any,
-        **kwargs: Any,
+        self: GroupMixin[CogT], name: str = ..., *args: Any, **kwargs: Any,
     ) -> Callable[
-        [
-            Union[
-                Callable[Concatenate[CogT, ContextT, P], Coro[T]],
-                Callable[Concatenate[ContextT, P], Coro[T]],
-            ]
-        ],
+        [Union[Callable[Concatenate[CogT, ContextT, P], Coro[T]], Callable[Concatenate[ContextT, P], Coro[T]],]],
         Group[CogT, P, T],
     ]:
         ...
 
     @overload
     def group(
-        self: GroupMixin[CogT],
-        name: str = ...,
-        cls: Type[GroupT] = ...,
-        *args: Any,
-        **kwargs: Any,
+        self: GroupMixin[CogT], name: str = ..., cls: Type[GroupT] = ..., *args: Any, **kwargs: Any,
     ) -> Callable[
-        [
-            Union[
-                Callable[Concatenate[CogT, ContextT, P], Coro[T]],
-                Callable[Concatenate[ContextT, P], Coro[T]],
-            ]
-        ],
-        GroupT,
+        [Union[Callable[Concatenate[CogT, ContextT, P], Coro[T]], Callable[Concatenate[ContextT, P], Coro[T]],]], GroupT,
     ]:
         ...
 
-    def group(
-        self,
-        name: str = MISSING,
-        cls: Type[Group[Any, ..., Any]] = MISSING,
-        *args: Any,
-        **kwargs: Any,
-    ) -> Any:
+    def group(self, name: str = MISSING, cls: Type[Group[Any, ..., Any]] = MISSING, *args: Any, **kwargs: Any,) -> Any:
         """A shortcut decorator that invokes :func:`.group` and adds it to
         the internal command list via :meth:`~.GroupMixin.add_command`.
 
@@ -1615,18 +1558,13 @@ if TYPE_CHECKING:
 
 
 @overload
-def command(
-    name: str = ...,
-    **attrs: Any,
-) -> _CommandDecorator:
+def command(name: str = ..., **attrs: Any,) -> _CommandDecorator:
     ...
 
 
 @overload
 def command(
-    name: str = ...,
-    cls: Type[CommandT] = ...,
-    **attrs: Any,
+    name: str = ..., cls: Type[CommandT] = ..., **attrs: Any,
 ) -> Callable[
     [
         Union[
@@ -1639,11 +1577,7 @@ def command(
     ...
 
 
-def command(
-    name: str = MISSING,
-    cls: Type[Command[Any, ..., Any]] = MISSING,
-    **attrs: Any,
-) -> Any:
+def command(name: str = MISSING, cls: Type[Command[Any, ..., Any]] = MISSING, **attrs: Any,) -> Any:
     """A decorator that transforms a function into a :class:`.Command`
     or if called with :func:`.group`, :class:`.Group`.
 
@@ -1685,18 +1619,13 @@ def command(
 
 
 @overload
-def group(
-    name: str = ...,
-    **attrs: Any,
-) -> _GroupDecorator:
+def group(name: str = ..., **attrs: Any,) -> _GroupDecorator:
     ...
 
 
 @overload
 def group(
-    name: str = ...,
-    cls: Type[GroupT] = ...,
-    **attrs: Any,
+    name: str = ..., cls: Type[GroupT] = ..., **attrs: Any,
 ) -> Callable[
     [
         Union[
@@ -1709,11 +1638,7 @@ def group(
     ...
 
 
-def group(
-    name: str = MISSING,
-    cls: Type[Group[Any, ..., Any]] = MISSING,
-    **attrs: Any,
-) -> Any:
+def group(name: str = MISSING, cls: Type[Group[Any, ..., Any]] = MISSING, **attrs: Any,) -> Any:
     """A decorator that transforms a function into a :class:`.Group`.
 
     This is similar to the :func:`~discord.ext.commands.command` decorator but the ``cls``
@@ -2255,9 +2180,7 @@ def is_nsfw() -> Callable[[T], T]:
 
 
 def cooldown(
-    rate: int,
-    per: float,
-    type: Union[BucketType, Callable[[Message], Any]] = BucketType.default,
+    rate: int, per: float, type: Union[BucketType, Callable[[Message], Any]] = BucketType.default,
 ) -> Callable[[T], T]:
     """A decorator that adds a cooldown to a :class:`.Command`
 
@@ -2296,8 +2219,7 @@ def cooldown(
 
 
 def dynamic_cooldown(
-    cooldown: Union[BucketType, Callable[[Message], Any]],
-    type: BucketType = BucketType.default,
+    cooldown: Union[BucketType, Callable[[Message], Any]], type: BucketType = BucketType.default,
 ) -> Callable[[T], T]:
     """A decorator that adds a dynamic cooldown to a :class:`.Command`
 

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -284,6 +284,9 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         requirements are met (e.g. ``?foo a b c`` when only expecting ``a``
         and ``b``). Otherwise :func:`.on_command_error` and local error handlers
         are called with :exc:`.TooManyArguments`. Defaults to ``True``.
+    cooldown: Optional[:class:`Cooldown`]
+        The cooldown of a command when invoked or ``None`` if the command
+        doesn't have a registered cooldown.
     cooldown_after_parsing: :class:`bool`
         If ``True``\, cooldown processing is done after argument parsing,
         which calls converters. If ``False`` then cooldown processing is done
@@ -657,6 +660,10 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         """
         return self.params.copy()
 
+    @property
+    def cooldown(self) -> Optional[Cooldown]:
+        return self._buckets._cooldown
+    
     @property
     def full_parent_name(self) -> str:
         """:class:`str`: Retrieves the fully qualified parent command name.

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -661,7 +661,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
     def cooldown(self) -> Optional[Cooldown]:
         """Optional[:class:`Cooldown`]: The cooldown of a command when invoked or ``None`` if the command
         doesn't have a registered cooldown.
-        
+
         .. versionadded:: 2.0
         """
         return self._buckets._cooldown


### PR DESCRIPTION
## Summary

This PR is to add a `command.cooldown` property to commands.

Currently the cooldown can only be retrieved by `command._buckets._cooldown` which is, frankly, poking through the internals of the library. A `command.cooldown` property would be preferred.

A use case could be showing the cooldown of a command in a help command.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
