### PR TITLE
feat: return embed from `clear_fields` and `remove_field`

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -602,18 +602,27 @@ class Embed:
 
         return self
 
-    def clear_fields(self) -> None:
-        """Removes all fields from this embed."""
+    def clear_fields(self) -> Self:
+        """Removes all fields from this embed.
+        
+        This function returns the class instance to allow for fluent-style
+        chaining.
+        """
         try:
             self._fields.clear()
         except AttributeError:
             self._fields = []
+            
+        return self
 
-    def remove_field(self, index: int) -> None:
+    def remove_field(self, index: int) -> Self:
         """Removes a field at a specified index.
 
         If the index is invalid or out of bounds then the error is
         silently swallowed.
+        
+        This function returns the class instance to allow for fluent-style
+        chaining.
 
         .. note::
 
@@ -629,6 +638,8 @@ class Embed:
             del self._fields[index]
         except (AttributeError, IndexError):
             pass
+        
+        return self
 
     def set_field_at(self, index: int, *, name: Any, value: Any, inline: bool = True) -> Self:
         """Modifies a field to the embed object.

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -612,7 +612,7 @@ class Embed:
             self._fields.clear()
         except AttributeError:
             self._fields = []
-            
+
         return self
 
     def remove_field(self, index: int) -> Self:
@@ -638,7 +638,7 @@ class Embed:
             del self._fields[index]
         except (AttributeError, IndexError):
             pass
-        
+
         return self
 
     def set_field_at(self, index: int, *, name: Any, value: Any, inline: bool = True) -> Self:

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -604,7 +604,7 @@ class Embed:
 
     def clear_fields(self) -> Self:
         """Removes all fields from this embed.
-        
+
         This function returns the class instance to allow for fluent-style
         chaining.
         """
@@ -620,7 +620,7 @@ class Embed:
 
         If the index is invalid or out of bounds then the error is
         silently swallowed.
-        
+
         This function returns the class instance to allow for fluent-style
         chaining.
 

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -607,6 +607,9 @@ class Embed:
 
         This function returns the class instance to allow for fluent-style
         chaining.
+
+        .. versionchanged:: 2.0
+            This function now returns the class instance.
         """
         try:
             self._fields.clear()
@@ -628,6 +631,9 @@ class Embed:
 
             When deleting a field by index, the index of the other fields
             shift to fill the gap just like a regular list.
+
+        .. versionchanged:: 2.0
+            This function now returns the class instance.
 
         Parameters
         -----------


### PR DESCRIPTION
## Summary

For consistency with all other Embed methods (eg. `add_field`, `remove_author`, `set_footer`, etc.), this makes `clear_fields` and `remove_field` return `self`.

### Example usage:

```py
await ctx.send(embed=embed.add_field(name="Test", value=f"field").remove_field(0))

await ctx.send(embed=embed.clear_fields().add_field(name="Test", value=f"field"))
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
