### PR TITLE
Make `app_commands.Command` and others comparable with `AppCommand(Group)`

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -542,7 +542,6 @@ class Command(Generic[GroupT, P, T]):
             # always returns True if the command is a guild command
             # so we need to change it to match the behavior of the API
             # for this comparison.
-            # otherwise it is handled correctly.
             cls_to_dict = self.to_dict()
             if self._guild_ids is not None:
                 cls_to_dict['dm_permission'] = True
@@ -551,8 +550,8 @@ class Command(Generic[GroupT, P, T]):
         else:
             return False
 
-    def __ne__(self, other: object) -> bool:
-        return not self.__eq__(other)
+    def __hash__(self) -> int:
+        return hash(self.to_dict().values())
 
     def __set_name__(self, owner: Type[Any], name: str) -> None:
         self._attr = name
@@ -1000,8 +999,8 @@ class ContextMenu:
         else:
             return False
 
-    def __ne__(self, other: object) -> bool:
-        return not self.__eq__(other)
+    def __hash__(self) -> int:
+        return hash(self.to_dict().values())
 
     @property
     def callback(self) -> ContextMenuCallback:
@@ -1288,8 +1287,8 @@ class Group:
         else:
             return False
 
-    def __ne__(self, other: object) -> bool:
-        return not self.__eq__(other)
+    def __hash__(self) -> int:
+        return hash(self.to_dict().values())
 
     def __set_name__(self, owner: Type[Any], name: str) -> None:
         self._attr = name

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -745,6 +745,14 @@ class Argument:
         A list of choices for the command to choose from for this argument.
     parent: Union[:class:`AppCommand`, :class:`AppCommandGroup`]
         The parent application command that has this argument.
+    channel_types: List[:class:`~discord.ChannelType`]
+        The channel types that are allowed for this parameter.
+    min_value: Optional[Union[:class:`int`, :class:`float`]]
+        The minimum supported value for this parameter.
+    max_value: Optional[Union[:class:`int`, :class:`float`]]
+        The maximum supported value for this parameter.
+    autocomplete: :class:`bool`
+        Whether the argument has autocomplete.
     """
 
     __slots__ = (
@@ -753,6 +761,10 @@ class Argument:
         'description',
         'required',
         'choices',
+        'channel_types',
+        'min_value',
+        'max_value',
+        'autocomplete',
         'parent',
         '_state',
     )
@@ -772,6 +784,10 @@ class Argument:
         self.name: str = data['name']
         self.description: str = data['description']
         self.required: bool = data.get('required', False)
+        self.min_value: Optional[Union[int, float]] = data.get('min_value')
+        self.max_value: Optional[Union[int, float]] = data.get('max_value')
+        self.autocomplete: bool = data.get('autocomplete', False)
+        self.channel_types: List[ChannelType] = [try_enum(ChannelType, d) for d in data.get('channel_types', [])]
         self.choices: List[Choice[Union[int, float, str]]] = [
             Choice(name=d['name'], value=d['value']) for d in data.get('choices', [])
         ]

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -201,28 +201,38 @@ class AppCommand(Hashable):
         self.dm_permission: bool = dm_permission
         self.nsfw: bool = data.get('nsfw', False)
 
-    def to_comparison_dict(self) -> ApplicationCommandPayload:
+    def to_comparison_dict(self) -> Dict[str, Any]:
         base = {
             'type': self.type.value,
             'name': self.name,
-            'description': self.description,
-            'options': [opt.to_dict() for opt in self.options],
             'nsfw': self.nsfw,
             'default_member_permissions': self.default_member_permissions and self.default_member_permissions.value,
             'dm_permission': self.dm_permission,
         }
-        # context menus don't support this.
-        if self.type in (AppCommandType.user, AppCommandType.message):
-            del base['options']
-            del base['description']
+        if self.type not in (AppCommandType.user, AppCommandType.message):
+            base['options'] = [opt.to_dict() for opt in self.options]
+            base['description'] = self.description
 
-        return base  # type: ignore # Type checker does not understand this literal.
+        return base
 
     def __str__(self) -> str:
         return self.name
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} id={self.id!r} name={self.name!r} type={self.type!r}>'
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, self.__class__):
+            return super().__eq__(other)
+        return NotImplemented
+
+    def __ne__(self, other: object) -> bool:
+        if isinstance(other, self.__class__):
+            return super().__ne__(other)
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return self.id >> 22
 
     @property
     def guild(self) -> Optional[Guild]:

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -206,7 +206,7 @@ class AppCommand(Hashable):
             'type': self.type.value,
             'name': self.name,
             'description': self.description,
-            'options': [opt.to_dict() for opt in self.options],
+            'options': [opt.to_comparison_dict() for opt in self.options],
             'nsfw': self.nsfw,
             'default_member_permissions': self.default_member_permissions and self.default_member_permissions.value,
             'dm_permission': self.dm_permission,
@@ -799,7 +799,7 @@ class Argument:
             Choice(name=d['name'], value=d['value']) for d in data.get('choices', [])
         ]
 
-    def to_dict(self) -> ApplicationCommandOption:
+    def to_comparison_dict(self) -> ApplicationCommandOption:
         base = {'name': self.name, 'type': self.type.value, 'description': self.description, 'required': self.required}
         if self.choices:
             base['choices'] = [choice.to_dict() for choice in self.choices]
@@ -861,12 +861,12 @@ class AppCommandGroup:
             app_command_option_factory(data=d, parent=self, state=self._state) for d in data.get('options', [])
         ]
 
-    def to_dict(self) -> 'ApplicationCommandOption':
+    def to_comparison_dict(self) -> 'ApplicationCommandOption':
         return {
             'name': self.name,
             'type': self.type.value,
             'description': self.description,
-            'options': [arg.to_dict() for arg in self.options],
+            'options': [arg.to_comparison_dict() for arg in self.options],
         }  # type: ignore # Type checker does not understand this literal.
 
 

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -799,6 +799,10 @@ class Argument:
             'description': self.description,
             'required': self.required,
             'choices': [choice.to_dict() for choice in self.choices],
+            'channel_types': [channel_type.value for channel_type in self.channel_types],
+            'min_value': self.min_value,
+            'max_value': self.max_value,
+            'autocomplete': self.autocomplete,
             'options': [],
         }  # type: ignore # Type checker does not understand this literal.
 

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -206,7 +206,7 @@ class AppCommand(Hashable):
             'type': self.type.value,
             'name': self.name,
             'description': self.description,
-            'options': [opt.to_comparison_dict() for opt in self.options],
+            'options': [opt.to_dict() for opt in self.options],
             'nsfw': self.nsfw,
             'default_member_permissions': self.default_member_permissions and self.default_member_permissions.value,
             'dm_permission': self.dm_permission,
@@ -799,7 +799,7 @@ class Argument:
             Choice(name=d['name'], value=d['value']) for d in data.get('choices', [])
         ]
 
-    def to_comparison_dict(self) -> ApplicationCommandOption:
+    def to_dict(self) -> ApplicationCommandOption:
         base = {'name': self.name, 'type': self.type.value, 'description': self.description, 'required': self.required}
         if self.choices:
             base['choices'] = [choice.to_dict() for choice in self.choices]
@@ -861,12 +861,12 @@ class AppCommandGroup:
             app_command_option_factory(data=d, parent=self, state=self._state) for d in data.get('options', [])
         ]
 
-    def to_comparison_dict(self) -> 'ApplicationCommandOption':
+    def to_dict(self) -> 'ApplicationCommandOption':
         return {
             'name': self.name,
             'type': self.type.value,
             'description': self.description,
-            'options': [arg.to_comparison_dict() for arg in self.options],
+            'options': [arg.to_dict() for arg in self.options],
         }  # type: ignore # Type checker does not understand this literal.
 
 


### PR DESCRIPTION
## Summary

Fixes #7669 and resolves [card-81287257](https://github.com/Rapptz/discord.py/projects/3#card-81287257)

This PR makes it possible to compare the following classes to the `AppCommand(Group)` modals and itself:

- app_commands.Command
- app_commands.ContextMenu
- app_commands.Group

I renamed the `AppCommand`'s `.to_dict()` method to `.to_comparison_dict()` [as discussed](https://discord.com/channels/336642139381301249/603069307286454290/984789577602592829) in the [discord.py server](https://discord.com/invite/dpy)

I have tested this thoughtfully but not with every possibility but it should be fine...

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
