### PR TITLE
Add missing `discord.EventStatus.ended` to API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2821,6 +2821,10 @@ of :class:`enum.Enum`.
 
         An alias for :attr:`cancelled`.
 
+    .. attribute:: ended
+
+        An alias for :attr:`completed`.
+
 .. _discord-api-audit-logs:
 
 Audit Log Data


### PR DESCRIPTION
## Summary

This PR adds `discord.EventStatus.ended` (an alias for `discord.EventStatus.completed`) to the API docs.

## Checklist

- [ ] ~~If code changes were made then they have been tested.~~
    - [ ] ~~I have updated the documentation to reflect the changes.~~
- [ ] ~~This PR fixes an issue.~~
- [ ] ~~This PR adds something new (e.g. new method or parameters).~~
- [ ] ~~This PR is a breaking change (e.g. methods or parameters removed/renamed)~~
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
