### PR TITLE
Fixed docstring of 'TextChannel.archived_threads'

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -125,7 +125,7 @@ else:
 
 
 CheckInputParameter = Union['Command[Any, ..., Any]', 'ContextMenu', CommandCallback, ContextMenuCallback]
-VALID_SLASH_COMMAND_NAME = re.compile(r'^[?!\w-]{1,32}$')
+VALID_SLASH_COMMAND_NAME = re.compile(r'^[\w-]{1,32}$')
 VALID_CONTEXT_MENU_NAME = re.compile(r'^[?!\w\s-]{1,32}$')
 CAMEL_CASE_REGEX = re.compile(r'(?<!^)(?=[A-Z])')
 

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -125,8 +125,8 @@ else:
 
 
 CheckInputParameter = Union['Command[Any, ..., Any]', 'ContextMenu', CommandCallback, ContextMenuCallback]
-VALID_SLASH_COMMAND_NAME = re.compile(r'^[\w-]{1,32}$')
-VALID_CONTEXT_MENU_NAME = re.compile(r'^[\w\s-]{1,32}$')
+VALID_SLASH_COMMAND_NAME = re.compile(r'^[?!\w-]{1,32}$')
+VALID_CONTEXT_MENU_NAME = re.compile(r'^[?!\w\s-]{1,32}$')
 CAMEL_CASE_REGEX = re.compile(r'(?<!^)(?=[A-Z])')
 
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -794,7 +794,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         limit: Optional[int] = 100,
         before: Optional[Union[Snowflake, datetime.datetime]] = None,
     ) -> AsyncIterator[Thread]:
-        """Returns an :term:`asynchronous iterator` that iterates over all archived threads in the guild,
+        """Returns an :term:`asynchronous iterator` that iterates over all archived threads in this text channel,
         in order of decreasing ID for joined threads, and decreasing :attr:`Thread.archive_timestamp` otherwise.
 
         You must have :attr:`~Permissions.read_message_history` to use this. If iterating over private threads


### PR DESCRIPTION
## Summary

It's a docs change. `TextChannel.archived_threads()` iterates over all archived threads in that **text channel** not that guild. 

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
