### PR TITLE
Use json_or_text helper for parsing webhook responses

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import logging
 import asyncio
-import json
 import re
 
 from urllib.parse import quote as urlquote
@@ -44,7 +43,7 @@ from ..user import BaseUser, User
 from ..flags import MessageFlags
 from ..asset import Asset
 from ..partial_emoji import PartialEmoji
-from ..http import Route, handle_message_parameters, MultipartParameters, HTTPClient
+from ..http import Route, handle_message_parameters, MultipartParameters, HTTPClient, json_or_text
 from ..mixins import Hashable
 from ..channel import TextChannel, PartialMessageable
 from ..file import File
@@ -182,9 +181,7 @@ class AsyncWebhookAdapter:
                             url,
                             response.status,
                         )
-                        data = (await response.text(encoding='utf-8')) or None
-                        if data and response.headers['Content-Type'] == 'application/json':
-                            data = json.loads(data)
+                        data = await json_or_text(response)
 
                         remaining = response.headers.get('X-Ratelimit-Remaining')
                         if remaining == '0' and response.status != 429:

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -178,9 +178,12 @@ class WebhookAdapter:
                         response.status = response.status_code  # type: ignore
 
                         data = response.text or None
-                        if data and response.headers['Content-Type'] == 'application/json':
-                            data = json.loads(data)
-
+                        try:
+                            if data and response.headers['Content-Type'] == 'application/json':
+                                data = json.loads(data)
+                        except KeyError:
+                            pass
+                        
                         remaining = response.headers.get('X-Ratelimit-Remaining')
                         if remaining == '0' and response.status_code != 429:
                             delta = utils._parse_ratelimit_header(response)

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -183,7 +183,7 @@ class WebhookAdapter:
                                 data = json.loads(data)
                         except KeyError:
                             pass
-                        
+
                         remaining = response.headers.get('X-Ratelimit-Remaining')
                         if remaining == '0' and response.status_code != 429:
                             delta = utils._parse_ratelimit_header(response)


### PR DESCRIPTION
## Summary

This pull request adds proper handling of KeyError caused by Cloudflare by using `json_or_text` helper similar to `HTTPClient`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
