### PR TITLE
Add `type` property to `app_commands.Command` and `app_commands.Group`

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -750,7 +750,7 @@ class Command(Generic[GroupT, P, T]):
 
     @property
     def type(self) -> Literal[AppCommandType.chat_input, AppCommandOptionType.subcommand]:
-        """Union[:class:`~discord.AppCommandType`, :class`~discord.AppCommandOptionType`]: The command's type.
+        """Union[:class:`~discord.AppCommandType`, :class:`~discord.AppCommandOptionType`]: The command's type.
         This is :attr:`~discord.AppCommandType.value` if the command is a subcommand,
         otherwise :attr:`~discord.AppCommandOptionType.subcommand` is returned.
         """


### PR DESCRIPTION
## Summary

This PR adds a `type` property to `app_commands.Command` and `app_commands.Group`.

For `app_commands.Group`, the new type property is used in `.to_dict()`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
