### PR TITLE
Properly use Optional's default value on parsing error

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -672,7 +672,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             except ArgumentParsingError as exc:
                 if self._is_typing_optional(param.annotation):
                     view.index = previous
-                    return None
+                    return None if param.required else await param.get_default(ctx)
                 else:
                     raise exc
         view.previous = previous


### PR DESCRIPTION
## Summary

Fixes #8118

Tested with:
```py
class SampleCog(commands.Cog):
    @commands.command()
    async def test1(self, ctx, opt: Optional[int] = 1, *, rest):
        await ctx.send(f"{opt=} {rest=}")

    @commands.command()
    async def test2(self, ctx, opt: Optional[int], *, rest):
        await ctx.send(f"{opt=} {rest=}")
```

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
