### PR TITLE
Use `__getitem__` to access `channel_id` in MessageReference payloads

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -468,7 +468,7 @@ class MessageReference:
     def with_state(cls, state: ConnectionState, data: MessageReferencePayload) -> Self:
         self = cls.__new__(cls)
         self.message_id = utils._get_as_snowflake(data, 'message_id')
-        self.channel_id = int(data.pop('channel_id'))
+        self.channel_id = int(data['channel_id'])
         self.guild_id = utils._get_as_snowflake(data, 'guild_id')
         self.fail_if_not_exists = data.get('fail_if_not_exists', True)
         self._state = state

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 from typing import List, Literal, Optional, TypedDict, Union
-from typing_extensions import NotRequired
+from typing_extensions import NotRequired, Required
 
 from .snowflake import Snowflake, SnowflakeList
 from .member import Member, UserWithMember
@@ -88,7 +88,7 @@ class MessageApplication(TypedDict):
 
 class MessageReference(TypedDict, total=False):
     message_id: Snowflake
-    channel_id: Snowflake
+    channel_id: Required[Snowflake]
     guild_id: Snowflake
     fail_if_not_exists: bool
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adjusts `MessageReference.with_state` to access the payload's `channel_id` via its `__getitem__` rather than `pop`.

Access via `pop` would cause a `KeyError` to be raised if instantiation was attempted multiple times with the same data (i.e. when calling `Context.from_interaction` within a message-based context menu command).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
