### PR TITLE
feat: Add context_menu_command Message type

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -221,9 +221,10 @@ class MessageType(Enum):
     guild_discovery_grace_period_final_warning = 17
     thread_created = 18
     reply = 19
-    application_command = 20
+    chat_input_command = 20
     thread_starter_message = 21
     guild_invite_reminder = 22
+    context_menu_command = 23
 
 
 class SpeakingState(Enum):

--- a/discord/message.py
+++ b/discord/message.py
@@ -1645,7 +1645,8 @@ class Message(PartialMessage, Hashable):
         return self.type not in (
             MessageType.default,
             MessageType.reply,
-            MessageType.application_command,
+            MessageType.chat_input_command,
+            MessageType.context_menu_command,
             MessageType.thread_starter_message,
         )
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1403,9 +1403,9 @@ of :class:`enum.Enum`.
         The system message denoting that the author is replying to a message.
 
         .. versionadded:: 2.0
-    .. attribute:: application_command
+    .. attribute:: chat_input_command
 
-        The system message denoting that an application (or "slash") command was executed.
+        The system message denoting that a slash command was executed.
 
         .. versionadded:: 2.0
     .. attribute:: guild_invite_reminder
@@ -1417,6 +1417,11 @@ of :class:`enum.Enum`.
 
         The system message denoting the message in the thread that is the one that started the
         thread's conversation topic.
+
+        .. versionadded:: 2.0
+    .. attribute:: context_menu_command
+
+        The system message denoting that a context menu command was executed.
 
         .. versionadded:: 2.0
 

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -1171,6 +1171,8 @@ The following changes have been made:
 
 - :meth:`Permissions.stage_moderator` now includes the :attr:`Permissions.manage_channels` permission and the :attr:`Permissions.request_to_speak` permission is no longer included.
 
+- ``MessageType.application_command`` has been renamed to :attr:`MessageType.chat_input_command` due to the addition of context menu commands.
+
 .. _migrating_2_0_commands:
 
 Command Extension Changes
@@ -1403,7 +1405,6 @@ Miscellanous Changes
 - ``BotMissingPermissions.missing_perms`` has been renamed to :attr:`ext.commands.BotMissingPermissions.missing_permissions`.
 - :meth:`ext.commands.Cog.cog_load` has been added as part of the :ref:`migrating_2_0_commands_extension_cog_async` changes.
 - :meth:`ext.commands.Cog.cog_unload` may now be a :term:`coroutine` due to the :ref:`migrating_2_0_commands_extension_cog_async` changes.
-- ``MessageType.application_command`` has been renamed to :attr:`MessageType.chat_input_command` due to the addition of context menu commands.
 
 .. _migrating_2_0_tasks:
 

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -1171,8 +1171,6 @@ The following changes have been made:
 
 - :meth:`Permissions.stage_moderator` now includes the :attr:`Permissions.manage_channels` permission and the :attr:`Permissions.request_to_speak` permission is no longer included.
 
-- ``MessageType.application_command`` has been renamed to :attr:`MessageType.chat_input_command` due to the addition of context menu commands.
-
 .. _migrating_2_0_commands:
 
 Command Extension Changes

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -1403,6 +1403,7 @@ Miscellanous Changes
 - ``BotMissingPermissions.missing_perms`` has been renamed to :attr:`ext.commands.BotMissingPermissions.missing_permissions`.
 - :meth:`ext.commands.Cog.cog_load` has been added as part of the :ref:`migrating_2_0_commands_extension_cog_async` changes.
 - :meth:`ext.commands.Cog.cog_unload` may now be a :term:`coroutine` due to the :ref:`migrating_2_0_commands_extension_cog_async` changes.
+- ``MessageType.application_command`` has been renamed to :attr:`MessageType.chat_input_command` due to the addition of context menu commands.
 
 .. _migrating_2_0_tasks:
 


### PR DESCRIPTION
## Summary

* Adds `context_menu_command` type to MessageType enum.

* The Message type `application_command` was renamed to `chat_input_command`

Docs reference: https://github.com/discord/discord-api-docs/blob/main/docs/resources/Channel.md#message-types

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
