### PR TITLE
A small grammar fix [app_commands.context_menu]

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -1310,7 +1310,7 @@ def command(
 
 
 def context_menu(*, name: str = MISSING) -> Callable[[ContextMenuCallback], ContextMenu]:
-    """Creates a application command context menu from a regular function.
+    """Creates an application command context menu from a regular function.
 
     This function must have a signature of :class:`~discord.Interaction` as its first parameter
     and taking either a :class:`~discord.Member`, :class:`~discord.User`, or :class:`~discord.Message`,


### PR DESCRIPTION
This just makes it so it adheres with the rule that `an` goes before a word that begins with a vowel.

## Summary

Docs Grammar Fix. Just makes it so that it adheres to the `an` before a word that begins with a vowel rule.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
