### PR TITLE
feat: Allow empty iterables as a command_prefix

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -1274,11 +1274,6 @@ class BotBase(GroupMixin[None]):
         await self.invoke(ctx)  # type: ignore
 
     async def on_message(self, message: Message, /) -> None:
-        # Skip processing commands if the command_prefix is an empty iterable.
-        # The empty string, however, is a valid prefix.
-        if not isinstance(self.command_prefix, str) and not self.command_prefix:
-            return
-        # Process commands in the message
         await self.process_commands(message)
 
 

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -1089,7 +1089,7 @@ class BotBase(GroupMixin[None]):
         if ret is None:
             ret = []
 
-        if not isinstance(ret, str):
+        elif not isinstance(ret, str):
             try:
                 ret = list(ret)  # type: ignore
             except TypeError:

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -154,14 +154,14 @@ _default: Any = _DefaultRepr()
 class BotBase(GroupMixin[None]):
     def __init__(
         self,
-        command_prefix: Optional[PrefixType[BotT]] = None,
+        command_prefix: PrefixType[BotT],
         help_command: Optional[HelpCommand[Any]] = _default,
         tree_cls: Type[app_commands.CommandTree] = app_commands.CommandTree,
         description: Optional[str] = None,
         **options: Any,
     ) -> None:
         super().__init__(**options)
-        self.command_prefix: Optional[PrefixType[BotT]] = command_prefix
+        self.command_prefix: PrefixType[BotT] = command_prefix
         self.extra_events: Dict[str, List[CoroFunc]] = {}
         # Self doesn't have the ClientT bound, but since this is a mixin it technically does
         self.__tree: app_commands.CommandTree[Self] = tree_cls(self)  # type: ignore
@@ -1086,10 +1086,7 @@ class BotBase(GroupMixin[None]):
             # self will be a Bot or AutoShardedBot
             ret = await discord.utils.maybe_coroutine(prefix, self, message)  # type: ignore
 
-        if ret is None:
-            ret = []
-
-        elif not isinstance(ret, str):
+        if not isinstance(ret, str):
             try:
                 ret = list(ret)  # type: ignore
             except TypeError:
@@ -1277,11 +1274,11 @@ class BotBase(GroupMixin[None]):
         await self.invoke(ctx)  # type: ignore
 
     async def on_message(self, message: Message, /) -> None:
-        # skip processing commands if the command_prefix is None or an
-        # empty iterable. The empty string, however, is a valid prefix.
+        # Skip processing commands if the command_prefix is an empty iterable.
+        # The empty string, however, is a valid prefix.
         if not isinstance(self.command_prefix, str) and not self.command_prefix:
             return
-        # process commands in the message
+        # Process commands in the message
         await self.process_commands(message)
 
 


### PR DESCRIPTION
## Problem

If you don't want any prefix or even pings to trigger commands (for example if you only have slash commands or have no prefixed commands), you currently need a hackish workaround such as:

```py
bot = commands.Bot(command_prefix=" ")  # initial whitespace is ignored in messages
```

## Solution

This change allows passing an empty iterable to not listen for any prefix. This way developers do not need to specify a prefix if they don't have any commands that use it (for example, if the bot only uses **slash commands** or listeners such as `on_message`)

```py
bot = commands.Bot(command_prefix=[])  # creates a Bot with no prefix
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
