### PR TITLE
Translation-related actions fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ '3.8', '3.x' ]
+        language: [ 'en', 'ja' ]
 
-    name: dists & docs ${{ matrix.python-version }}
+    name: dists & docs (${{ matrix.python-version }}/${{ matrix.language }})
     steps:
       - uses: actions/checkout@v2
         with:
@@ -47,25 +48,13 @@ jobs:
         shell: bash
         run: |
           cd docs
+          sphinx-build -b html -D language=${DOCS_LANGUAGE} -a -n -T -W --keep-going . _build/html || EXIT_STATUS=$?
+        env:
+          DOCS_LANGUAGE: ${{ matrix.language }}
 
-          EXIT_STATUS=0
-          # Build English docs
-          sphinx-build -b html -D language=en -a -n -T -W --keep-going . _build_en || EXIT_STATUS=$?
-          # Build Japanese docs
-          sphinx-build -b html -D language=ja -a -n -T -W --keep-going . _build_ja || EXIT_STATUS=$?
-
-          exit ${EXIT_STATUS}
-
-      # - name: Upload EN docs
+      # - name: Upload docs
       #   uses: actions/upload-artifact@v2
       #   if: always()
       #   with:
-      #     name: docs-en
-      #     path: docs/_build_en/*
-
-      # - name: Upload JA docs
-      #   uses: actions/upload-artifact@v2
-      #   if: always()
-      #   with:
-      #     name: docs-ja
-      #     path: docs/_build_ja/*
+      #     name: docs-${{ matrix.language }}
+      #     path: docs/_build/html/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         shell: bash
         run: |
           cd docs
-          sphinx-build -b html -D language=${DOCS_LANGUAGE} -a -n -T -W --keep-going . _build/html || EXIT_STATUS=$?
+          sphinx-build -b html -D language=${DOCS_LANGUAGE} -a -n -T -W --keep-going . _build/html
         env:
           DOCS_LANGUAGE: ${{ matrix.language }}
 

--- a/.github/workflows/crowdin_download.yml
+++ b/.github/workflows/crowdin_download.yml
@@ -6,8 +6,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-environment:
+    runs-on: ubuntu-latest
+    environment: Crowdin
+    outputs:
+      available: ${{ steps.check.outputs.available }}
+    steps:
+      - id: check
+        if: env.CROWDIN_API_KEY != null
+        run: |
+          echo "::set-output name=available::true"
+        env:
+          CROWDIN_API_KEY: ${{ secrets.CROWDIN_API_KEY }}
+
   download:
     runs-on: ubuntu-latest
+    needs: [ check-environment ]
+    if: needs.check-environment.outputs.available == 'true'
     environment: Crowdin
     name: download
     steps:
@@ -42,3 +57,16 @@ jobs:
             Created by the [Crowdin download workflow](.github/workflows/crowdin_download.yml).
           branch: "auto/crowdin"
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+
+      - name: Close and reopen the PR with different token to trigger CI
+        uses: actions/github-script@v3
+        env:
+          PR_NUMBER: ${{ steps.cpr_crowdin.outputs.pull-request-number }}
+          PR_OPERATION: ${{ steps.cpr_crowdin.outputs.pull-request-operation }}
+        with:
+          github-token: ${{ secrets.GH_REPO_SCOPED_TOKEN }}
+          script: |
+            const script = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/close_and_reopen_pr.js`
+            );
+            console.log(script({github, context}));

--- a/.github/workflows/scripts/close_and_reopen_pr.js
+++ b/.github/workflows/scripts/close_and_reopen_pr.js
@@ -1,0 +1,28 @@
+module.exports = (async function ({github, context}) {
+    const pr_number = process.env.PR_NUMBER;
+    const pr_operation = process.env.PR_OPERATION;
+
+    if (!['created', 'updated'].includes(pr_operation)) {
+        console.log('PR was not created as there were no changes.')
+        return;
+    }
+
+    // Close the PR
+    github.issues.update({
+        issue_number: pr_number,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        state: 'closed'
+    });
+
+    // Wait a moment for GitHub to process it...
+    await new Promise(r => setTimeout(r, 2000));
+
+    // Then reopen the PR so it runs CI
+    github.issues.update({
+        issue_number: pr_number,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        state: 'open'
+    });
+})


### PR DESCRIPTION
## Summary

This splits the docs builds back out into separate `en` and `ja` builds to make it clear when a failing docs build is due to crowdin/gettext issues, and uses a PAT to close/reopen PRs made from crowdin downstream so they actually run the checks properly.

Also, I added a check env job that should make it so that forks of the repo that lack the Crowdin environment don't bother running the main download cron.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
