### PR TITLE
Fix wrong variable in audit logs

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3350,7 +3350,7 @@ class Guild(Hashable):
 
                 before = Object(id=int(entries[-1]['id']))
 
-            return data, entries, after, limit
+            return data, entries, before, limit
 
         async def _after_strategy(retrieve, after, limit):
             after_id = after.id if after else None


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Return `before` and not `after` for before strategy in audit logs
This is what I get for copy paste

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
