### PR TITLE
Fixed Documentation Errors for discord.Invite and on_integration_update

### DIFF
--- a/discord/invite.py
+++ b/discord/invite.py
@@ -302,16 +302,16 @@ class Invite(Hashable):
         The URL fragment used for the invite.
     guild: Optional[Union[:class:`Guild`, :class:`Object`, :class:`PartialInviteGuild`]]
         The guild the invite is for. Can be ``None`` if it's from a group direct message.
-    revoked: :class:`bool`
+    revoked: Optional[:class:`bool`]
         Indicates if the invite has been revoked.
-    created_at: :class:`datetime.datetime`
+    created_at: Optional[:class:`datetime.datetime`]
         An aware UTC datetime object denoting the time the invite was created.
-    temporary: :class:`bool`
+    temporary: Optional[:class:`bool`]
         Indicates that the invite grants temporary membership.
         If ``True``, members who joined via this invite will be kicked upon disconnect.
-    uses: :class:`int`
+    uses: Optional[:class:`int`]
         How many times the invite has been used.
-    max_uses: :class:`int`
+    max_uses: Optional[:class:`int`]
         How many times the invite can be used.
         A value of ``0`` indicates that it has unlimited uses.
     inviter: Optional[:class:`User`]
@@ -327,7 +327,7 @@ class Invite(Hashable):
 
         .. versionadded:: 2.0
 
-    channel: Union[:class:`abc.GuildChannel`, :class:`Object`, :class:`PartialInviteChannel`]
+    channel: Optional[Union[:class:`abc.GuildChannel`, :class:`Object`, :class:`PartialInviteChannel`]]
         The channel the invite is for.
     target_type: :class:`InviteTarget`
         The type of target for the voice channel invite.

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -295,7 +295,7 @@ class Invite(Hashable):
 
     Attributes
     -----------
-    max_age: :class:`int`
+    max_age: Optional[:class:`int`]
         How long before the invite expires in seconds.
         A value of ``0`` indicates that it doesn't expire.
     code: :class:`str`

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -615,7 +615,7 @@ Integrations
 
     .. versionadded:: 2.0
 
-    :param integration: The integration that was created.
+    :param integration: The integration that was updated.
     :type integration: :class:`Integration`
 
 .. function:: on_guild_integrations_update(guild)


### PR DESCRIPTION
## Summary

Max age is optional however it is not documented as being optional.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
