### PR TITLE
[docs] Fix capitalization typo in spoiler parameter documentation

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -193,7 +193,7 @@ class Client:
     http_trace: :class:`aiohttp.TraceConfig`
         The trace configuration to use for tracking HTTP requests the library does using ``aiohttp``.
         This allows you to check requests the library is using. For more information, check the
-        `aiottp documentation <https://docs.aiohttp.org/en/stable/client_advanced.html#client-tracing>`_.
+        `aiohttp documentation <https://docs.aiohttp.org/en/stable/client_advanced.html#client-tracing>`_.
 
         .. versionadded:: 2.0
 

--- a/discord/file.py
+++ b/discord/file.py
@@ -67,7 +67,7 @@ class File:
             To pass binary data, consider usage of ``io.BytesIO``.
 
     spoiler: :class:`bool`
-        Whether the attachment is a spoiler. if left unspecified, the :attr:`~File.filename` is used
+        Whether the attachment is a spoiler. If left unspecified, the :attr:`~File.filename` is used
         to determine if the file is a spoiler.
     description: Optional[:class:`str`]
         The file description to display, currently only supported for images.


### PR DESCRIPTION
## Summary

Capitalize the first word (if) after a dot (.) in spoiler parameter documentation in `discord.File`.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
