### PR TITLE
Add missing ctx in example

### DIFF
--- a/discord/ext/commands/parameters.py
+++ b/discord/ext/commands/parameters.py
@@ -195,7 +195,7 @@ def parameter(
     .. code-block:: python3
 
         @bot.command()
-        async def wave(to: discord.User = commands.parameter(default=lambda ctx: ctx.author)):
+        async def wave(ctx, to: discord.User = commands.parameter(default=lambda ctx: ctx.author)):
             await ctx.send(f'Hello {to.mention} :wave:')
 
     Parameters


### PR DESCRIPTION
## Summary
Add missing `ctx` parameter for example command for `commands.parameter`
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
