### PR TITLE
Add util to parse formatted_dt

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1149,3 +1149,25 @@ def format_dt(dt: datetime.datetime, /, style: Optional[TimestampStyle] = None) 
     if style is None:
         return f'<t:{int(dt.timestamp())}>'
     return f'<t:{int(dt.timestamp())}:{style}>'
+
+
+def resolve_formatted_dt(formatted_dt: str) -> Optional[Tuple[datetime.datetime, Optional[str]]]:
+    """A helper function that can take discord formatted datetimes  like those produced by :meth:`~discord.utils.format_dt`
+    and return the relevant datetime. 
+    If unable to parse a datetime from formatted_dt, it will return None.
+    .. versionadded:: 2.0
+    Parameters
+    -----------
+    formatted_dt: :class:`str`
+        The formatted datetime string.
+    Returns
+    --------
+    Optional[Tuple[:class:`datetime.datetime`, Optional[:class:`str`]]
+        A tuple containing the datetime and the flag if present. Otherwise None.
+    """
+    match = re.match(r'<t:(-?[0-9]+)(:[tTdDfFR])?>$', formatted_dt)
+    if match:
+        try:
+            return datetime.datetime.fromtimestamp(int(match.group(1)), tz=datetime.timezone.utc), match.group(2)
+        except (ValueError, OverflowError, OSError):
+            return


### PR DESCRIPTION
## Summary

This PR ads a utility to turn the output of a formatted dt into a datetime object.

It is useful for:
—When sending a dt, parsing them
—Reading dt sent by other bots
— Future proofing if discord adds a UI way to send then

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
