### PR TITLE
Use `static_format` over `format` if present

### DIFF
--- a/discord/asset.py
+++ b/discord/asset.py
@@ -387,7 +387,12 @@ class Asset(AssetMixin):
                     raise ValueError(f'format must be one of {VALID_ASSET_FORMATS}')
             else:
                 if format not in VALID_STATIC_FORMATS:
-                    raise ValueError(f'format must be one of {VALID_STATIC_FORMATS}')
+                    # don't bother raising if static_format is set to a valid static format.
+                    if static_format is not MISSING and static_format in VALID_STATIC_FORMATS:
+                        format = static_format
+                    else:
+                        raise ValueError(f'format must be one of {VALID_STATIC_FORMATS}')
+
             url = url.with_path(f'{path}.{format}')
 
         if static_format is not MISSING and not self._animated:

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -355,7 +355,7 @@ class Asset(AssetMixin):
 
 
         .. versionchanged:: 2.0
-            ``static_format`` is now preferred over ``format`` 
+            ``static_format`` is now preferred over ``format``
             if both are present and the asset is not animated.
 
         .. versionchanged:: 2.0

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -386,12 +386,8 @@ class Asset(AssetMixin):
                 if format not in VALID_ASSET_FORMATS:
                     raise ValueError(f'format must be one of {VALID_ASSET_FORMATS}')
             else:
-                if format not in VALID_STATIC_FORMATS:
-                    # don't bother raising if static_format is set to a valid static format.
-                    if static_format is not MISSING and static_format in VALID_STATIC_FORMATS:
-                        format = static_format
-                    else:
-                        raise ValueError(f'format must be one of {VALID_STATIC_FORMATS}')
+                if static_format is MISSING and format not in VALID_STATIC_FORMATS:
+                    raise ValueError(f'format must be one of {VALID_STATIC_FORMATS}')
 
             url = url.with_path(f'{path}.{format}')
 

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -388,7 +388,6 @@ class Asset(AssetMixin):
             else:
                 if static_format is MISSING and format not in VALID_STATIC_FORMATS:
                     raise ValueError(f'format must be one of {VALID_STATIC_FORMATS}')
-
             url = url.with_path(f'{path}.{format}')
 
         if static_format is not MISSING and not self._animated:

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -353,6 +353,11 @@ class Asset(AssetMixin):
     ) -> Self:
         """Returns a new asset with the passed components replaced.
 
+
+        .. versionchanged:: 2.0
+            ``static_format`` is now preferred over ``format`` 
+            if both are present and the asset is not animated.
+
         .. versionchanged:: 2.0
             This function will now raise :exc:`ValueError` instead of
             ``InvalidArgument``.


### PR DESCRIPTION

## Summary

Fixes #7345 and resolved [card-81287372](https://github.com/Rapptz/discord.py/projects/3#card-81287372)

This PR uses `static_format` if `format` is not in VALID_STATIC_FORMATS and static_format is.
Not sure if this is the right way to do this.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
