### PR TITLE
Make guild and guilds args in Bot.remove_cog() keyword-only

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -667,6 +667,7 @@ class BotBase(GroupMixin[None]):
         self,
         name: str,
         /,
+        *,
         guild: Optional[Snowflake] = MISSING,
         guilds: List[Snowflake] = MISSING,
     ) -> Optional[Cog]:


### PR DESCRIPTION
## Summary

Makes it consistent with `Bot.add_cog()` as I assume it was an oversight that these were not made keyword-only in the first place.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
