### PR TITLE
Update migration guide with change to Message.channel_mentions type

### DIFF
--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -569,6 +569,7 @@ For convenience, :class:`Thread` has a set of properties and methods that return
 The following changes have been made:
 
 - :attr:`Message.channel` may now be a :class:`Thread`.
+- :attr:`Message.channel_mentions` list may now contain a :class:`Thread`.
 - :attr:`AuditLogEntry.target` may now be a :class:`Thread`.
 - :attr:`PartialMessage.channel` may now be a :class:`Thread`.
 - :attr:`Guild.get_channel` does not return :class:`Thread`\s.


### PR DESCRIPTION
## Summary

Elements in `Message.channel_mentions` list might now be a `Thread`.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
