### PR TITLE
Add functionality to CommandTree.get_commands

### DIFF
--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -544,7 +544,7 @@ class CommandTree(Generic[ClientT]):
 
         Returns
         ---------
-        Union[List[:class:`ContextMenu`], List[Union[:class:`Command`, :class:`Group`], List[:class:`Command`, :class:`Group`, :class:`ContextMenu`]]
+        List[Union[:class:`ContextMenu`, :class:`Command`, :class:`Group`]]
             The application commands from the tree.
         """
         if type is None:

--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -540,7 +540,7 @@ class CommandTree(Generic[ClientT]):
             If not given or ``None`` then only global commands are returned.
         type: Optional[:class:`~discord.AppCommandType`]
             The type of commands to get. When not given or ``None``, then all
-            the commands for the given guild are returned.
+            command types are returned.
 
         Returns
         ---------

--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -540,7 +540,7 @@ class CommandTree(Generic[ClientT]):
             If not given or ``None`` then only global commands are returned.
         type: Optional[:class:`~discord.AppCommandType`]
             The type of commands to get. When not given or ``None``, then all
-            the commands are returned.
+            the commands for the given guild are returned.
 
         Returns
         ---------

--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -499,7 +499,7 @@ class CommandTree(Generic[ClientT]):
         self,
         *,
         guild: Optional[Snowflake] = ...,
-        type: Literal[AppCommandType.chat_input] = ...,
+        type: Literal[AppCommandType.chat_input],
     ) -> List[Union[Command[Any, ..., Any], Group]]:
         ...
 

--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -511,7 +511,7 @@ class CommandTree(Generic[ClientT]):
         type: AppCommandType,
     ) -> Union[List[Union[Command[Any, ..., Any], Group]], List[ContextMenu]]:
         ...
-        
+
     @overload
     def get_commands(
         self,
@@ -528,7 +528,7 @@ class CommandTree(Generic[ClientT]):
         type: Optional[AppCommandType] = None,
     ) -> Union[
         List[ContextMenu],
-        List[Union[Command[Any, ..., Any], Group]], 
+        List[Union[Command[Any, ..., Any], Group]],
         List[Union[Command[Any, ..., Any], Group, ContextMenu]],
     ]:
         """Gets all application commands from the tree.

--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -511,13 +511,26 @@ class CommandTree(Generic[ClientT]):
         type: AppCommandType,
     ) -> Union[List[Union[Command[Any, ..., Any], Group]], List[ContextMenu]]:
         ...
+        
+    @overload
+    def get_commands(
+        self,
+        *,
+        guild: Optional[Snowflake] = ...,
+        type: Optional[AppCommandType] = ...,
+    ) -> List[Union[Command[Any, ..., Any], Group, ContextMenu]]:
+        ...
 
     def get_commands(
         self,
         *,
         guild: Optional[Snowflake] = None,
-        type: AppCommandType = AppCommandType.chat_input,
-    ) -> Union[List[Union[Command[Any, ..., Any], Group]], List[ContextMenu]]:
+        type: Optional[AppCommandType] = None,
+    ) -> Union[
+        List[ContextMenu],
+        List[Union[Command[Any, ..., Any], Group]], 
+        List[Union[Command[Any, ..., Any], Group, ContextMenu]],
+    ]:
         """Gets all application commands from the tree.
 
         Parameters
@@ -525,15 +538,17 @@ class CommandTree(Generic[ClientT]):
         guild: Optional[:class:`~discord.abc.Snowflake`]
             The guild to get the commands from, not including global commands.
             If not given or ``None`` then only global commands are returned.
-        type: :class:`~discord.AppCommandType`
-            The type of commands to get. Defaults to :attr:`~discord.AppCommandType.chat_input`,
-            i.e. slash commands.
+        type: Optional[:class:`~discord.AppCommandType`]
+            The type of commands to get. When not given or ``None``, then all
+            the commands are returned.
 
         Returns
         ---------
-        Union[List[:class:`ContextMenu`], List[Union[:class:`Command`, :class:`Group`]]
+        Union[List[:class:`ContextMenu`], List[Union[:class:`Command`, :class:`Group`], List[:class:`Command`, :class:`Group`, :class:`ContextMenu`]]
             The application commands from the tree.
         """
+        if type is None:
+            return self._get_all_commands(guild=guild)
 
         if type is AppCommandType.chat_input:
             if guild is None:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Before this, the way to get all available commands for the given guild was to call `CommandTree.get_commands()` 3 times with different `type` parameters, and then join them using something like functools. This allows us to call `CommandTree.get_commands()` with no `type` parameter and get all of the commands for the given guild.

```python
# before
raw = [
    bot.tree.get_commands(guild=guild, type=discord.AppCommandType.chat_input),
    bot.tree.get_commands(guild=guild, type=discord.AppCommandType.message),
    bot.tree.get_commands(guild=guild, type=discord.AppCommandType.user),
]
commands = functools.chain.from_iterable(raw)

# after
commands = bot.tree.get_commands(guild=guild)
commands = bot.tree.get_commands()
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
