### PR TITLE
Fix InvalidArgument typo on Webhook.edit

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1260,7 +1260,7 @@ class Webhook(BaseWebhook):
 
         .. versionchanged:: 2.0
             This function will now raise :exc:`ValueError` instead of
-            ``~InvalidArgument``.
+            ``InvalidArgument``.
 
         Parameters
         ------------


### PR DESCRIPTION
## Summary

This fixes a formatting typo in `Webhook.edit`'s docs. It's from one of my PRs, my bad.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
