### PR TITLE
feat: filename and description kwargs for to_file

### DIFF
--- a/discord/asset.py
+++ b/discord/asset.py
@@ -125,7 +125,13 @@ class AssetMixin:
             with open(fp, 'wb') as f:
                 return f.write(data)
 
-    async def to_file(self, *, spoiler: bool = False) -> File:
+    async def to_file(
+        self,
+        *,
+        filename: Optional[str] = None,
+        description: Optional[str] = None,
+        spoiler: bool = False,
+    ) -> File:
         """|coro|
 
         Converts the asset into a :class:`File` suitable for sending via
@@ -135,6 +141,11 @@ class AssetMixin:
 
         Parameters
         -----------
+        filename: Optional[:class:`str`]
+            The filename of the file. If not provided, then the filename from
+            the asset's URL is used.
+        description: Optional[:class:`str`]
+            The description for the file.
         spoiler: :class:`bool`
             Whether the file is a spoiler.
 
@@ -142,12 +153,12 @@ class AssetMixin:
         ------
         DiscordException
             The asset does not have an associated state.
+        InvalidArgument
+            The asset is a unicode emoji.
         TypeError
             The asset is a sticker with lottie type.
         HTTPException
             Downloading the asset failed.
-        Forbidden
-            You do not have permissions to access this asset.
         NotFound
             The asset was deleted.
 
@@ -158,9 +169,8 @@ class AssetMixin:
         """
 
         data = await self.read()
-        url = yarl.URL(self.url)
-        _, _, filename = url.path.rpartition('/')
-        return File(io.BytesIO(data), filename=filename, spoiler=spoiler)
+        filename = filename or yarl.URL(self.url).name
+        return File(io.BytesIO(data), filename=filename, description=description, spoiler=spoiler)
 
 
 class Asset(AssetMixin):

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -153,7 +153,7 @@ class AssetMixin:
         ------
         DiscordException
             The asset does not have an associated state.
-        InvalidArgument
+        ValueError
             The asset is a unicode emoji.
         TypeError
             The asset is a sticker with lottie type.

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -128,7 +128,7 @@ class AssetMixin:
     async def to_file(
         self,
         *,
-        filename: Optional[str] = None,
+        filename: Optional[str] = MISSING,
         description: Optional[str] = None,
         spoiler: bool = False,
     ) -> File:
@@ -169,8 +169,8 @@ class AssetMixin:
         """
 
         data = await self.read()
-        filename = filename or yarl.URL(self.url).name
-        return File(io.BytesIO(data), filename=filename, description=description, spoiler=spoiler)
+        file_filename = filename or yarl.URL(self.url).name
+        return File(io.BytesIO(data), filename=file_filename, description=description, spoiler=spoiler)
 
 
 class Asset(AssetMixin):

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -169,7 +169,7 @@ class AssetMixin:
         """
 
         data = await self.read()
-        file_filename = filename or yarl.URL(self.url).name
+        file_filename = filename if filename is not MISSING else yarl.URL(self.url).name
         return File(io.BytesIO(data), filename=file_filename, description=description, spoiler=spoiler)
 
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -306,8 +306,8 @@ class Attachment(Hashable):
     async def to_file(
         self,
         *,
-        filename: Optional[str] = None,
-        description: Optional[str] = None,
+        filename: Optional[str] = MISSING,
+        description: Optional[str] = MISSING,
         use_cached: bool = False,
         spoiler: bool = False,
     ) -> File:
@@ -321,13 +321,13 @@ class Attachment(Hashable):
         Parameters
         -----------
         filename: Optional[:class:`str`]
-            The filename of the attachment. If not specified, then the filename
-            from the attachment will be used.
+            The filename to use for the file. If not specified then the filename
+            of the attachment is used instead.
 
             .. versionadded:: 2.0
         description: Optional[:class:`str`]
-            The description of the attachment. If not specified, then the
-            description from the attachment will be used.
+            The description to use for the file. If not specified then the
+            description of the attachment is used instead.
 
             .. versionadded:: 2.0
         use_cached: :class:`bool`
@@ -360,9 +360,9 @@ class Attachment(Hashable):
         """
 
         data = await self.read(use_cached=use_cached)
-        filename = filename or self.filename
-        description = description or self.description
-        return File(io.BytesIO(data), filename=filename, description=description, spoiler=spoiler)
+        file_filename = filename if filename is not MISSING else self.filename
+        file_description = description if description is not MISSING else self.description
+        return File(io.BytesIO(data), filename=file_filename, description=file_description, spoiler=spoiler)
 
     def to_dict(self) -> AttachmentPayload:
         result: AttachmentPayload = {

--- a/discord/message.py
+++ b/discord/message.py
@@ -303,7 +303,14 @@ class Attachment(Hashable):
         data = await self._http.get_from_cdn(url)
         return data
 
-    async def to_file(self, *, use_cached: bool = False, spoiler: bool = False) -> File:
+    async def to_file(
+        self,
+        *,
+        filename: Optional[str] = None,
+        description: Optional[str] = None,
+        use_cached: bool = False,
+        spoiler: bool = False,
+    ) -> File:
         """|coro|
 
         Converts the attachment into a :class:`File` suitable for sending via
@@ -313,6 +320,16 @@ class Attachment(Hashable):
 
         Parameters
         -----------
+        filename: Optional[:class:`str`]
+            The filename of the attachment. If not specified, then the filename
+            from the attachment will be used.
+
+            .. versionadded:: 2.0
+        description: Optional[:class:`str`]
+            The description of the attachment. If not specified, then the
+            description from the attachment will be used.
+
+            .. versionadded:: 2.0
         use_cached: :class:`bool`
             Whether to use :attr:`proxy_url` rather than :attr:`url` when downloading
             the attachment. This will allow attachments to be saved after deletion
@@ -343,7 +360,9 @@ class Attachment(Hashable):
         """
 
         data = await self.read(use_cached=use_cached)
-        return File(io.BytesIO(data), filename=self.filename, description=self.description, spoiler=spoiler)
+        filename = filename or self.filename
+        description = description or self.description
+        return File(io.BytesIO(data), filename=filename, description=description, spoiler=spoiler)
 
     def to_dict(self) -> AttachmentPayload:
         result: AttachmentPayload = {


### PR DESCRIPTION
## Summary

Adds kwargs to `Asset.to_file` and `Attachment.to_file` for overriding the `filename` or `description` when creating the `File`.

Fixes to docstrings

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
