### PR TITLE
Print help when no args are provided to `python -m discord`

### DIFF
--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -56,6 +56,8 @@ def show_version() -> None:
 def core(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
     if args.version:
         show_version()
+    else:
+        parser.print_help()
 
 
 _bot_template = """#!/usr/bin/env python3


### PR DESCRIPTION
## Summary

I was surprised to get absolutely no output when I tried running `python -m discord` instead of `python -m discord --version` so here's a fix for that.
Perhaps I should also `sys.exit()` with non-zero code here but wasn't sure if you want that so I left it as-is for now.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
