### PR TITLE
Handle special case of the default role in Role.mention

### DIFF
--- a/discord/role.py
+++ b/discord/role.py
@@ -341,7 +341,14 @@ class Role(Hashable):
 
     @property
     def mention(self) -> str:
-        """:class:`str`: Returns a string that allows you to mention a role."""
+        """:class:`str`: Returns a string that allows you to mention a role.
+
+        .. versionchanged:: 2.0
+            Mentioning the :attr:`~Guild.default_role` will now return ``@everyone`` instead of ``<@&{role_id}>``.
+
+        """
+        if self.is_default():
+            return '@everyone'
         return f'<@&{self.id}>'
 
     @property


### PR DESCRIPTION
## Summary

Make pinging the guild's default role return ``@everyone`` instead of ``<@&role_id>``, so it actually pings.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
