### PR TITLE
Add note for command tree in Bot's docstring.

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -1291,7 +1291,7 @@ class Bot(BotBase, discord.Client):
     
     Unlike :class:`discord.Client`, This class does not require manually setting
     a :class:`~discord.app_commands.CommandTree` and is automatically set upon 
-    instansiating the class.
+    instantiating the class.
 
     Attributes
     -----------

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -1288,9 +1288,9 @@ class Bot(BotBase, discord.Client):
 
     This class also subclasses :class:`.GroupMixin` to provide the functionality
     to manage commands.
-    
+
     Unlike :class:`discord.Client`, This class does not require manually setting
-    a :class:`~discord.app_commands.CommandTree` and is automatically set upon 
+    a :class:`~discord.app_commands.CommandTree` and is automatically set upon
     instantiating the class.
 
     Attributes

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -1288,6 +1288,10 @@ class Bot(BotBase, discord.Client):
 
     This class also subclasses :class:`.GroupMixin` to provide the functionality
     to manage commands.
+    
+    Unlike :class:`discord.Client`, This class does not require manually setting
+    a :class:`~discord.app_commands.CommandTree` and is automatically set upon 
+    instansiating the class.
 
     Attributes
     -----------


### PR DESCRIPTION
## Summary

This pull request adds a note about automatic setting of `CommandTree` in `Bot` class. This caused confusion among users in Discord server and issues like #7785

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
