### PR TITLE
Implement Application Command Permissions models + fetching

### DIFF
--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -39,8 +39,8 @@ __all__ = (
     'AppCommandGroup',
     'AppCommandChannel',
     'AppCommandThread',
-    'GuildAppCommandPermissions',
     'AppCommandPermissions',
+    'GuildAppCommandPermissions',
     'Argument',
     'Choice',
     'AllChannels',
@@ -343,30 +343,29 @@ class AppCommand(Hashable):
     async def fetch_permissions(self, guild: Snowflake) -> GuildAppCommandPermissions:
         """|coro|
 
-        Retrieves the application command permission for this command in the guild.
+        Retrieves this command's permission in the guild.
 
         Parameters
         -----------
         guild: :class:`~discord.abc.Snowflake`
-            The guild to retrieve the application command permissions for.
+            The guild to retrieve the permissions from.
 
         Raises
         -------
         Forbidden
-            You do not have permission to fetch the application command permission.
+            You do not have permission to fetch application command's permissions.
         HTTPException
-            Fetching the application command permission failed.
+            Fetching the application command's permissions failed.
         MissingApplicationID
             The client does not have an application ID.
         NotFound
-            The command's permissions could not be found.
-            This can happen if the permissions are synced
-            and not overriden in the guild.
+            The application command's permissions could not be found.
+            This can indicate that the permissions are synced with the guild.
 
         Returns
         --------
         :class:`GuildAppCommandPermissions`
-            The application command permission permissions for this command in the guild
+            An object representing the application command's permissions in the guild.
         """
         state = self._state
         if not state.application_id:
@@ -860,17 +859,16 @@ class AppCommandPermissions:
 
     Attributes
     -----------
-    guild: :class:`Guild`
-        The guild that the permission is for.
+    guild: :class:`.Guild`
+        The guild assosiated with this permission.
     id: :class:`int`
-        ID of the channel, guild, user or role.
-    object: Union[:class:`AllChannels`, :class:`GuildChannel`, :class:`Role`, :class:`Member`, :class:`.Object`, :class:`User`]
-        The role, user, or channel that the permission is for. Falls back to :class:`.Object` if not found.
-    type: :class:`AppCommandPermissionType`
+        ID of which this permission is for, it can be a channel, guild, guild-1, user or role ID.
+    object: Union[:class:`.AllChannels`, :class:`.GuildChannel`, :class:`.Role`, :class:`.Member`, :class:`~discord.User`, :class:`.Object`]
+        The role, user, or channel assosiated with this permission. Falls back to :class:`.Object` if not found in cache.
+    type: :class:`.AppCommandPermissionType`
         The type of permission.
     permission: :class:`bool`
-        The permission value.
-
+        The permission value. True for allow, False for deny.
     """
 
     __slots__ = ('id', 'type', 'permission', 'object', 'guild', '_state')
@@ -918,27 +916,25 @@ class GuildAppCommandPermissions:
     -----------
     application_id: :class:`int`
         The application ID.
-    command Optional[:class:`AppCommand`]
-        The application command that the permission is for.
+    command: :class:`.AppCommand`
+        The application command assosiated with the permissions.
     id: :class:`int`
-        ID of the command or the application ID
+        ID of the command or the application ID.
         When the this is the application ID instead of a command ID,
         the permissions apply to all commands that do not contain explicit overwrites.
-    guild: :class:`Guild`
-        The guild that the permission is for.
+    guild: :class:`.Guild`
+        The guild assosiated with the permissions.
     guild_id: :class:`int`
-        The guild ID that the permission is for.
+        The guild ID assosiated with the permissions.
     permissions: List[:class:`AppCommandPermissions`]
-        Permissions for the command in the guild, max of 100
+       The permissions, this is a max of 100.
     """
 
     __slots__ = ('id', 'application_id', 'command', 'guild_id', 'guild', 'permissions', '_state')
 
-    def __init__(
-        self, *, data: GuildApplicationCommandPermissions, state: ConnectionState, command: Optional[AppCommand] = None
-    ) -> None:
+    def __init__(self, *, data: GuildApplicationCommandPermissions, state: ConnectionState, command: AppCommand) -> None:
         self._state: ConnectionState = state
-        self.command: Optional[AppCommand] = command
+        self.command: AppCommand = command
 
         self.id: int = int(data['id'])
         self.application_id: int = int(data['application_id'])

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -864,7 +864,7 @@ class AppCommandPermissions:
     guild: :class:`~discord.Guild`
         The guild assosiated with this permission.
     id: :class:`int`
-        The ID of the permission target, such as a role, channel, or guild. 
+        The ID of the permission target, such as a role, channel, or guild.
         The special ``guild_id - 1`` sentinel is used to represent "all channels".
     target: Any
         The role, user, or channel associated with this permission. This could also be the :class:`AllChannels` sentinel type.
@@ -934,7 +934,7 @@ class GuildAppCommandPermissions:
        The permissions, this is a max of 100.
     """
 
-    __slots__ = ('id', 'application_id', 'command', 'guild_id', 'guild', 'permissions', '_state')
+    __slots__ = ('id', 'application_id', 'command', 'guild_id', 'permissions', '_state')
 
     def __init__(self, *, data: GuildApplicationCommandPermissions, state: ConnectionState, command: AppCommand) -> None:
         self._state: ConnectionState = state
@@ -954,6 +954,7 @@ class GuildAppCommandPermissions:
     def guild(self) -> Optional[Guild]:
         """Optional[:class:`~discord.Guild`]: The guild associated with the permissions."""
         return self._state._get_guild(self.guild_id)
+
 
 def app_command_option_factory(
     parent: ApplicationCommandParent, data: ApplicationCommandOption, *, state: Optional[ConnectionState] = None

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -369,7 +369,7 @@ class AppCommand(Hashable):
 
         data = await state.http.get_application_command_permissions(
             state.application_id,
-            self.guild_id,
+            guild,
             self.id,
         )
         return GuildAppCommandPermissions(data=data, state=state, command=self)

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -32,7 +32,7 @@ from ..mixins import Hashable
 from ..utils import _get_as_snowflake, parse_time, snowflake_time, MISSING
 from ..object import Object
 
-from typing import Generic, List, TYPE_CHECKING, Optional, TypeVar, Union
+from typing import Any, Dict, Generic, List, TYPE_CHECKING, Optional, TypeVar, Union
 
 __all__ = (
     'AppCommand',
@@ -58,7 +58,6 @@ if TYPE_CHECKING:
         ApplicationCommand as ApplicationCommandPayload,
         ApplicationCommandOptionChoice,
         ApplicationCommandOption,
-        _BaseGuildApplicationCommandPermissions,
         ApplicationCommandPermissions,
         GuildApplicationCommandPermissions,
     )
@@ -945,7 +944,7 @@ class GuildAppCommandPermissions:
             AppCommandPermissions(data=value, guild=self.guild, state=self._state) for value in data['permissions']
         ]
 
-    def to_dict(self) -> _BaseGuildApplicationCommandPermissions:
+    def to_dict(self) -> Dict[str, Any]:
         return {'permissions': [p.to_dict() for p in self.permissions]}
 
 

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -33,7 +33,6 @@ from .invite import Invite
 from .mixins import Hashable
 from .object import Object
 from .permissions import PermissionOverwrite, Permissions
-from .app_commands.models import AppCommandPermissions
 
 __all__ = (
     'AuditLogDiff',
@@ -276,12 +275,10 @@ class AuditLogChanges:
             self.after.app_command_permissions = []
 
             for d in data:
-
                 self._handle_app_command_permissions(
                     self.before,
                     self.after,
                     entry,
-                    int(d['key']),
                     d.get('old_value'),  # type: ignore # old value will be an ApplicationCommandPermissions if present
                     d.get('new_value'),  # type: ignore # new value will be an ApplicationCommandPermissions if present
                 )
@@ -363,18 +360,19 @@ class AuditLogChanges:
         before: AuditLogDiff,
         after: AuditLogDiff,
         entry: AuditLogEntry,
-        target_id: int,
         old_value: Optional[ApplicationCommandPermissions],
         new_value: Optional[ApplicationCommandPermissions],
     ):
+        # Avoid circular imports
+        from .app_commands.models import AppCommandPermissions
+
         guild = entry.guild
         state = entry._state
-
         if old_value is not None:
             before.app_command_permissions.append(AppCommandPermissions(data=old_value, guild=guild, state=state))
 
         if new_value is not None:
-            after.app_command_permissions.append(AppCommandPermissions(data=ew_value, guild=guild, state=state))
+            after.app_command_permissions.append(AppCommandPermissions(data=new_value, guild=guild, state=state))
 
 
 class _AuditLogProxy:

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -67,7 +67,7 @@ if TYPE_CHECKING:
     from .sticker import GuildSticker
     from .threads import Thread
     from .integrations import PartialIntegration
-    from .app_commands import AppCommand
+    from .app_commands import AppCommand, AppCommandPermissions
 
     TargetType = Union[
         Guild,
@@ -96,6 +96,20 @@ def _transform_color(entry: AuditLogEntry, data: int) -> Colour:
 
 def _transform_snowflake(entry: AuditLogEntry, data: Snowflake) -> int:
     return int(data)
+
+
+def _transform_app_command_permissions(
+    entry: AuditLogEntry, data: ApplicationCommandPermissions
+) -> Optional[AppCommandPermissions]:
+    # avoid circular import
+    from discord.app_commands.models import AppCommandPermissions
+
+    if data is None:
+        return None
+
+    state = entry._state
+    guild = entry.guild
+    return AppCommandPermissions(data=data, guild=guild, state=state)
 
 
 def _transform_channel(entry: AuditLogEntry, data: Optional[Snowflake]) -> Optional[Union[abc.GuildChannel, Object]]:
@@ -261,6 +275,7 @@ class AuditLogChanges:
         'entity_type':                   (None, _enum_transformer(enums.EntityType)),
         'preferred_locale':              (None, _enum_transformer(enums.Locale)),
         'image_hash':                    ('cover_image', _transform_cover_image),
+        'app_command_permission_update': ('app_command_permissions', _transform_app_command_permissions),
     }
     # fmt: on
 
@@ -268,24 +283,14 @@ class AuditLogChanges:
         self.before: AuditLogDiff = AuditLogDiff()
         self.after: AuditLogDiff = AuditLogDiff()
 
-        if entry.action is enums.AuditLogAction.app_command_permission_update:
+        for elem in data:
             # special case entire process since each
             # element in data is a different target
-            self.before.app_command_permissions = []
-            self.after.app_command_permissions = []
-
-            for d in data:
-                self._handle_app_command_permissions(
-                    self.before,
-                    self.after,
-                    entry,
-                    d.get('old_value'),  # type: ignore # old value will be an ApplicationCommandPermissions if present
-                    d.get('new_value'),  # type: ignore # new value will be an ApplicationCommandPermissions if present
-                )
-            return
-
-        for elem in data:
-            attr = elem['key']
+            # key is the target id
+            if entry.action is enums.AuditLogAction.app_command_permission_update:
+                attr = entry.action.name
+            else:
+                attr = elem['key']
 
             # special cases for role add/remove
             if attr == '$add':
@@ -354,25 +359,6 @@ class AuditLogChanges:
             data.append(role)
 
         setattr(second, 'roles', data)
-
-    def _handle_app_command_permissions(
-        self,
-        before: AuditLogDiff,
-        after: AuditLogDiff,
-        entry: AuditLogEntry,
-        old_value: Optional[ApplicationCommandPermissions],
-        new_value: Optional[ApplicationCommandPermissions],
-    ):
-        # Avoid circular imports
-        from .app_commands.models import AppCommandPermissions
-
-        guild = entry.guild
-        state = entry._state
-        if old_value is not None:
-            before.app_command_permissions.append(AppCommandPermissions(data=old_value, guild=guild, state=state))
-
-        if new_value is not None:
-            after.app_command_permissions.append(AppCommandPermissions(data=new_value, guild=guild, state=state))
 
 
 class _AuditLogProxy:

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -682,6 +682,12 @@ class AppCommandType(Enum):
     message = 3
 
 
+class AppCommandPermissionType(Enum):
+    role = 1
+    user = 2
+    channel = 3
+
+
 def create_unknown_value(cls: Type[E], val: Any) -> E:
     value_cls = cls._enum_value_cls_  # type: ignore # This is narrowed below
     name = f'unknown_{val}'

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -62,6 +62,7 @@ __all__ = (
     'EventStatus',
     'AppCommandType',
     'AppCommandOptionType',
+    'AppCommandPermissionType',
 )
 
 if TYPE_CHECKING:

--- a/discord/http.py
+++ b/discord/http.py
@@ -2035,20 +2035,6 @@ class HTTPClient:
         )
         return self.request(r, json=payload)
 
-    def bulk_edit_guild_application_command_permissions(
-        self,
-        application_id: Snowflake,
-        guild_id: Snowflake,
-        payload: List[command._BaseGuildApplicationCommandPermissions],
-    ) -> Response[None]:
-        r = Route(
-            'PUT',
-            '/applications/{application_id}/guilds/{guild_id}/commands/permissions',
-            application_id=application_id,
-            guild_id=guild_id,
-        )
-        return self.request(r, json=payload)
-
     # Misc
 
     def application_info(self) -> Response[appinfo.AppInfo]:

--- a/discord/http.py
+++ b/discord/http.py
@@ -2024,7 +2024,7 @@ class HTTPClient:
         application_id: Snowflake,
         guild_id: Snowflake,
         command_id: Snowflake,
-        payload: Dict[str, Any],
+        payload: command._BaseGuildApplicationCommandPermissions,
     ) -> Response[None]:
         r = Route(
             'PUT',
@@ -2039,7 +2039,7 @@ class HTTPClient:
         self,
         application_id: Snowflake,
         guild_id: Snowflake,
-        payload: List[Dict[str, Any]],
+        payload: List[command._BaseGuildApplicationCommandPermissions],
     ) -> Response[None]:
         r = Route(
             'PUT',

--- a/discord/http.py
+++ b/discord/http.py
@@ -2024,7 +2024,7 @@ class HTTPClient:
         application_id: Snowflake,
         guild_id: Snowflake,
         command_id: Snowflake,
-        payload: command._BaseGuildApplicationCommandPermissions,
+        payload: Dict[str, Any],
     ) -> Response[None]:
         r = Route(
             'PUT',

--- a/discord/types/command.py
+++ b/discord/types/command.py
@@ -202,8 +202,11 @@ class ApplicationCommandPermissions(TypedDict):
     permission: bool
 
 
-class GuildApplicationCommandPermissions(TypedDict):
+class _BaseGuildApplicationCommandPermissions(TypedDict):
+    permissions: List[ApplicationCommandPermissions]
+
+
+class GuildApplicationCommandPermissions(_BaseGuildApplicationCommandPermissions):
     id: Snowflake
     application_id: Snowflake
     guild_id: Snowflake
-    permissions: List[ApplicationCommandPermissions]

--- a/discord/types/command.py
+++ b/discord/types/command.py
@@ -202,11 +202,8 @@ class ApplicationCommandPermissions(TypedDict):
     permission: bool
 
 
-class _BaseGuildApplicationCommandPermissions(TypedDict):
-    permissions: List[ApplicationCommandPermissions]
-
-
-class GuildApplicationCommandPermissions(_BaseGuildApplicationCommandPermissions):
+class GuildApplicationCommandPermissions(TypedDict):
     id: Snowflake
     application_id: Snowflake
     guild_id: Snowflake
+    permissions: List[ApplicationCommandPermissions]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3514,7 +3514,7 @@ AuditLogDiff
 
         The permissions of the app command.
 
-        :type: List[:class:`~discord.app_commands.AppCommandPermissions`]
+        :type: :class:`~discord.app_commands.AppCommandPermissions`
 
 .. this is currently missing the following keys: reason and application_id
    I'm not sure how to about porting these

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3512,13 +3512,9 @@ AuditLogDiff
 
     .. attribute:: app_command_permissions
 
-        A list of application command permission tuples that represents a
-        target and a :class:`bool` for said target.
+        The permissions of the app command.
 
-        The first element is the object being targeted, which can either
-        be a :class:`Member`, :class:`abc.GuildChannel`,
-        :class:`~discord.app_commands.AllChannels`, or :class:`Role`.
-        :type: List[Tuple[target, :class:`bool`]]
+        :type: List[:class:`~discord.app_commands.AppCommandPermissions`]
 
 .. this is currently missing the following keys: reason and application_id
    I'm not sure how to about porting these

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -121,6 +121,22 @@ AppCommandThread
 .. autoclass:: discord.app_commands.AppCommandThread()
     :members:
 
+AppCommandPermissions
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: discord.app_commands.AppCommandPermissions
+
+.. autoclass:: discord.app_commands.AppCommandPermissions()
+    :members:
+
+GuildAppCommandPermissions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: discord.app_commands.GuildAppCommandPermissions
+
+.. autoclass:: discord.app_commands.GuildAppCommandPermissions()
+    :members:
+
 Argument
 ~~~~~~~~~~
 
@@ -359,6 +375,22 @@ Enumerations
     .. attribute:: message
 
         A message context menu command.
+
+.. class:: AppCommandPermissionType
+    
+    The application command's permission type.
+
+    .. versionadded:: 2.0
+
+    .. attribute:: role
+
+        The permission is for a role.
+    .. attribute:: channel
+
+        The permission is for one or all channels.
+    .. attribute:: user
+
+        The permission is for a user.
 
 .. _discord_ui_kit:
 


### PR DESCRIPTION
## Summary

Resolves [card-81287908](https://github.com/Rapptz/discord.py/projects/3#card-81287908)

This PR adds the following classes:
- `GuildAppCommandPermissions`
- `AppCommandPermissions`
- `AppCommandPermissionType` (enum)

Also added a `.fetch_permissions()` method to `AppCommand` to fetch the command's permissions, replaced the tuple for the app permissions audit log with `AppCommandPermissions` and removed `HTTPClient.bulk_edit_guild_application_command_permissions()` method since in was [disabled in V2](https://discord.com/developers/docs/change-log#updated-command-permissions). 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
