### PR TITLE
Add Context.current_argument

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -97,6 +97,11 @@ class Context(discord.abc.Messageable, Generic[BotT]):
         This is only of use for within converters.
 
         .. versionadded:: 2.0
+    current_argument: Optional[:class:`str`]
+        The argument string of the :attr:`current_parameter` that is currently being converted.
+        This is only of use for within converters.
+
+        .. versionadded:: 2.0
     prefix: Optional[:class:`str`]
         The prefix that was used to invoke the command.
     command: Optional[:class:`Command`]
@@ -141,6 +146,7 @@ class Context(discord.abc.Messageable, Generic[BotT]):
         subcommand_passed: Optional[str] = None,
         command_failed: bool = False,
         current_parameter: Optional[inspect.Parameter] = None,
+        current_argument: Optional[str] = None,
     ):
         self.message: Message = message
         self.bot: BotT = bot
@@ -155,6 +161,7 @@ class Context(discord.abc.Messageable, Generic[BotT]):
         self.subcommand_passed: Optional[str] = subcommand_passed
         self.command_failed: bool = command_failed
         self.current_parameter: Optional[inspect.Parameter] = current_parameter
+        self.current_argument: Optional[str] = current_argument
         self._state: ConnectionState = self.message._state
 
     async def invoke(self, command: Command[CogT, P, T], /, *args: P.args, **kwargs: P.kwargs) -> T:

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -604,10 +604,10 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
         previous = view.index
         if consume_rest_is_special:
-            argument = view.read_rest().strip()
+            ctx.current_argument = argument = view.read_rest().strip()
         else:
             try:
-                argument = view.get_quoted_word()
+                ctx.current_argument = argument = view.get_quoted_word()
             except ArgumentParsingError as exc:
                 if self._is_typing_optional(param.annotation):
                     view.index = previous
@@ -630,7 +630,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
             view.skip_ws()
             try:
-                argument = view.get_quoted_word()
+                ctx.current_argument = argument = view.get_quoted_word()
                 value = await run_converters(ctx, converter, argument, param)  # type: ignore
             except (CommandError, ArgumentParsingError):
                 view.index = previous
@@ -646,7 +646,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         view = ctx.view
         previous = view.index
         try:
-            argument = view.get_quoted_word()
+            ctx.current_argument = argument = view.get_quoted_word()
             value = await run_converters(ctx, converter, argument, param)  # type: ignore
         except (CommandError, ArgumentParsingError):
             view.index = previous
@@ -754,7 +754,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
                 # kwarg only param denotes "consume rest" semantics
                 if self.rest_is_raw:
                     converter = get_converter(param)
-                    argument = view.read_rest()
+                    ctx.current_argument = argument = view.read_rest()
                     kwargs[name] = await run_converters(ctx, converter, argument, param)
                 else:
                     kwargs[name] = await self.transform(ctx, param)


### PR DESCRIPTION
## Summary

Similar to `Context.current_parameter`, this PR adds `Context.current_argument` which contains the argument string that is currently being converted.

This stores the string that is currently passed to the "top-level" call to `run_converters()` which is symmetric to `Context.current_parameter`. This should be rather intuitive. There might be some value to having access to the currently parsed argument of the nested calls to `run_converters()` which could be done with an attribute containing a structure that would be used as a stack (so that the consumer could access any part of it). Proper stack popping would probably complicate this quite a bit and I'm not sure this is something that you would be interested in.

Both `Context.current_parameter` and `Context.current_argument` can be used inside converters as well as error handlers where these contain data about parameters that we last attempted (successfully or not) to run converters for.
I imagine that there might not be that much use for this inside the converter *but* I do think that it could be quite useful for error handling.

I was considering adding some tests but there aren't any existing ones for commands extension and creating a Context to test with would require some mocking which so far d.py has managed to avoid (+ I'm not sure how you would want this to be handled if we were to add tests for commands extension).

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
