### PR TITLE
remove the use of `!` in the `Member.mention` property

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -551,8 +551,6 @@ class Member(discord.abc.Messageable, _UserTag):
     @property
     def mention(self) -> str:
         """:class:`str`: Returns a string that allows you to mention the member."""
-        if self.nick:
-            return f'<@!{self._user.id}>'
         return f'<@{self._user.id}>'
 
     @property


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Removes the (now) unneeded check in `Member.mention` for the `!` in mention syntax.
This has now been officially removed from Discord.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
