### PR TITLE
Select values contextvar

### DIFF
--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
 
 V = TypeVar('V', bound='View', covariant=True)
 
-selected_values: ContextVar[List[str]] = ContextVar('selected_values')
+selected_values: ContextVar[Optional[List[str]]] = ContextVar('selected_values', default=None)
 
 
 class Select(Item[V]):
@@ -261,7 +261,8 @@ class Select(Item[V]):
     @property
     def values(self) -> List[str]:
         """List[:class:`str`]: A list of values that have been selected by the user."""
-        return selected_values.get()
+        values = selected_values.get()
+        return values if values is not None else []
 
     @property
     def width(self) -> int:


### PR DESCRIPTION
## Summary

This fixes race conditions that can occur when you don't immediately copy `.values` in a `Select`'s callback.

Using this code for testing:
```py
class MyView(View):
    @select(options=[SelectOption(label='one'), SelectOption(label='two')])
    async def myselect(self, itx: Interaction, select: Select):
        before_sleep = select.values[:]
        await itx.response.defer()
        await asyncio.sleep(5)
        after_sleep = select.values[:]
        await itx.followup.send(f'{before_sleep = }\n{after_sleep = }')


class TestCog(commands.Cog):
    @commands.command()
    async def test(self, ctx: commands.Context):
        await ctx.send(view=MyView())
```
Select one option then select the other within 5 seconds.
Without the patch, `after_sleep` will be the second option selected.
With this patch, `after_sleep` will remain the same as `before_sleep`.

Excuse compact mode, just want to keep these short.
First without patch, second with:
![image](https://user-images.githubusercontent.com/8661717/173128201-35c4ed37-a637-4a52-842b-127e3903cd4c.png)![image](https://user-images.githubusercontent.com/8661717/173128218-1721f83b-ba8f-4af7-b142-c900029dedde.png)

Selects still work as expected in modals.

Only foreseen issue is that if you use selects as a way to "store" choices, like with a "confirm" button, those choices would not be available if accessed from the button's callback. The select callback would need to cache the choices. This is also true currently if the view message is not ephemeral, as anyone could affect the Select's values.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
