### PR TITLE
Improve component typing

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -1633,13 +1633,13 @@ class Message(PartialMessage, Hashable):
                     self.role_mentions.append(role)
 
     def _handle_components(self, data: List[ComponentPayload]) -> None:
-        self.components = components = []
+        self.components = []
 
         for component_data in data:
             component = _component_factory(component_data)
 
             if component is not None:
-                components.append(component)
+                self.components.append(component)
 
     def _handle_interaction(self, data: MessageInteractionPayload):
         self.interaction = MessageInteraction(state=self._state, guild=self.guild, data=data)

--- a/discord/partial_emoji.py
+++ b/discord/partial_emoji.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
     from .state import ConnectionState
     from datetime import datetime
-    from .types.message import PartialEmoji as PartialEmojiPayload
+    from .types.emoji import Emoji as EmojiPayload, PartialEmoji as PartialEmojiPayload
     from .types.activity import ActivityEmoji
 
 
@@ -148,13 +148,16 @@ class PartialEmoji(_EmojiTag, AssetMixin):
 
         return cls(name=value, id=None, animated=False)
 
-    def to_dict(self) -> Dict[str, Any]:
-        o: Dict[str, Any] = {'name': self.name}
-        if self.id:
-            o['id'] = self.id
+    def to_dict(self) -> EmojiPayload:
+        payload: EmojiPayload = {
+            'id': self.id,
+            'name': self.name,
+        }
+
         if self.animated:
-            o['animated'] = self.animated
-        return o
+            payload['animated'] = self.animated
+
+        return payload
 
     def _to_partial(self) -> PartialEmoji:
         return self

--- a/discord/state.py
+++ b/discord/state.py
@@ -727,7 +727,7 @@ class ConnectionState:
             inner_data = data['data']
             custom_id = inner_data['custom_id']
             components = inner_data['components']
-            self._view_store.dispatch_modal(custom_id, interaction, components)  # type: ignore
+            self._view_store.dispatch_modal(custom_id, interaction, components)
         self.dispatch('interaction', interaction)
 
     def parse_presence_update(self, data: gw.PresenceUpdateEvent) -> None:

--- a/discord/types/components.py
+++ b/discord/types/components.py
@@ -36,7 +36,7 @@ TextStyle = Literal[1, 2]
 
 class ActionRow(TypedDict):
     type: Literal[1]
-    components: List[Component]
+    components: List[ActionRowChildComponent]
 
 
 class ButtonComponent(TypedDict):
@@ -79,4 +79,5 @@ class TextInput(TypedDict):
     max_length: NotRequired[int]
 
 
-Component = Union[ActionRow, ButtonComponent, SelectMenu, TextInput]
+ActionRowChildComponent = Union[ButtonComponent, SelectMenu, TextInput]
+Component = Union[ActionRow, ActionRowChildComponent]

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -186,7 +186,7 @@ ModalSubmitComponentInteractionData = Union[ModalSubmitActionRowInteractionData,
 
 class ModalSubmitInteractionData(TypedDict):
     custom_id: str
-    components: List[ModalSubmitActionRowInteractionData]
+    components: List[ModalSubmitComponentInteractionData]
 
 
 InteractionData = Union[

--- a/discord/ui/button.py
+++ b/discord/ui/button.py
@@ -120,7 +120,6 @@ class Button(Item[V]):
                 raise TypeError(f'expected emoji to be str, Emoji, or PartialEmoji not {emoji.__class__}')
 
         self._underlying = ButtonComponent._raw_construct(
-            type=ComponentType.button,
             custom_id=custom_id,
             url=url,
             disabled=disabled,

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -117,7 +117,6 @@ class Select(Item[V]):
         options = [] if options is MISSING else options
         self._underlying = SelectMenu._raw_construct(
             custom_id=custom_id,
-            type=ComponentType.select,
             placeholder=placeholder,
             min_values=min_values,
             max_values=max_values,

--- a/discord/ui/text_input.py
+++ b/discord/ui/text_input.py
@@ -114,7 +114,6 @@ class TextInput(Item[V]):
             raise TypeError(f'expected custom_id to be str not {custom_id.__class__!r}')
 
         self._underlying = TextInputComponent._raw_construct(
-            type=ComponentType.text_input,
             label=label,
             style=style,
             custom_id=custom_id,
@@ -238,7 +237,7 @@ class TextInput(Item[V]):
 
     @property
     def type(self) -> Literal[ComponentType.text_input]:
-        return ComponentType.text_input
+        return self._underlying.type
 
     def is_dispatchable(self) -> bool:
         return False

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -281,7 +281,7 @@ class View:
             one of its subclasses.
         """
         view = View(timeout=timeout)
-        for component in _walk_all_components(message.components):
+        for component in _walk_all_components(message.components):  # type: ignore
             view.add_item(_component_to_item(component))
         return view
 
@@ -634,7 +634,15 @@ class ViewStore:
     def remove_message_tracking(self, message_id: int) -> Optional[View]:
         return self._synced_message_views.pop(message_id, None)
 
-    def update_from_message(self, message_id: int, components: List[ComponentPayload]) -> None:
+    def update_from_message(self, message_id: int, data: List[ComponentPayload]) -> None:
+        components: List[Component] = []
+
+        for component_data in data:
+            component = _component_factory(component_data)
+
+            if component is not None:
+                components.append(component)
+
         # pre-req: is_message_tracked == true
         view = self._synced_message_views[message_id]
-        view._refresh([_component_factory(d) for d in components])
+        view._refresh(components)


### PR DESCRIPTION
## Summary

Improves component typing in a few different ways:

- The type of the `SelectOption.emoji` attribute has been corrected in code and docs
- `ActionRow.children` and `Message.components` are now a union of possible types instead of `Component` for better editor support
  
  I did not know how to properly narrow these down to not include TextInput on Message.components and action rows on messages so I have not done it for now.
- All `type: ignore` comments in `components.py` have been resolved
- Some misc fixes in the types subpackage to support these changes properly

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
