### PR TITLE
Fix check for when transformer autocomplete is overridden

### DIFF
--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -710,7 +710,8 @@ def annotation_to_parameter(annotation: Any, parameter: inspect.Parameter) -> Co
     if parameter.kind in (parameter.POSITIONAL_ONLY, parameter.VAR_KEYWORD, parameter.VAR_POSITIONAL):
         raise TypeError(f'unsupported parameter kind in callback: {parameter.kind!s}')
 
-    if inner.autocomplete is not Transformer.autocomplete:
+    autocomplete_func = getattr(inner.autocomplete, '__func__', inner.autocomplete)
+    if autocomplete_func is not Transformer.autocomplete.__func__:
         from .commands import _validate_auto_complete_callback
 
         result.autocomplete = _validate_auto_complete_callback(inner.autocomplete, skip_binding=True)


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
