### PR TITLE
Add NotFound to ban docstring

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3174,6 +3174,8 @@ class Guild(Hashable):
 
         Raises
         -------
+        NotFound
+            The requested user was not found.
         Forbidden
             You do not have the proper permissions to ban.
         HTTPException


### PR DESCRIPTION
## Summary

- Added discord.errors.NotFound to the Raises portion of the ban class method docstring, as it is raised when trying to ban an invalid user.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
