### PR TITLE
Added NotFound to the Raises docstring in unban

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3198,6 +3198,8 @@ class Guild(Hashable):
 
         Raises
         -------
+        NotFound
+            The requested unban was not found.
         Forbidden
             You do not have the proper permissions to unban.
         HTTPException


### PR DESCRIPTION
## Summary

- Added discord.errors.NotFound to the Raises portion of the unban class method docstring, as it is raised when trying to unban a non-banned member.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
