### PR TITLE
Add application command permissions to audit log

### DIFF
--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -78,6 +78,8 @@ class AllChannels:
 
     Attributes
     -----------
+    id: :class:`int`
+        The guilds id - 1.
     guild: :class:`~discord.Guild`
         The guild the application command permission is for.
     """

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -82,7 +82,10 @@ class AllChannels:
         The guild the application command permission is for.
     """
 
-    __slots__ = ('id', 'guild',)
+    __slots__ = (
+        'id',
+        'guild',
+    )
 
     def __init__(self, guild: Guild):
         self.id = guild.id - 1

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -82,9 +82,10 @@ class AllChannels:
         The guild the application command permission is for.
     """
 
-    __slots__ = ('guild',)
+    __slots__ = ('id', 'guild',)
 
     def __init__(self, guild: Guild):
+        self.id = guild.id - 1
         self.guild = guild
 
     def __repr__(self):

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -39,6 +39,7 @@ __all__ = (
     'AppCommandThread',
     'Argument',
     'Choice',
+    'AllChannels',
 )
 
 ChoiceT = TypeVar('ChoiceT', str, int, float, Union[str, int, float])
@@ -68,6 +69,17 @@ if TYPE_CHECKING:
     from ..threads import Thread
 
     ApplicationCommandParent = Union['AppCommand', 'AppCommandGroup']
+
+
+class AllChannels:
+    """Represents all channels for application command permissions.
+
+    .. versionadded:: 2.0
+    """
+    __slots__ = ()
+
+    def __repr__(self):
+        return 'All Channels'
 
 
 class AppCommand(Hashable):

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -81,6 +81,7 @@ class AllChannels:
     guild: :class:`~discord.Guild`
         The guild the application command permission is for.
     """
+
     __slots__ = ('guild',)
 
     def __init__(self, guild: Guild):

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -75,11 +75,19 @@ class AllChannels:
     """Represents all channels for application command permissions.
 
     .. versionadded:: 2.0
+
+    Attributes
+    -----------
+    guild: :class:`~discord.Guild`
+        The guild the application command permission is for.
     """
-    __slots__ = ()
+    __slots__ = ('guild',)
+
+    def __init__(self, guild: Guild):
+        self.guild = guild
 
     def __repr__(self):
-        return 'All Channels'
+        return f'<All Channels guild={self.guild}>'
 
 
 class AppCommand(Hashable):

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -62,7 +62,6 @@ if TYPE_CHECKING:
     from .types.invite import Invite as InvitePayload
     from .types.role import Role as RolePayload
     from .types.snowflake import Snowflake
-    from .types.command import ApplicationCommandPermissions as ApplicationCommandPermissionsPayload
     from .user import User
     from .stage_instance import StageInstance
     from .sticker import GuildSticker

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -54,7 +54,6 @@ if TYPE_CHECKING:
     from .types.audit_log import (
         AuditLogChange as AuditLogChangePayload,
         AuditLogEntry as AuditLogEntryPayload,
-        _AuditLogChange_AppCommandPermissions,
     )
     from .types.channel import (
         PermissionOverwrite as PermissionOverwritePayload,
@@ -62,6 +61,7 @@ if TYPE_CHECKING:
     from .types.invite import Invite as InvitePayload
     from .types.role import Role as RolePayload
     from .types.snowflake import Snowflake
+    from .types.command import ApplicationCommandPermissions
     from .user import User
     from .stage_instance import StageInstance
     from .sticker import GuildSticker
@@ -263,11 +263,14 @@ class AuditLogChanges:
             self.after.app_command_permissions = []
 
             for d in data:
+
                 self._handle_app_command_permissions(
                     self.before,
                     self.after,
                     entry,
-                    d,  # type: ignore # should only be app command permission update events
+                    int(d['key']),
+                    d.get('old_value'),  # type: ignore # old value will be an ApplicationCommandPermissions if present
+                    d.get('new_value'),  # type: ignore # new value will be an ApplicationCommandPermissions if present
                 )
             return
 
@@ -347,12 +350,11 @@ class AuditLogChanges:
         before: AuditLogDiff,
         after: AuditLogDiff,
         entry: AuditLogEntry,
-        data: _AuditLogChange_AppCommandPermissions
+        target_id: int,
+        old_value: Optional[ApplicationCommandPermissions],
+        new_value: Optional[ApplicationCommandPermissions],
     ):
         guild = entry.guild
-        target_id = int(data['key'])
-        old_value = data.get('old_value')
-        new_value = data.get('new_value')
 
         old_permission = new_permission = target = None
 

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -359,7 +359,7 @@ class AuditLogChanges:
         old_permission = new_permission = target = None
 
         if target_id == (guild.id - 1):
-            # circular import
+            # avoid circular import
             from .app_commands import AllChannels
 
             # all channels

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -361,6 +361,7 @@ class AuditLogChanges:
         if target_id == (guild.id - 1):
             # circular import
             from .app_commands import AllChannels
+
             # all channels
             target = AllChannels(guild)
         else:
@@ -389,6 +390,7 @@ class AuditLogChanges:
         if new_value is not None:
             new_permission = new_value['permission']
             after.app_command_permissions.append((target, new_permission))
+
 
 class _AuditLogProxy:
     def __init__(self, **kwargs: Any) -> None:
@@ -469,7 +471,7 @@ class AuditLogEntry(Hashable):
         integrations: Dict[int, PartialIntegration],
         app_commands: Dict[int, AppCommand],
         data: AuditLogEntryPayload,
-        guild: Guild
+        guild: Guild,
     ):
         self._state: ConnectionState = guild._state
         self.guild: Guild = guild
@@ -673,15 +675,11 @@ class AuditLogEntry(Hashable):
     def _convert_target_guild_scheduled_event(self, target_id: int) -> Union[ScheduledEvent, Object]:
         return self.guild.get_scheduled_event(target_id) or Object(id=target_id)
 
-    def _convert_target_integration(self, target_id: int)-> Union[PartialIntegration, Object]:
+    def _convert_target_integration(self, target_id: int) -> Union[PartialIntegration, Object]:
         return self._get_integration(target_id) or Object(target_id)
 
-    def _convert_target_app_command(self, target_id: int)-> Union[AppCommand, Object]:
+    def _convert_target_app_command(self, target_id: int) -> Union[AppCommand, Object]:
         return self._get_app_command(target_id) or Object(target_id)
 
     def _convert_target_integration_or_app_command(self, target_id: int) -> Union[PartialIntegration, AppCommand, Object]:
-        return (
-            self._get_integration_by_app_id(target_id) or
-            self._get_app_command(target_id) or
-            Object(target_id)
-        )
+        return self._get_integration_by_app_id(target_id) or self._get_app_command(target_id) or Object(target_id)

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -298,106 +298,108 @@ class AuditLogActionCategory(Enum):
 
 class AuditLogAction(Enum):
     # fmt: off
-    guild_update             = 1
-    channel_create           = 10
-    channel_update           = 11
-    channel_delete           = 12
-    overwrite_create         = 13
-    overwrite_update         = 14
-    overwrite_delete         = 15
-    kick                     = 20
-    member_prune             = 21
-    ban                      = 22
-    unban                    = 23
-    member_update            = 24
-    member_role_update       = 25
-    member_move              = 26
-    member_disconnect        = 27
-    bot_add                  = 28
-    role_create              = 30
-    role_update              = 31
-    role_delete              = 32
-    invite_create            = 40
-    invite_update            = 41
-    invite_delete            = 42
-    webhook_create           = 50
-    webhook_update           = 51
-    webhook_delete           = 52
-    emoji_create             = 60
-    emoji_update             = 61
-    emoji_delete             = 62
-    message_delete           = 72
-    message_bulk_delete      = 73
-    message_pin              = 74
-    message_unpin            = 75
-    integration_create       = 80
-    integration_update       = 81
-    integration_delete       = 82
-    stage_instance_create    = 83
-    stage_instance_update    = 84
-    stage_instance_delete    = 85
-    sticker_create           = 90
-    sticker_update           = 91
-    sticker_delete           = 92
-    scheduled_event_create   = 100
-    scheduled_event_update   = 101
-    scheduled_event_delete   = 102
-    thread_create            = 110
-    thread_update            = 111
-    thread_delete            = 112
+    guild_update                  = 1
+    channel_create                = 10
+    channel_update                = 11
+    channel_delete                = 12
+    overwrite_create              = 13
+    overwrite_update              = 14
+    overwrite_delete              = 15
+    kick                          = 20
+    member_prune                  = 21
+    ban                           = 22
+    unban                         = 23
+    member_update                 = 24
+    member_role_update            = 25
+    member_move                   = 26
+    member_disconnect             = 27
+    bot_add                       = 28
+    role_create                   = 30
+    role_update                   = 31
+    role_delete                   = 32
+    invite_create                 = 40
+    invite_update                 = 41
+    invite_delete                 = 42
+    webhook_create                = 50
+    webhook_update                = 51
+    webhook_delete                = 52
+    emoji_create                  = 60
+    emoji_update                  = 61
+    emoji_delete                  = 62
+    message_delete                = 72
+    message_bulk_delete           = 73
+    message_pin                   = 74
+    message_unpin                 = 75
+    integration_create            = 80
+    integration_update            = 81
+    integration_delete            = 82
+    stage_instance_create         = 83
+    stage_instance_update         = 84
+    stage_instance_delete         = 85
+    sticker_create                = 90
+    sticker_update                = 91
+    sticker_delete                = 92
+    scheduled_event_create        = 100
+    scheduled_event_update        = 101
+    scheduled_event_delete        = 102
+    thread_create                 = 110
+    thread_update                 = 111
+    thread_delete                 = 112
+    app_command_permission_update = 121
     # fmt: on
 
     @property
     def category(self) -> Optional[AuditLogActionCategory]:
         # fmt: off
         lookup: Dict[AuditLogAction, Optional[AuditLogActionCategory]] = {
-            AuditLogAction.guild_update:           AuditLogActionCategory.update,
-            AuditLogAction.channel_create:         AuditLogActionCategory.create,
-            AuditLogAction.channel_update:         AuditLogActionCategory.update,
-            AuditLogAction.channel_delete:         AuditLogActionCategory.delete,
-            AuditLogAction.overwrite_create:       AuditLogActionCategory.create,
-            AuditLogAction.overwrite_update:       AuditLogActionCategory.update,
-            AuditLogAction.overwrite_delete:       AuditLogActionCategory.delete,
-            AuditLogAction.kick:                   None,
-            AuditLogAction.member_prune:           None,
-            AuditLogAction.ban:                    None,
-            AuditLogAction.unban:                  None,
-            AuditLogAction.member_update:          AuditLogActionCategory.update,
-            AuditLogAction.member_role_update:     AuditLogActionCategory.update,
-            AuditLogAction.member_move:            None,
-            AuditLogAction.member_disconnect:      None,
-            AuditLogAction.bot_add:                None,
-            AuditLogAction.role_create:            AuditLogActionCategory.create,
-            AuditLogAction.role_update:            AuditLogActionCategory.update,
-            AuditLogAction.role_delete:            AuditLogActionCategory.delete,
-            AuditLogAction.invite_create:          AuditLogActionCategory.create,
-            AuditLogAction.invite_update:          AuditLogActionCategory.update,
-            AuditLogAction.invite_delete:          AuditLogActionCategory.delete,
-            AuditLogAction.webhook_create:         AuditLogActionCategory.create,
-            AuditLogAction.webhook_update:         AuditLogActionCategory.update,
-            AuditLogAction.webhook_delete:         AuditLogActionCategory.delete,
-            AuditLogAction.emoji_create:           AuditLogActionCategory.create,
-            AuditLogAction.emoji_update:           AuditLogActionCategory.update,
-            AuditLogAction.emoji_delete:           AuditLogActionCategory.delete,
-            AuditLogAction.message_delete:         AuditLogActionCategory.delete,
-            AuditLogAction.message_bulk_delete:    AuditLogActionCategory.delete,
-            AuditLogAction.message_pin:            None,
-            AuditLogAction.message_unpin:          None,
-            AuditLogAction.integration_create:     AuditLogActionCategory.create,
-            AuditLogAction.integration_update:     AuditLogActionCategory.update,
-            AuditLogAction.integration_delete:     AuditLogActionCategory.delete,
-            AuditLogAction.stage_instance_create:  AuditLogActionCategory.create,
-            AuditLogAction.stage_instance_update:  AuditLogActionCategory.update,
-            AuditLogAction.stage_instance_delete:  AuditLogActionCategory.delete,
-            AuditLogAction.sticker_create:         AuditLogActionCategory.create,
-            AuditLogAction.sticker_update:         AuditLogActionCategory.update,
-            AuditLogAction.sticker_delete:         AuditLogActionCategory.delete,
-            AuditLogAction.scheduled_event_create: AuditLogActionCategory.create,
-            AuditLogAction.scheduled_event_update: AuditLogActionCategory.update,
-            AuditLogAction.scheduled_event_delete: AuditLogActionCategory.delete,
-            AuditLogAction.thread_create:          AuditLogActionCategory.create,
-            AuditLogAction.thread_update:          AuditLogActionCategory.update,
-            AuditLogAction.thread_delete:          AuditLogActionCategory.delete,
+            AuditLogAction.guild_update:                  AuditLogActionCategory.update,
+            AuditLogAction.channel_create:                AuditLogActionCategory.create,
+            AuditLogAction.channel_update:                AuditLogActionCategory.update,
+            AuditLogAction.channel_delete:                AuditLogActionCategory.delete,
+            AuditLogAction.overwrite_create:              AuditLogActionCategory.create,
+            AuditLogAction.overwrite_update:              AuditLogActionCategory.update,
+            AuditLogAction.overwrite_delete:              AuditLogActionCategory.delete,
+            AuditLogAction.kick:                          None,
+            AuditLogAction.member_prune:                  None,
+            AuditLogAction.ban:                           None,
+            AuditLogAction.unban:                         None,
+            AuditLogAction.member_update:                 AuditLogActionCategory.update,
+            AuditLogAction.member_role_update:            AuditLogActionCategory.update,
+            AuditLogAction.member_move:                   None,
+            AuditLogAction.member_disconnect:             None,
+            AuditLogAction.bot_add:                       None,
+            AuditLogAction.role_create:                   AuditLogActionCategory.create,
+            AuditLogAction.role_update:                   AuditLogActionCategory.update,
+            AuditLogAction.role_delete:                   AuditLogActionCategory.delete,
+            AuditLogAction.invite_create:                 AuditLogActionCategory.create,
+            AuditLogAction.invite_update:                 AuditLogActionCategory.update,
+            AuditLogAction.invite_delete:                 AuditLogActionCategory.delete,
+            AuditLogAction.webhook_create:                AuditLogActionCategory.create,
+            AuditLogAction.webhook_update:                AuditLogActionCategory.update,
+            AuditLogAction.webhook_delete:                AuditLogActionCategory.delete,
+            AuditLogAction.emoji_create:                  AuditLogActionCategory.create,
+            AuditLogAction.emoji_update:                  AuditLogActionCategory.update,
+            AuditLogAction.emoji_delete:                  AuditLogActionCategory.delete,
+            AuditLogAction.message_delete:                AuditLogActionCategory.delete,
+            AuditLogAction.message_bulk_delete:           AuditLogActionCategory.delete,
+            AuditLogAction.message_pin:                   None,
+            AuditLogAction.message_unpin:                 None,
+            AuditLogAction.integration_create:            AuditLogActionCategory.create,
+            AuditLogAction.integration_update:            AuditLogActionCategory.update,
+            AuditLogAction.integration_delete:            AuditLogActionCategory.delete,
+            AuditLogAction.stage_instance_create:         AuditLogActionCategory.create,
+            AuditLogAction.stage_instance_update:         AuditLogActionCategory.update,
+            AuditLogAction.stage_instance_delete:         AuditLogActionCategory.delete,
+            AuditLogAction.sticker_create:                AuditLogActionCategory.create,
+            AuditLogAction.sticker_update:                AuditLogActionCategory.update,
+            AuditLogAction.sticker_delete:                AuditLogActionCategory.delete,
+            AuditLogAction.scheduled_event_create:        AuditLogActionCategory.create,
+            AuditLogAction.scheduled_event_update:        AuditLogActionCategory.update,
+            AuditLogAction.scheduled_event_delete:        AuditLogActionCategory.delete,
+            AuditLogAction.thread_create:                 AuditLogActionCategory.create,
+            AuditLogAction.thread_delete:                 AuditLogActionCategory.delete,
+            AuditLogAction.thread_update:                 AuditLogActionCategory.update,
+            AuditLogAction.app_command_permission_update: AuditLogActionCategory.update,
         }
         # fmt: on
         return lookup[self]
@@ -435,6 +437,8 @@ class AuditLogAction(Enum):
             return 'guild_scheduled_event'
         elif v < 113:
             return 'thread'
+        elif v < 122:
+            return 'integration_or_app_command'
 
 
 class UserFlags(Enum):

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3356,7 +3356,7 @@ class Guild(Hashable):
                 data.get('application_commands', []),
                 entries,
                 after,
-                limit
+                limit,
             )
 
         async def _after_strategy(retrieve, after, limit):
@@ -3379,7 +3379,7 @@ class Guild(Hashable):
                 data.get('application_commands', []),
                 entries,
                 after,
-                limit
+                limit,
             )
 
         if user is not MISSING:
@@ -3435,6 +3435,7 @@ class Guild(Hashable):
 
             # fix circular import
             from .app_commands import AppCommand
+
             app_commands = (AppCommand(data=raw_command, state=self._state) for raw_command in raw_app_commands)
             app_command_map = {app_command.id: app_command for app_command in app_commands}
 
@@ -3444,11 +3445,7 @@ class Guild(Hashable):
                     continue
 
                 yield AuditLogEntry(
-                    data=raw_entry,
-                    users=user_map,
-                    integrations=integration_map,
-                    app_commands=app_command_map,
-                    guild=self
+                    data=raw_entry, users=user_map, integrations=integration_map, app_commands=app_command_map, guild=self
                 )
 
     async def widget(self) -> Widget:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3352,7 +3352,6 @@ class Guild(Hashable):
 
             return data, entries, after, limit
 
-
         async def _after_strategy(retrieve, after, limit):
             after_id = after.id if after else None
             data = await self._state.http.get_audit_logs(

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3421,14 +3421,12 @@ class Guild(Hashable):
             user_map = {user.id: user for user in users}
 
             integrations = (
-                PartialIntegration(data=raw_integration, guild=self)
-                for raw_integration in data.get('integrations', [])
+                PartialIntegration(data=raw_i, guild=self) for raw_i in data.get('integrations', [])
             )
             integration_map = {integration.id: integration for integration in integrations}
 
             app_commands = (
-                AppCommand(data=raw_command, state=self._state)
-                for raw_command in data.get('application_commands', [])
+                AppCommand(data=raw_cmd, state=self._state) for raw_cmd in data.get('application_commands', [])
             )
             app_command_map = {app_command.id: app_command for app_command in app_commands}
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3346,18 +3346,12 @@ class Guild(Hashable):
 
             if data and entries:
                 if limit is not None:
-                    limit -= len(data)
+                    limit -= len(entries)
 
                 before = Object(id=int(entries[-1]['id']))
 
-            return (
-                data.get('users', []),
-                data.get('integrations', []),
-                data.get('application_commands', []),
-                entries,
-                after,
-                limit,
-            )
+            return data, entries, after, limit
+
 
         async def _after_strategy(retrieve, after, limit):
             after_id = after.id if after else None
@@ -3369,18 +3363,11 @@ class Guild(Hashable):
 
             if data and entries:
                 if limit is not None:
-                    limit -= len(data)
+                    limit -= len(entries)
 
                 after = Object(id=int(entries[0]['id']))
 
-            return (
-                data.get('users', []),
-                data.get('integrations', []),
-                data.get('application_commands', []),
-                entries,
-                after,
-                limit,
-            )
+            return data, entries, after, limit
 
         if user is not MISSING:
             user_id = user.id
@@ -3419,33 +3406,43 @@ class Guild(Hashable):
             if retrieve < 1:
                 return
 
-            raw_users, raw_integrations, raw_app_commands, data, state, limit = await strategy(retrieve, state, limit)
+            data, raw_entries, state, limit = await strategy(retrieve, state, limit)
 
             # Terminate loop on next iteration; there's no data left after this
             if len(data) < 100:
                 limit = 0
 
             if reverse:
-                data = reversed(data)
+                raw_entries = reversed(raw_entries)
             if predicate:
-                data = filter(predicate, data)
+                raw_entries = filter(predicate, raw_entries)
 
-            users = (User(data=raw_user, state=self._state) for raw_user in raw_users)
+            users = (User(data=raw_user, state=self._state) for raw_user in data.get('users', []))
             user_map = {user.id: user for user in users}
 
-            integrations = (PartialIntegration(data=raw_integration, guild=self) for raw_integration in raw_integrations)
+            integrations = (
+                PartialIntegration(data=raw_integration, guild=self)
+                for raw_integration in data.get('integrations', [])
+            )
             integration_map = {integration.id: integration for integration in integrations}
 
-            app_commands = (AppCommand(data=raw_command, state=self._state) for raw_command in raw_app_commands)
+            app_commands = (
+                AppCommand(data=raw_command, state=self._state)
+                for raw_command in data.get('application_commands', [])
+            )
             app_command_map = {app_command.id: app_command for app_command in app_commands}
 
-            for raw_entry in data:
+            for raw_entry in raw_entries:
                 # Weird Discord quirk
                 if raw_entry['action_type'] is None:
                     continue
 
                 yield AuditLogEntry(
-                    data=raw_entry, users=user_map, integrations=integration_map, app_commands=app_command_map, guild=self
+                    data=raw_entry,
+                    users=user_map,
+                    integrations=integration_map,
+                    app_commands=app_command_map,
+                    guild=self,
                 )
 
     async def widget(self) -> Widget:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3420,14 +3420,10 @@ class Guild(Hashable):
             users = (User(data=raw_user, state=self._state) for raw_user in data.get('users', []))
             user_map = {user.id: user for user in users}
 
-            integrations = (
-                PartialIntegration(data=raw_i, guild=self) for raw_i in data.get('integrations', [])
-            )
+            integrations = (PartialIntegration(data=raw_i, guild=self) for raw_i in data.get('integrations', []))
             integration_map = {integration.id: integration for integration in integrations}
 
-            app_commands = (
-                AppCommand(data=raw_cmd, state=self._state) for raw_cmd in data.get('application_commands', [])
-            )
+            app_commands = (AppCommand(data=raw_cmd, state=self._state) for raw_cmd in data.get('application_commands', []))
             app_command_map = {app_command.id: app_command for app_command in app_commands}
 
             for raw_entry in raw_entries:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3408,7 +3408,7 @@ class Guild(Hashable):
             data, raw_entries, state, limit = await strategy(retrieve, state, limit)
 
             # Terminate loop on next iteration; there's no data left after this
-            if len(data) < 100:
+            if len(raw_entries) < 100:
                 limit = 0
 
             if reverse:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3411,6 +3411,9 @@ class Guild(Hashable):
             if after and after != OLDEST_OBJECT:
                 predicate = lambda m: int(m['id']) > after.id
 
+        # avoid circular import
+        from .app_commands import AppCommand
+
         while True:
             retrieve = min(100 if limit is None else limit, 100)
             if retrieve < 1:
@@ -3432,9 +3435,6 @@ class Guild(Hashable):
 
             integrations = (PartialIntegration(data=raw_integration, guild=self) for raw_integration in raw_integrations)
             integration_map = {integration.id: integration for integration in integrations}
-
-            # fix circular import
-            from .app_commands import AppCommand
 
             app_commands = (AppCommand(data=raw_command, state=self._state) for raw_command in raw_app_commands)
             app_command_map = {app_command.id: app_command for app_command in app_commands}

--- a/discord/integrations.py
+++ b/discord/integrations.py
@@ -410,6 +410,7 @@ class PartialIntegration:
         self.account: IntegrationAccount = IntegrationAccount(data['account'])
         self.application_id: Optional[int] = _get_as_snowflake(data, 'application_id')
 
+
 def _integration_factory(value: str) -> Tuple[Type[Integration], str]:
     if value == 'discord':
         return BotIntegration, value

--- a/discord/integrations.py
+++ b/discord/integrations.py
@@ -117,7 +117,7 @@ class Integration:
         self._from_data(data)
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r}>"
+        return f'<{self.__class__.__name__} id={self.id} name={self.name!r}>'
 
     def _from_data(self, data: IntegrationPayload) -> None:
         self.id: int = int(data['id'])
@@ -401,18 +401,14 @@ class PartialIntegration:
         self._from_data(data)
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__} id={self.id} name={self.name!r}>"
+        return f'<{self.__class__.__name__} id={self.id} name={self.name!r}>'
 
     def _from_data(self, data: PartialIntegrationPayload) -> None:
         self.id: int = int(data['id'])
         self.type: IntegrationType = data['type']
         self.name: str = data['name']
         self.account: IntegrationAccount = IntegrationAccount(data['account'])
-        application_id = data.get('application_id')
-        self.application_id: Optional[int] = None
-        if application_id is not None:
-            self.application_id = int(application_id)
-
+        self.application_id: Optional[int] = _get_as_snowflake(data, 'application_id')
 
 def _integration_factory(value: str) -> Tuple[Type[Integration], str]:
     if value == 'discord':

--- a/discord/integrations.py
+++ b/discord/integrations.py
@@ -381,8 +381,8 @@ class PartialIntegration:
         The integration type (i.e. Twitch).
     account: :class:`IntegrationAccount`
         The account linked to this integration.
-    application_id: :class:`int`
-        The application id this integration belongs to.
+    application_id: Optional[:class:`int`]
+        The id of the application this integration belongs to.
     """
 
     __slots__ = ('guild', '_state', 'id', 'type', 'name', 'account', 'application_id',)
@@ -401,10 +401,9 @@ class PartialIntegration:
         self.name: str = data['name']
         self.account: IntegrationAccount = IntegrationAccount(data['account'])
         application_id = data.get('application_id')
+        self.application_id: Optional[int] = None
         if application_id is not None:
             self.application_id = int(application_id)
-        else:
-            self.application_id = None
 
 
 def _integration_factory(value: str) -> Tuple[Type[Integration], str]:

--- a/discord/integrations.py
+++ b/discord/integrations.py
@@ -36,6 +36,7 @@ __all__ = (
     'Integration',
     'StreamIntegration',
     'BotIntegration',
+    'PartialIntegration',
 )
 
 if TYPE_CHECKING:
@@ -49,6 +50,7 @@ if TYPE_CHECKING:
         BotIntegration as BotIntegrationPayload,
         IntegrationType,
         IntegrationApplication as IntegrationApplicationPayload,
+        PartialIntegration as PartialIntegrationPayload,
     )
 
 
@@ -360,6 +362,49 @@ class BotIntegration(Integration):
     def _from_data(self, data: BotIntegrationPayload) -> None:
         super()._from_data(data)
         self.application: IntegrationApplication = IntegrationApplication(data=data['application'], state=self._state)
+
+
+class PartialIntegration:
+    """Represents a partial guild integration.
+
+    .. versionadded:: 2.0
+
+    Attributes
+    -----------
+    id: :class:`int`
+        The integration ID.
+    name: :class:`str`
+        The integration name.
+    guild: :class:`Guild`
+        The guild of the integration.
+    type: :class:`str`
+        The integration type (i.e. Twitch).
+    account: :class:`IntegrationAccount`
+        The account linked to this integration.
+    application_id: :class:`int`
+        The application id this integration belongs to.
+    """
+
+    __slots__ = ('guild', '_state', 'id', 'type', 'name', 'account', 'application_id',)
+
+    def __init__(self, *, data: PartialIntegrationPayload, guild: Guild):
+        self.guild: Guild = guild
+        self._state: ConnectionState = guild._state
+        self._from_data(data)
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} id={self.id} name={self.name!r}>"
+
+    def _from_data(self, data: PartialIntegrationPayload) -> None:
+        self.id: int = int(data['id'])
+        self.type: IntegrationType = data['type']
+        self.name: str = data['name']
+        self.account: IntegrationAccount = IntegrationAccount(data['account'])
+        application_id = data.get('application_id')
+        if application_id is not None:
+            self.application_id = int(application_id)
+        else:
+            self.application_id = None
 
 
 def _integration_factory(value: str) -> Tuple[Type[Integration], str]:

--- a/discord/integrations.py
+++ b/discord/integrations.py
@@ -385,7 +385,15 @@ class PartialIntegration:
         The id of the application this integration belongs to.
     """
 
-    __slots__ = ('guild', '_state', 'id', 'type', 'name', 'account', 'application_id',)
+    __slots__ = (
+        'guild',
+        '_state',
+        'id',
+        'type',
+        'name',
+        'account',
+        'application_id',
+    )
 
     def __init__(self, *, data: PartialIntegrationPayload, guild: Guild):
         self.guild: Guild = guild

--- a/discord/types/audit_log.py
+++ b/discord/types/audit_log.py
@@ -36,6 +36,7 @@ from .snowflake import Snowflake
 from .role import Role
 from .channel import ChannelType, PrivacyLevel, VideoQualityMode, PermissionOverwrite
 from .threads import Thread
+from .command import ApplicationCommand, ApplicationCommandPermissions
 
 AuditLogEvent = Literal[
     1,
@@ -85,6 +86,7 @@ AuditLogEvent = Literal[
     110,
     111,
     112,
+    121,
 ]
 
 
@@ -242,6 +244,12 @@ class _AuditLogChange_EntityType(TypedDict):
     old_value: EntityType
 
 
+class _AuditLogChange_AppCommandPermissions(TypedDict):
+    key: str
+    new_value: ApplicationCommandPermissions
+    old_value: ApplicationCommandPermissions
+
+
 AuditLogChange = Union[
     _AuditLogChange_Str,
     _AuditLogChange_AssetHash,
@@ -260,6 +268,7 @@ AuditLogChange = Union[
     _AuditLogChange_PrivacyLevel,
     _AuditLogChange_Status,
     _AuditLogChange_EntityType,
+    _AuditLogChange_AppCommandPermissions,
 ]
 
 
@@ -272,6 +281,8 @@ class AuditEntryInfo(TypedDict):
     id: Snowflake
     type: Literal['0', '1']
     role_name: str
+    application_id: Snowflake
+    guild_id: Snowflake
 
 
 class AuditLogEntry(TypedDict):
@@ -291,3 +302,4 @@ class AuditLog(TypedDict):
     integrations: List[PartialIntegration]
     threads: List[Thread]
     guild_scheduled_events: List[GuildScheduledEvent]
+    application_commands: List[ApplicationCommand]

--- a/discord/types/command.py
+++ b/discord/types/command.py
@@ -192,7 +192,7 @@ ApplicationCommand = Union[
 ]
 
 
-ApplicationCommandPermissionType = Literal[1, 2]
+ApplicationCommandPermissionType = Literal[1, 2, 3]
 
 
 class ApplicationCommandPermissions(TypedDict):

--- a/discord/types/integration.py
+++ b/discord/types/integration.py
@@ -53,6 +53,7 @@ class PartialIntegration(TypedDict):
     name: str
     type: IntegrationType
     account: IntegrationAccount
+    application_id: Snowflake
 
 
 IntegrationType = Literal['twitch', 'youtube', 'discord']

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2474,13 +2474,13 @@ of :class:`enum.Enum`.
         were updated.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        a :class:`PartialInteraction` for an integrations general permissions,
+        a :class:`PartialIntegration` for an integrations general permissions,
         :class:`~discord.app_commands.AppCommand` for a specific commands permissions,
         or :class:`Object` with the ID of the command or integration which
         was updated.
 
         When this is the action, the type of :attr:`~AuditLogEntry.extra` is
-        set to an :class:`PartialInteraction` or :class:`Object` with the ID of
+        set to an :class:`PartialIntegration` or :class:`Object` with the ID of
         application that command or integration belongs to.
 
         Possible attributes for :class:`AuditLogDiff`:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2239,7 +2239,8 @@ of :class:`enum.Enum`.
         A guild integration was created.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Object` with the integration ID of the integration which was created.
+        a :class:`PartialIntegration` or :class:`Object` with the
+        integration ID of the integration which was created.
 
         .. versionadded:: 1.3
 
@@ -2248,7 +2249,8 @@ of :class:`enum.Enum`.
         A guild integration was updated.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Object` with the integration ID of the integration which was updated.
+        a :class:`PartialIntegration` or :class:`Object` with the
+        integration ID of the integration which was updated.
 
         .. versionadded:: 1.3
 
@@ -2257,7 +2259,8 @@ of :class:`enum.Enum`.
         A guild integration was deleted.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Object` with the integration ID of the integration which was deleted.
+        a :class:`PartialIntegration` or :class:`Object` with the
+        integration ID of the integration which was deleted.
 
         .. versionadded:: 1.3
 
@@ -2462,6 +2465,27 @@ of :class:`enum.Enum`.
         - :attr:`~AuditLogDiff.locked`
         - :attr:`~AuditLogDiff.auto_archive_duration`
         - :attr:`~AuditLogDiff.invitable`
+
+        .. versionadded:: 2.0
+
+    .. attribute:: app_command_permission_update
+
+        An application command or integrations application command permissions
+        were updated.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.target` is
+        a :class:`PartialInteraction` for an integrations general permissions,
+        :class:`~discord.app_commands.AppCommand` for a specific commands permissions,
+        or :class:`Object` with the ID of the command or integration which
+        was updated.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
+        set to an :class:`PartialInteraction` or :class:`Object` with the ID of
+        application that command or integration belongs to.
+
+        Possible attributes for :class:`AuditLogDiff`:
+
+        - :attr:`~AuditLogDiff.app_command_permissions`
 
         .. versionadded:: 2.0
 
@@ -3477,6 +3501,16 @@ AuditLogDiff
 
         :type: :class:`Asset`
 
+    .. attribute:: app_command_permissions
+
+        A list of application command permission tuples that represents a
+        target and a :class:`bool` for said target.
+
+        The first element is the object being targeted, which can either
+        be a :class:`Member`, :class:`abc.GuildChannel`,
+        :class:`~discord.app_commands.AllChannels`, or :class:`Role`.
+        :type: List[Tuple[target, :class:`bool`]]
+
 .. this is currently missing the following keys: reason and application_id
    I'm not sure how to about porting these
 
@@ -3725,6 +3759,9 @@ Integration
     :members:
 
 .. autoclass:: StreamIntegration()
+    :members:
+
+.. autoclass:: PartialIntegration()
     :members:
 
 Member

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -129,6 +129,14 @@ Argument
 .. autoclass:: discord.app_commands.Argument()
     :members:
 
+AllChannels
+~~~~~~~~~~
+
+.. attributetable:: discord.app_commands.AllChannels
+
+.. autoclass:: discord.app_commands.AllChannels()
+    :members:
+
 Data Classes
 --------------
 

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -130,7 +130,7 @@ Argument
     :members:
 
 AllChannels
-~~~~~~~~~~
+~~~~~~~~~~~~
 
 .. attributetable:: discord.app_commands.AllChannels
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
I am probably missing something.

- Add `PartialIntegration`
  - `entry.target` will be `PartialIntegration` when updating general app command permissions or `AppCommand` when updating a specific app commands permissions or Object with matching ID if neither could be matched. A little more rich than `Object` vs `AppCommand`.
  - Can also be used for integration actions. Untested with non discord integrations and don't have any to test.
- Add `app_commands.AllChannels` as special value for all channels. 
- Add `AuditLogDiff.app_command_permissions` that is a `List[Tuple[target, bool]]`
  - target = `Union[Member, abc.GuildChannel, Role, AllChannels, Object]`
- Add `AuditLogAction.app_command_permission_update`
- Set `entry.extra` to a`PartialIntegration` or Object with id=application id for `app_command_permission_update`
- Fixed bug where `guild.audit_logs` with a limit>100 fetched too many entries
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
