### PR TITLE
Fix typo in context menu error message

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -426,7 +426,7 @@ def _get_context_menu_parameter(func: ContextMenuCallback) -> Tuple[str, Any, Ap
     if len(params) != 2:
         msg = (
             f'context menu callback {func.__qualname__!r} requires 2 parameters, '
-            'the first one being the annotation and the other one explicitly '
+            'the first one being the interaction and the other one explicitly '
             'annotated with either discord.Message, discord.User, discord.Member, '
             'or a typing.Union of discord.Member and discord.User'
         )


### PR DESCRIPTION
This fixes the text for the TypeError raised when the signature of the callback of a context menu are not as expected

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
The string in the TypeError exception mentioned incorrectly that the first argument of a context menu callback had to be an annotation, where it should be an **interaction**.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
