### PR TITLE
[commands] fix case_insensitive bug in parse_flags

### DIFF
--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -518,7 +518,7 @@ class FlagConverter(metaclass=FlagsMeta):
                 value = argument[last_position : begin - 1].lstrip()
                 if not value:
                     raise MissingFlagArgument(last_flag)
-                
+
                 name = last_flag.name.casefold() if case_insensitive else last_flag.name
 
                 try:

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -537,10 +537,7 @@ class FlagConverter(metaclass=FlagsMeta):
             if not value:
                 raise MissingFlagArgument(last_flag)
 
-            if case_insensitive:
-                name = last_flag.name.casefold()
-            else:
-                name = last_flag.name
+            name = last_flag.name.casefold() if case_insensitive else last_flag.name
 
             try:
                 values = result[name]

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -518,11 +518,16 @@ class FlagConverter(metaclass=FlagsMeta):
                 value = argument[last_position : begin - 1].lstrip()
                 if not value:
                     raise MissingFlagArgument(last_flag)
+                
+                if case_insensitive:
+                    name = last_flag.name.casefold()
+                else:
+                    name = last_flag.name
 
                 try:
-                    values = result[last_flag.name]
+                    values = result[name]
                 except KeyError:
-                    result[last_flag.name] = [value]
+                    result[name] = [value]
                 else:
                     values.append(value)
 
@@ -535,10 +540,15 @@ class FlagConverter(metaclass=FlagsMeta):
             if not value:
                 raise MissingFlagArgument(last_flag)
 
+            if case_insensitive:
+                name = last_flag.name.casefold()
+            else:
+                name = last_flag.name
+
             try:
-                values = result[last_flag.name]
+                values = result[name]
             except KeyError:
-                result[last_flag.name] = [value]
+                result[name] = [value]
             else:
                 values.append(value)
 

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -519,10 +519,7 @@ class FlagConverter(metaclass=FlagsMeta):
                 if not value:
                     raise MissingFlagArgument(last_flag)
                 
-                if case_insensitive:
-                    name = last_flag.name.casefold()
-                else:
-                    name = last_flag.name
+                name = last_flag.name.casefold() if case_insensitive else last_flag.name
 
                 try:
                     values = result[name]


### PR DESCRIPTION
## Summary

When accounting for `case_insensitive` in `FlagConverter`, a bit of additional code is needed inside `parse_flags`. Otherwise flags with names that aren't all lowercase will not be found in `convert`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
