### PR TITLE
Add support for int() to return ID for AppCommand and AppCommandChannel

### DIFF
--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -95,6 +95,10 @@ class AppCommand(Hashable):
         .. describe:: str(x)
 
             Returns the application command's name.
+            
+        .. describe:: int(x)
+
+            Returns the application command's ID.
 
     Attributes
     -----------
@@ -147,6 +151,9 @@ class AppCommand(Hashable):
     def __str__(self) -> str:
         return self.name
 
+    def __int__(self) -> int:
+        return self.id
+    
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} id={self.id!r} name={self.name!r} type={self.type!r}>'
 
@@ -236,6 +243,10 @@ class AppCommandChannel(Hashable):
 
             Returns the channel's name.
 
+        .. describe:: int(x)
+
+            Returns the channel's ID.
+            
     Attributes
     -----------
     id: :class:`int`
@@ -277,6 +288,9 @@ class AppCommandChannel(Hashable):
     def __str__(self) -> str:
         return self.name
 
+    def __int__(self) -> int:
+        return self.id
+    
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} id={self.id!r} name={self.name!r} type={self.type!r}>'
 


### PR DESCRIPTION
## Summary

Adding the ability to get the ID of an AppCommand or AppCommandChannel using int()

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
