### PR TITLE
Change some methods to use positional-only marker

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -390,7 +390,7 @@ class Client:
         # Schedules the task
         return self.loop.create_task(wrapped, name=f'discord.py: {event_name}')
 
-    def dispatch(self, event: str, *args: Any, **kwargs: Any) -> None:
+    def dispatch(self, event: str, /, *args: Any, **kwargs: Any) -> None:
         _log.debug('Dispatching event %s', event)
         method = 'on_' + event
 
@@ -430,7 +430,7 @@ class Client:
         else:
             self._schedule_event(coro, method, *args, **kwargs)
 
-    async def on_error(self, event_method: str, *args: Any, **kwargs: Any) -> None:
+    async def on_error(self, event_method: str, /, *args: Any, **kwargs: Any) -> None:
         """|coro|
 
         The default error handler provided by the client.
@@ -438,6 +438,10 @@ class Client:
         By default this prints to :data:`sys.stderr` however it could be
         overridden to have a different implementation.
         Check :func:`~discord.on_error` for more details.
+
+        .. versionchanged:: 2.0
+
+            ``event_method`` parameter is now positional-only.
         """
         print(f'Ignoring exception in {event_method}', file=sys.stderr)
         traceback.print_exc()
@@ -977,6 +981,7 @@ class Client:
     def wait_for(
         self,
         event: str,
+        /,
         *,
         check: Optional[Callable[..., bool]] = None,
         timeout: Optional[float] = None,
@@ -1036,6 +1041,10 @@ class Client:
                     else:
                         await channel.send('\N{THUMBS UP SIGN}')
 
+        .. versionchanged:: 2.0
+
+            ``event`` parameter is now positional-only.
+
 
         Parameters
         ------------
@@ -1082,7 +1091,7 @@ class Client:
 
     # event registration
 
-    def event(self, coro: Coro) -> Coro:
+    def event(self, coro: Coro, /) -> Coro:
         """A decorator that registers an event to listen to.
 
         You can find more info about the events on the :ref:`documentation below <discord-api-events>`.
@@ -1097,6 +1106,10 @@ class Client:
             @client.event
             async def on_ready():
                 print('Ready!')
+
+        .. versionchanged:: 2.0
+
+            ``coro`` parameter is now positional-only.
 
         Raises
         --------

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -92,10 +92,18 @@ T = TypeVar('T')
 CFT = TypeVar('CFT', bound='CoroFunc')
 
 
-def when_mentioned(bot: _Bot, msg: Message) -> List[str]:
+def when_mentioned(bot: _Bot, msg: Message, /) -> List[str]:
     """A callable that implements a command prefix equivalent to being mentioned.
 
     These are meant to be passed into the :attr:`.Bot.command_prefix` attribute.
+
+        .. versionchanged:: 2.0
+
+            ``bot`` parameter is now positional-only.
+
+        .. versionchanged:: 2.0
+
+            ``msg`` parameter is now positional-only.
     """
     # bot.user will never be None when this is called
     return [f'<@{bot.user.id}> ', f'<@!{bot.user.id}> ']  # type: ignore
@@ -185,7 +193,7 @@ class BotBase(GroupMixin[None]):
 
     # internal helpers
 
-    def dispatch(self, event_name: str, *args: Any, **kwargs: Any) -> None:
+    def dispatch(self, event_name: str, /, *args: Any, **kwargs: Any) -> None:
         # super() will resolve to Client
         super().dispatch(event_name, *args, **kwargs)  # type: ignore
         ev = 'on_' + event_name
@@ -208,7 +216,7 @@ class BotBase(GroupMixin[None]):
 
         await super().close()  # type: ignore
 
-    async def on_command_error(self, context: Context[BotT], exception: errors.CommandError) -> None:
+    async def on_command_error(self, context: Context[BotT], exception: errors.CommandError, /) -> None:
         """|coro|
 
         The default command error handler provided by the bot.
@@ -217,6 +225,14 @@ class BotBase(GroupMixin[None]):
         overridden to have a different implementation.
 
         This only fires if you do not specify any listeners for command error.
+
+        .. versionchanged:: 2.0
+
+            ``context`` parameter is now positional-only.
+
+        .. versionchanged:: 2.0
+
+            ``exception`` parameter is now positional-only.
         """
         if self.extra_events.get('on_command_error', None):
             return
@@ -234,7 +250,7 @@ class BotBase(GroupMixin[None]):
 
     # global check registration
 
-    def check(self, func: T) -> T:
+    def check(self, func: T, /) -> T:
         r"""A decorator that adds a global check to the bot.
 
         A global check is similar to a :func:`.check` that is applied
@@ -258,6 +274,9 @@ class BotBase(GroupMixin[None]):
             def check_commands(ctx):
                 return ctx.command.qualified_name in allowed_commands
 
+        .. versionchanged:: 2.0
+
+            ``func`` parameter is now positional-only.
         """
         # T was used instead of Check to ensure the type matches on return
         self.add_check(func)  # type: ignore
@@ -312,7 +331,7 @@ class BotBase(GroupMixin[None]):
         except ValueError:
             pass
 
-    def check_once(self, func: CFT) -> CFT:
+    def check_once(self, func: CFT, /) -> CFT:
         r"""A decorator that adds a "call once" global check to the bot.
 
         Unlike regular global checks, this one is called only once
@@ -346,11 +365,15 @@ class BotBase(GroupMixin[None]):
             def whitelist(ctx):
                 return ctx.message.author.id in my_whitelist
 
+        .. versionchanged:: 2.0
+
+            ``func`` parameter is now positional-only.
+
         """
         self.add_check(func, call_once=True)
         return func
 
-    async def can_run(self, ctx: Context[BotT], *, call_once: bool = False) -> bool:
+    async def can_run(self, ctx: Context[BotT], /, *, call_once: bool = False) -> bool:
         data = self._check_once if call_once else self._checks
 
         if len(data) == 0:
@@ -359,7 +382,7 @@ class BotBase(GroupMixin[None]):
         # type-checker doesn't distinguish between functions and methods
         return await discord.utils.async_all(f(ctx) for f in data)  # type: ignore
 
-    async def is_owner(self, user: User) -> bool:
+    async def is_owner(self, user: User, /) -> bool:
         """|coro|
 
         Checks if a :class:`~discord.User` or :class:`~discord.Member` is the owner of
@@ -371,6 +394,10 @@ class BotBase(GroupMixin[None]):
         .. versionchanged:: 1.3
             The function also checks if the application is team-owned if
             :attr:`owner_ids` is not set.
+
+        .. versionchanged:: 2.0
+
+            ``user`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -397,7 +424,7 @@ class BotBase(GroupMixin[None]):
                 self.owner_id = owner_id = app.owner.id
                 return user.id == owner_id
 
-    def before_invoke(self, coro: CFT) -> CFT:
+    def before_invoke(self, coro: CFT, /) -> CFT:
         """A decorator that registers a coroutine as a pre-invoke hook.
 
         A pre-invoke hook is called directly before the command is
@@ -412,6 +439,10 @@ class BotBase(GroupMixin[None]):
             only called if all checks and argument parsing procedures pass
             without error. If any check or argument parsing procedures fail
             then the hooks are not called.
+
+        .. versionchanged:: 2.0
+
+            ``coro`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -429,7 +460,7 @@ class BotBase(GroupMixin[None]):
         self._before_invoke = coro
         return coro
 
-    def after_invoke(self, coro: CFT) -> CFT:
+    def after_invoke(self, coro: CFT, /) -> CFT:
         r"""A decorator that registers a coroutine as a post-invoke hook.
 
         A post-invoke hook is called directly after the command is
@@ -445,6 +476,10 @@ class BotBase(GroupMixin[None]):
             however, **always** called regardless of the internal command
             callback raising an error (i.e. :exc:`.CommandInvokeError`\).
             This makes it ideal for clean-up scenarios.
+
+        .. versionchanged:: 2.0
+
+            ``coro`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -464,8 +499,12 @@ class BotBase(GroupMixin[None]):
 
     # listener registration
 
-    def add_listener(self, func: CoroFunc, name: str = MISSING) -> None:
+    def add_listener(self, func: CoroFunc, /, name: str = MISSING) -> None:
         """The non decorator alternative to :meth:`.listen`.
+
+        .. versionchanged:: 2.0
+
+            ``func`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -496,8 +535,12 @@ class BotBase(GroupMixin[None]):
         else:
             self.extra_events[name] = [func]
 
-    def remove_listener(self, func: CoroFunc, name: str = MISSING) -> None:
+    def remove_listener(self, func: CoroFunc, /, name: str = MISSING) -> None:
         """Removes a listener from the pool of listeners.
+
+        .. versionchanged:: 2.0
+
+            ``func`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -516,7 +559,7 @@ class BotBase(GroupMixin[None]):
             except ValueError:
                 pass
 
-    def listen(self, name: str = MISSING) -> Callable[[CFT], CFT]:
+    def listen(self, name: str = MISSING, /) -> Callable[[CFT], CFT]:
         """A decorator that registers another function as an external
         event listener. Basically this allows you to listen to multiple
         events from different places e.g. such as :func:`.on_ready`
@@ -539,6 +582,10 @@ class BotBase(GroupMixin[None]):
                 print('two')
 
         Would print one and two in an unspecified order.
+
+        .. versionchanged:: 2.0
+
+            ``name`` parameter is now positional-only.
 
         Raises
         -------
@@ -816,7 +863,7 @@ class BotBase(GroupMixin[None]):
         except ImportError:
             raise errors.ExtensionNotFound(name)
 
-    async def load_extension(self, name: str, *, package: Optional[str] = None) -> None:
+    async def load_extension(self, name: str, /, *, package: Optional[str] = None) -> None:
         """|coro|
 
         Loads an extension.
@@ -831,6 +878,10 @@ class BotBase(GroupMixin[None]):
         .. versionchanged:: 2.0
 
             This method is now a :term:`coroutine`.
+
+        .. versionchanged:: 2.0
+
+            ``name`` parameter is now positional-only.
 
         Parameters
         ------------
@@ -869,7 +920,7 @@ class BotBase(GroupMixin[None]):
 
         await self._load_from_module_spec(spec, name)
 
-    async def unload_extension(self, name: str, *, package: Optional[str] = None) -> None:
+    async def unload_extension(self, name: str, /, *, package: Optional[str] = None) -> None:
         """|coro|
 
         Unloads an extension.
@@ -885,6 +936,10 @@ class BotBase(GroupMixin[None]):
         .. versionchanged:: 2.0
 
             This method is now a :term:`coroutine`.
+
+        .. versionchanged:: 2.0
+
+            ``name`` parameter is now positional-only.
 
         Parameters
         ------------
@@ -916,13 +971,17 @@ class BotBase(GroupMixin[None]):
         await self._remove_module_references(lib.__name__)
         await self._call_module_finalizers(lib, name)
 
-    async def reload_extension(self, name: str, *, package: Optional[str] = None) -> None:
+    async def reload_extension(self, name: str, /, *, package: Optional[str] = None) -> None:
         """Atomically reloads an extension.
 
         This replaces the extension with the same extension, only refreshed. This is
         equivalent to a :meth:`unload_extension` followed by a :meth:`load_extension`
         except done in an atomic way. That is, if an operation fails mid-reload then
         the bot will roll-back to the prior working state.
+
+        .. versionchanged:: 2.0
+
+            ``name`` parameter is now positional-only.
 
         Parameters
         ------------
@@ -1023,11 +1082,15 @@ class BotBase(GroupMixin[None]):
 
     # command processing
 
-    async def get_prefix(self, message: Message) -> Union[List[str], str]:
+    async def get_prefix(self, message: Message, /) -> Union[List[str], str]:
         """|coro|
 
         Retrieves the prefix the bot is listening to
         with the message as a context.
+
+        .. versionchanged:: 2.0
+
+            ``message`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -1068,6 +1131,7 @@ class BotBase(GroupMixin[None]):
     async def get_context(
         self,
         message: Message,
+        /,
     ) -> Context[Self]:  # type: ignore
         ...
 
@@ -1075,6 +1139,7 @@ class BotBase(GroupMixin[None]):
     async def get_context(
         self,
         message: Message,
+        /,
         *,
         cls: Type[ContextT] = ...,
     ) -> ContextT:
@@ -1083,6 +1148,7 @@ class BotBase(GroupMixin[None]):
     async def get_context(
         self,
         message: Message,
+        /,
         *,
         cls: Type[ContextT] = MISSING,
     ) -> Any:
@@ -1097,6 +1163,10 @@ class BotBase(GroupMixin[None]):
         context, :attr:`.Context.valid` must be checked to make sure it is.
         If the context is not valid then it is not a valid candidate to be
         invoked under :meth:`~.Bot.invoke`.
+
+        .. versionchanged:: 2.0
+
+            ``message`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -1165,11 +1235,15 @@ class BotBase(GroupMixin[None]):
         ctx.command = self.all_commands.get(invoker)
         return ctx
 
-    async def invoke(self, ctx: Context[BotT]) -> None:
+    async def invoke(self, ctx: Context[BotT], /) -> None:
         """|coro|
 
         Invokes the command given under the invocation context and
         handles all the internal event dispatch mechanisms.
+
+        .. versionchanged:: 2.0
+
+            ``ctx`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -1191,7 +1265,7 @@ class BotBase(GroupMixin[None]):
             exc = errors.CommandNotFound(f'Command "{ctx.invoked_with}" is not found')
             self.dispatch('command_error', ctx, exc)
 
-    async def process_commands(self, message: Message) -> None:
+    async def process_commands(self, message: Message, /) -> None:
         """|coro|
 
         This function processes the commands that have been registered
@@ -1208,6 +1282,10 @@ class BotBase(GroupMixin[None]):
         This also checks if the message's author is a bot and doesn't
         call :meth:`~.Bot.get_context` or :meth:`~.Bot.invoke` if so.
 
+        .. versionchanged:: 2.0
+
+            ``message`` parameter is now positional-only.
+
         Parameters
         -----------
         message: :class:`discord.Message`
@@ -1220,7 +1298,7 @@ class BotBase(GroupMixin[None]):
         # the type of the invocation context's bot attribute will be correct
         await self.invoke(ctx)  # type: ignore
 
-    async def on_message(self, message: Message) -> None:
+    async def on_message(self, message: Message, /) -> None:
         await self.process_commands(message)
 
 

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -99,11 +99,7 @@ def when_mentioned(bot: _Bot, msg: Message, /) -> List[str]:
 
         .. versionchanged:: 2.0
 
-            ``bot`` parameter is now positional-only.
-
-        .. versionchanged:: 2.0
-
-            ``msg`` parameter is now positional-only.
+            ``bot`` and ``msg`` parameters are now positional-only.
     """
     # bot.user will never be None when this is called
     return [f'<@{bot.user.id}> ', f'<@!{bot.user.id}> ']  # type: ignore
@@ -228,11 +224,7 @@ class BotBase(GroupMixin[None]):
 
         .. versionchanged:: 2.0
 
-            ``context`` parameter is now positional-only.
-
-        .. versionchanged:: 2.0
-
-            ``exception`` parameter is now positional-only.
+            ``context`` and ``exception`` parameters are now positional-only.
         """
         if self.extra_events.get('on_command_error', None):
             return
@@ -559,7 +551,7 @@ class BotBase(GroupMixin[None]):
             except ValueError:
                 pass
 
-    def listen(self, name: str = MISSING, /) -> Callable[[CFT], CFT]:
+    def listen(self, name: str = MISSING) -> Callable[[CFT], CFT]:
         """A decorator that registers another function as an external
         event listener. Basically this allows you to listen to multiple
         events from different places e.g. such as :func:`.on_ready`
@@ -582,10 +574,6 @@ class BotBase(GroupMixin[None]):
                 print('two')
 
         Would print one and two in an unspecified order.
-
-        .. versionchanged:: 2.0
-
-            ``name`` parameter is now positional-only.
 
         Raises
         -------
@@ -863,7 +851,7 @@ class BotBase(GroupMixin[None]):
         except ImportError:
             raise errors.ExtensionNotFound(name)
 
-    async def load_extension(self, name: str, /, *, package: Optional[str] = None) -> None:
+    async def load_extension(self, name: str, *, package: Optional[str] = None) -> None:
         """|coro|
 
         Loads an extension.
@@ -878,10 +866,6 @@ class BotBase(GroupMixin[None]):
         .. versionchanged:: 2.0
 
             This method is now a :term:`coroutine`.
-
-        .. versionchanged:: 2.0
-
-            ``name`` parameter is now positional-only.
 
         Parameters
         ------------
@@ -920,7 +904,7 @@ class BotBase(GroupMixin[None]):
 
         await self._load_from_module_spec(spec, name)
 
-    async def unload_extension(self, name: str, /, *, package: Optional[str] = None) -> None:
+    async def unload_extension(self, name: str, *, package: Optional[str] = None) -> None:
         """|coro|
 
         Unloads an extension.
@@ -936,10 +920,6 @@ class BotBase(GroupMixin[None]):
         .. versionchanged:: 2.0
 
             This method is now a :term:`coroutine`.
-
-        .. versionchanged:: 2.0
-
-            ``name`` parameter is now positional-only.
 
         Parameters
         ------------
@@ -971,17 +951,13 @@ class BotBase(GroupMixin[None]):
         await self._remove_module_references(lib.__name__)
         await self._call_module_finalizers(lib, name)
 
-    async def reload_extension(self, name: str, /, *, package: Optional[str] = None) -> None:
+    async def reload_extension(self, name: str, *, package: Optional[str] = None) -> None:
         """Atomically reloads an extension.
 
         This replaces the extension with the same extension, only refreshed. This is
         equivalent to a :meth:`unload_extension` followed by a :meth:`load_extension`
         except done in an atomic way. That is, if an operation fails mid-reload then
         the bot will roll-back to the prior working state.
-
-        .. versionchanged:: 2.0
-
-            ``name`` parameter is now positional-only.
 
         Parameters
         ------------

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -114,7 +114,7 @@ else:
     P = TypeVar('P')
 
 
-def unwrap_function(function: Callable[..., Any]) -> Callable[..., Any]:
+def unwrap_function(function: Callable[..., Any], /) -> Callable[..., Any]:
     partial = functools.partial
     while True:
         if hasattr(function, '__wrapped__'):
@@ -128,6 +128,7 @@ def unwrap_function(function: Callable[..., Any]) -> Callable[..., Any]:
 def get_signature_parameters(
     function: Callable[..., Any],
     globalns: Dict[str, Any],
+    /,
     *,
     skip_parameters: Optional[int] = None,
 ) -> Dict[str, inspect.Parameter]:
@@ -161,7 +162,7 @@ def get_signature_parameters(
     return params
 
 
-def wrap_callback(coro: Callable[P, Coro[T]]) -> Callable[P, Coro[Optional[T]]]:
+def wrap_callback(coro: Callable[P, Coro[T]], /) -> Callable[P, Coro[Optional[T]]]:
     @functools.wraps(coro)
     async def wrapped(*args: P.args, **kwargs: P.kwargs) -> Optional[T]:
         try:
@@ -178,7 +179,7 @@ def wrap_callback(coro: Callable[P, Coro[T]]) -> Callable[P, Coro[Optional[T]]]:
 
 
 def hooked_wrapped_callback(
-    command: Command[Any, ..., Any], ctx: Context[BotT], coro: Callable[P, Coro[T]]
+    command: Command[Any, ..., Any], ctx: Context[BotT], coro: Callable[P, Coro[T]], /
 ) -> Callable[P, Coro[Optional[T]]]:
     @functools.wraps(coro)
     async def wrapped(*args: P.args, **kwargs: P.kwargs) -> Optional[T]:
@@ -322,6 +323,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             Callable[Concatenate[CogT, ContextT, P], Coro[T]],
             Callable[Concatenate[ContextT, P], Coro[T]],
         ],
+        /,
         **kwargs: Any,
     ) -> None:
         if not asyncio.iscoroutinefunction(func):
@@ -488,7 +490,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         self.__init__(self.callback, **dict(self.__original_kwargs__, **kwargs))
         self.cog = cog
 
-    async def __call__(self, context: Context[BotT], *args: P.args, **kwargs: P.kwargs) -> T:
+    async def __call__(self, context: Context[BotT], /, *args: P.args, **kwargs: P.kwargs) -> T:
         """|coro|
 
         Calls the internal callback that the command holds.
@@ -500,6 +502,10 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             the proper arguments and types to this function.
 
         .. versionadded:: 1.3
+
+        .. versionchanged:: 2.0
+
+            ``context`` parameter is now positional-only.
         """
         if self.cog is not None:
             return await self.callback(self.cog, context, *args, **kwargs)  # type: ignore
@@ -543,7 +549,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         else:
             return self.copy()
 
-    async def dispatch_error(self, ctx: Context[BotT], error: CommandError) -> None:
+    async def dispatch_error(self, ctx: Context[BotT], error: CommandError, /) -> None:
         ctx.command_failed = True
         cog = self.cog
         try:
@@ -566,7 +572,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         finally:
             ctx.bot.dispatch('command_error', ctx, error)
 
-    async def transform(self, ctx: Context[BotT], param: inspect.Parameter) -> Any:
+    async def transform(self, ctx: Context[BotT], param: inspect.Parameter, /) -> Any:
         required = param.default is param.empty
         converter = get_converter(param)
         consume_rest_is_special = param.kind == param.KEYWORD_ONLY and not self.rest_is_raw
@@ -758,7 +764,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         if not self.ignore_extra and not view.eof:
             raise TooManyArguments('Too many arguments passed to ' + self.qualified_name)
 
-    async def call_before_hooks(self, ctx: Context[BotT]) -> None:
+    async def call_before_hooks(self, ctx: Context[BotT], /) -> None:
         # now that we're done preparing we can call the pre-command hooks
         # first, call the command local hook:
         cog = self.cog
@@ -783,7 +789,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         if hook is not None:
             await hook(ctx)
 
-    async def call_after_hooks(self, ctx: Context[BotT]) -> None:
+    async def call_after_hooks(self, ctx: Context[BotT], /) -> None:
         cog = self.cog
         if self._after_invoke is not None:
             instance = getattr(self._after_invoke, '__self__', cog)
@@ -812,7 +818,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
                 if retry_after:
                     raise CommandOnCooldown(bucket, retry_after, self._buckets.type)  # type: ignore
 
-    async def prepare(self, ctx: Context[BotT]) -> None:
+    async def prepare(self, ctx: Context[BotT], /) -> None:
         ctx.command = self
 
         if not await self.can_run(ctx):
@@ -836,8 +842,12 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
                 await self._max_concurrency.release(ctx)  # type: ignore
             raise
 
-    def is_on_cooldown(self, ctx: Context[BotT]) -> bool:
+    def is_on_cooldown(self, ctx: Context[BotT], /) -> bool:
         """Checks whether the command is currently on cooldown.
+
+        .. versionchanged:: 2.0
+
+            ``ctx`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -857,8 +867,12 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         current = dt.replace(tzinfo=datetime.timezone.utc).timestamp()
         return bucket.get_tokens(current) == 0
 
-    def reset_cooldown(self, ctx: Context[BotT]) -> None:
+    def reset_cooldown(self, ctx: Context[BotT], /) -> None:
         """Resets the cooldown on this command.
+
+        .. versionchanged:: 2.0
+
+            ``ctx`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -869,10 +883,14 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             bucket = self._buckets.get_bucket(ctx.message)
             bucket.reset()
 
-    def get_cooldown_retry_after(self, ctx: Context[BotT]) -> float:
+    def get_cooldown_retry_after(self, ctx: Context[BotT], /) -> float:
         """Retrieves the amount of seconds before this command can be tried again.
 
         .. versionadded:: 1.4
+
+        .. versionchanged:: 2.0
+
+            ``ctx`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -893,7 +911,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
         return 0.0
 
-    async def invoke(self, ctx: Context[BotT]) -> None:
+    async def invoke(self, ctx: Context[BotT], /) -> None:
         await self.prepare(ctx)
 
         # terminate the invoked_subcommand chain.
@@ -904,7 +922,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         injected = hooked_wrapped_callback(self, ctx, self.callback)
         await injected(*ctx.args, **ctx.kwargs)  # type: ignore
 
-    async def reinvoke(self, ctx: Context[BotT], *, call_hooks: bool = False) -> None:
+    async def reinvoke(self, ctx: Context[BotT], /, *, call_hooks: bool = False) -> None:
         ctx.command = self
         await self._parse_arguments(ctx)
 
@@ -921,12 +939,16 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             if call_hooks:
                 await self.call_after_hooks(ctx)
 
-    def error(self, coro: ErrorT) -> ErrorT:
+    def error(self, coro: ErrorT, /) -> ErrorT:
         """A decorator that registers a coroutine as a local error handler.
 
         A local error handler is an :func:`.on_command_error` event limited to
         a single command. However, the :func:`.on_command_error` is still
         invoked afterwards as the catch-all.
+
+        .. versionchanged:: 2.0
+
+            ``coro`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -952,7 +974,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         """
         return hasattr(self, 'on_error')
 
-    def before_invoke(self, coro: HookT) -> HookT:
+    def before_invoke(self, coro: HookT, /) -> HookT:
         """A decorator that registers a coroutine as a pre-invoke hook.
 
         A pre-invoke hook is called directly before the command is
@@ -962,6 +984,10 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         This pre-invoke hook takes a sole parameter, a :class:`.Context`.
 
         See :meth:`.Bot.before_invoke` for more info.
+
+        .. versionchanged:: 2.0
+
+            ``coro`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -979,7 +1005,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         self._before_invoke = coro
         return coro
 
-    def after_invoke(self, coro: HookT) -> HookT:
+    def after_invoke(self, coro: HookT, /) -> HookT:
         """A decorator that registers a coroutine as a post-invoke hook.
 
         A post-invoke hook is called directly after the command is
@@ -989,6 +1015,10 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         This post-invoke hook takes a sole parameter, a :class:`.Context`.
 
         See :meth:`.Bot.after_invoke` for more info.
+
+        .. versionchanged:: 2.0
+
+            ``coro`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -1081,7 +1111,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
         return ' '.join(result)
 
-    async def can_run(self, ctx: Context[BotT]) -> bool:
+    async def can_run(self, ctx: Context[BotT], /) -> bool:
         """|coro|
 
         Checks if the command can be executed by checking all the predicates
@@ -1090,6 +1120,10 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
         .. versionchanged:: 1.3
             Checks whether the command is disabled or not
+
+        .. versionchanged:: 2.0
+
+            ``ctx`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -1469,7 +1503,7 @@ class Group(GroupMixin[CogT], Command[CogT, P, T]):
             ret.add_command(cmd.copy())
         return ret
 
-    async def invoke(self, ctx: Context[BotT]) -> None:
+    async def invoke(self, ctx: Context[BotT], /) -> None:
         ctx.invoked_subcommand = None
         ctx.subcommand_passed = None
         early_invoke = not self.invoke_without_command
@@ -1500,7 +1534,7 @@ class Group(GroupMixin[CogT], Command[CogT, P, T]):
             view.previous = previous
             await super().invoke(ctx)
 
-    async def reinvoke(self, ctx: Context[BotT], *, call_hooks: bool = False) -> None:
+    async def reinvoke(self, ctx: Context[BotT], /, *, call_hooks: bool = False) -> None:
         ctx.invoked_subcommand = None
         early_invoke = not self.invoke_without_command
         if early_invoke:
@@ -1685,7 +1719,7 @@ def group(
     return command(name=name, cls=cls, **attrs)
 
 
-def check(predicate: Check[ContextT]) -> Callable[[T], T]:
+def check(predicate: Check[ContextT], /) -> Callable[[T], T]:
     r"""A decorator that adds a check to the :class:`.Command` or its
     subclasses. These checks could be accessed via :attr:`.Command.checks`.
 
@@ -1749,6 +1783,10 @@ def check(predicate: Check[ContextT]) -> Callable[[T], T]:
         @is_me()
         async def only_me(ctx):
             await ctx.send('Only you!')
+
+    .. versionchanged:: 2.0
+
+        ``predicate`` parameter is now positional-only.
 
     Parameters
     -----------
@@ -1849,7 +1887,7 @@ def check_any(*checks: Check[ContextT]) -> Callable[[T], T]:
     return check(predicate)
 
 
-def has_role(item: Union[int, str]) -> Callable[[T], T]:
+def has_role(item: Union[int, str], /) -> Callable[[T], T]:
     """A :func:`.check` that is added that checks if the member invoking the
     command has the role specified via the name or ID specified.
 
@@ -1869,6 +1907,10 @@ def has_role(item: Union[int, str]) -> Callable[[T], T]:
 
         Raise :exc:`.MissingRole` or :exc:`.NoPrivateMessage`
         instead of generic :exc:`.CheckFailure`
+
+    .. versionchanged:: 2.0
+
+        ``item`` parameter is now positional-only.
 
     Parameters
     -----------
@@ -1937,7 +1979,7 @@ def has_any_role(*items: Union[int, str]) -> Callable[[T], T]:
     return check(predicate)
 
 
-def bot_has_role(item: int) -> Callable[[T], T]:
+def bot_has_role(item: int, /) -> Callable[[T], T]:
     """Similar to :func:`.has_role` except checks if the bot itself has the
     role.
 
@@ -1949,6 +1991,10 @@ def bot_has_role(item: int) -> Callable[[T], T]:
 
         Raise :exc:`.BotMissingRole` or :exc:`.NoPrivateMessage`
         instead of generic :exc:`.CheckFailure`
+
+    .. versionchanged:: 2.0
+
+        ``item`` parameter is now positional-only.
     """
 
     def predicate(ctx):
@@ -2320,13 +2366,17 @@ def max_concurrency(number: int, per: BucketType = BucketType.default, *, wait: 
     return decorator  # type: ignore
 
 
-def before_invoke(coro: Hook[ContextT]) -> Callable[[T], T]:
+def before_invoke(coro: Hook[ContextT], /) -> Callable[[T], T]:
     """A decorator that registers a coroutine as a pre-invoke hook.
 
     This allows you to refer to one before invoke hook for several commands that
     do not have to be within the same cog.
 
     .. versionadded:: 1.4
+
+    .. versionchanged:: 2.0
+
+        ``coro`` parameter is now positional-only.
 
     Example
     ---------
@@ -2368,13 +2418,17 @@ def before_invoke(coro: Hook[ContextT]) -> Callable[[T], T]:
     return decorator  # type: ignore
 
 
-def after_invoke(coro: Hook[ContextT]) -> Callable[[T], T]:
+def after_invoke(coro: Hook[ContextT], /) -> Callable[[T], T]:
     """A decorator that registers a coroutine as a post-invoke hook.
 
     This allows you to refer to one after invoke hook for several commands that
     do not have to be within the same cog.
 
     .. versionadded:: 1.4
+
+    .. versionchanged:: 2.0
+
+        ``coro`` parameter is now positional-only.
     """
 
     def decorator(func: Union[Command, CoroFunc]) -> Union[Command, CoroFunc]:

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -498,11 +498,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
 
         .. versionchanged:: 2.0
 
-            ``command`` parameter is now positional-only.
-
-        .. versionchanged:: 2.0
-
-            ``string`` parameter is now positional-only.
+            ``command`` and ``string`` parameters are now positional-only.
 
         Parameters
         ------------
@@ -665,11 +661,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
 
         .. versionchanged:: 2.0
 
-            ``ctx`` parameter is now positional-only.
-
-        .. versionchanged:: 2.0
-
-            ``error`` parameter is now positional-only.
+            ``ctx`` and ``error`` parameters are now positional-only.
 
         Parameters
         ------------
@@ -836,11 +828,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
 
         .. versionchanged:: 2.0
 
-            ``ctx`` parameter is now positional-only.
-
-        .. versionchanged:: 2.0
-
-            ``command`` parameter is now positional-only.
+            ``ctx`` and ``command`` parameters are now positional-only.
 
         Parameters
         -----------
@@ -1235,11 +1223,7 @@ class MinimalHelpCommand(HelpCommand[ContextT]):
 
         .. versionchanged:: 2.0
 
-            ``commands`` parameter is now positional-only.
-
-        .. versionchanged:: 2.0
-
-            ``heading`` parameter is now positional-only.
+            ``commands`` and ``heading`` parameters are now positional-only.
 
         Parameters
         -----------

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -274,7 +274,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
         if not hasattr(self.on_help_command_error, '__help_command_not_overridden__'):
             self.on_error = self.on_help_command_error
 
-    async def __call__(self, context: ContextT, *args: Any, **kwargs: Any) -> Any:
+    async def __call__(self, context: ContextT, /, *args: Any, **kwargs: Any) -> Any:
         return await self._set_context(context, *args, **kwargs)
 
     async def _set_context(self, context: ContextT, *args: Any, **kwargs: Any) -> Any:
@@ -306,13 +306,13 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
     async def _parse_arguments(self, ctx: ContextT) -> None:
         return await self._call_without_cog(super()._parse_arguments, ctx)
 
-    async def call_before_hooks(self, ctx: ContextT) -> None:
+    async def call_before_hooks(self, ctx: ContextT, /) -> None:
         return await self._call_without_cog(super().call_before_hooks, ctx)
 
-    async def call_after_hooks(self, ctx: ContextT) -> None:
+    async def call_after_hooks(self, ctx: ContextT, /) -> None:
         return await self._call_without_cog(super().call_after_hooks, ctx)
 
-    async def can_run(self, ctx: ContextT) -> bool:
+    async def can_run(self, ctx: ContextT, /) -> bool:
         return await self._call_without_cog(super().can_run, ctx)
 
     def get_bot_mapping(self) -> Dict[Optional[Cog], List[Command[Any, ..., Any]]]:
@@ -343,8 +343,12 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
             return command_name
         return ctx.invoked_with
 
-    def get_command_signature(self, command: Command[Any, ..., Any]) -> str:
+    def get_command_signature(self, command: Command[Any, ..., Any], /) -> str:
         """Retrieves the signature portion of the help page.
+
+        .. versionchanged:: 2.0
+
+            ``command`` parameter is now positional-only.
 
         Parameters
         ------------
@@ -378,10 +382,14 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
 
         return f'{self.context.clean_prefix}{alias} {command.signature}'
 
-    def remove_mentions(self, string: str) -> str:
+    def remove_mentions(self, string: str, /) -> str:
         """Removes mentions from the string to prevent abuse.
 
         This includes ``@everyone``, ``@here``, member mentions and role mentions.
+
+        .. versionchanged:: 2.0
+
+            ``string`` parameter is now positional-only.
 
         Returns
         -------
@@ -450,13 +458,17 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
         if cog is not None:
             self._inject_into_cog(cog)
 
-    def command_not_found(self, string: str) -> str:
+    def command_not_found(self, string: str, /) -> str:
         """|maybecoro|
 
         A method called when a command is not found in the help command.
         This is useful to override for i18n.
 
         Defaults to ``No command called {0} found.``
+
+        .. versionchanged:: 2.0
+
+            ``string`` parameter is now positional-only.
 
         Parameters
         ------------
@@ -471,7 +483,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
         """
         return f'No command called "{string}" found.'
 
-    def subcommand_not_found(self, command: Command[Any, ..., Any], string: str) -> str:
+    def subcommand_not_found(self, command: Command[Any, ..., Any], string: str, /) -> str:
         """|maybecoro|
 
         A method called when a command did not have a subcommand requested in the help command.
@@ -483,6 +495,14 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
             - If there is no subcommand in the ``command`` parameter.
         - ``'Command "{command.qualified_name}" has no subcommand named {string}'``
             - If the ``command`` parameter has subcommands but not one named ``string``.
+
+        .. versionchanged:: 2.0
+
+            ``command`` parameter is now positional-only.
+
+        .. versionchanged:: 2.0
+
+            ``string`` parameter is now positional-only.
 
         Parameters
         ------------
@@ -504,6 +524,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
     async def filter_commands(
         self,
         commands: Iterable[Command[Any, ..., Any]],
+        /,
         *,
         sort: bool = False,
         key: Optional[Callable[[Command[Any, ..., Any]], Any]] = None,
@@ -514,6 +535,10 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
 
         This takes into account the :attr:`verify_checks` and :attr:`show_hidden`
         attributes.
+
+        .. versionchanged:: 2.0
+
+            ``commands`` parameter is now positional-only.
 
         Parameters
         ------------
@@ -563,8 +588,12 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
             ret.sort(key=key)
         return ret
 
-    def get_max_size(self, commands: Sequence[Command[Any, ..., Any]]) -> int:
+    def get_max_size(self, commands: Sequence[Command[Any, ..., Any]], /) -> int:
         """Returns the largest name length of the specified command list.
+
+        .. versionchanged:: 2.0
+
+            ``commands`` parameter is now positional-only.
 
         Parameters
         ------------
@@ -594,7 +623,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
         """
         return self.context.channel
 
-    async def send_error_message(self, error: str) -> None:
+    async def send_error_message(self, error: str, /) -> None:
         """|coro|
 
         Handles the implementation when an error happens in the help command.
@@ -609,6 +638,10 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
 
             You can access the invocation context with :attr:`HelpCommand.context`.
 
+        .. versionchanged:: 2.0
+
+            ``error`` parameter is now positional-only.
+
         Parameters
         ------------
         error: :class:`str`
@@ -619,7 +652,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
         await destination.send(error)
 
     @_not_overridden
-    async def on_help_command_error(self, ctx: ContextT, error: CommandError) -> None:
+    async def on_help_command_error(self, ctx: ContextT, error: CommandError, /) -> None:
         """|coro|
 
         The help command's error handler, as specified by :ref:`ext_commands_error_handler`.
@@ -630,6 +663,14 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
         By default this method does nothing and just propagates to the default
         error handlers.
 
+        .. versionchanged:: 2.0
+
+            ``ctx`` parameter is now positional-only.
+
+        .. versionchanged:: 2.0
+
+            ``error`` parameter is now positional-only.
+
         Parameters
         ------------
         ctx: :class:`Context`
@@ -639,7 +680,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
         """
         pass
 
-    async def send_bot_help(self, mapping: Mapping[Optional[Cog], List[Command[Any, ..., Any]]]) -> None:
+    async def send_bot_help(self, mapping: Mapping[Optional[Cog], List[Command[Any, ..., Any]]], /) -> None:
         """|coro|
 
         Handles the implementation of the bot command page in the help command.
@@ -659,6 +700,10 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
             Also, the commands in the mapping are not filtered. To do the filtering
             you will have to call :meth:`filter_commands` yourself.
 
+        .. versionchanged:: 2.0
+
+            ``mapping`` parameter is now positional-only.
+
         Parameters
         ------------
         mapping: Mapping[Optional[:class:`Cog`], List[:class:`Command`]]
@@ -668,7 +713,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
         """
         return None
 
-    async def send_cog_help(self, cog: Cog) -> None:
+    async def send_cog_help(self, cog: Cog, /) -> None:
         """|coro|
 
         Handles the implementation of the cog page in the help command.
@@ -689,6 +734,10 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
             The commands returned not filtered. To do the filtering you will have to call
             :meth:`filter_commands` yourself.
 
+        .. versionchanged:: 2.0
+
+            ``cog`` parameter is now positional-only.
+
         Parameters
         -----------
         cog: :class:`Cog`
@@ -696,7 +745,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
         """
         return None
 
-    async def send_group_help(self, group: Group[Any, ..., Any]) -> None:
+    async def send_group_help(self, group: Group[Any, ..., Any], /) -> None:
         """|coro|
 
         Handles the implementation of the group page in the help command.
@@ -717,6 +766,10 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
             :attr:`Group.commands`. The commands returned not filtered. To do the
             filtering you will have to call :meth:`filter_commands` yourself.
 
+        .. versionchanged:: 2.0
+
+            ``group`` parameter is now positional-only.
+
         Parameters
         -----------
         group: :class:`Group`
@@ -724,7 +777,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
         """
         return None
 
-    async def send_command_help(self, command: Command[Any, ..., Any]) -> None:
+    async def send_command_help(self, command: Command[Any, ..., Any], /) -> None:
         """|coro|
 
         Handles the implementation of the single command page in the help command.
@@ -755,6 +808,10 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
             There are more than just these attributes but feel free to play around with
             these to help you get started to get the output that you want.
 
+        .. versionchanged:: 2.0
+
+            ``command`` parameter is now positional-only.
+
         Parameters
         -----------
         command: :class:`Command`
@@ -762,7 +819,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
         """
         return None
 
-    async def prepare_help_command(self, ctx: ContextT, command: Optional[str] = None) -> None:
+    async def prepare_help_command(self, ctx: ContextT, command: Optional[str] = None, /) -> None:
         """|coro|
 
         A low level method that can be used to prepare the help command
@@ -777,6 +834,14 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
             This is called *inside* the help command callback body. So all
             the usual rules that happen inside apply here as well.
 
+        .. versionchanged:: 2.0
+
+            ``ctx`` parameter is now positional-only.
+
+        .. versionchanged:: 2.0
+
+            ``command`` parameter is now positional-only.
+
         Parameters
         -----------
         ctx: :class:`Context`
@@ -786,7 +851,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
         """
         pass
 
-    async def command_callback(self, ctx: ContextT, *, command: Optional[str] = None) -> Any:
+    async def command_callback(self, ctx: ContextT, /, *, command: Optional[str] = None) -> Any:
         """|coro|
 
         The actual implementation of the help command.
@@ -804,6 +869,10 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
         - :meth:`send_error_message`
         - :meth:`on_help_command_error`
         - :meth:`prepare_help_command`
+
+        .. versionchanged:: 2.0
+
+            ``ctx`` parameter is now positional-only.
         """
         await self.prepare_help_command(ctx, command)
 
@@ -899,8 +968,13 @@ class DefaultHelpCommand(HelpCommand[ContextT]):
 
         super().__init__(**options)
 
-    def shorten_text(self, text: str) -> str:
-        """:class:`str`: Shortens text to fit into the :attr:`width`."""
+    def shorten_text(self, text: str, /) -> str:
+        """:class:`str`: Shortens text to fit into the :attr:`width`.
+
+        .. versionchanged:: 2.0
+
+            ``text`` parameter is now positional-only.
+        """
         if len(text) > self.width:
             return text[: self.width - 3].rstrip() + '...'
         return text
@@ -914,7 +988,7 @@ class DefaultHelpCommand(HelpCommand[ContextT]):
         )
 
     def add_indented_commands(
-        self, commands: Sequence[Command[Any, ..., Any]], *, heading: str, max_size: Optional[int] = None
+        self, commands: Sequence[Command[Any, ..., Any]], /, *, heading: str, max_size: Optional[int] = None
     ) -> None:
         """Indents a list of commands after the specified heading.
 
@@ -924,6 +998,10 @@ class DefaultHelpCommand(HelpCommand[ContextT]):
         :attr:`indent` spaces, padded to ``max_size`` followed by
         the command's :attr:`Command.short_doc` and then shortened
         to fit into the :attr:`width`.
+
+        .. versionchanged:: 2.0
+
+            ``commands`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -957,8 +1035,12 @@ class DefaultHelpCommand(HelpCommand[ContextT]):
         for page in self.paginator.pages:
             await destination.send(page)
 
-    def add_command_formatting(self, command: Command[Any, ..., Any]) -> None:
+    def add_command_formatting(self, command: Command[Any, ..., Any], /) -> None:
         """A utility function to format the non-indented block of commands and groups.
+
+        .. versionchanged:: 2.0
+
+            ``command`` parameter is now positional-only.
 
         Parameters
         ------------
@@ -989,11 +1071,11 @@ class DefaultHelpCommand(HelpCommand[ContextT]):
         else:
             return ctx.channel
 
-    async def prepare_help_command(self, ctx: ContextT, command: str) -> None:
+    async def prepare_help_command(self, ctx: ContextT, command: Optional[str] = None, /) -> None:
         self.paginator.clear()
         await super().prepare_help_command(ctx, command)
 
-    async def send_bot_help(self, mapping: Mapping[Optional[Cog], List[Command[Any, ..., Any]]]) -> None:
+    async def send_bot_help(self, mapping: Mapping[Optional[Cog], List[Command[Any, ..., Any]]], /) -> None:
         ctx = self.context
         bot = ctx.bot
 
@@ -1023,12 +1105,12 @@ class DefaultHelpCommand(HelpCommand[ContextT]):
 
         await self.send_pages()
 
-    async def send_command_help(self, command: Command[Any, ..., Any]) -> None:
+    async def send_command_help(self, command: Command[Any, ..., Any], /) -> None:
         self.add_command_formatting(command)
         self.paginator.close_page()
         await self.send_pages()
 
-    async def send_group_help(self, group: Group[Any, ..., Any]) -> None:
+    async def send_group_help(self, group: Group[Any, ..., Any], /) -> None:
         self.add_command_formatting(group)
 
         filtered = await self.filter_commands(group.commands, sort=self.sort_commands)
@@ -1042,7 +1124,7 @@ class DefaultHelpCommand(HelpCommand[ContextT]):
 
         await self.send_pages()
 
-    async def send_cog_help(self, cog: Cog) -> None:
+    async def send_cog_help(self, cog: Cog, /) -> None:
         if cog.description:
             self.paginator.add_line(cog.description, empty=True)
 
@@ -1128,7 +1210,7 @@ class MinimalHelpCommand(HelpCommand[ContextT]):
             f"You can also use `{self.context.clean_prefix}{command_name} [category]` for more info on a category."
         )
 
-    def get_command_signature(self, command: Command[Any, ..., Any]) -> str:
+    def get_command_signature(self, command: Command[Any, ..., Any], /) -> str:
         return f'{self.context.clean_prefix}{command.qualified_name} {command.signature}'
 
     def get_ending_note(self) -> str:
@@ -1143,13 +1225,21 @@ class MinimalHelpCommand(HelpCommand[ContextT]):
         """
         return ''
 
-    def add_bot_commands_formatting(self, commands: Sequence[Command[Any, ..., Any]], heading: str) -> None:
+    def add_bot_commands_formatting(self, commands: Sequence[Command[Any, ..., Any]], heading: str, /) -> None:
         """Adds the minified bot heading with commands to the output.
 
         The formatting should be added to the :attr:`paginator`.
 
         The default implementation is a bold underline heading followed
         by commands separated by an EN SPACE (U+2002) in the next line.
+
+        .. versionchanged:: 2.0
+
+            ``commands`` parameter is now positional-only.
+
+        .. versionchanged:: 2.0
+
+            ``heading`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -1164,13 +1254,17 @@ class MinimalHelpCommand(HelpCommand[ContextT]):
             self.paginator.add_line(f'__**{heading}**__')
             self.paginator.add_line(joined)
 
-    def add_subcommand_formatting(self, command: Command[Any, ..., Any]) -> None:
+    def add_subcommand_formatting(self, command: Command[Any, ..., Any], /) -> None:
         """Adds formatting information on a subcommand.
 
         The formatting should be added to the :attr:`paginator`.
 
         The default implementation is the prefix and the :attr:`Command.qualified_name`
         optionally followed by an En dash and the command's :attr:`Command.short_doc`.
+
+        .. versionchanged:: 2.0
+
+            ``command`` parameter is now positional-only.
 
         Parameters
         -----------
@@ -1180,7 +1274,7 @@ class MinimalHelpCommand(HelpCommand[ContextT]):
         fmt = '{0}{1} \N{EN DASH} {2}' if command.short_doc else '{0}{1}'
         self.paginator.add_line(fmt.format(self.context.clean_prefix, command.qualified_name, command.short_doc))
 
-    def add_aliases_formatting(self, aliases: Sequence[str]) -> None:
+    def add_aliases_formatting(self, aliases: Sequence[str], /) -> None:
         """Adds the formatting information on a command's aliases.
 
         The formatting should be added to the :attr:`paginator`.
@@ -1190,6 +1284,10 @@ class MinimalHelpCommand(HelpCommand[ContextT]):
 
         This is not called if there are no aliases to format.
 
+        .. versionchanged:: 2.0
+
+            ``aliases`` parameter is now positional-only.
+
         Parameters
         -----------
         aliases: Sequence[:class:`str`]
@@ -1197,8 +1295,12 @@ class MinimalHelpCommand(HelpCommand[ContextT]):
         """
         self.paginator.add_line(f'**{self.aliases_heading}** {", ".join(aliases)}', empty=True)
 
-    def add_command_formatting(self, command: Command[Any, ..., Any]) -> None:
+    def add_command_formatting(self, command: Command[Any, ..., Any], /) -> None:
         """A utility function to format commands and groups.
+
+        .. versionchanged:: 2.0
+
+            ``command`` parameter is now positional-only.
 
         Parameters
         ------------
@@ -1233,11 +1335,11 @@ class MinimalHelpCommand(HelpCommand[ContextT]):
         else:
             return ctx.channel
 
-    async def prepare_help_command(self, ctx: ContextT, command: str) -> None:
+    async def prepare_help_command(self, ctx: ContextT, command: Optional[str] = None, /) -> None:
         self.paginator.clear()
         await super().prepare_help_command(ctx, command)
 
-    async def send_bot_help(self, mapping: Mapping[Optional[Cog], List[Command[Any, ..., Any]]]) -> None:
+    async def send_bot_help(self, mapping: Mapping[Optional[Cog], List[Command[Any, ..., Any]]], /) -> None:
         ctx = self.context
         bot = ctx.bot
 
@@ -1268,7 +1370,7 @@ class MinimalHelpCommand(HelpCommand[ContextT]):
 
         await self.send_pages()
 
-    async def send_cog_help(self, cog: Cog) -> None:
+    async def send_cog_help(self, cog: Cog, /) -> None:
         bot = self.context.bot
         if bot.description:
             self.paginator.add_line(bot.description, empty=True)
@@ -1293,7 +1395,7 @@ class MinimalHelpCommand(HelpCommand[ContextT]):
 
         await self.send_pages()
 
-    async def send_group_help(self, group: Group[Any, ..., Any]) -> None:
+    async def send_group_help(self, group: Group[Any, ..., Any], /) -> None:
         self.add_command_formatting(group)
 
         filtered = await self.filter_commands(group.commands, sort=self.sort_commands)
@@ -1313,7 +1415,7 @@ class MinimalHelpCommand(HelpCommand[ContextT]):
 
         await self.send_pages()
 
-    async def send_command_help(self, command: Command[Any, ..., Any]) -> None:
+    async def send_command_help(self, command: Command[Any, ..., Any], /) -> None:
         self.add_command_formatting(command)
         self.paginator.close_page()
         await self.send_pages()

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -939,6 +939,7 @@ Parameters in the following methods are now all positional-only:
 - :meth:`Client.fetch_webhook`
 - :meth:`Client.fetch_widget`
 - :meth:`Message.add_reaction`
+- :meth:`Client.error`
 - :meth:`abc.Messageable.fetch_message`
 - :meth:`abc.GuildChannel.permissions_for`
 - :meth:`DMChannel.get_partial_message`
@@ -950,6 +951,9 @@ Parameters in the following methods are now all positional-only:
 The following parameters are now positional-only:
 
 - ``iterable`` in :meth:`utils.get`
+- ``event`` in :meth:`Client.dispatch`
+- ``event_method`` in :meth:`Client.on_error`
+- ``event`` in :meth:`Client.wait_for`
 
 The following are now keyword-only:
 
@@ -1247,14 +1251,97 @@ define their type hints more accurately.
 Function Signature Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Parameters in the following methods are now all positional-only:
+
+- :meth:`ext.commands.when_mentioned`
+- :meth:`ext.commands.Bot.on_command_error`
+- :meth:`ext.commands.Bot.check`
+- :meth:`ext.commands.Bot.check_once`
+- :meth:`ext.commands.Bot.is_owner`
+- :meth:`ext.commands.Bot.before_invoke`
+- :meth:`ext.commands.Bot.after_invoke`
+- :meth:`ext.commands.Bot.listen`
+- :meth:`ext.commands.Bot.get_prefix`
+- :meth:`ext.commands.Bot.invoke`
+- :meth:`ext.commands.Bot.process_commands`
+- :meth:`ext.commands.Bot.on_message`
+- :meth:`ext.commands.Command.dispatch_error`
+- :meth:`ext.commands.Command.transform`
+- :meth:`ext.commands.Command.call_before_hooks`
+- :meth:`ext.commands.Command.call_after_hooks`
+- :meth:`ext.commands.Command.prepare`
+- :meth:`ext.commands.Command.is_on_cooldown`
+- :meth:`ext.commands.Command.reset_cooldown`
+- :meth:`ext.commands.Command.get_cooldown_retry_after`
+- :meth:`ext.commands.Command.invoke`
+- :meth:`ext.commands.Command.error`
+- :meth:`ext.commands.Command.before_invoke`
+- :meth:`ext.commands.Command.after_invoke`
+- :meth:`ext.commands.Command.can_run`
+- :meth:`ext.commands.Group.invoke`
+- :meth:`ext.commands.check`
+- :meth:`ext.commands.has_role`
+- :meth:`ext.commands.bot_has_role`
+- :meth:`ext.commands.before_invoke`
+- :meth:`ext.commands.after_invoke`
+- :meth:`ext.commands.HelpCommand.call_before_hooks`
+- :meth:`ext.commands.HelpCommand.call_after_hooks`
+- :meth:`ext.commands.HelpCommand.can_run`
+- :meth:`ext.commands.HelpCommand.get_command_signature`
+- :meth:`ext.commands.HelpCommand.remove_mentions`
+- :meth:`ext.commands.HelpCommand.command_not_found`
+- :meth:`ext.commands.HelpCommand.subcommand_not_found`
+- :meth:`ext.commands.HelpCommand.get_max_size`
+- :meth:`ext.commands.HelpCommand.send_error_message`
+- :meth:`ext.commands.HelpCommand.on_help_command_error`
+- :meth:`ext.commands.HelpCommand.send_bot_help`
+- :meth:`ext.commands.HelpCommand.send_cog_help`
+- :meth:`ext.commands.HelpCommand.send_group_help`
+- :meth:`ext.commands.HelpCommand.send_command_help`
+- :meth:`ext.commands.HelpCommand.prepare_help_command`
+- :meth:`ext.commands.DefaultHelpCommand.shorten_text`
+- :meth:`ext.commands.DefaultHelpCommand.add_command_formatting`
+- :meth:`ext.commands.DefaultHelpCommand.prepare_help_command`
+- :meth:`ext.commands.DefaultHelpCommand.send_bot_help`
+- :meth:`ext.commands.DefaultHelpCommand.send_command_help`
+- :meth:`ext.commands.DefaultHelpCommand.send_group_help`
+- :meth:`ext.commands.DefaultHelpCommand.send_cog_help`
+- :meth:`ext.commands.MinimalHelpCommand.get_command_signature`
+- :meth:`ext.commands.MinimalHelpCommand.add_bot_commands_formatting`
+- :meth:`ext.commands.MinimalHelpCommand.add_subcommand_formatting`
+- :meth:`ext.commands.MinimalHelpCommand.add_aliases_formatting`
+- :meth:`ext.commands.MinimalHelpCommand.add_command_formatting`
+- :meth:`ext.commands.MinimalHelpCommand.prepare_help_command`
+- :meth:`ext.commands.MinimalHelpCommand.send_bot_help`
+- :meth:`ext.commands.MinimalHelpCommand.send_cog_help`
+- :meth:`ext.commands.MinimalHelpCommand.send_group_help`
+- :meth:`ext.commands.MinimalHelpCommand.send_command_help`
+
 The following parameters are now positional-only:
 
+- ``event_name`` in :meth:`ext.commands.Bot.dispatch`
+- ``func`` in :meth:`ext.commands.Bot.check`
 - ``func`` in :meth:`ext.commands.Bot.add_check`
 - ``func`` in :meth:`ext.commands.Bot.remove_check`
+- ``func`` in :meth:`ext.commands.Bot.check_once`
+- ``ctx`` in :meth:`ext.commands.Bot.can_run`
+- ``func`` in :meth:`ext.commands.Bot.add_listener`
+- ``func`` in :meth:`ext.commands.Bot.remove_listener`
+- ``name`` in :meth:`ext.commands.Bot.load_extension`
+- ``name`` in :meth:`ext.commands.Bot.unload_extension`
+- ``name`` in :meth:`ext.commands.Bot.reload_extension`
+- ``message`` in :meth:`ext.commands.Bot.get_context`
 - ``func`` in :meth:`ext.commands.Command.add_check`
 - ``func`` in :meth:`ext.commands.Command.remove_check`
+- ``context`` in :meth:`ext.commands.Command.__call__`
+- ``ctx`` in :meth:`ext.commands.Command.reinvoke`
+- ``ctx`` in :meth:`ext.commands.Group.reinvoke`
+- ``context`` in :meth:`ext.commands.HelpCommand.__call__`
+- ``commands`` in :meth:`ext.commands.HelpCommand.filter_commands`
+- ``ctx`` in :meth:`ext.commands.HelpCommand.command_callback`
 - ``func`` in :meth:`ext.commands.HelpCommand.add_check`
 - ``func`` in :meth:`ext.commands.HelpCommand.remove_check`
+- ``commands`` in :meth:`ext.commands.DefaultHelpCommand.add_indented_commands`
 - ``cog`` in :meth:`ext.commands.Bot.add_cog`
 - ``name`` in :meth:`ext.commands.Bot.get_cog`
 - ``name`` in :meth:`ext.commands.Bot.remove_cog`

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -1260,7 +1260,6 @@ Parameters in the following methods are now all positional-only:
 - :meth:`ext.commands.Bot.is_owner`
 - :meth:`ext.commands.Bot.before_invoke`
 - :meth:`ext.commands.Bot.after_invoke`
-- :meth:`ext.commands.Bot.listen`
 - :meth:`ext.commands.Bot.get_prefix`
 - :meth:`ext.commands.Bot.invoke`
 - :meth:`ext.commands.Bot.process_commands`
@@ -1327,9 +1326,6 @@ The following parameters are now positional-only:
 - ``ctx`` in :meth:`ext.commands.Bot.can_run`
 - ``func`` in :meth:`ext.commands.Bot.add_listener`
 - ``func`` in :meth:`ext.commands.Bot.remove_listener`
-- ``name`` in :meth:`ext.commands.Bot.load_extension`
-- ``name`` in :meth:`ext.commands.Bot.unload_extension`
-- ``name`` in :meth:`ext.commands.Bot.reload_extension`
 - ``message`` in :meth:`ext.commands.Bot.get_context`
 - ``func`` in :meth:`ext.commands.Command.add_check`
 - ``func`` in :meth:`ext.commands.Command.remove_check`


### PR DESCRIPTION
## Summary

Changes some arguments in public methods to positional-only. A few of these (like the changes to `Client.dispatch()` and `BotBase.dispatch()`) fix incompatible override issues.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
