### PR TITLE
add a richer type for `Message.application`

### DIFF
--- a/discord/asset.py
+++ b/discord/asset.py
@@ -255,7 +255,7 @@ class Asset(AssetMixin):
         )
 
     @classmethod
-    def _from_app_icon(cls, state: _State, object_id: int, icon_hash: str, asset_type: Literal['icon', 'cover_image']) -> Self
+    def _from_app_icon(cls, state: _State, object_id: int, icon_hash: str, asset_type: Literal['icon', 'cover_image']) -> Self:
         return cls(
             state,
             url=f'{cls.BASE}/app-icons/{object_id}/{asset_type}.png?size=1024',

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -255,7 +255,7 @@ class Asset(AssetMixin):
         )
 
     @classmethod
-    def _from_app_icon(cls, state: _State, object_id: int, icon_hash: str, asset_type: Literal['icon', 'cover_image']):
+    def _from_app_icon(cls, state: _State, object_id: int, icon_hash: str, asset_type: Literal['icon', 'cover_image']) -> Self
         return cls(
             state,
             url=f'{cls.BASE}/app-icons/{object_id}/{asset_type}.png?size=1024',

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -255,6 +255,15 @@ class Asset(AssetMixin):
         )
 
     @classmethod
+    def _from_app_icon(cls, state: _State, object_id: int, icon_hash: str, asset_type: Literal['icon', 'cover_image']):
+        return cls(
+            state,
+            url=f'{cls.BASE}/app-icons/{object_id}/{asset_type}.png?size=1024',
+            key=icon_hash,
+            animated=False,
+        )
+
+    @classmethod
     def _from_cover_image(cls, state: _State, object_id: int, cover_image_hash: str) -> Self:
         return cls(
             state,

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -255,7 +255,9 @@ class Asset(AssetMixin):
         )
 
     @classmethod
-    def _from_app_icon(cls, state: _State, object_id: int, icon_hash: str, asset_type: Literal['icon', 'cover_image']) -> Self:
+    def _from_app_icon(
+        cls, state: _State, object_id: int, icon_hash: str, asset_type: Literal['icon', 'cover_image']
+    ) -> Self:
         return cls(
             state,
             url=f'{cls.BASE}/app-icons/{object_id}/{asset_type}.png?size=1024',

--- a/discord/message.py
+++ b/discord/message.py
@@ -1378,7 +1378,7 @@ class Message(PartialMessage, Hashable):
         The rich presence enabled application associated with this message.
 
         .. versionchanged:: 2.0
-            This now returns a richer interface type, not a `dict` of the raw payload.
+            Type is now :class:`MessageApplication` instead of :class:`dict`.
 
     stickers: List[:class:`StickerItem`]
         A list of sticker items given to the message.

--- a/discord/message.py
+++ b/discord/message.py
@@ -615,6 +615,8 @@ def flatten_handlers(cls: Type[Message]) -> Type[Message]:
 class MessageApplication:
     """Represents a message's application data from a :class:`~discord.Message`.
 
+    .. versionadded:: 2.0
+
     Attributes
     -----------
     id: :class:`int`
@@ -623,19 +625,9 @@ class MessageApplication:
         The application description.
     name: :class:`str`
         The application's name.
-
-    .. versionadded:: 2.0
-
     """
 
-    __slots__ = (
-        '_state',
-        '_icon',
-        '_cover_image',
-        'id',
-        'description',
-        'name',
-    )
+    __slots__ = ('_state', '_icon', '_cover_image', 'id', 'description', 'name')
 
     def __init__(self, *, state: ConnectionState, data: MessageApplicationPayload) -> None:
         self._state: ConnectionState = state
@@ -646,13 +638,14 @@ class MessageApplication:
         self._cover_image: Optional[str] = data.get('cover_image')
 
     def __repr__(self) -> str:
-        return f"<MessageApplication id={self.id} name={self.name!r}>"
+        return f'<MessageApplication id={self.id} name={self.name!r}>'
 
     @property
     def icon(self) -> Optional[Asset]:
         """Optional[:class:`Asset`]: The application's icon, if any."""
         if self._icon:
             return Asset._from_app_icon(state=self._state, object_id=self.id, icon_hash=self._icon, asset_type='icon')
+        return None
 
     @property
     def cover(self) -> Optional[Asset]:
@@ -661,6 +654,7 @@ class MessageApplication:
             return Asset._from_app_icon(
                 state=self._state, object_id=self.id, icon_hash=self._cover_image, asset_type='cover_image'
             )
+        return None
 
 
 class PartialMessage(Hashable):
@@ -1382,6 +1376,9 @@ class Message(PartialMessage, Hashable):
         - ``party_id``: The party ID associated with the party.
     application: Optional[:class:`~discord.MessageApplication`]
         The rich presence enabled application associated with this message.
+
+        .. versionchanged:: 2.0
+            This now returns a richer interface type, not a `dict` of the raw payload.
 
     stickers: List[:class:`StickerItem`]
         A list of sticker items given to the message.

--- a/discord/message.py
+++ b/discord/message.py
@@ -45,6 +45,7 @@ from typing import (
 )
 
 from . import utils
+from .asset import Asset
 from .reaction import Reaction
 from .emoji import Emoji
 from .partial_emoji import PartialEmoji
@@ -106,6 +107,7 @@ __all__ = (
     'MessageInteraction',
     'MessageReference',
     'DeletedReferencedMessage',
+    'MessageApplication',
 )
 
 
@@ -608,6 +610,54 @@ def flatten_handlers(cls: Type[Message]) -> Type[Message]:
     cls._HANDLERS = handlers
     cls._CACHED_SLOTS = [attr for attr in cls.__slots__ if attr.startswith('_cs_')]
     return cls
+
+
+class MessageApplication:
+    """Represents a message's application data from a :class:`~discord.Message`.
+
+    Attributes
+    -----------
+    id: :class:`int`
+        The application ID.
+    description: :class:`str`
+        The application description.
+    name: :class:`str`
+        The application's name.
+    """
+
+    __slots__ = (
+        '_state',
+        '_icon',
+        '_cover_image',
+        'id',
+        'description',
+        'name',
+    )
+
+    def __init__(self, *, state: ConnectionState, data: MessageApplicationPayload) -> None:
+        self._state: ConnectionState = state
+        self.id: int = int(data['id'])
+        self.description: str = data['description']
+        self.name: str = data['name']
+        self._icon: Optional[str] = data['icon']
+        self._cover_image: Optional[str] = data.get('cover_image')
+
+    def __repr__(self) -> str:
+        return f"<MessageApplication id={self.id} name={self.name!r}>"
+
+    @property
+    def icon(self) -> Optional[Asset]:
+        """Optional[:class:`Asset`]: The application's icon, if any."""
+        if self._icon:
+            return Asset._from_app_icon(state=self._state, object_id=self.id, icon_hash=self._icon, asset_type='icon')
+
+    @property
+    def cover(self) -> Optional[Asset]:
+        """Optional[:class:`Asset`]: The application's cover image, if any."""
+        if self._cover_image:
+            return Asset._from_app_icon(
+                state=self._state, object_id=self.id, icon_hash=self._cover_image, asset_type='cover_image'
+            )
 
 
 class PartialMessage(Hashable):
@@ -1327,16 +1377,9 @@ class Message(PartialMessage, Hashable):
 
         - ``type``: An integer denoting the type of message activity being requested.
         - ``party_id``: The party ID associated with the party.
-    application: Optional[:class:`dict`]
+    application: Optional[:class:`~discord.MessageApplication`]
         The rich presence enabled application associated with this message.
 
-        It is a dictionary with the following keys:
-
-        - ``id``: A string representing the application's ID.
-        - ``name``: A string representing the application's name.
-        - ``description``: A string representing the application's description.
-        - ``icon``: A string representing the icon ID of the application.
-        - ``cover_image``: A string representing the embed's image asset ID.
     stickers: List[:class:`StickerItem`]
         A list of sticker items given to the message.
 
@@ -1409,7 +1452,6 @@ class Message(PartialMessage, Hashable):
         self.reactions: List[Reaction] = [Reaction(message=self, data=d) for d in data.get('reactions', [])]
         self.attachments: List[Attachment] = [Attachment(data=a, state=self._state) for a in data['attachments']]
         self.embeds: List[Embed] = [Embed.from_dict(a) for a in data['embeds']]
-        self.application: Optional[MessageApplicationPayload] = data.get('application')
         self.activity: Optional[MessageActivityPayload] = data.get('activity')
         self._edited_timestamp: Optional[datetime.datetime] = utils.parse_time(data['edited_timestamp'])
         self.type: MessageType = try_enum(MessageType, data['type'])
@@ -1460,6 +1502,14 @@ class Message(PartialMessage, Hashable):
 
                     # the channel will be the correct type here
                     ref.resolved = self.__class__(channel=chan, data=resolved, state=state)  # type: ignore
+
+        self.application: Optional[MessageApplication] = None
+        try:
+            application = data['application']
+        except KeyError:
+            pass
+        else:
+            self.application = MessageApplication(state=self._state, data=application)
 
         for handler in ('author', 'member', 'mentions', 'mention_roles', 'components'):
             try:
@@ -1559,7 +1609,8 @@ class Message(PartialMessage, Hashable):
         self.flags = MessageFlags._from_value(value)
 
     def _handle_application(self, value: MessageApplicationPayload) -> None:
-        self.application = value
+        application = MessageApplication(state=self._state, data=value)
+        self.application = application
 
     def _handle_activity(self, value: MessageActivityPayload) -> None:
         self.activity = value

--- a/discord/message.py
+++ b/discord/message.py
@@ -623,6 +623,9 @@ class MessageApplication:
         The application description.
     name: :class:`str`
         The application's name.
+
+    .. versionadded:: 2.0
+
     """
 
     __slots__ = (

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4236,6 +4236,14 @@ PartialMessage
 .. autoclass:: PartialMessage
     :members:
 
+MessageApplication
+~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: MessageApplication
+
+.. autoclass:: MessageApplication
+    :members:
+
 Intents
 ~~~~~~~~~~
 

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -1218,6 +1218,8 @@ The following changes have been made:
 
 - :attr:`File.filename` will no longer be ``None``, in situations where previously this was the case the filename is set to `'untitled'`.
 
+- :attr:`Message.application` will no longer be a raw `dict` of the API payload and now returns an instance of :class:`MessageApplication`.
+
 :meth:`VoiceProtocol.connect` signature changes.
 --------------------------------------------------
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR adds `MessageApplication` as a richer type for `Message.application`.

It also adds a new classmethod to `Asset` for getting app-icons cdn contents.
The `.icon` and `.cover_image` properties have not been tested currently, but have followed the API docs and payload types.

Resolves [this card](https://github.com/Rapptz/discord.py/projects/3#card-82881897).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
