### PR TITLE
Update extensions primer in line with async breaking changes

### DIFF
--- a/docs/ext/commands/extensions.rst
+++ b/docs/ext/commands/extensions.rst
@@ -10,7 +10,7 @@ There comes a time in the bot development when you want to extend the bot functi
 Primer
 --------
 
-An extension at its core is a python file with an entry point called ``setup``. This setup must be a plain Python function (not a coroutine). It takes a single parameter -- the :class:`~.commands.Bot` that loads the extension.
+An extension at its core is a python file with an entry point called ``setup``. This setup must be a plain Python coroutine. It takes a single parameter -- the :class:`~.commands.Bot` that loads the extension.
 
 An example extension looks like this:
 
@@ -25,7 +25,7 @@ An example extension looks like this:
         await ctx.send(f'Hello {ctx.author.display_name}.')
 
     async def setup(bot):
-        bot.add_command(hello)
+        await bot.add_command(hello)
 
 In this example we define a simple command, and when the extension is loaded this command is added to the bot. Now the final step to this is loading the extension, which we do by calling :meth:`.Bot.load_extension`. To load this extension we call ``await bot.load_extension('hello')``.
 

--- a/docs/ext/commands/extensions.rst
+++ b/docs/ext/commands/extensions.rst
@@ -10,7 +10,7 @@ There comes a time in the bot development when you want to extend the bot functi
 Primer
 --------
 
-An extension at its core is a python file with an entry point called ``setup``. This setup function must be an asynchronous coroutine. It takes a single parameter -- the :class:`~.commands.Bot` that loads the extension.
+An extension at its core is a python file with an entry point called ``setup``. This setup function must be a Python coroutine. It takes a single parameter -- the :class:`~.commands.Bot` that loads the extension.
 
 An example extension looks like this:
 

--- a/docs/ext/commands/extensions.rst
+++ b/docs/ext/commands/extensions.rst
@@ -10,7 +10,7 @@ There comes a time in the bot development when you want to extend the bot functi
 Primer
 --------
 
-An extension at its core is a python file with an entry point called ``setup``. This setup must be a plain Python coroutine. It takes a single parameter -- the :class:`~.commands.Bot` that loads the extension.
+An extension at its core is a python file with an entry point called ``setup``. This setup function must be an asynchronous coroutine. It takes a single parameter -- the :class:`~.commands.Bot` that loads the extension.
 
 An example extension looks like this:
 
@@ -25,7 +25,7 @@ An example extension looks like this:
         await ctx.send(f'Hello {ctx.author.display_name}.')
 
     async def setup(bot):
-        await bot.add_command(hello)
+        bot.add_command(hello)
 
 In this example we define a simple command, and when the extension is loaded this command is added to the bot. Now the final step to this is loading the extension, which we do by calling :meth:`.Bot.load_extension`. To load this extension we call ``await bot.load_extension('hello')``.
 


### PR DESCRIPTION
## Summary

Since the setup function in extensions is now a coroutine due to the recent 2.0 breaking changes, I wanted this to reflect in the docs
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
