### PR TITLE
Add guild avatar to on_member_update docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -709,6 +709,7 @@ Members
     - roles
     - pending
     - timeout
+    - guild avatar
 
     Due to a Discord limitation, this event is not dispatched when a member's timeout expires.
 


### PR DESCRIPTION
## Summary
Add "guild avatar" to things that called `on_member_update`, as `GUILD_MEMBER_UPDATE` event is dispatched when a guild avatar changes.

## Checklist
- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
