### PR TITLE
Fix typos in AppCommandPermissions attributes doc

### DIFF
--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -862,7 +862,7 @@ class AppCommandPermissions:
     Attributes
     -----------
     guild: :class:`~discord.Guild`
-        The guild assosiated with this permission.
+        The guild associated with this permission.
     id: :class:`int`
         The ID of the permission target, such as a role, channel, or guild.
         The special ``guild_id - 1`` sentinel is used to represent "all channels".
@@ -872,7 +872,7 @@ class AppCommandPermissions:
     type: :class:`.AppCommandPermissionType`
         The type of permission.
     permission: :class:`bool`
-        The permission value. True for allow, False for deny.
+        The permission value. ``True`` for allow, ``False`` for deny.
     """
 
     __slots__ = ('id', 'type', 'permission', 'target', 'guild', '_state')


### PR DESCRIPTION
## Summary

Fix a typo in AppCommandPermissions' guild attribute and a missing codeblock for booleans in AppCommandPermissions' permission attribute.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
