### PR TITLE
[tasks] Fix Task.failed() only being True while error handler runs

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -271,7 +271,6 @@ class Loop(Generic[LF]):
             self._is_being_cancelled = False
             self._current_loop = 0
             self._stop_next_iteration = False
-            self._has_failed = False
 
     def __get__(self, obj: T, objtype: Type[T]) -> Loop[LF]:
         if obj is None:
@@ -397,6 +396,7 @@ class Loop(Generic[LF]):
         if self._injected is not None:
             args = (self._injected, *args)
 
+        self._has_failed = False
         self._task = asyncio.create_task(self._loop(*args, **kwargs))
         return self._task
 


### PR DESCRIPTION
## Summary

Fixes Task.failed() only returning True while the Tasks error handler is being called.

The failed state is instead reset whenever the task is (re)started, meaning it's more useful for code outside of the task context or when debugging.

```py
import asyncio

from discord.ext import tasks


@tasks.loop(seconds=1, count=1)
async def working_example():
    pass


@tasks.loop(seconds=1, count=1)
async def raising_example():
    raise Exception('This task is broken.')


async def main():
    working_example.start()
    raising_example.start()

    # Wait until tasks have run
    await working_example.get_task()

    print(working_example.failed())
    print(raising_example.failed())  # True after patch, False before


asyncio.run(main())
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
