### PR TITLE
Add support for application tags and install params.

### DIFF
--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -111,14 +111,17 @@ class AppInfo:
         The application's privacy policy URL, if set.
 
         .. versionadded:: 2.0
+
     tags: List[:class:`str`]
         The list of tags describing the functionality of the application.
 
         .. versionadded:: 2.0
+
     custom_install_url: List[:class:`str`]
         The custom authorization URL for the application, if enabled.
 
         .. versionadded:: 2.0
+
     install_params: Optional[:class:`AppInstallParams`]
         The settings for custom authorization URL of application, if enabled.
 

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -178,10 +178,10 @@ class AppInfo:
         self._cover_image: Optional[str] = data.get('cover_image')
         self.terms_of_service_url: Optional[str] = data.get('terms_of_service_url')
         self.privacy_policy_url: Optional[str] = data.get('privacy_policy_url')
-        self.tags: List[str] = data.get("tags", [])
-        self.custom_install_url: Optional[str] = data.get("custom_install_url")
+        self.tags: List[str] = data.get('tags', [])
+        self.custom_install_url: Optional[str] = data.get('custom_install_url')
 
-        params = data.get("install_params")
+        params = data.get('install_params')
         self.install_params: Optional[AppInstallParams] = AppInstallParams(params) if params else None
 
     def __repr__(self) -> str:
@@ -308,11 +308,8 @@ class AppInstallParams:
         The permissions to give to application in the guild.
     """
 
-    __slots__ = (
-        "scopes",
-        "permissions",
-    )
+    __slots__ = ('scopes', 'permissions')
 
     def __init__(self, data: InstallParamsPayload) -> None:
-        self.scopes: List[str] = data.get("scopes", [])
-        self.permissions: Permissions = Permissions._from_value(int(data["permissions"]))
+        self.scopes: List[str] = data.get('scopes', [])
+        self.permissions: Permissions = Permissions(int(data['permissions']))

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -29,6 +29,7 @@ from typing import List, TYPE_CHECKING, Optional
 from . import utils
 from .asset import Asset
 from .flags import ApplicationFlags
+from .permissions import Permissions
 
 if TYPE_CHECKING:
     from .guild import Guild
@@ -36,6 +37,7 @@ if TYPE_CHECKING:
         AppInfo as AppInfoPayload,
         PartialAppInfo as PartialAppInfoPayload,
         Team as TeamPayload,
+        InstallParams as InstallParamsPayload,
     )
     from .user import User
     from .state import ConnectionState
@@ -43,6 +45,7 @@ if TYPE_CHECKING:
 __all__ = (
     'AppInfo',
     'PartialAppInfo',
+    'AppInstallParams',
 )
 
 
@@ -108,6 +111,18 @@ class AppInfo:
         The application's privacy policy URL, if set.
 
         .. versionadded:: 2.0
+    tags: List[:class:`str`]
+        The list of tags describing the functionality of the application.
+
+        .. versionadded:: 2.0
+    custom_install_url: List[:class:`str`]
+        The custom authorization URL for the application, if enabled.
+
+        .. versionadded:: 2.0
+    install_params: Optional[:class:`AppInstallParams`]
+        The settings for custom authorization URL of application, if enabled.
+
+        .. versionadded:: 2.0
     """
 
     __slots__ = (
@@ -129,6 +144,9 @@ class AppInfo:
         '_flags',
         'terms_of_service_url',
         'privacy_policy_url',
+        'tags',
+        'custom_install_url',
+        'install_params',
     )
 
     def __init__(self, state: ConnectionState, data: AppInfoPayload):
@@ -157,6 +175,11 @@ class AppInfo:
         self._cover_image: Optional[str] = data.get('cover_image')
         self.terms_of_service_url: Optional[str] = data.get('terms_of_service_url')
         self.privacy_policy_url: Optional[str] = data.get('privacy_policy_url')
+        self.tags: List[str] = data.get("tags", [])
+        self.custom_install_url: Optional[str] = data.get("custom_install_url")
+
+        params = data.get("install_params")
+        self.install_params: Optional[AppInstallParams] = AppInstallParams(params) if params else None
 
     def __repr__(self) -> str:
         return (
@@ -266,3 +289,27 @@ class PartialAppInfo:
         .. versionadded:: 2.0
         """
         return ApplicationFlags._from_value(self._flags)
+
+
+class AppInstallParams:
+    """Represents the settings for custom authorization URL of an application.
+
+    .. versionadded:: 2.0
+
+    Attributes
+    ----------
+    scopes: List[:class:`str`]
+        The list of `OAuth2 scopes <https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes>`_
+        to add the application to a guild with.
+    permissions: :class:`Permissions`
+        The permissions to give to application in the guild.
+    """
+
+    __slots__ = (
+        "scopes",
+        "permissions",
+    )
+
+    def __init__(self, data: InstallParamsPayload) -> None:
+        self.scopes: List[str] = data.get("scopes", [])
+        self.permissions: Permissions = Permissions._from_value(int(data["permissions"]))

--- a/discord/types/appinfo.py
+++ b/discord/types/appinfo.py
@@ -32,6 +32,11 @@ from .team import Team
 from .snowflake import Snowflake
 
 
+class InstallParams(TypedDict):
+    scopes: List[str]
+    permissions: str
+
+
 class BaseAppInfo(TypedDict):
     id: Snowflake
     name: str
@@ -54,6 +59,9 @@ class AppInfo(BaseAppInfo):
     privacy_policy_url: NotRequired[str]
     hook: NotRequired[bool]
     max_participants: NotRequired[int]
+    tags: NotRequired[List[str]]
+    install_params: NotRequired[InstallParams]
+    custom_install_url: NotRequired[str]
 
 
 class PartialAppInfo(BaseAppInfo, total=False):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -72,6 +72,14 @@ PartialAppInfo
 .. autoclass:: PartialAppInfo()
     :members:
 
+AppInstallParams
+~~~~~~~~~~~~~~~~
+
+.. attributetable:: AppInstallParams
+
+.. autoclass:: AppInstallParams()
+    :members:
+
 Team
 ~~~~~
 


### PR DESCRIPTION
## Summary

This pull request adds support for `tags`, `custom_install_url` and `install_params` on `AppInfo`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
