### PR TITLE
Add `ValueError` to `PartialEmoji.read`'s docstring

### DIFF
--- a/discord/partial_emoji.py
+++ b/discord/partial_emoji.py
@@ -233,6 +233,26 @@ class PartialEmoji(_EmojiTag, AssetMixin):
         return f'{Asset.BASE}/emojis/{self.id}.{fmt}'
 
     async def read(self) -> bytes:
+        """|coro|
+
+        Retrieves the content of this asset as a :class:`bytes` object.
+
+        Raises
+        ------
+        DiscordException
+            There was no internal connection state.
+        HTTPException
+            Downloading the asset failed.
+        NotFound
+            The asset was deleted.
+        ValueError
+            The PartialEmoji is not a custom emoji.
+
+        Returns
+        -------
+        :class:`bytes`
+            The content of the asset.
+        """
         if self.is_unicode_emoji():
             raise ValueError('PartialEmoji is not a custom emoji')
 


### PR DESCRIPTION
## Summary

Being subclassed, had to bring the whole docstring in and add the ValueError lines.

~~There goes my lines of code to commit ratio of 1.75 🙄~~

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
