### PR TITLE
Add ForumChannel to Thread.parent_id docstring

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -91,7 +91,7 @@ class Thread(Messageable, Hashable):
     id: :class:`int`
         The thread ID.
     parent_id: :class:`int`
-        The parent :class:`TextChannel` ID this thread belongs to.
+        The parent :class:`TextChannel` or :class:`ForumChannel` ID this thread belongs to.
     owner_id: :class:`int`
         The user's ID that created this thread.
     last_message_id: Optional[:class:`int`]


### PR DESCRIPTION
## Summary

It adds `ForumChannel` to `Thread.parent_id` docstring.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
