### PR TITLE
Method `create_integration()` of `discord.Guild` unsupported for bots

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -1147,6 +1147,15 @@ table.docutils tbody tr td ol.last {
   margin-bottom: 0;
 }
 
+/* added when the `align` attribute is specified in the `image` directive */
+main img.align-left {
+  margin-left: .5em;
+}
+
+main img.align-right {
+  margin-right: .5em;
+}
+
 .align-default {
   text-align: left !important;
 }


### PR DESCRIPTION
## Summary

Add a note saying: `This can only be used by non-bot accounts.` and a deprecation warning (e.g. `Deprecated since version 2.0.`)

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, …)
