### PR TITLE
Fix typo

### DIFF
--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -961,7 +961,7 @@ Parameters in the following methods are now all positional-only:
 - :meth:`Client.fetch_webhook`
 - :meth:`Client.fetch_widget`
 - :meth:`Message.add_reaction`
-- :meth:`Client.error`
+- :meth:`Client.on_error`
 - :meth:`abc.Messageable.fetch_message`
 - :meth:`abc.GuildChannel.permissions_for`
 - :meth:`DMChannel.get_partial_message`


### PR DESCRIPTION
The method "Client.error" does not exist, change it to Client.on_error.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR fixes a typo in `migrating.rst`. The method `Client.error` does not exist, it should be `Client.on_error` which was changed in [this pull request](https://github.com/Rapptz/discord.py/pull/7745).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
