### PR TITLE
Rename use_slash_commands

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -175,7 +175,7 @@ class Permissions(BaseFlags):
         - :attr:`administrator`
 
         .. versionchanged:: 1.7
-           Added :attr:`stream`, :attr:`priority_speaker` and :attr:`use_slash_commands` permissions.
+           Added :attr:`stream`, :attr:`priority_speaker` and :attr:`use_application_commands` permissions.
 
         .. versionchanged:: 2.0
            Added :attr:`create_public_threads`, :attr:`create_private_threads`, :attr:`manage_threads`,
@@ -213,7 +213,7 @@ class Permissions(BaseFlags):
 
         .. versionchanged:: 1.7
            Permission :attr:`read_messages` is no longer part of the text permissions.
-           Added :attr:`use_slash_commands` permission.
+           Added :attr:`use_application_commands` permission.
 
         .. versionchanged:: 2.0
            Added :attr:`create_public_threads`, :attr:`create_private_threads`, :attr:`manage_threads`,
@@ -517,7 +517,7 @@ class Permissions(BaseFlags):
         return 1 << 30
 
     @flag_value
-    def use_slash_commands(self) -> int:
+    def use_application_commands(self) -> int:
         """:class:`bool`: Returns ``True`` if a user can use slash commands.
 
         .. versionadded:: 1.7
@@ -707,7 +707,7 @@ class PermissionOverwrite:
         manage_webhooks: Optional[bool]
         manage_emojis: Optional[bool]
         manage_emojis_and_stickers: Optional[bool]
-        use_slash_commands: Optional[bool]
+        use_application_commands: Optional[bool]
         request_to_speak: Optional[bool]
         manage_events: Optional[bool]
         manage_threads: Optional[bool]

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -1095,6 +1095,9 @@ The following deprecated functionality have been removed:
 
     - Use ``chunk_guild_at_startup`` instead.
 
+- ``Permissions.use_slash_commands`` and ``PermissionOverwrite.use_slash_commands``
+    - Use :attr:`Permissions.use_application_commands` and ``PermissionOverwrite.use_application_commands`` instead.
+
 The following have been removed:
 
 - ``MemberCacheFlags.online``


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

`permissions.py`: Updated `use_slash_commands` to `use_application_commands` so as to follow Discord's naming for it.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
