### PR TITLE
Update comments after `# type: ignore` to be compatible with PEP 484

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -511,7 +511,7 @@ class GuildChannel:
 
         If there is no category then this is ``None``.
         """
-        return self.guild.get_channel(self.category_id)  # type: ignore - These are coerced into CategoryChannel
+        return self.guild.get_channel(self.category_id)  # type: ignore # These are coerced into CategoryChannel
 
     @property
     def permissions_synced(self) -> bool:
@@ -843,7 +843,7 @@ class GuildChannel:
         obj = cls(state=self._state, guild=self.guild, data=data)
 
         # temporarily add it to the cache
-        self.guild._channels[obj.id] = obj  # type: ignore - obj is a GuildChannel
+        self.guild._channels[obj.id] = obj  # type: ignore # obj is a GuildChannel
         return obj
 
     async def clone(self, *, name: Optional[str] = None, reason: Optional[str] = None) -> Self:

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -1272,9 +1272,9 @@ def describe(**parameters: str) -> Callable[[T], T]:
             _populate_descriptions(inner._params, parameters)
         else:
             try:
-                inner.__discord_app_commands_param_description__.update(parameters)  # type: ignore - Runtime attribute access
+                inner.__discord_app_commands_param_description__.update(parameters)  # type: ignore # Runtime attribute access
             except AttributeError:
-                inner.__discord_app_commands_param_description__ = parameters  # type: ignore - Runtime attribute assignment
+                inner.__discord_app_commands_param_description__ = parameters  # type: ignore # Runtime attribute assignment
 
         return inner
 
@@ -1341,9 +1341,9 @@ def choices(**parameters: List[Choice[ChoiceT]]) -> Callable[[T], T]:
             _populate_choices(inner._params, parameters)
         else:
             try:
-                inner.__discord_app_commands_param_choices__.update(parameters)  # type: ignore - Runtime attribute access
+                inner.__discord_app_commands_param_choices__.update(parameters)  # type: ignore # Runtime attribute access
             except AttributeError:
-                inner.__discord_app_commands_param_choices__ = parameters  # type: ignore - Runtime attribute assignment
+                inner.__discord_app_commands_param_choices__ = parameters  # type: ignore # Runtime attribute assignment
 
         return inner
 
@@ -1393,9 +1393,9 @@ def autocomplete(**parameters: AutocompleteCallback[GroupT, ChoiceT]) -> Callabl
             _populate_autocomplete(inner._params, parameters)
         else:
             try:
-                inner.__discord_app_commands_param_autocomplete__.update(parameters)  # type: ignore - Runtime attribute access
+                inner.__discord_app_commands_param_autocomplete__.update(parameters)  # type: ignore # Runtime attribute access
             except AttributeError:
-                inner.__discord_app_commands_param_autocomplete__ = parameters  # type: ignore - Runtime attribute assignment
+                inner.__discord_app_commands_param_autocomplete__ = parameters  # type: ignore # Runtime attribute assignment
 
         return inner
 

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -142,7 +142,7 @@ class AppCommand(Hashable):
             'name': self.name,
             'description': self.description,
             'options': [opt.to_dict() for opt in self.options],
-        }  # type: ignore -- Type checker does not understand this literal.
+        }  # type: ignore # Type checker does not understand this literal.
 
     def __str__(self) -> str:
         return self.name
@@ -319,7 +319,7 @@ class AppCommandChannel(Hashable):
             The full channel.
         """
         client = self._state._get_client()
-        return await client.fetch_channel(self.id)  # type: ignore -- This is explicit narrowing
+        return await client.fetch_channel(self.id)  # type: ignore # This is explicit narrowing
 
     @property
     def mention(self) -> str:
@@ -493,7 +493,7 @@ class AppCommandThread(Hashable):
             The full thread.
         """
         client = self._state._get_client()
-        return await client.fetch_channel(self.id)  # type: ignore -- This is explicit narrowing
+        return await client.fetch_channel(self.id)  # type: ignore # This is explicit narrowing
 
 
 class Argument:
@@ -554,7 +554,7 @@ class Argument:
             'required': self.required,
             'choices': [choice.to_dict() for choice in self.choices],
             'options': [],
-        }  # type: ignore -- Type checker does not understand this literal.
+        }  # type: ignore # Type checker does not understand this literal.
 
 
 class AppCommandGroup:
@@ -623,7 +623,7 @@ class AppCommandGroup:
             'required': self.required,
             'choices': [choice.to_dict() for choice in self.choices],
             'options': [arg.to_dict() for arg in self.arguments],
-        }  # type: ignore -- Type checker does not understand this literal.
+        }  # type: ignore # Type checker does not understand this literal.
 
 
 def app_command_option_factory(

--- a/discord/app_commands/namespace.py
+++ b/discord/app_commands/namespace.py
@@ -134,17 +134,17 @@ class Namespace:
             opt_type = option['type']
             name = option['name']
             if opt_type in (3, 4, 5):  # string, integer, boolean
-                value = option['value']  # type: ignore -- Key is there
+                value = option['value']  # type: ignore # Key is there
                 self.__dict__[name] = value
             elif opt_type == 10:  # number
-                value = option['value']  # type: ignore -- Key is there
+                value = option['value']  # type: ignore # Key is there
                 if value is None:
                     self.__dict__[name] = float('nan')
                 else:
                     self.__dict__[name] = float(value)
             elif opt_type in (6, 7, 8, 9, 11):
                 # Remaining ones should be snowflake based ones with resolved data
-                snowflake: str = option['value']  # type: ignore -- Key is there
+                snowflake: str = option['value']  # type: ignore # Key is there
                 if opt_type == 9:  # Mentionable
                     # Mentionable is User | Role, these do not cause any conflict
                     key = ResolveKey.any_with(snowflake)

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -132,19 +132,19 @@ def _transform_icon(entry: AuditLogEntry, data: Optional[str]) -> Optional[Asset
     if entry.action is enums.AuditLogAction.guild_update:
         return Asset._from_guild_icon(entry._state, entry.guild.id, data)
     else:
-        return Asset._from_icon(entry._state, entry._target_id, data, path='role')  # type: ignore - target_id won't be None in this case
+        return Asset._from_icon(entry._state, entry._target_id, data, path='role')  # type: ignore # target_id won't be None in this case
 
 
 def _transform_avatar(entry: AuditLogEntry, data: Optional[str]) -> Optional[Asset]:
     if data is None:
         return None
-    return Asset._from_avatar(entry._state, entry._target_id, data)  # type: ignore - target_id won't be None in this case
+    return Asset._from_avatar(entry._state, entry._target_id, data)  # type: ignore # target_id won't be None in this case
 
 
 def _transform_cover_image(entry: AuditLogEntry, data: Optional[str]) -> Optional[Asset]:
     if data is None:
         return None
-    return Asset._from_scheduled_event_cover_image(entry._state, entry._target_id, data)  # type: ignore - target_id won't be None in this case
+    return Asset._from_scheduled_event_cover_image(entry._state, entry._target_id, data)  # type: ignore # target_id won't be None in this case
 
 
 def _guild_hash_transformer(path: str) -> Callable[[AuditLogEntry, Optional[str]], Optional[Asset]]:
@@ -258,10 +258,10 @@ class AuditLogChanges:
 
             # special cases for role add/remove
             if attr == '$add':
-                self._handle_role(self.before, self.after, entry, elem['new_value'])  # type: ignore - new_value is a list of roles in this case
+                self._handle_role(self.before, self.after, entry, elem['new_value'])  # type: ignore # new_value is a list of roles in this case
                 continue
             elif attr == '$remove':
-                self._handle_role(self.after, self.before, entry, elem['new_value'])  # type: ignore - new_value is a list of roles in this case
+                self._handle_role(self.after, self.before, entry, elem['new_value'])  # type: ignore # new_value is a list of roles in this case
                 continue
 
             try:
@@ -318,7 +318,7 @@ class AuditLogChanges:
 
             if role is None:
                 role = Object(id=role_id)
-                role.name = e['name']  # type: ignore - Object doesn't usually have name
+                role.name = e['name']  # type: ignore # Object doesn't usually have name
 
             data.append(role)
 
@@ -456,7 +456,7 @@ class AuditLogEntry(Hashable):
                     role = self.guild.get_role(instance_id)
                     if role is None:
                         role = Object(id=instance_id)
-                        role.name = self.extra.get('role_name')  # type: ignore - Object doesn't usually have name
+                        role.name = self.extra.get('role_name')  # type: ignore # Object doesn't usually have name
                     self.extra = role
             elif self.action.name.startswith('stage_instance'):
                 channel_id = int(extra['channel_id'])
@@ -548,7 +548,7 @@ class AuditLogEntry(Hashable):
             'code': changeset.code,
             'temporary': changeset.temporary,
             'uses': changeset.uses,
-            'channel': None,  # type: ignore - the channel is passed to the Invite constructor directly
+            'channel': None,  # type: ignore # the channel is passed to the Invite constructor directly
         }
 
         obj = Invite(state=self._state, data=fake_payload, guild=self.guild, channel=changeset.channel)

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -600,7 +600,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         from .webhook import Webhook
 
         if avatar is not None:
-            avatar = utils._bytes_to_base64_data(avatar)  # type: ignore - Silence reassignment error
+            avatar = utils._bytes_to_base64_data(avatar)  # type: ignore # Silence reassignment error
 
         data = await self._state.http.create_webhook(self.id, name=str(name), avatar=avatar, reason=reason)
         return Webhook.from_state(data, state=self._state)

--- a/discord/client.py
+++ b/discord/client.py
@@ -803,7 +803,7 @@ class Client:
         Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.abc.PrivateChannel`]]
             The returned channel or ``None`` if not found.
         """
-        return self._connection.get_channel(id)  # type: ignore - The cache contains all channel types
+        return self._connection.get_channel(id)  # type: ignore # The cache contains all channel types
 
     def get_partial_messageable(self, id: int, *, type: Optional[ChannelType] = None) -> PartialMessageable:
         """Returns a partial messageable with the given channel ID.
@@ -1180,7 +1180,7 @@ class Client:
                 continue
 
             if activity is not None:
-                me.activities = (activity,)  # type: ignore - Type checker does not understand the downcast here
+                me.activities = (activity,)  # type: ignore # Type checker does not understand the downcast here
             else:
                 me.activities = ()
 

--- a/discord/components.py
+++ b/discord/components.py
@@ -126,7 +126,7 @@ class ActionRow(Component):
         return {
             'type': int(self.type),
             'components': [child.to_dict() for child in self.children],
-        }  # type: ignore - Type checker does not understand these are the same
+        }  # type: ignore # Type checker does not understand these are the same
 
 
 class Button(Component):
@@ -198,7 +198,7 @@ class Button(Component):
         if self.emoji:
             payload['emoji'] = self.emoji.to_dict()
 
-        return payload  # type: ignore - Type checker does not understand these are the same
+        return payload  # type: ignore # Type checker does not understand these are the same
 
 
 class SelectMenu(Component):
@@ -364,7 +364,7 @@ class SelectOption:
         }
 
         if self.emoji:
-            payload['emoji'] = self.emoji.to_dict()  # type: ignore - This Dict[str, Any] is compatible with PartialEmoji
+            payload['emoji'] = self.emoji.to_dict()  # type: ignore # This Dict[str, Any] is compatible with PartialEmoji
 
         if self.description:
             payload['description'] = self.description

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -709,4 +709,4 @@ class Embed:
         if self.title:
             result['title'] = self.title
 
-        return result  # type: ignore - This payload is equivalent to the EmbedData type
+        return result  # type: ignore # This payload is equivalent to the EmbedData type

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -116,8 +116,8 @@ class Emoji(_EmojiTag, AssetMixin):
     def _from_data(self, emoji: EmojiPayload):
         self.require_colons: bool = emoji.get('require_colons', False)
         self.managed: bool = emoji.get('managed', False)
-        self.id: int = int(emoji['id'])  # type: ignore - This won't be None for full emoji objects.
-        self.name: str = emoji['name']  # type: ignore - This won't be None for full emoji objects.
+        self.id: int = int(emoji['id'])  # type: ignore # This won't be None for full emoji objects.
+        self.name: str = emoji['name']  # type: ignore # This won't be None for full emoji objects.
         self.animated: bool = emoji.get('animated', False)
         self.available: bool = emoji.get('available', True)
         self._roles: SnowflakeList = SnowflakeList(map(int, emoji.get('roles', [])))
@@ -256,4 +256,4 @@ class Emoji(_EmojiTag, AssetMixin):
             payload['roles'] = [role.id for role in roles]
 
         data = await self._state.http.edit_custom_emoji(self.guild_id, self.id, payload=payload, reason=reason)
-        return Emoji(guild=self.guild, data=data, state=self._state)  # type: ignore - if guild is None, the http request would have failed
+        return Emoji(guild=self.guild, data=data, state=self._state)  # type: ignore # if guild is None, the http request would have failed

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -128,7 +128,7 @@ class EnumMeta(type):
         attrs['_enum_member_names_'] = member_names
         attrs['_enum_value_cls_'] = value_cls
         actual_cls = super().__new__(cls, name, bases, attrs)
-        value_cls._actual_enum_cls_ = actual_cls  # type: ignore - Runtime attribute isn't understood
+        value_cls._actual_enum_cls_ = actual_cls  # type: ignore # Runtime attribute isn't understood
         return actual_cls
 
     def __iter__(cls) -> Iterator[Any]:
@@ -678,7 +678,7 @@ class AppCommandType(Enum):
 
 
 def create_unknown_value(cls: Type[E], val: Any) -> E:
-    value_cls = cls._enum_value_cls_  # type: ignore - This is narrowed below
+    value_cls = cls._enum_value_cls_  # type: ignore # This is narrowed below
     name = f'unknown_{val}'
     return value_cls(name=name, value=val)
 
@@ -690,6 +690,6 @@ def try_enum(cls: Type[E], val: Any) -> E:
     """
 
     try:
-        return cls._enum_value_map_[val]  # type: ignore - All errors are caught below
+        return cls._enum_value_map_[val]  # type: ignore # All errors are caught below
     except (KeyError, TypeError, AttributeError):
         return create_unknown_value(cls, val)

--- a/discord/errors.py
+++ b/discord/errors.py
@@ -117,7 +117,7 @@ class HTTPException(DiscordException):
 
     def __init__(self, response: _ResponseType, message: Optional[Union[str, Dict[str, Any]]]):
         self.response: _ResponseType = response
-        self.status: int = response.status  # type: ignore - This attribute is filled by the library even if using requests
+        self.status: int = response.status  # type: ignore # This attribute is filled by the library even if using requests
         self.code: int
         self.text: str
         if isinstance(message, dict):

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -375,7 +375,7 @@ class PartialMessageConverter(Converter[discord.PartialMessage]):
         guild_id, message_id, channel_id = self._get_id_matches(ctx, argument)
         channel = self._resolve_channel(ctx, guild_id, channel_id)
         if not channel or not isinstance(channel, discord.abc.Messageable):
-            raise ChannelNotFound(channel_id)  # type: ignore - channel_id won't be None here
+            raise ChannelNotFound(channel_id)  # type: ignore # channel_id won't be None here
         return discord.PartialMessage(channel=channel, id=message_id)
 
 
@@ -407,7 +407,7 @@ class MessageConverter(IDConverter[discord.Message]):
         except discord.NotFound:
             raise MessageNotFound(argument)
         except discord.Forbidden:
-            raise ChannelNotReadable(channel)  # type: ignore - type-checker thinks channel could be a DMChannel at this point
+            raise ChannelNotReadable(channel)  # type: ignore # type-checker thinks channel could be a DMChannel at this point
 
 
 class GuildChannelConverter(IDConverter[discord.abc.GuildChannel]):

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1622,7 +1622,7 @@ def command(
     [
         Union[
             Callable[Concatenate[ContextT, P], Coro[Any]],
-            Callable[Concatenate[CogT, ContextT, P], Coro[Any]],  # type: ignore - CogT is used here to allow covariance
+            Callable[Concatenate[CogT, ContextT, P], Coro[Any]],  # type: ignore # CogT is used here to allow covariance
         ]
     ],
     CommandT,
@@ -1691,7 +1691,7 @@ def group(
 ) -> Callable[
     [
         Union[
-            Callable[Concatenate[CogT, ContextT, P], Coro[Any]],  # type: ignore - CogT is used here to allow covariance
+            Callable[Concatenate[CogT, ContextT, P], Coro[Any]],  # type: ignore # CogT is used here to allow covariance
             Callable[Concatenate[ContextT, P], Coro[Any]],
         ]
     ],

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -361,7 +361,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
             The signature for the command.
         """
 
-        parent: Optional[Group[Any, ..., Any]] = command.parent  # type: ignore - the parent will be a Group
+        parent: Optional[Group[Any, ..., Any]] = command.parent  # type: ignore # the parent will be a Group
         entries = []
         while parent is not None:
             if not parent.signature or parent.invoke_without_command:
@@ -561,7 +561,7 @@ class HelpCommand(HelpCommandCommand, Generic[ContextT]):
         if self.verify_checks is False:
             # if we do not need to verify the checks then we can just
             # run it straight through normally without using await.
-            return sorted(iterator, key=key) if sort else list(iterator)  # type: ignore - the key shouldn't be None
+            return sorted(iterator, key=key) if sort else list(iterator)  # type: ignore # the key shouldn't be None
 
         if self.verify_checks is None and not self.context.guild:
             # if verify_checks is None and we're in a DM, don't verify

--- a/discord/ext/commands/view.py
+++ b/discord/ext/commands/view.py
@@ -181,7 +181,7 @@ class StringView:
                 next_char = self.get()
                 valid_eof = not next_char or next_char.isspace()
                 if not valid_eof:
-                    raise InvalidEndOfQuotedStringError(next_char)  # type: ignore - this will always be a string
+                    raise InvalidEndOfQuotedStringError(next_char)  # type: ignore # this will always be a string
 
                 # we're quoted so it's okay
                 return ''.join(result)

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -829,7 +829,7 @@ class DiscordVoiceWebSocket:
         self._close_code: Optional[int] = None
         self.secret_key: Optional[str] = None
         if hook:
-            self._hook = hook  # type: ignore - type-checker doesn't like overriding methods
+            self._hook = hook  # type: ignore # type-checker doesn't like overriding methods
 
     async def _hook(self, *args: Any) -> None:
         pass

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -403,7 +403,7 @@ class Guild(Hashable):
 
     def _update_voice_state(self, data: GuildVoiceState, channel_id: int) -> Tuple[Optional[Member], VoiceState, VoiceState]:
         user_id = int(data['user_id'])
-        channel: Optional[VocalGuildChannel] = self.get_channel(channel_id)  # type: ignore - this will always be a voice channel
+        channel: Optional[VocalGuildChannel] = self.get_channel(channel_id)  # type: ignore # this will always be a voice channel
         try:
             # check if we should remove the voice state from cache
             if channel is None:
@@ -512,7 +512,7 @@ class Guild(Hashable):
         cache_joined = self._state.member_cache_flags.joined
         self_id = self._state.self_id
         for mdata in guild.get('members', []):
-            member = Member(data=mdata, guild=self, state=state)  # type: ignore - Members will have the 'user' key in this scenario
+            member = Member(data=mdata, guild=self, state=state)  # type: ignore # Members will have the 'user' key in this scenario
             if cache_joined or member.id == self_id:
                 self._add_member(member)
 
@@ -604,7 +604,7 @@ class Guild(Hashable):
         """:class:`Member`: Similar to :attr:`Client.user` except an instance of :class:`Member`.
         This is essentially used to get the member version of yourself.
         """
-        self_id = self._state.user.id  # type: ignore - state.user won't be None if we're logged in
+        self_id = self._state.user.id  # type: ignore # state.user won't be None if we're logged in
         # The self member is *always* cached
         return self.get_member(self_id)  # type: ignore
 
@@ -2028,11 +2028,11 @@ class Guild(Hashable):
         if ch_type in (ChannelType.group, ChannelType.private):
             raise InvalidData('Channel ID resolved to a private channel')
 
-        guild_id = int(data['guild_id'])  # type: ignore - channel won't be a private channel
+        guild_id = int(data['guild_id'])  # type: ignore # channel won't be a private channel
         if self.id != guild_id:
             raise InvalidData('Guild ID resolved to a different guild')
 
-        channel: GuildChannel = factory(guild=self, state=self._state, data=data)  # type: ignore - channel won't be a private channel
+        channel: GuildChannel = factory(guild=self, state=self._state, data=data)  # type: ignore # channel won't be a private channel
         return channel
 
     async def bans(self) -> List[BanEntry]:
@@ -3166,7 +3166,7 @@ class Guild(Hashable):
         payload['max_uses'] = 0
         payload['max_age'] = 0
         payload['uses'] = payload.get('uses', 0)
-        return Invite(state=self._state, data=payload, guild=self, channel=channel)  # type: ignore - we're faking a payload here
+        return Invite(state=self._state, data=payload, guild=self, channel=channel)  # type: ignore # we're faking a payload here
 
     async def audit_logs(
         self,

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -143,7 +143,7 @@ class Interaction:
     def __init__(self, *, data: InteractionPayload, state: ConnectionState):
         self._state: ConnectionState = state
         self._client: Client = state._get_client()
-        self._session: ClientSession = state.http._HTTPClient__session  # type: ignore - Mangled attribute for __session
+        self._session: ClientSession = state.http._HTTPClient__session  # type: ignore # Mangled attribute for __session
         self._original_message: Optional[InteractionMessage] = None
         self._from_data(data)
 
@@ -178,7 +178,7 @@ class Interaction:
         if self.guild_id:
             guild = self.guild or Object(id=self.guild_id)
             try:
-                member = data['member']  # type: ignore - The key is optional and handled
+                member = data['member']  # type: ignore # The key is optional and handled
             except KeyError:
                 pass
             else:
@@ -187,7 +187,7 @@ class Interaction:
                 self._permissions = self.user._permissions or 0
         else:
             try:
-                self.user = User(state=self._state, data=data['user'])  # type: ignore - The key is optional and handled
+                self.user = User(state=self._state, data=data['user'])  # type: ignore # The key is optional and handled
             except KeyError:
                 pass
 

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -533,7 +533,7 @@ class Invite(Hashable):
         """
         self.scheduled_event_id = scheduled_event.id
         try:
-            self.scheduled_event = self.guild.get_scheduled_event(scheduled_event.id)  # type: ignore - handled below
+            self.scheduled_event = self.guild.get_scheduled_event(scheduled_event.id)  # type: ignore # handled below
         except AttributeError:
             self.scheduled_event = None
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -507,7 +507,7 @@ class MessageReference:
             result['guild_id'] = self.guild_id
         if self.fail_if_not_exists is not None:
             result['fail_if_not_exists'] = self.fail_if_not_exists
-        return result  # type: ignore - Type checker doesn't understand these are the same.
+        return result  # type: ignore # Type checker doesn't understand these are the same.
 
     to_message_reference_dict = to_dict
 

--- a/discord/player.py
+++ b/discord/player.py
@@ -163,7 +163,7 @@ class FFmpegAudio(AudioSource):
         kwargs.update(subprocess_kwargs)
 
         self._process: subprocess.Popen = self._spawn_process(args, **kwargs)
-        self._stdout: IO[bytes] = self._process.stdout  # type: ignore - process stdout is explicitly set
+        self._stdout: IO[bytes] = self._process.stdout  # type: ignore # process stdout is explicitly set
         self._stdin: Optional[IO[bytes]] = None
         self._pipe_thread: Optional[threading.Thread] = None
 

--- a/discord/state.py
+++ b/discord/state.py
@@ -245,7 +245,7 @@ class ConnectionState:
         self._command_tree: Optional[CommandTree] = None
 
         if not intents.members or cache_flags._empty:
-            self.store_user = self.store_user_no_intents  # type: ignore - This reassignment is on purpose
+            self.store_user = self.store_user_no_intents  # type: ignore # This reassignment is on purpose
 
         self.parsers: Dict[str, Callable[[Any], None]]
         self.parsers = parsers = {}
@@ -333,7 +333,7 @@ class ConnectionState:
 
     def _update_references(self, ws: DiscordWebSocket) -> None:
         for vc in self.voice_clients:
-            vc.main_ws = ws  # type: ignore - Silencing the unknown attribute (ok at runtime).
+            vc.main_ws = ws  # type: ignore # Silencing the unknown attribute (ok at runtime).
 
     def store_user(self, data: Union[UserPayload, PartialUserPayload]) -> User:
         # this way is 300% faster than `dict.setdefault`.
@@ -794,7 +794,7 @@ class ConnectionState:
             channel = guild.get_channel(channel_id)
             if channel is not None:
                 old_channel = copy.copy(channel)
-                channel._update(guild, data)  # type: ignore - the data payload varies based on the channel type.
+                channel._update(guild, data)  # type: ignore # the data payload varies based on the channel type.
                 self.dispatch('guild_channel_update', old_channel, channel)
             else:
                 _log.debug('CHANNEL_UPDATE referencing an unknown channel ID: %s. Discarding.', channel_id)
@@ -1018,7 +1018,7 @@ class ConnectionState:
             self.dispatch('member_update', old_member, member)
         else:
             if self.member_cache_flags.joined:
-                member = Member(data=data, guild=guild, state=self)  # type: ignore - the data is not complete, contains a delta of values
+                member = Member(data=data, guild=guild, state=self)  # type: ignore # the data is not complete, contains a delta of values
 
                 # Force an update on the inner user if necessary
                 user_update = member._update_inner_user(user)
@@ -1623,17 +1623,17 @@ class AutoShardedConnectionState(ConnectionState):
                 self.application_flags: ApplicationFlags = ApplicationFlags._from_value(application['flags'])
 
         for guild_data in data['guilds']:
-            self._add_guild_from_data(guild_data)  # type: ignore - _add_guild_from_data requires a complete Guild payload
+            self._add_guild_from_data(guild_data)  # type: ignore # _add_guild_from_data requires a complete Guild payload
 
         if self._messages:
             self._update_message_references()
 
         self.dispatch('connect')
-        self.dispatch('shard_connect', data['__shard_id__'])  # type: ignore - This is an internal discord.py key
+        self.dispatch('shard_connect', data['__shard_id__'])  # type: ignore # This is an internal discord.py key
 
         if self._ready_task is None:
             self._ready_task = asyncio.create_task(self._delay_ready())
 
     def parse_resumed(self, data: gw.ResumedEvent) -> None:
         self.dispatch('resumed')
-        self.dispatch('shard_resumed', data['__shard_id__'])  # type: ignore - This is an internal discord.py key
+        self.dispatch('shard_resumed', data['__shard_id__'])  # type: ignore # This is an internal discord.py key

--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -123,7 +123,7 @@ class StickerPack(Hashable):
     @property
     def banner(self) -> Optional[Asset]:
         """:class:`Asset`: The banner asset of the sticker pack."""
-        return self._banner and Asset._from_sticker_banner(self._state, self._banner)  # type: ignore - type-checker thinks _banner could be Literal[0]
+        return self._banner and Asset._from_sticker_banner(self._state, self._banner)  # type: ignore
 
     def __repr__(self) -> str:
         return f'<StickerPack id={self.id} name={self.name!r} description={self.description!r}>'

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -278,7 +278,7 @@ class VoiceClient(VoiceProtocol):
     @property
     def user(self) -> ClientUser:
         """:class:`ClientUser`: The user connected to voice (i.e. ourselves)."""
-        return self._state.user  # type: ignore - user can't be None after login
+        return self._state.user  # type: ignore
 
     def checked_add(self, attr: str, value: int, limit: int) -> None:
         val = getattr(self, attr)
@@ -301,7 +301,7 @@ class VoiceClient(VoiceProtocol):
                 # We're being disconnected so cleanup
                 await self.disconnect()
             else:
-                self.channel = channel_id and self.guild.get_channel(int(channel_id))  # type: ignore - this won't be None
+                self.channel = channel_id and self.guild.get_channel(int(channel_id))  # type: ignore
         else:
             self._voice_state_complete.set()
 


### PR DESCRIPTION
## Summary

Without this, mypy outright refuses to run when d.py is part of dependencies:
![image](https://user-images.githubusercontent.com/6032823/160306414-edb4ae81-5a76-4768-8ae7-85210dcc22ed.png)
[Per PEP 484](https://peps.python.org/pep-0484/#type-comments):
> In some cases, linting tools or other comments may be needed on the same line as a type comment. In these cases, the type comment should be before other comments and linting markers:
> > ```py
> > # type: ignore # <comment or other marker>
> > ```

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
