### PR TITLE
Added state to oauth_url function

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -288,7 +288,7 @@ def oauth_url(
     redirect_uri: str = MISSING,
     scopes: Iterable[str] = MISSING,
     disable_guild_select: bool = False,
-    state: str = MISSING,
+    state: str = MISSING
 ) -> str:
     """A helper function that returns the OAuth2 URL for inviting the bot
     into guilds.
@@ -341,7 +341,7 @@ def oauth_url(
         if redirect_uri is not MISSING:
             url += '&response_type=code&' + urlencode({'redirect_uri': redirect_uri})
         if state is not MISSING:
-            url += urlencode({'state': state})
+            url += f'&{urlencode({"state": state})}'
     return url
 
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -288,13 +288,14 @@ def oauth_url(
     redirect_uri: str = MISSING,
     scopes: Iterable[str] = MISSING,
     disable_guild_select: bool = False,
+    state: str = MISSING
 ) -> str:
     """A helper function that returns the OAuth2 URL for inviting the bot
     into guilds.
 
     .. versionchanged:: 2.0
 
-        ``permissions``, ``guild``, ``redirect_uri``, and ``scopes`` parameters
+        ``permissions``, ``guild``, ``redirect_uri``, ``scopes`` and ``state`` parameters
         are now keyword-only.
 
     Parameters
@@ -316,6 +317,10 @@ def oauth_url(
         Whether to disallow the user from changing the guild dropdown.
 
         .. versionadded:: 2.0
+    state: :class:`str`
+        The state to return after the authorization.
+
+        .. versionadded:: 2.0
 
     Returns
     --------
@@ -334,6 +339,8 @@ def oauth_url(
         url += '&response_type=code&' + urlencode({'redirect_uri': redirect_uri})
     if disable_guild_select:
         url += '&disable_guild_select=true'
+    if state is not MISSING:
+        url += f'&state={state}'
     return url
 
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -634,7 +634,7 @@ async def maybe_coroutine(f: MaybeAwaitableFunc[P, T], *args: P.args, **kwargs: 
 
 async def async_all(gen: Iterable[Awaitable[T]], *, check: Callable[[T], bool] = _isawaitable) -> bool:
     for elem in gen:
-        if check(elem):
+        if check(elem): # type: ignore
             elem = await elem
         if not elem:
             return False

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -288,7 +288,7 @@ def oauth_url(
     redirect_uri: str = MISSING,
     scopes: Iterable[str] = MISSING,
     disable_guild_select: bool = False,
-    state: str = MISSING
+    state: str = MISSING,
 ) -> str:
     """A helper function that returns the OAuth2 URL for inviting the bot
     into guilds.
@@ -341,7 +341,7 @@ def oauth_url(
         if redirect_uri is not MISSING:
             url += '&response_type=code&' + urlencode({'redirect_uri': redirect_uri})
         if state is not MISSING:
-            url += f'&state={state}'
+            url += urlencode({'state': state})
     return url
 
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -634,7 +634,7 @@ async def maybe_coroutine(f: MaybeAwaitableFunc[P, T], *args: P.args, **kwargs: 
 
 async def async_all(gen: Iterable[Awaitable[T]], *, check: Callable[[T], bool] = _isawaitable) -> bool:
     for elem in gen:
-        if check(elem): # type: ignore
+        if check(elem):  # type: ignore
             elem = await elem
         if not elem:
             return False

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -288,7 +288,7 @@ def oauth_url(
     redirect_uri: str = MISSING,
     scopes: Iterable[str] = MISSING,
     disable_guild_select: bool = False,
-    state: str = MISSING
+    state: str = MISSING,
 ) -> str:
     """A helper function that returns the OAuth2 URL for inviting the bot
     into guilds.

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -288,14 +288,14 @@ def oauth_url(
     redirect_uri: str = MISSING,
     scopes: Iterable[str] = MISSING,
     disable_guild_select: bool = False,
-    state: str = MISSING,
+    state: str = MISSING
 ) -> str:
     """A helper function that returns the OAuth2 URL for inviting the bot
     into guilds.
 
     .. versionchanged:: 2.0
 
-        ``permissions``, ``guild``, ``redirect_uri``, and ``scopes`` parameters
+        ``permissions``, ``guild``, ``redirect_uri``, ``scopes`` and ``state`` parameters
         are now keyword-only.
 
     Parameters
@@ -333,15 +333,15 @@ def oauth_url(
         url += f'&permissions={permissions.value}'
     if guild is not MISSING:
         url += f'&guild_id={guild.id}'
-    if redirect_uri is not MISSING:
-        from urllib.parse import urlencode
-
-        url += '&response_type=code&' + urlencode({'redirect_uri': redirect_uri})
     if disable_guild_select:
         url += '&disable_guild_select=true'
-    if state is not MISSING:
-        encoded = urlencode({'state': state})
-        url += f'&{encoded}'
+    if redirect_uri is not MISSING or state is not MISSING:
+        from urllib.parse import urlencode
+        
+        if redirect_uri is not MISSING:
+            url += '&response_type=code&' + urlencode({'redirect_uri': redirect_uri})
+        if state is not MISSING:
+            url += f'&state={state}'
     return url
 
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -337,7 +337,6 @@ def oauth_url(
         url += '&disable_guild_select=true'
     if redirect_uri is not MISSING or state is not MISSING:
         from urllib.parse import urlencode
-        
         if redirect_uri is not MISSING:
             url += '&response_type=code&' + urlencode({'redirect_uri': redirect_uri})
         if state is not MISSING:

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -337,6 +337,7 @@ def oauth_url(
         url += '&disable_guild_select=true'
     if redirect_uri is not MISSING or state is not MISSING:
         from urllib.parse import urlencode
+
         if redirect_uri is not MISSING:
             url += '&response_type=code&' + urlencode({'redirect_uri': redirect_uri})
         if state is not MISSING:

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -340,7 +340,8 @@ def oauth_url(
     if disable_guild_select:
         url += '&disable_guild_select=true'
     if state is not MISSING:
-        url += f'&state={state}'
+        encoded = urlencode({'state': state})
+        url += f'&{encoded}'
     return url
 
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -634,7 +634,7 @@ async def maybe_coroutine(f: MaybeAwaitableFunc[P, T], *args: P.args, **kwargs: 
 
 async def async_all(gen: Iterable[Awaitable[T]], *, check: Callable[[T], bool] = _isawaitable) -> bool:
     for elem in gen:
-        if check(elem):  # type: ignore
+        if check(elem):
             elem = await elem
         if not elem:
             return False

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -295,7 +295,7 @@ def oauth_url(
 
     .. versionchanged:: 2.0
 
-        ``permissions``, ``guild``, ``redirect_uri``, ``scopes`` and ``state`` parameters
+        ``permissions``, ``guild``, ``redirect_uri``, and ``scopes`` parameters
         are now keyword-only.
 
     Parameters


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Added state to oauth_url function, sometimes state is require in oauth url like this https://discord.com/oauth2/authorize?client_id=935242576343224352&permissions=8&scope=applications.commands%20bot&response_type=code&state=cube12345%3F%2FDirect%20From%20Bot&redirect_uri=https%3A%2F%2Fminatonamikaze-invites.herokuapp.com%2Finvite

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
