### PR TITLE
Add Reaction into typehint of add_reaction()

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -974,7 +974,7 @@ class PartialMessage(Hashable):
         # pinned exists on PartialMessage for duck typing purposes
         self.pinned = False
 
-    async def add_reaction(self, emoji: EmojiInputType, /) -> None:
+    async def add_reaction(self, emoji: Union[EmojiInputType, Reaction], /) -> None:
         """|coro|
 
         Adds a reaction to the message.


### PR DESCRIPTION
## Summary

Changing just the input parameter typehinting of `message.add_reaction()` to accept `Reaction` as well as `EmojiInputType`, so it now reads `async def add_reaction(self, emoji: Union[EmojiInputType, Reaction], /) -> None:`

- The docs list `Reaction` as a valid input
- `remove_reaction()` and `clear_reaction()` have `Reaction` as a valid input
- The referenced `convert_emoji_reaction()` function takes in `Reaction` as an input,

Compare the following:
https://github.com/Rapptz/discord.py/blob/544bb1e237ae29febb487ffeda1e7309be1b198c/discord/message.py#L977
https://github.com/Rapptz/discord.py/blob/544bb1e237ae29febb487ffeda1e7309be1b198c/discord/message.py#L1016
https://github.com/Rapptz/discord.py/blob/544bb1e237ae29febb487ffeda1e7309be1b198c/discord/message.py#L1059

So I think the input parameter for `add_reaction()` should have `Reaction` as a valid input as well (not sure if this counts as a code change)

I feel like another valid option would be to just add `Reaction` into `EmojiInputType`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (no documentation changes needed)
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
