### PR TITLE
Fix typings of `deaf` and `mute` in `PartialMember`

### DIFF
--- a/discord/types/member.py
+++ b/discord/types/member.py
@@ -34,8 +34,8 @@ class Nickname(TypedDict):
 class PartialMember(TypedDict):
     roles: SnowflakeList
     joined_at: str
-    deaf: str
-    mute: str
+    deaf: bool
+    mute: bool
 
 
 class Member(PartialMember, total=False):


### PR DESCRIPTION
## Summary

According to the discord docs the `deaf` and `mute` fields of a member are bools, however they were annotated as strings 
![](https://cdn.discordapp.com/attachments/603069307286454290/984531551494762577/unknown.png)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
