### PR TITLE
Add error decorator to app_commands.Group

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -1282,8 +1282,7 @@ class Group:
     def error(self, coro: ErrorFunc) -> ErrorFunc:
         """A decorator that registers a coroutine as a local error handler.
 
-        The local error handler is called whenever an exception is raised in the body
-        of the command or during handling of the command. The error handler must take
+        The local error handler is called whenever an exception is raised in a child command. The error handler must take
         2 parameters, the interaction and the error.
 
         The error passed will be derived from :exc:`AppCommandError`.

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -1282,8 +1282,8 @@ class Group:
     def error(self, coro: ErrorFunc) -> ErrorFunc:
         """A decorator that registers a coroutine as a local error handler.
 
-        The local error handler is called whenever an exception is raised in a child command. The error handler must take
-        2 parameters, the interaction and the error.
+        The local error handler is called whenever an exception is raised in a child command.
+        The error handler must take 2 parameters, the interaction and the error.
 
         The error passed will be derived from :exc:`AppCommandError`.
 

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -1302,7 +1302,7 @@ class Group:
         if len(params) != 2:
             raise TypeError('The error handler must have 2 parameters.')
 
-        self.on_error = coro
+        self.on_error = coro  # type: ignore
         return coro
 
     async def interaction_check(self, interaction: Interaction) -> bool:

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -1262,6 +1262,7 @@ class Group:
 
     async def on_error(self, interaction: Interaction, error: AppCommandError) -> None:
         """|coro|
+
         A callback that is called when a child's command raises an :exc:`AppCommandError`.
 
         To get the command that failed, :attr:`discord.Interaction.command` should be used.

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -70,10 +70,7 @@ if TYPE_CHECKING:
     # reference the other to prevent type checking errors in callbacks
     from discord.ext.commands import Cog
 
-    ErrorFunc = Callable[
-        [Interaction, AppCommandError],
-        Coroutine[Any, Any, Any],
-    ]
+    ErrorFunc = Callable[[Interaction, AppCommandError], Coroutine[Any, Any, None]]
 
 __all__ = (
     'Command',

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -1296,7 +1296,7 @@ class Group:
         Raises
         -------
         TypeError
-            The coroutine passed is not actually a coroutine.
+            The coroutine passed is not actually a coroutine, or is an invalid coroutine.
         """
 
         if not inspect.iscoroutinefunction(coro):


### PR DESCRIPTION
## Summary

This pull request fixes an inconsistency in the `app_commands.Group` class, compared to the `app_commands.Command`, `app_commands.ContextMenu`, and `app_commands.CommandTree` classes by adding a `@error` decorator for registering error handlers at the group level.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
