### PR TITLE
Fix minor convention mistakes in basic examples

### DIFF
--- a/examples/app_commands/basic.py
+++ b/examples/app_commands/basic.py
@@ -67,7 +67,7 @@ async def joined(interaction: discord.Interaction, member: Optional[discord.Memb
     member = member or interaction.user
 
     # The format_dt function formats the date time into a human readable representation in the official client
-    await interaction.response.send_message(f'{member} joined at {discord.utils.format_dt(member.joined_at)}')
+    await interaction.response.send_message(f'{member} joined {discord.utils.format_dt(member.joined_at)}')
 
 
 # A Context Menu command is an app command that can be run on a member or on a message by

--- a/examples/app_commands/basic.py
+++ b/examples/app_commands/basic.py
@@ -67,7 +67,7 @@ async def joined(interaction: discord.Interaction, member: Optional[discord.Memb
     member = member or interaction.user
 
     # The format_dt function formats the date time into a human readable representation in the official client
-    await interaction.response.send_message(f'{member} joined on {discord.utils.format_dt(member.joined_at)}')
+    await interaction.response.send_message(f'{member} joined at {discord.utils.format_dt(member.joined_at)}')
 
 
 # A Context Menu command is an app command that can be run on a member or on a message by
@@ -78,7 +78,7 @@ async def joined(interaction: discord.Interaction, member: Optional[discord.Memb
 @client.tree.context_menu(name='Show Join Date')
 async def show_join_date(interaction: discord.Interaction, member: discord.Member):
     # The format_dt function formats the date time into a human readable representation in the official client
-    await interaction.response.send_message(f'{member} joined on {discord.utils.format_dt(member.joined_at)}')
+    await interaction.response.send_message(f'{member} joined at {discord.utils.format_dt(member.joined_at)}')
 
 
 # This context menu command only works on messages

--- a/examples/app_commands/basic.py
+++ b/examples/app_commands/basic.py
@@ -3,6 +3,7 @@ from typing import Optional
 import discord
 from discord import app_commands
 
+
 MY_GUILD = discord.Object(id=0)  # replace with your guild id
 
 
@@ -13,14 +14,14 @@ class MyClient(discord.Client):
         # state required to make it work. This is a separate class because it
         # allows all the extra state to be opt-in.
         # Whenever you want to work with application commands, your tree is used
-        # to store it and work with it.
+        # to store and work with them.
         # Note: When using commands.Bot instead of discord.Client, the bot will
         # maintain its own tree instead.
         self.tree = app_commands.CommandTree(self)
 
     # In this basic example, we just synchronize the app commands to one guild.
     # Instead of specifying a guild to every command, we copy over our global commands instead.
-    # By doing so we don't have to wait up to an hour until they are shown to the end-user.
+    # By doing so, we don't have to wait up to an hour until they are shown to the end-user.
     async def setup_hook(self):
         # This copies the global commands over to your guild.
         self.tree.copy_global_to(guild=MY_GUILD)
@@ -30,7 +31,7 @@ class MyClient(discord.Client):
 intents = discord.Intents.default()
 
 # In order to use a basic synchronization of the app commands in the setup_hook,
-# you have replace the 0 with your bots application_id you find in the developer portal.
+# you have to replace the 0 with your bot's application_id that you find in the developer portal.
 client = MyClient(intents=intents, application_id=0)
 
 
@@ -57,16 +58,16 @@ async def add(interaction: discord.Interaction, first_value: int, second_value: 
 
 
 # To make an argument optional, you can either give it a supported default argument
-# or you can mark it as Optional from the typing library. This example does both.
+# or you can mark it as Optional from the typing standard library. This example does both.
 @client.tree.command()
-@app_commands.describe(member='The member you want to get the joined date from, defaults to the user who uses the command')
+@app_commands.describe(member='The member you want to get the joined date from; defaults to the user who uses the command')
 async def joined(interaction: discord.Interaction, member: Optional[discord.Member] = None):
     """Says when a member joined."""
     # If no member is explicitly provided then we use the command user here
     member = member or interaction.user
 
     # The format_dt function formats the date time into a human readable representation in the official client
-    await interaction.response.send_message(f'{member} joined in {discord.utils.format_dt(member.joined_at)}')
+    await interaction.response.send_message(f'{member} joined on {discord.utils.format_dt(member.joined_at)}')
 
 
 # A Context Menu command is an app command that can be run on a member or on a message by
@@ -77,7 +78,7 @@ async def joined(interaction: discord.Interaction, member: Optional[discord.Memb
 @client.tree.context_menu(name='Show Join Date')
 async def show_join_date(interaction: discord.Interaction, member: discord.Member):
     # The format_dt function formats the date time into a human readable representation in the official client
-    await interaction.response.send_message(f'{member} joined in {discord.utils.format_dt(member.joined_at)}')
+    await interaction.response.send_message(f'{member} joined on {discord.utils.format_dt(member.joined_at)}')
 
 
 # This context menu command only works on messages

--- a/examples/basic_bot.py
+++ b/examples/basic_bot.py
@@ -57,7 +57,7 @@ async def repeat(ctx, times: int, content='repeating...'):
 @bot.command()
 async def joined(ctx, member: discord.Member):
     """Says when a member joined."""
-    await ctx.send(f'{member.name} joined at {member.joined_at}')
+    await ctx.send(f'{member.name} joined {member.joined_at}')
 
 
 @bot.group()

--- a/examples/basic_bot.py
+++ b/examples/basic_bot.py
@@ -57,7 +57,7 @@ async def repeat(ctx, times: int, content='repeating...'):
 @bot.command()
 async def joined(ctx, member: discord.Member):
     """Says when a member joined."""
-    await ctx.send(f'{member.name} joined {member.joined_at}')
+    await ctx.send(f'{member.name} joined {discord.utils.format_dt(member.joined_at)}')
 
 
 @bot.group()

--- a/examples/basic_bot.py
+++ b/examples/basic_bot.py
@@ -57,7 +57,7 @@ async def repeat(ctx, times: int, content='repeating...'):
 @bot.command()
 async def joined(ctx, member: discord.Member):
     """Says when a member joined."""
-    await ctx.send(f'{member.name} joined in {member.joined_at}')
+    await ctx.send(f'{member.name} joined at {member.joined_at}')
 
 
 @bot.group()


### PR DESCRIPTION
## Summary
This PR just fixes some minor convention errors in the [app_command basic example](https://github.com/Rapptz/discord.py/blob/master/examples/app_commands/basic.py) as well as the [basic bot example](https://github.com/Rapptz/discord.py/blob/master/examples/basic_bot.py).

## Checklist
- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, etc.).
