### PR TITLE
Documented Embed limits in docstrings

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -544,7 +544,7 @@ class Embed:
         """Adds a field to the embed object.
 
         This function returns the class instance to allow for fluent-style
-        chaining.
+        chaining. Can only be up to 25 fields.
 
         Parameters
         -----------
@@ -573,7 +573,7 @@ class Embed:
         """Inserts a field before a specified index to the embed.
 
         This function returns the class instance to allow for fluent-style
-        chaining.
+        chaining. Can only be up to 25 fields.
 
         .. versionadded:: 1.2
 
@@ -633,7 +633,7 @@ class Embed:
     def set_field_at(self, index: int, *, name: Any, value: Any, inline: bool = True) -> Self:
         """Modifies a field to the embed object.
 
-        The index must point to a valid pre-existing field.
+        The index must point to a valid pre-existing field. Can only be up to 25 fields.
 
         This function returns the class instance to allow for fluent-style
         chaining.

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -117,6 +117,7 @@ class Embed:
     title: Optional[:class:`str`]
         The title of the embed.
         This can be set during initialisation.
+        Can only be up to 256 characters.
     type: :class:`str`
         The type of embed. Usually "rich".
         This can be set during initialisation.
@@ -125,6 +126,7 @@ class Embed:
     description: Optional[:class:`str`]
         The description of the embed.
         This can be set during initialisation.
+        Can only be up to 4096 characters.
     url: Optional[:class:`str`]
         The URL of the embed.
         This can be set during initialisation.
@@ -335,7 +337,7 @@ class Embed:
         Parameters
         -----------
         text: :class:`str`
-            The footer text.
+            The footer text. Can only be up to 2048 characters.
         icon_url: :class:`str`
             The URL of the footer icon. Only HTTP(S) is supported.
         """
@@ -493,7 +495,7 @@ class Embed:
         Parameters
         -----------
         name: :class:`str`
-            The name of the author.
+            The name of the author. Can only be up to 256 characters.
         url: :class:`str`
             The URL for the author.
         icon_url: :class:`str`
@@ -547,9 +549,9 @@ class Embed:
         Parameters
         -----------
         name: :class:`str`
-            The name of the field.
+            The name of the field. Can only be up to 256 characters.
         value: :class:`str`
-            The value of the field.
+            The value of the field. Can only be up to 1024 characters.
         inline: :class:`bool`
             Whether the field should be displayed inline.
         """
@@ -580,9 +582,9 @@ class Embed:
         index: :class:`int`
             The index of where to insert the field.
         name: :class:`str`
-            The name of the field.
+            The name of the field. Can only be up to 256 characters.
         value: :class:`str`
-            The value of the field.
+            The value of the field. Can only be up to 1024 characters.
         inline: :class:`bool`
             Whether the field should be displayed inline.
         """
@@ -641,9 +643,9 @@ class Embed:
         index: :class:`int`
             The index of the field to modify.
         name: :class:`str`
-            The name of the field.
+            The name of the field. Can only be up to 256 characters.
         value: :class:`str`
-            The value of the field.
+            The value of the field. Can only be up to 1024 characters.
         inline: :class:`bool`
             Whether the field should be displayed inline.
 


### PR DESCRIPTION
## Summary

For ease of use, the PR documents the embed limits in the `Embed`'s docstring as well as its functions according to [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object-embed-limits). 

This can get to be very useful for beginner programmers as just by using the functions the user already can most likely read what is allowed in the API and therefore keep it in mind as result.

<html>
<body>
<!--StartFragment-->

FIELD | LIMIT
-- | --
title | 256 characters
description | 4096 characters
fields | Up to 25 field objects
field.name | 256 characters
field.value | 1024 characters
footer.text | 2048 characters
author.name | 256 characters

<!--EndFragment-->
</body>
</html>

### Implemented in

* `Embed`
* `Embed.set_footer`
* `Embed.set_author`
* `Embed.add_field`
* `Embed.insert_field_at`


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)