### PR TITLE
Remove trigger_typing / update the typing context manager

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1543,32 +1543,30 @@ class Messageable:
             await ret.delete(delay=delete_after)
         return ret
 
-    async def trigger_typing(self) -> None:
-        """|coro|
-
-        Triggers a *typing* indicator to the destination.
-
-        *Typing* indicator will go away after 10 seconds, or after a message is sent.
-        """
-
-        channel = await self._get_channel()
-        await self._state.http.send_typing(channel.id)
-
     def typing(self) -> Typing:
-        """Returns an asynchronous context manager that allows you to type for an indefinite period of time.
-
-        This is useful for denoting long computations in your bot.
+        """Returns an asynchronous context manager that allows you to send a typing indicator to
+        the destination for an indefinite period of time, or 10 seconds if the context manager
+        is ``awaited``.
 
         Example Usage: ::
 
             async with channel.typing():
                 # simulate something heavy
-                await asyncio.sleep(10)
+                await asyncio.sleep(20)
 
-            await channel.send('done!')
+            await channel.send('Done!')
+
+        Example Usage: ::
+
+            await channel.typing()
+            # Do some computational magic for about 10 seconds
+            await channel.send('Done!')
 
         .. versionchanged:: 2.0
             This no longer works with the ``with`` syntax, ``async with`` must be used instead.
+
+        .. versionchanged:: 2.0
+            Added functionality to ``await`` the context manager to send a typing indicator for 10 seconds.
         """
         return Typing(self)
 

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1546,7 +1546,7 @@ class Messageable:
     def typing(self) -> Typing:
         """Returns an asynchronous context manager that allows you to send a typing indicator to
         the destination for an indefinite period of time, or 10 seconds if the context manager
-        is ``awaited``.
+        is called using ``await``.
 
         Example Usage: ::
 

--- a/discord/context_managers.py
+++ b/discord/context_managers.py
@@ -25,10 +25,10 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Optional, Type, TypeVar
+from typing import TYPE_CHECKING, Coroutine, Generator, Optional, Type, TypeVar, Any
 
 if TYPE_CHECKING:
-    from .abc import Messageable
+    from .abc import Messageable, MessageableChannel
 
     from types import TracebackType
 
@@ -53,21 +53,35 @@ class Typing:
     def __init__(self, messageable: Messageable) -> None:
         self.loop: asyncio.AbstractEventLoop = messageable._state.loop
         self.messageable: Messageable = messageable
+        self.channel: Optional[MessageableChannel] = None
+
+    async def _get_channel(self) -> MessageableChannel:
+        if self.channel:
+            return self.channel
+
+        self.channel = channel = await self.messageable._get_channel()
+        return channel
+
+    async def wrapped_typer(self) -> None:
+        channel = await self._get_channel()
+        await channel._state.http.send_typing(channel.id)
+
+    def __call__(self) -> Coroutine[Any, Any, None]:
+        return self.wrapped_typer()
+
+    def __await__(self) -> Generator[None, None, None]:
+        return self.wrapped_typer().__await__()
 
     async def do_typing(self) -> None:
-        try:
-            channel = self._channel
-        except AttributeError:
-            channel = await self.messageable._get_channel()
-
+        channel = await self._get_channel()
         typing = channel._state.http.send_typing
 
         while True:
-            await typing(channel.id)
             await asyncio.sleep(5)
+            await typing(channel.id)
 
     async def __aenter__(self) -> None:
-        self._channel = channel = await self.messageable._get_channel()
+        channel = await self._get_channel()
         await channel._state.http.send_typing(channel.id)
         self.task: asyncio.Task[None] = self.loop.create_task(self.do_typing())
         self.task.add_done_callback(_typing_done_callback)

--- a/discord/context_managers.py
+++ b/discord/context_managers.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Coroutine, Generator, Optional, Type, TypeVar, Any
+from typing import TYPE_CHECKING, Generator, Optional, Type, TypeVar
 
 if TYPE_CHECKING:
     from .abc import Messageable, MessageableChannel
@@ -65,9 +65,6 @@ class Typing:
     async def wrapped_typer(self) -> None:
         channel = await self._get_channel()
         await channel._state.http.send_typing(channel.id)
-
-    def __call__(self) -> Coroutine[Any, Any, None]:
-        return self.wrapped_typer()
 
     def __await__(self) -> Generator[None, None, None]:
         return self.wrapped_typer().__await__()

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -1151,7 +1151,7 @@ The following have been removed:
 
 - ``abc.Messageable.trigger_typing``
 
-    - Use :meth:`abc.Messageable.typing` instead.
+    - Use :meth:`abc.Messageable.typing` with ``await`` instead.
 
 Miscellaneous Changes
 ----------------------

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -1149,6 +1149,10 @@ The following have been removed:
 
     - Consider using the newer documented :func:`on_socket_event_type` event instead.
 
+- ``abc.Messageable.trigger_typing``
+
+    - Use :meth:`abc.Messageable.typing` instead.
+
 Miscellaneous Changes
 ----------------------
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR removes the coroutine `Messageable.trigger_typing` and replaces it with only `Messageable.typing`. To do so, the `Typing` context manager has been updated to allow for the user to await it. This pr, from a user's perspective, simplifies sending a typing notification to a destination.

Previously:
```python
await ctx.trigger_typing()
# do some computational magic
await ctx.send('Done!')

async with ctx.typing():
    await asyncio.sleep(20)
    await ctx.send('Done')
```

Updated:
```python
await ctx.typing()
# do some computational magic
await ctx.send('Done!')

async with ctx.typing():
    await asycio.sleep(20)
    await ctx.send('Done!')
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)