### PR TITLE
Fix attribute error for role overwrite auditlog and add threads

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -456,7 +456,7 @@ class AuditLogEntry(Hashable):
                     role = self.guild.get_role(instance_id)
                     if role is None:
                         role = Object(id=instance_id)
-                        role.name = self.extra.get('role_name')  # type: ignore # Object doesn't usually have name
+                        role.name = extra.get('role_name')  # type: ignore # Object doesn't usually have name
                     self.extra = role
             elif self.action.name.startswith('stage_instance'):
                 channel_id = int(extra['channel_id'])

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -337,7 +337,7 @@ class _AuditLogProxyMemberPrune(_AuditLogProxy):
 
 
 class _AuditLogProxyMemberMoveOrMessageDelete(_AuditLogProxy):
-    channel: abc.GuildChannel
+    channel: Union[abc.GuildChannel, Thread]
     count: int
 
 
@@ -346,7 +346,7 @@ class _AuditLogProxyMemberDisconnect(_AuditLogProxy):
 
 
 class _AuditLogProxyPinAction(_AuditLogProxy):
-    channel: abc.GuildChannel
+    channel: Union[abc.GuildChannel, Thread]
     message_id: int
 
 
@@ -434,7 +434,7 @@ class AuditLogEntry(Hashable):
                 channel_id = int(extra['channel_id'])
                 self.extra = _AuditLogProxyMemberMoveOrMessageDelete(
                     count=int(extra['count']),
-                    channel=self.guild.get_channel(channel_id) or Object(id=channel_id),
+                    channel=self.guild.get_channel_or_thread(channel_id) or Object(id=channel_id),
                 )
             elif self.action is enums.AuditLogAction.member_disconnect:
                 # The member disconnect action has a dict with some information
@@ -443,7 +443,7 @@ class AuditLogEntry(Hashable):
                 # the pin actions have a dict with some information
                 channel_id = int(extra['channel_id'])
                 self.extra = _AuditLogProxyPinAction(
-                    channel=self.guild.get_channel(channel_id) or Object(id=channel_id),
+                    channel=self.guild.get_channel_or_thread(channel_id) or Object(id=channel_id),
                     message_id=int(extra['message_id']),
                 )
             elif self.action.name.startswith('overwrite_'):


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fix attribute error in audit logs for overwrite actions when getting target role id returns None .

Change `get_channel` to `get_channel_or_thread` for message delete/(un)pin actions.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
