### PR TITLE
add self_deaf and self_mute params to Connectable.connect and related…

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1806,8 +1806,12 @@ class Connectable(Protocol):
             Defaults to :class:`~discord.VoiceClient`.
         self_mute: :class:`bool`
             Indicates if the client should be self-muted.
+
+            .. versionadded: 2.0
         self_deaf: :class:`bool`
             Indicates if the client should be self-deafened.
+
+            .. versionadded: 2.0
 
         Raises
         -------

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1783,6 +1783,8 @@ class Connectable(Protocol):
         timeout: float = 60.0,
         reconnect: bool = True,
         cls: Callable[[Client, Connectable], T] = MISSING,
+        self_deaf: bool = False,
+        self_mute: bool = False,
     ) -> T:
         """|coro|
 
@@ -1802,6 +1804,10 @@ class Connectable(Protocol):
         cls: Type[:class:`~discord.VoiceProtocol`]
             A type that subclasses :class:`~discord.VoiceProtocol` to connect with.
             Defaults to :class:`~discord.VoiceClient`.
+        self_mute: :class:`bool`
+            Indicates if the client should be self-muted.
+        self_deaf: :class:`bool`
+            Indicates if the client should be self-deafened.
 
         Raises
         -------
@@ -1838,7 +1844,7 @@ class Connectable(Protocol):
         state._add_voice_client(key_id, voice)
 
         try:
-            await voice.connect(timeout=timeout, reconnect=reconnect)
+            await voice.connect(timeout=timeout, reconnect=reconnect, self_deaf=self_deaf, self_mute=self_mute)
         except asyncio.TimeoutError:
             try:
                 await voice.disconnect(force=True)

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -149,7 +149,7 @@ class VoiceProtocol:
         """
         raise NotImplementedError
 
-    async def connect(self, *, timeout: float, reconnect: bool) -> None:
+    async def connect(self, *, timeout: float, reconnect: bool, self_deaf: bool = False, self_mute: bool = False) -> None:
         """|coro|
 
         An abstract method called when the client initiates the connection request.
@@ -169,6 +169,10 @@ class VoiceProtocol:
             The timeout for the connection.
         reconnect: :class:`bool`
             Whether reconnection is expected.
+        self_mute: :class:`bool`
+            Indicates if the client should be self-muted.
+        self_deaf: :class:`bool`
+            Indicates if the client should be self-deafened.
         """
         raise NotImplementedError
 
@@ -339,8 +343,8 @@ class VoiceClient(VoiceProtocol):
 
         self._voice_server_complete.set()
 
-    async def voice_connect(self) -> None:
-        await self.channel.guild.change_voice_state(channel=self.channel)
+    async def voice_connect(self, self_deaf: bool = False, self_mute: bool = False) -> None:
+        await self.channel.guild.change_voice_state(channel=self.channel, self_deaf=self_deaf, self_mute=self_mute)
 
     async def voice_disconnect(self) -> None:
         _log.info('The voice handshake is being terminated for Channel ID %s (Guild ID %s)', self.channel.id, self.guild.id)
@@ -367,7 +371,7 @@ class VoiceClient(VoiceProtocol):
         self._connected.set()
         return ws
 
-    async def connect(self, *, reconnect: bool, timeout: float) -> None:
+    async def connect(self, *, reconnect: bool, timeout: float, self_deaf: bool = False, self_mute: bool = False) -> None:
         _log.info('Connecting to voice...')
         self.timeout = timeout
 
@@ -381,7 +385,7 @@ class VoiceClient(VoiceProtocol):
             ]
 
             # Start the connection flow
-            await self.voice_connect()
+            await self.voice_connect(self_deaf=self_deaf, self_mute=self_mute)
 
             try:
                 await utils.sane_wait_for(futures, timeout=timeout)

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -171,8 +171,12 @@ class VoiceProtocol:
             Whether reconnection is expected.
         self_mute: :class:`bool`
             Indicates if the client should be self-muted.
+
+            .. versionadded: 2.0
         self_deaf: :class:`bool`
             Indicates if the client should be self-deafened.
+
+            .. versionadded: 2.0
         """
         raise NotImplementedError
 

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -1212,6 +1212,11 @@ The following changes have been made:
 
 - :attr:`File.filename` will no longer be ``None``, in situations where previously this was the case the filename is set to `'untitled'`.
 
+:meth:`VoiceProtocol.connect` signature changes.
+--------------------------------------------------
+
+:meth:`VoiceProtocol.connect` will now be passed 2 keyword only arguments, ``self_deaf`` and ``self_mute``. These indicate
+whether or not the client should join the voice chat being deafened or muted.
 
 .. _migrating_2_0_commands:
 


### PR DESCRIPTION
… classes

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Adds support for passing ``self_deaf`` and ``self_mute`` to Connectable.connect (and VoiceProtocol) to have the client self deafen /mute when it joins. 

Closes #7805.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
