### PR TITLE
Change Parameters -> Attributes header in HybridGroup

### DIFF
--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -437,7 +437,7 @@ class HybridGroup(Group[CogT, P, T]):
 
     .. versionadded:: 2.0
 
-    Parameters
+    Attributes
     -----------
     fallback: Optional[:class:`str`]
         The command name to use as a fallback for the application command. Since


### PR DESCRIPTION
## Summary

This seems to make the most sense considering that this class is not supposed to be constructed directly *and* docstrings of Command/Group use `Attributes` instead as well. I assume that there wasn't any reason not to document it as a publically available attribute.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
