### PR TITLE
Fix modal example not passing application_id

### DIFF
--- a/examples/modal.py
+++ b/examples/modal.py
@@ -9,12 +9,12 @@ TEST_GUILD = discord.Object(0)
 
 
 class MyClient(discord.Client):
-    def __init__(self) -> None:
+    def __init__(self, application_id: int) -> None:
         # Just default intents and a `discord.Client` instance
         # We don't need a `commands.Bot` instance because we are not
         # creating text-based commands.
         intents = discord.Intents.default()
-        super().__init__(intents=intents)
+        super().__init__(intents=intents, application_id=application_id)
 
         # We need an `discord.app_commands.CommandTree` instance
         # to register application commands (slash commands in this case)
@@ -64,7 +64,9 @@ class Feedback(discord.ui.Modal, title='Feedback'):
         traceback.print_tb(error.__traceback__)
 
 
-client = MyClient()
+# In order to use a basic synchronization of the app commands in the setup_hook,
+# replace 0 with your bot's application_id that you can find in the developer portal.
+client = MyClient(application_id=0)
 
 
 @client.tree.command(guild=TEST_GUILD, description="Submit feedback")


### PR DESCRIPTION
## Summary
Fix missing `application_id` on modal example.

## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
