### PR TITLE
[commands] fix BucketType.default bypassing dynamic_cooldown

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -2315,7 +2315,7 @@ def cooldown(
 
 def dynamic_cooldown(
     cooldown: Union[BucketType, Callable[[Message], Any]],
-    type: BucketType = BucketType.default,
+    type: BucketType,
 ) -> Callable[[T], T]:
     """A decorator that adds a dynamic cooldown to a :class:`.Command`
 
@@ -2347,6 +2347,9 @@ def dynamic_cooldown(
     """
     if not callable(cooldown):
         raise TypeError("A callable must be provided")
+
+    if type is BucketType.default:
+        raise ValueError('BucketType.default cannot be used in dynamic cooldowns')
 
     def decorator(func: Union[Command, CoroFunc]) -> Union[Command, CoroFunc]:
         if isinstance(func, Command):

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -356,7 +356,7 @@ Checks
 .. autofunction:: discord.ext.commands.cooldown(rate, per, type=discord.ext.commands.BucketType.default)
     :decorator:
 
-.. autofunction:: discord.ext.commands.dynamic_cooldown(cooldown, type=BucketType.default)
+.. autofunction:: discord.ext.commands.dynamic_cooldown(cooldown, type)
     :decorator:
 
 .. autofunction:: discord.ext.commands.max_concurrency(number, per=discord.ext.commands.BucketType.default, *, wait=False)


### PR DESCRIPTION
## Summary

`BucketType.default` effectively bypasses `dynamic_cooldown`.
This makes `type` required and raises an error if `BucketType.default` is passed.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
