### PR TITLE
feat: parse slash arg descriptions from docstrings

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -129,13 +129,69 @@ CheckInputParameter = Union['Command[Any, ..., Any]', 'ContextMenu', CommandCall
 VALID_SLASH_COMMAND_NAME = re.compile(r'^[\w-]{1,32}$')
 CAMEL_CASE_REGEX = re.compile(r'(?<!^)(?=[A-Z])')
 
+ARG_NAME_SUBREGEX = r"(?:\\?\*)*(?P<name>[^\s:\-]+)"
+
+ARG_DESCRIPTION_SUBREGEX = r"(?P<description>(?:.|\n)+?(?:\Z|\r?\n(?=[\S\r\n])))"
+
+ARG_TYPE_SUBREGEX = r"(?P<type>.+)"
+
+GOOGLE_DOCSTRING_ARG_REGEX = re.compile(
+    rf"^{ARG_NAME_SUBREGEX}[ \t]*(?:\({ARG_TYPE_SUBREGEX}\))?[ \t]*:[ \t]*{ARG_DESCRIPTION_SUBREGEX}",
+    re.MULTILINE,
+)
+
+SPHINX_DOCSTRING_ARG_REGEX = re.compile(
+    rf"^:param {ARG_NAME_SUBREGEX}:[ \t]+{ARG_DESCRIPTION_SUBREGEX}[ \t]*(?::type [^\s:]+:[ \t]+{ARG_TYPE_SUBREGEX})?",
+    re.MULTILINE,
+)
+
+NUMPY_DOCSTRING_ARG_REGEX = re.compile(
+    rf"^{ARG_NAME_SUBREGEX}(?:[ \t]*:)?(?:[ \t]+{ARG_TYPE_SUBREGEX})?[ \t]*\r?\n[ \t]+{ARG_DESCRIPTION_SUBREGEX}",
+    re.MULTILINE,
+)
+
 
 def _shorten(
     input: str,
     *,
     _wrapper: TextWrapper = TextWrapper(width=100, max_lines=1, replace_whitespace=True, placeholder='…'),
 ) -> str:
+    try:
+        # split on the first double newline since arguments may appear after that
+        input, _ = re.split(r'\n\s*\n', input, maxsplit=1)
+    except ValueError:
+        pass
     return _wrapper.fill(' '.join(input.strip().split()))
+
+
+def _parse_args_from_docstring(func: Callable[..., Any]) -> Dict[str, str]:
+    args: Dict[str, str] = {}
+
+    if docstring := inspect.cleandoc(inspect.getdoc(func) or "").strip():
+        # Extract the arguments
+        # Note: These are loose regexes, but they are good enough for our purposes
+        # For Google-style, look only at the lines that are indented
+        section_lines = inspect.cleandoc("\n".join(line for line in docstring.splitlines() if line.startswith(("\t", "  "))))
+        docstring_styles = (
+            GOOGLE_DOCSTRING_ARG_REGEX.finditer(section_lines),
+            SPHINX_DOCSTRING_ARG_REGEX.finditer(docstring),
+            NUMPY_DOCSTRING_ARG_REGEX.finditer(docstring),
+        )
+
+        # Choose the style with the largest number of arguments matched
+        matched_args = []
+        actual_args = inspect.signature(func).parameters.keys()
+        for matches in docstring_styles:
+            style_matched_args = [match for match in matches if match.group("name") in actual_args]
+            if len(style_matched_args) > len(matched_args):
+                matched_args = style_matched_args
+
+        # Parse the arguments
+        for arg in matched_args:
+            arg_description = re.sub(r"\n\s*", " ", arg.group("description")).strip()
+            args[arg.group("name")] = arg_description
+
+    return args
 
 
 def _to_kebab_case(text: str) -> str:
@@ -211,7 +267,7 @@ def _populate_descriptions(params: Dict[str, CommandParameter], descriptions: Di
         if not isinstance(description, str):
             raise TypeError('description must be a string')
 
-        param.description = description
+        param.description = _shorten(description)
 
     if descriptions:
         first = next(iter(descriptions))
@@ -313,13 +369,15 @@ def _extract_parameters_from_callback(func: Callable[..., Any], globalns: Dict[s
     values = sorted(parameters, key=lambda a: a.required, reverse=True)
     result = {v.name: v for v in values}
 
+    descriptions = _parse_args_from_docstring(func)
+
     try:
-        descriptions = func.__discord_app_commands_param_description__
+        descriptions.update(func.__discord_app_commands_param_description__)
     except AttributeError:
         for param in values:
             if param.description is MISSING:
                 param.description = '…'
-    else:
+    if descriptions:
         _populate_descriptions(result, descriptions)
 
     try:


### PR DESCRIPTION
## Summary

This PR adds the ability to specify option descriptions using docstrings instead of passing them in the decorator.

If, however, the description is explicitly specified, the docstring will not be used.

## Why this should be added

Since many developers will be following good practices, you will likely have docstrings anyway, this allows you to explain what the function and arguments do only once and not have it repeated in two places.

Additionally, this will allow cleaner code, since you will be able to add descriptions to options with fewer decorators.
## Changes

If the description is not specified in the decorator, the docstring will used before defaulting to "...".

The code has been tested on docstrings in the style of [Google](https://google.github.io/styleguide/pyguide.html#Comments), [Numpy](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard), [Sphinx (rst)](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html).

Example code (Numpy-style):

```py
@bot.tree.command(name="botcmd1")
@app_commands.guilds(discord.Object(id=TESTING_GUILD_ID))
async def cmd1(interaction: discord.Interaction, arg: str, arg2: int):
    """Test command. This is a longer description. It takes more than 100 characters, so it will be truncated.

    Parameters
    ----------
    arg : str
        Docstring description of arg. This is a very long description that should be truncated because it is too long.

        It even has a newline.
    arg2 : int
        Docstring description of arg2.
    """
    await interaction.response.send_message("Hello from test command!", ephemeral=True)
```

```py
@app_commands.command(name="cmd1")
@app_commands.guilds(discord.Object(id=TESTING_GUILD_ID))
async def cmd(self, interaction: discord.Interaction):
    """First slash command."""
    await interaction.response.send_message("Hello from command 1!", ephemeral=True)
```

Numpy Style

```py
    """Summary line. This is the command description.

    Extended description of function. This is not used for the command description.

    Parameters
    ----------
    interaction : Interaction
        Interaction object
    my_arg : int
        Description of arg1
    my_second_arg : str
        Description of arg2
        Second line of description.
    """
```

Google Style

```py
    """Summary line.

    Extended description of function.

    Args:
        interaction (Interaction): Interaction object
        my_arg (int): Description of arg1
        my_second_arg (str): Description of arg2

            Second line of description.
    """
```

Sphinx RST Style

```py
    """Repeats your messages that you send as arguments

    :param interaction: The interaction object
    :type interaction: :class:`discord.Interaction`
    :param my_arg: The first message to repeat. This
        argument is required.
    :type my_arg: :class:`str`
    :param my_second_arg: The second message to repeat.
        This argument is required.
    :type my_second_arg: :class:`str`
    :return: None
    :rtpye: NoneType
    """
```

Dpy style (numpy with no spaces after arg names)

```py
    """Repeats your messages that you send as arguments

    Parameters
    ----------
    interaction: :class:`discord.Interaction`
        The interaction object
    my_arg: :class:`str`
        The first message to repeat. This
        argument is required.
    my_second_arg: :class:`str`
        The second message to repeat.
        This argument is required.
    """
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)*
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)