### PR TITLE
Allow receiving messages from voice channels

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -571,6 +571,7 @@ class PartialMessage(Hashable):
     def __init__(self, *, channel: MessageableChannel, id: int) -> None:
         if not isinstance(channel, PartialMessageable) and channel.type not in (
             ChannelType.text,
+            ChannelType.voice,
             ChannelType.news,
             ChannelType.private,
             ChannelType.news_thread,


### PR DESCRIPTION
## Summary
Now some guilds are able to send messages in voice channels. However, this raises `TypeError` and causes the bot to crash when someone sends a message here.

## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
