### PR TITLE
Fix typos in some View methods' docstrings

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -256,6 +256,7 @@ class View:
         """Adds an item to the view.
         This function returns the class instance to allow for fluent-style
         chaining.
+
         Parameters
         -----------
         item: :class:`Item`

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -254,6 +254,7 @@ class View:
 
     def add_item(self, item: Item[Any]) -> Self:
         """Adds an item to the view.
+
         This function returns the class instance to allow for fluent-style
         chaining.
 
@@ -285,6 +286,7 @@ class View:
 
     def remove_item(self, item: Item[Any]) -> Self:
         """Removes an item from the view.
+
         This function returns the class instance to allow for fluent-style
         chaining.
 
@@ -304,6 +306,7 @@ class View:
 
     def clear_items(self) -> Self:
         """Removes all items from the view.
+
         This function returns the class instance to allow for fluent-style
         chaining.
         """


### PR DESCRIPTION
## Summary

This fixes whitespace typos that introduced inconsistency in docstrings and caused docs of View.add_item to look slightly bugged.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
