### PR TITLE
Remove user account reference in docstring

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -437,8 +437,8 @@ class Thread(Messageable, Hashable):
         without discrimination.
 
         You must have the :attr:`~Permissions.manage_messages` permission to
-        delete messages even if they are your own (unless you are a user
-        account). The :attr:`~Permissions.read_message_history` permission is
+        delete messages even if they are your own. 
+        The :attr:`~Permissions.read_message_history` permission is
         also needed to retrieve message history.
 
         Examples

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -437,7 +437,7 @@ class Thread(Messageable, Hashable):
         without discrimination.
 
         You must have the :attr:`~Permissions.manage_messages` permission to
-        delete messages even if they are your own. 
+        delete messages even if they are your own.
         The :attr:`~Permissions.read_message_history` permission is
         also needed to retrieve message history.
 


### PR DESCRIPTION
## Summary

The docstring for purge in a thread was outdated, still mentioning user accounts. This pr fixes that

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
