### PR TITLE
patch typing on Role and Member .edit methods

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -28,7 +28,7 @@ import datetime
 import inspect
 import itertools
 from operator import attrgetter
-from typing import Any, Awaitable, Callable, Collection, Dict, List, Optional, TYPE_CHECKING, Tuple, Union, Type
+from typing import Any, Awaitable, Callable, Collection, Dict, List, Optional, TYPE_CHECKING, Tuple, Union, Type, overload
 
 import discord.abc
 
@@ -731,6 +731,25 @@ class Member(discord.abc.Messageable, _UserTag):
         Kicks this member. Equivalent to :meth:`Guild.kick`.
         """
         await self.guild.kick(self, reason=reason)
+
+    @overload
+    async def edit(self, *, reason: Optional[str] = None) -> None:
+        ...
+
+    @overload
+    async def edit(
+        self,
+        *,
+        nick: Optional[str] = MISSING,
+        mute: bool = MISSING,
+        deafen: bool = MISSING,
+        suppress: bool = MISSING,
+        roles: Collection[discord.abc.Snowflake] = MISSING,
+        voice_channel: Optional[VocalGuildChannel] = MISSING,
+        timed_out_until: Optional[datetime.datetime] = MISSING,
+        reason: Optional[str] = None,
+    ) -> Member:
+        ...
 
     async def edit(
         self,

--- a/discord/role.py
+++ b/discord/role.py
@@ -389,7 +389,7 @@ class Role(Hashable):
         mentionable: bool = MISSING,
         position: int = MISSING,
         reason: Optional[str] = MISSING,
-    ) -> Optional[Role]:
+    ) -> Role:
         """|coro|
 
         Edits the role.


### PR DESCRIPTION
## Summary

- changed return type of Role.edit from `Optional[Role]` to `Role`,
because None is never returned
- added overloads to Member.edit so that
the return type is inferred correctly

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - Docs of Role.edit are already up to date
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

## Todo

- [ ] Find other possible cases where Member.edit returns None
- [ ] Update Returns section in Member.edit docs to explain when None is returned
