### PR TITLE
refactor(rename): refactor attribute access

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -1347,11 +1347,11 @@ def rename(**parameters: str) -> Callable[[T], T]:
         if isinstance(inner, Command):
             _populate_renames(inner._params, parameters)
         else:
-            try:
-                inner.__discord_app_commands_param_rename__.update(parameters)  # type: ignore - Runtime attribute access
-            except AttributeError:
-                inner.__discord_app_commands_param_rename__ = parameters  # type: ignore - Runtime attribute assignment
-
+            rename_param = getattr(inner, "__discord_app_commands_param_rename__")
+            if rename_param:
+                rename_param.update(parameters)
+            else:
+                setattr(inner, "__discord_app_commands_param_rename__", parameters)
         return inner
 
     return decorator


### PR DESCRIPTION
## Summary

Mypy reported that #type: ignore is invalid.

This is a refactoring that solves this.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
