### PR TITLE
Update api.rst documentation to add timeout to on_member_update

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -683,6 +683,7 @@ Members
     - nickname
     - roles
     - pending
+    - timeout
 
     This requires :attr:`Intents.members` to be enabled.
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Just updating the API reference doc to note that on_member_update is also called when communication_disabled_until (aka timeout) is updated (so, when users are timed out) - which I just denoted as timeout. Unsure if using communication_disable_until (as in discord docs) or timeout is preferable.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
