### PR TITLE
Add support for archive duration in Guild.create_text_channel

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1180,6 +1180,7 @@ class Guild(Hashable):
         slowmode_delay: int = MISSING,
         nsfw: bool = MISSING,
         overwrites: Mapping[Union[Role, Member], PermissionOverwrite] = MISSING,
+        default_auto_archive_duration: int = MISSING,
     ) -> TextChannel:
         """|coro|
 
@@ -1245,6 +1246,10 @@ class Guild(Hashable):
             The maximum value possible is `21600`.
         nsfw: :class:`bool`
             To mark the channel as NSFW or not.
+        default_auto_archive_duration: :class:`int`
+            The default auto archive duration for threads created in the text channel (in minutes).
+
+            .. versionadded:: 2.0
         reason: Optional[:class:`str`]
             The reason for creating this channel. Shows up on the audit log.
 
@@ -1275,6 +1280,9 @@ class Guild(Hashable):
 
         if nsfw is not MISSING:
             options['nsfw'] = nsfw
+
+        if default_auto_archive_duration is not MISSING:
+            options["default_auto_archive_duration"] = default_auto_archive_duration
 
         data = await self._create_channel(
             name, overwrites=overwrites, channel_type=ChannelType.text, category=category, reason=reason, **options

--- a/discord/http.py
+++ b/discord/http.py
@@ -922,7 +922,7 @@ class HTTPClient:
             'rate_limit_per_user',
             'rtc_region',
             'video_quality_mode',
-            'auto_archive_duration',
+            'default_auto_archive_duration',
         )
         payload.update({k: v for k, v in options.items() if k in valid_keys and v is not None})
 


### PR DESCRIPTION
## Summary

This pull request adds support for setting `default_auto_archive_duration`  in `Guild.create_text_channel` method.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
