### PR TITLE
feat: to_file for assets and emojis

### DIFF
--- a/discord/asset.py
+++ b/discord/asset.py
@@ -29,6 +29,7 @@ import os
 from typing import Any, Literal, Optional, TYPE_CHECKING, Tuple, Union
 from .errors import DiscordException
 from . import utils
+from .file import File
 
 import yarl
 
@@ -92,7 +93,7 @@ class AssetMixin:
         Parameters
         ----------
         fp: Union[:class:`io.BufferedIOBase`, :class:`os.PathLike`]
-            The file-like object to save this attachment to or the filename
+            The file-like object to save this asset to or the filename
             to use. If a filename is passed then a file is created with that
             filename and used instead.
         seek_begin: :class:`bool`
@@ -123,6 +124,39 @@ class AssetMixin:
         else:
             with open(fp, 'wb') as f:
                 return f.write(data)
+
+    async def to_file(self, *, spoiler: bool = False) -> File:
+        """|coro|
+
+        Converts the asset into a :class:`File` suitable for sending via
+        :meth:`abc.Messageable.send`.
+
+        .. versionadded:: 2.0
+
+        Parameters
+        -----------
+        spoiler: :class:`bool`
+            Whether the file is a spoiler.
+
+        Raises
+        ------
+        HTTPException
+            Downloading the asset failed.
+        Forbidden
+            You do not have permissions to access this asset
+        NotFound
+            The asset was deleted.
+
+        Returns
+        -------
+        :class:`File`
+            The asset as a file suitable for sending.
+        """
+
+        data = await self.read()
+        url = yarl.URL(self.url)
+        filename = url.path.split('/')[-1]
+        return File(io.BytesIO(data), filename=filename, spoiler=spoiler)
 
 
 class Asset(AssetMixin):

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -155,7 +155,7 @@ class AssetMixin:
 
         data = await self.read()
         url = yarl.URL(self.url)
-        filename = url.path.split('/')[-1]
+        _, _, filename = url.path.rpartition('/')
         return File(io.BytesIO(data), filename=filename, spoiler=spoiler)
 
 

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -140,10 +140,14 @@ class AssetMixin:
 
         Raises
         ------
+        DiscordException
+            The asset does not have an associated state.
+        TypeError
+            The asset is a sticker with lottie type.
         HTTPException
             Downloading the asset failed.
         Forbidden
-            You do not have permissions to access this asset
+            You do not have permissions to access this asset.
         NotFound
             The asset was deleted.
 


### PR DESCRIPTION
## Summary

* Adds `to_file` to all objects that use `AssetMixin` (`Asset`, `Emoji`, `PartialEmoji`, `Sticker`)

This feature was lightly discussed [on Discord](https://canary.discord.com/channels/336642139381301249/603069307286454290/958918196021313596). The idea comes from VJ#5945.

## Example code

```py
@bot.command()
async def avatar_file(ctx: commands.Context[commands.Bot]):
    file = await ctx.author.display_avatar.to_file()
    await ctx.send(file=file)

@bot.command()
async def emoji_file(ctx: commands.Context[commands.Bot], emoji: discord.Emoji):
    file = await emoji.to_file()
    await ctx.send(file=file)

@bot.command()
async def partial_emoji_file(ctx: commands.Context[commands.Bot], partial_emoji: discord.PartialEmoji):
    file = await partial_emoji.to_file()
    await ctx.send(file=file)

@bot.command()
async def sticker_file(ctx: commands.Context[commands.Bot], message_id: int):
    msg = await ctx.channel.fetch_message(message_id)
    file = await msg.stickers[0].to_file()
    await ctx.send(file=file)
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
