### PR TITLE
Add `TextInput` to `Item` docstring

### DIFF
--- a/discord/ui/item.py
+++ b/discord/ui/item.py
@@ -51,6 +51,7 @@ class Item(Generic[V]):
 
     - :class:`discord.ui.Button`
     - :class:`discord.ui.Select`
+    - :class:`discord.ui.TextInput`
 
     .. versionadded:: 2.0
     """


### PR DESCRIPTION
## Summary
`TextInput` subclasses `Item` but is missing from docstring
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
