### PR TITLE
Add Permissions.elevated()

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -253,6 +253,27 @@ class Permissions(BaseFlags):
         return cls(0b1010000000000000000010000)
 
     @classmethod
+    def elevated(cls) -> Self:
+        """A factory method that creates a :class:`Permissions` with all permissions
+        that Discord calls elevated set to ``True``. These permissions are currently:
+
+        - :attr:`kick_members`
+        - :attr:`ban_members`
+        - :attr:`administrator`
+        - :attr:`manage_channels`
+        - :attr:`manage_guild`
+        - :attr:`manage_messages`
+        - :attr:`manage_roles`
+        - :attr:`manage_webhooks`
+        - :attr:`manage_emojis_and_stickers`
+        - :attr:`manage_threads`
+        - :attr:`moderate_members`
+
+        .. versionadded:: 2.0
+        """
+        return cls(0b10000010001110000000000000010000000111110)
+
+    @classmethod
     def advanced(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Advanced" permissions from the official Discord UI set to ``True``.

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -255,7 +255,7 @@ class Permissions(BaseFlags):
     @classmethod
     def elevated(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all permissions
-        that Discord calls elevated set to ``True``. These permissions are currently:
+        that require 2FA set to ``True``. These permissions are currently:
 
         - :attr:`kick_members`
         - :attr:`ban_members`


### PR DESCRIPTION
## Summary

This adds Permissions.elevated(), which returns a Permissions Object with all Permissions that Discord calls [elevated](https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags) 
(marked with a `*`) set to True.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
