### PR TITLE
Fix small grammatical error in integration docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -615,7 +615,7 @@ Integrations
 
     .. versionadded:: 2.0
 
-    :param integration: The integration that was created.
+    :param integration: The integration that was updated.
     :type integration: :class:`Integration`
 
 .. function:: on_guild_integrations_update(guild)


### PR DESCRIPTION
## Summary

In the docs for `on_integration_update`, the `integration` parameter said it returns the integration that was created, when it should have said "updated". This PR fixes that.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
