### PR TITLE
Implement `@rename` decorator

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -1314,6 +1314,29 @@ def describe(**parameters: str) -> Callable[[T], T]:
 
 
 def rename(**parameters: str) -> Callable[[T], T]:
+    r"""Renames the given parameters by their name using the key of the keyword argument
+    as the name.
+
+    Example:
+
+    .. code-block:: python3
+
+        @app_commands.command()
+        @app_commands.rename(the_member_to_ban='member')
+        async def ban(interaction: discord.Interaction, the_member_to_ban: discord.Member):
+            await interaction.response.send_message(f'Banned {the_member_to_ban}')
+
+    Parameters
+    -----------
+    \*\*parameters
+        The name of the parameters.
+
+    Raises
+    --------
+    ValueError
+        The parameter name is already used by another parameter.
+    """
+
     def decorator(inner: T) -> T:
         if isinstance(inner, Command):
             _populate_renames(inner._params, parameters)

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -236,6 +236,10 @@ def _populate_renames(params: Dict[str, CommandParameter], renames: Dict[str, st
         rename_map[name] = new_name
         params[name]._rename = new_name
 
+    if renames:
+        first = next(iter(renames))
+        raise ValueError(f'unknown parameter given: {first}')
+
 
 def _populate_choices(params: Dict[str, CommandParameter], all_choices: Dict[str, List[Choice]]) -> None:
     for name, param in params.items():
@@ -1335,6 +1339,8 @@ def rename(**parameters: str) -> Callable[[T], T]:
     --------
     ValueError
         The parameter name is already used by another parameter.
+    TypeError
+        The parameter name is not found.
     """
 
     def decorator(inner: T) -> T:

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -101,12 +101,13 @@ class CommandParameter:
     min_value: Optional[Union[int, float]] = None
     max_value: Optional[Union[int, float]] = None
     autocomplete: Optional[Callable[..., Coroutine[Any, Any, Any]]] = None
+    _rename: str = MISSING
     _annotation: Any = MISSING
 
     def to_dict(self) -> Dict[str, Any]:
         base = {
             'type': self.type.value,
-            'name': self.name,
+            'name': self.display_name,
             'description': self.description,
             'required': self.required,
         }
@@ -145,6 +146,11 @@ class CommandParameter:
                 raise TransformerError(value, self.type, self._annotation) from e
 
         return value
+
+    @property
+    def display_name(self) -> str:
+        """:class:`str`: The name of the parameter as it should be displayed to the user."""
+        return self.name if self._rename is MISSING else self._rename
 
 
 class Transformer:

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -462,6 +462,9 @@ Decorators
 .. autofunction:: discord.app_commands.describe
     :decorator:
 
+.. autofunction:: discord.app_commands.rename
+    :decorator:
+
 .. autofunction:: discord.app_commands.choices
     :decorator:
 


### PR DESCRIPTION
## Summary

Took me a while.

```py
@app_commands.command()
@app_commands.rename(the_member_to_ban='member')
async def ban(interaction: discord.Interaction, the_member_to_ban: discord.Member):
    await interaction.response.send_message(f'Banned {the_member_to_ban}')
```
<img width="287" alt="Appearance in client" src="https://user-images.githubusercontent.com/26068884/160359318-82168d1d-555e-4b95-890e-c62cd8b829f3.png">


## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

