### PR TITLE
Add support for extension setup variables for providing arguments from within `setup()`

### DIFF
--- a/docs/ext/commands/extensions.rst
+++ b/docs/ext/commands/extensions.rst
@@ -29,6 +29,8 @@ An example extension looks like this:
 
 In this example we define a simple command, and when the extension is loaded this command is added to the bot. Now the final step to this is loading the extension, which we do by calling :meth:`.Bot.load_extension`. To load this extension we call ``await bot.load_extension('hello')``.
 
+It is also possible to pass setup variables to an extension. When a dictionary is passed to the ``extension_vars`` parameter of :meth:`.Bot.load_extension`, its contents will become available to the ``setup`` function from the :attr:`~.Bot.extension_vars` bot attribute.
+
 .. admonition:: Cogs
     :class: helpful
 


### PR DESCRIPTION
## Summary

This PR adds a unified way to safely provide setup variables to extensions. It makes use of  `ContextVar` objects to store these variables as a dictionary. Extensions can access these variables by using the new `Bot.extension_vars` property from within their `setup()` function. To pass these setup variables, one can call `Bot.(re)load_extension("extname", package=..., extension_vars=dict(var1=1, var2=2, ...))`

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
