### PR TITLE
Add autocomplete method to Transformers

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -167,10 +167,11 @@ def validate_context_menu_name(name: str) -> str:
 
 
 def _validate_auto_complete_callback(
-    callback: AutocompleteCallback[GroupT, ChoiceT]
+    callback: AutocompleteCallback[GroupT, ChoiceT],
+    skip_binding: bool = False,
 ) -> AutocompleteCallback[GroupT, ChoiceT]:
 
-    requires_binding = is_inside_class(callback)
+    requires_binding = is_inside_class(callback) and not skip_binding
     required_parameters = 2 + requires_binding
     callback.requires_binding = requires_binding
     params = inspect.signature(callback).parameters

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -171,9 +171,16 @@ def _validate_auto_complete_callback(
     skip_binding: bool = False,
 ) -> AutocompleteCallback[GroupT, ChoiceT]:
 
-    requires_binding = is_inside_class(callback) and not skip_binding
-    required_parameters = 2 + requires_binding
+    binding = getattr(callback, '__self__', None)
+    if binding is not None:
+        callback = callback.__func__
+
+    requires_binding = (binding is None and is_inside_class(callback)) or skip_binding
+    
     callback.requires_binding = requires_binding
+    callback.binding = binding
+    
+    required_parameters = 2 + requires_binding
     params = inspect.signature(callback).parameters
     if len(params) != required_parameters:
         raise TypeError('autocomplete callback requires either 2 or 3 parameters to be passed')
@@ -582,8 +589,9 @@ class Command(Generic[GroupT, P, T]):
             raise CommandSignatureMismatch(self)
 
         if param.autocomplete.requires_binding:
-            if self.binding is not None:
-                choices = await param.autocomplete(self.binding, interaction, value)
+            binding = param.autocomplete.binding or self.binding
+            if binding is not None:
+                choices = await param.autocomplete(binding, interaction, value)
             else:
                 raise TypeError('autocomplete parameter expected a bound self parameter but one was not provided')
         else:

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -176,10 +176,10 @@ def _validate_auto_complete_callback(
         callback = callback.__func__
 
     requires_binding = (binding is None and is_inside_class(callback)) or skip_binding
-    
+
     callback.requires_binding = requires_binding
     callback.binding = binding
-    
+
     required_parameters = 2 + requires_binding
     params = inspect.signature(callback).parameters
     if len(params) != required_parameters:

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -258,7 +258,9 @@ class Transformer:
 
     @classmethod
     @_not_overridden
-    async def autocomplete(cls, interaction: Interaction, value: Union[int, float, str]) -> List[Choice[Union[int, float, str]]]:
+    async def autocomplete(
+        cls, interaction: Interaction, value: Union[int, float, str]
+    ) -> List[Choice[Union[int, float, str]]]:
         """|coro|
 
         An autocomplete prompt handler to be automatically used by options using this transformer.

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -265,7 +265,7 @@ class Transformer:
 
         .. note::
 
-            Autocomplete is only supported for options with :attr:`~discord.app.commands.Transformer.type`
+            Autocomplete is only supported for options with :meth:`~discord.app.commands.Transformer.type`
             :attr:`~discord.AppCommandOptionType.string`, :attr:`~discord.AppCommandOptionType.integer`,
             and :attr:`~discord.AppCommandOptionType.number`.
 

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -265,8 +265,8 @@ class Transformer:
 
         .. note::
 
-            Autocomplete is only supported for options with :attr:`~discord.app.commands.Transformer.type` 
-            :attr:`~discord.AppCommandOptionType.string`, :attr:`~discord.AppCommandOptionType.integer`, 
+            Autocomplete is only supported for options with :attr:`~discord.app.commands.Transformer.type`
+            :attr:`~discord.AppCommandOptionType.string`, :attr:`~discord.AppCommandOptionType.integer`,
             and :attr:`~discord.AppCommandOptionType.number`.
 
         Parameters
@@ -280,9 +280,10 @@ class Transformer:
         --------
         List[:class:`~discord.app_commands.Choice`]
             A list of choices to be displayed to the user, a maximum of 25.
-        
+
         """
         raise NotImplementedError('Derived classes can implement this.')
+
 
 class _TransformMetadata:
     __discord_app_commands_transform__: ClassVar[bool] = True

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -265,7 +265,7 @@ class Transformer:
 
         .. note::
 
-            Autocomplete is only supported for options with :meth:`~discord.app.commands.Transformer.type`
+            Autocomplete is only supported for options with :meth:`~discord.app_commands.Transformer.type`
             :attr:`~discord.AppCommandOptionType.string`, :attr:`~discord.AppCommandOptionType.integer`,
             and :attr:`~discord.AppCommandOptionType.number`.
 

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -714,9 +714,6 @@ def annotation_to_parameter(annotation: Any, parameter: inspect.Parameter) -> Co
     if parameter.kind in (parameter.POSITIONAL_ONLY, parameter.VAR_KEYWORD, parameter.VAR_POSITIONAL):
         raise TypeError(f'unsupported parameter kind in callback: {parameter.kind!s}')
 
-    print(Transformer.autocomplete.__func__)
-    print(inner.autocomplete.__func__)
-
     if not hasattr(inner.autocomplete.__func__, '__transformer_autocomplete_not_overridden__'):
         from .commands import _validate_auto_complete_callback
 

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -265,9 +265,9 @@ class Transformer:
 
         .. note::
 
-            Autocomplete is only supported for options with :meth:`~discord.app_commands.Transformer.type`
-            :attr:`~discord.AppCommandOptionType.string`, :attr:`~discord.AppCommandOptionType.integer`,
-            and :attr:`~discord.AppCommandOptionType.number`.
+            Autocomplete is only supported for options with a :meth:`~discord.app_commands.Transformer.type`
+            of :attr:`~discord.AppCommandOptionType.string`, :attr:`~discord.AppCommandOptionType.integer`,
+            or :attr:`~discord.AppCommandOptionType.number`.
 
         Parameters
         -----------

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -258,7 +258,7 @@ class Transformer:
 
     @classmethod
     @_not_overridden
-    async def autocomplete(cls, interaction: Interaction, value: ChoiceT) -> List[Choice[ChoiceT]]:
+    async def autocomplete(cls, interaction: Interaction, value: Union[int, float, str]) -> List[Choice[Union[int, float, str]]]:
         """|coro|
 
         An autocomplete prompt handler to be automatically used by options using this transformer.


### PR DESCRIPTION
## Summary

This pr adds a new Transformer.autocomplete method which will automatically assign the autocomplete function on commands which use the transformer.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
