### PR TITLE
Support dynamic rich presence asset URLs

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -293,28 +293,28 @@ class Activity(BaseActivity):
     @property
     def large_image_url(self) -> Optional[str]:
         """Optional[:class:`str`]: Returns a URL pointing to the large image asset of this activity if applicable."""
-        if self.application_id is None:
-            return None
-
         try:
             large_image = self.assets['large_image']
         except KeyError:
             return None
         else:
-            return Asset.BASE + f'/app-assets/{self.application_id}/{large_image}.png'
+            return self._image_url(large_image)
 
     @property
     def small_image_url(self) -> Optional[str]:
         """Optional[:class:`str`]: Returns a URL pointing to the small image asset of this activity if applicable."""
-        if self.application_id is None:
-            return None
-
         try:
             small_image = self.assets['small_image']
         except KeyError:
             return None
         else:
-            return Asset.BASE + f'/app-assets/{self.application_id}/{small_image}.png'
+            return self._image_url(small_image)
+
+    def _image_url(self, image: str) -> Optional[str]:
+        if image.startswith('mp:'):
+            return f'https://media.discordapp.net/{image[3:]}'
+        elif self.application_id is not None:
+            return Asset.BASE + f'/app-assets/{self.application_id}/{image}.png'
 
     @property
     def large_image_text(self) -> Optional[str]:


### PR DESCRIPTION
## Summary

Allows more easily fetching dynamic rich presence images via `Activity.large/small_image_url` instead of having to manually construct them from activity assets.

These can be set by apps as an alternative to assets uploaded in the dev portal.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
