### PR TITLE
Fix caching of `UnionType`

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1032,9 +1032,9 @@ def evaluate_annotation(
     if implicit_str and isinstance(tp, str):
         if tp in cache:
             return cache[tp]
-        evaluated = eval(tp, globals, locals)
+        evaluated = evaluate_annotation(eval(tp, globals, locals), globals, locals, cache)
         cache[tp] = evaluated
-        return evaluate_annotation(evaluated, globals, locals, cache)
+        return evaluated
 
     if hasattr(tp, '__args__'):
         implicit_str = True


### PR DESCRIPTION
## Summary

Given the following code running in Python 3.10:

```python
from __future__ import annotations

import discord
from discord import app_commands

class MyGroup(app_commands.Group):
    @app_commands.command()
    async def thing(
        self,
        interaction: discord.Interaction,
        one: str | None = None,
        two: str | None = None,
    ) -> None:
        ...
```

An exception is raised:

```
Traceback (most recent call last):
  File "/Users/bryan/Projects/discord.py/test.py", line 7, in <module>
    class MyGroup(app_commands.Group):
  File "/Users/bryan/Projects/discord.py/test.py", line 9, in MyGroup
    async def thing(
  File "/Users/bryan/Projects/discord.py/discord/app_commands/commands.py", line 1234, in decorator
    return Command(
  File "/Users/bryan/Projects/discord.py/discord/app_commands/commands.py", line 428, in __init__
    self._params: Dict[str, CommandParameter] = _extract_parameters_from_callback(callback, callback.__globals__)
  File "/Users/bryan/Projects/discord.py/discord/app_commands/commands.py", line 310, in _extract_parameters_from_callback
    param = annotation_to_parameter(resolved, parameter)
  File "/Users/bryan/Projects/discord.py/discord/app_commands/transformers.py", line 640, in annotation_to_parameter
    (inner, default) = get_supported_annotation(annotation)
  File "/Users/bryan/Projects/discord.py/discord/app_commands/transformers.py", line 599, in get_supported_annotation
    raise TypeError(f'unsupported type annotation {annotation!r}')
TypeError: unsupported type annotation str | None
```

If `two` is removed from the command signature or changed to some other annotation, the exception is no longer raised. The root cause is that `discord.utils.evaluate_annotation()` is caching the `UnionType` rather than the converted annotation which is then returned from `discord.utils.resolve_annotation()` in `discord.app_commands.commands._extract_parameters_from_callback()` on the second iteration at line 309 which causes the exception at line 310. Caching the `typing.Union` instead of the `UnionType` fixes the problem.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
