### PR TITLE
Correct documentation for `custom_id` in TextInput

### DIFF
--- a/discord/ui/text_input.py
+++ b/discord/ui/text_input.py
@@ -122,7 +122,7 @@ class TextInput(Item[V]):
 
     @property
     def custom_id(self) -> str:
-        """:class:`str`: The ID of the select menu that gets received during an interaction."""
+        """:class:`str`: The ID of the text input that gets received during an interaction."""
         return self._underlying.custom_id
 
     @custom_id.setter


### PR DESCRIPTION
## Summary
Corrects documentation for `custom_id` in `discord.ui.TextInput` specifying select menu instead of text input.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
