### PR TITLE
[types] Add overload to run_converters

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -1244,7 +1244,9 @@ async def _actual_conversion(ctx: Context[BotT], converter, argument: str, param
 
 
 @overload
-async def run_converters(ctx: Context[BotT], converter: Converter[T], argument: str, param: Parameter) -> T:
+async def run_converters(
+    ctx: Context[BotT], converter: Union[Type[Converter[T]], Converter[T]], argument: str, param: Parameter
+) -> T:
     ...
 
 

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -35,6 +35,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    overload,
     Protocol,
     Tuple,
     Type,
@@ -1240,6 +1241,16 @@ async def _actual_conversion(ctx: Context[BotT], converter, argument: str, param
             name = converter.__class__.__name__  # type: ignore
 
         raise BadArgument(f'Converting to "{name}" failed for parameter "{param.name}".') from exc
+
+
+@overload
+async def run_converters(ctx: Context[BotT], converter: Converter[T], argument: str, param: Parameter) -> T:
+    ...
+
+
+@overload
+async def run_converters(ctx: Context[BotT], converter: Any, argument: str, param: Parameter) -> Any:
+    ...
 
 
 async def run_converters(ctx: Context[BotT], converter: Any, argument: str, param: Parameter) -> Any:


### PR DESCRIPTION
## Summary

PR Adds an overload to `run_converters` for explicitly passed `Converter` classes/instances

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
