### PR TITLE
Thread newly created

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -847,9 +847,11 @@ class ConnectionState:
             return
 
         thread = Thread(guild=guild, state=guild._state, data=data)
-        has_thread = guild.get_thread(thread.id)
         guild._add_thread(thread)
-        if not has_thread:
+        
+        if thread.newly_created:
+            self.dispatch('thread_create', thread)
+        else:
             self.dispatch('thread_join', thread)
 
     def parse_thread_update(self, data: gw.ThreadUpdateEvent) -> None:

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -125,8 +125,8 @@ class Thread(Messageable, Hashable):
     archive_timestamp: :class:`datetime.datetime`
         An aware timestamp of when the thread's archived status was last updated in UTC.
     newly_created: :class:`bool`
-        Denotes if this :class:`Thread` is newly created. This will be ``True`` when the thread
-        was created, but will be ``False`` if the client has joined the thread.
+        This will be ``True`` when the thread is first created, otherwise ``False``. This allows
+        the client to distinguish between joining a thread and when a thread is created.
     """
 
     __slots__ = (

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -124,6 +124,9 @@ class Thread(Messageable, Hashable):
         Usually a value of 60, 1440, 4320 and 10080.
     archive_timestamp: :class:`datetime.datetime`
         An aware timestamp of when the thread's archived status was last updated in UTC.
+    newly_created: :class:`bool`
+        Denotes if this :class:`Thread` is newly created. This will be ``True`` when the thread
+        was created, but will be ``False`` if the client has joined the thread.
     """
 
     __slots__ = (
@@ -138,6 +141,7 @@ class Thread(Messageable, Hashable):
         'last_message_id',
         'message_count',
         'member_count',
+        'newly_created',
         'slowmode_delay',
         'me',
         'locked',
@@ -177,6 +181,7 @@ class Thread(Messageable, Hashable):
         self.slowmode_delay: int = data.get('rate_limit_per_user', 0)
         self.message_count: int = data['message_count']
         self.member_count: int = data['member_count']
+        self.newly_created: bool = data.get('newly_created', False)
         self._unroll_metadata(data['thread_metadata'])
 
         self.me: Optional[ThreadMember]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1096,11 +1096,21 @@ Stages
 Threads
 ~~~~~~~~
 
+.. function:: on_thread_create(thread)
 
+    Called whenever a thread has been created. The attribute :attr:`Thread.newly_created`
+    will be ``True`` when this event is called.
+
+    This requires :attr:`Intents.guilds` to be enabled.
+
+    .. versionadded:: 2.0
+
+    :param thread: The thread that was created.
+    :type thread: :class:`Thread`
+ 
 .. function:: on_thread_join(thread)
 
-    Called whenever a thread is joined or created. Note that from the API's perspective there is no way to
-    differentiate between a thread being created or the bot joining a thread.
+    Called whenever a thread is joined.
 
     Note that you can get the guild from :attr:`Thread.guild`.
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds `Thread.newly_created` into the Thread object. This attribute gets passed to `THREAD_CREATE` when the thread has been created but the bot has not joined it. It allows us to separate `thread_join` to `thread_create` and `thread_join`. thread_join is now only for when the client joins the thread, and thread_create for when a new thread has been created.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ x] If code changes were made then they have been tested.
    - [x ] I have updated the documentation to reflect the changes.
- [ x] This PR fixes an issue.
- [ x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
