### PR TITLE
Separately delay ready event for each shard

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -484,7 +484,6 @@ class Client:
         self.loop = loop
         self.http.loop = loop
         self._connection.loop = loop
-        await self._connection.async_setup()
 
         self._ready = asyncio.Event()
 

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -546,8 +546,6 @@ class DiscordWebSocket:
             self._trace = trace = data.get('_trace', [])
             self.sequence = msg['s']
             self.session_id = data['session_id']
-            # pass back shard ID to ready handler
-            data['__shard_id__'] = self.shard_id
             _log.info(
                 'Shard ID %s has connected to Gateway: %s (Session ID: %s).',
                 self.shard_id,

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -423,8 +423,6 @@ class AutoShardedClient(Client):
             initial = shard_id == shard_ids[0]
             await self.launch_shard(gateway, shard_id, initial=initial)
 
-        self._connection.shards_launched.set()
-
     async def _async_setup_hook(self) -> None:
         await super()._async_setup_hook()
         self.__queue = asyncio.PriorityQueue()

--- a/discord/types/gateway.py
+++ b/discord/types/gateway.py
@@ -60,17 +60,12 @@ class GatewayBot(Gateway):
     session_start_limit: SessionStartLimit
 
 
-class ShardInfo(TypedDict):
-    shard_id: int
-    shard_count: int
-
-
 class ReadyEvent(TypedDict):
     v: int
     user: User
     guilds: List[UnavailableGuild]
     session_id: str
-    shard: ShardInfo
+    shard: List[int]  # shard_id, num_shards
     application: GatewayAppInfo
 
 


### PR DESCRIPTION
## Summary

Fixes #5857. As this allows simplifying the delay logic a lot I've mostly copied the implementation from the regular ConnectionState.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
