### PR TITLE
Correct activity button type

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -74,9 +74,7 @@ type: int
 sync_id: str
 session_id: str
 flags: int
-buttons: list[dict]
-    label: str (max: 32)
-    url: str (max: 512)
+buttons: list[str (max: 32)]
 
 There are also activity flags which are mostly uninteresting for the library atm.
 
@@ -96,7 +94,6 @@ if TYPE_CHECKING:
         ActivityTimestamps,
         ActivityParty,
         ActivityAssets,
-        ActivityButton,
     )
 
     from .state import ConnectionState
@@ -187,12 +184,8 @@ class Activity(BaseActivity):
 
         - ``id``: A string representing the party ID.
         - ``size``: A list of up to two integer elements denoting (current_size, maximum_size).
-    buttons: List[:class:`dict`]
-        An list of dictionaries representing custom buttons shown in a rich presence.
-        Each dictionary contains the following keys:
-
-        - ``label``: A string representing the text shown on the button.
-        - ``url``: A string representing the URL opened upon clicking the button.
+    buttons: List[:class:`str`]
+        An list of strings representing the labels of custom buttons shown in a rich presence.
 
         .. versionadded:: 2.0
 
@@ -231,7 +224,7 @@ class Activity(BaseActivity):
         self.flags: int = kwargs.pop('flags', 0)
         self.sync_id: Optional[str] = kwargs.pop('sync_id', None)
         self.session_id: Optional[str] = kwargs.pop('session_id', None)
-        self.buttons: List[ActivityButton] = kwargs.pop('buttons', [])
+        self.buttons: List[str] = kwargs.pop('buttons', [])
 
         activity_type = kwargs.pop('type', -1)
         self.type: ActivityType = (

--- a/discord/types/activity.py
+++ b/discord/types/activity.py
@@ -76,11 +76,6 @@ class ActivityEmoji(TypedDict):
     animated: NotRequired[bool]
 
 
-class ActivityButton(TypedDict):
-    label: str
-    url: str
-
-
 ActivityType = Literal[0, 1, 2, 4, 5]
 
 
@@ -106,5 +101,5 @@ class Activity(_BaseActivity, total=False):
     secrets: ActivitySecrets
     session_id: Optional[str]
     instance: bool
-    buttons: List[ActivityButton]
+    buttons: List[str]
     sync_id: str


### PR DESCRIPTION
## Summary

Fixes the typing for activity buttons being incorrect.

https://discord.com/developers/docs/topics/gateway#activity-object-activity-buttons
> When received over the gateway, the buttons field is an array of strings, which are the button labels.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
