### PR TITLE
Fix scope typo in FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -490,8 +490,8 @@ My bot's commands are not showing up!
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Did you :meth:`~.CommandTree.sync` your command? Commands need to be synced before they will appear.
-2. Did you invite your bot with the correct permissions? Bots need to be invited with the ``application.commands``
+2. Did you invite your bot with the correct permissions? Bots need to be invited with the ``applications.commands``
    scope in addition to the ``bot`` scope. For example, invite the bot with the following URL:
    ``https://discord.com/oauth2/authorize?client_id=<client id>&scope=applications.commands+bot``.
    Alternatively, if you use :func:`utils.oauth_url`, you can call the function as such:
-   ``oauth_url(<other options>, scopes=("bot", "application.commands"))``.
+   ``oauth_url(<other options>, scopes=("bot", "applications.commands"))``.


### PR DESCRIPTION
## Summary
This PR fixes a typo in the faq when mentioning the applications.commands scope

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
