### PR TITLE
Update migration guide with loop-related changes to Client's constructor

### DIFF
--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -110,6 +110,8 @@ Quick example:
     client = MyClient()
     client.run(TOKEN)
 
+With this change, constructor of :class:`Client` no longer accepts ``connector`` and ``loop`` parameters.
+
 In parallel with this change, changes were made to loading and unloading of commands extension extensions and cogs, 
 see :ref:`migrating_2_0_commands_extension_cog_async` for more information.
 


### PR DESCRIPTION
## Summary

Adds removal of `connector` and `loop` params to `Client` constructor to the migration guide.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
