### PR TITLE
Fix typo in PartialMessageable docstring.

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2116,7 +2116,7 @@ class GroupChannel(discord.abc.Messageable, Hashable):
 
 class PartialMessageable(discord.abc.Messageable, Hashable):
     """Represents a partial messageable to aid with working messageable channels when
-    only a channel ID are present.
+    only a channel ID is present.
 
     The only way to construct this class is through :meth:`Client.get_partial_messageable`.
 


### PR DESCRIPTION
## Summary

Fix a typo in PartialMessagable's documentation.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
