### PR TITLE
Fix typo and capitalizations in docs

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -1376,7 +1376,7 @@ class BotBase(GroupMixin[None]):
 
 
 class Bot(BotBase, discord.Client):
-    """Represents a discord bot.
+    """Represents a Discord bot.
 
     This class is a subclass of :class:`discord.Client` and as a result
     anything that you can do with a :class:`discord.Client` you can do with
@@ -1385,7 +1385,7 @@ class Bot(BotBase, discord.Client):
     This class also subclasses :class:`.GroupMixin` to provide the functionality
     to manage commands.
 
-    Unlike :class:`discord.Client`, This class does not require manually setting
+    Unlike :class:`discord.Client`, this class does not require manually setting
     a :class:`~discord.app_commands.CommandTree` and is automatically set upon
     instantiating the class.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1229,7 +1229,7 @@ Threads
 
 .. function:: on_raw_thread_update(payload)
 
-    Called whenever a thread is update. Unlike :func:`on_thread_update` this
+    Called whenever a thread is updated. Unlike :func:`on_thread_update` this
     is called regardless of the thread being in the internal thread cache or not.
 
     This requires :attr:`Intents.guilds` to be enabled.


### PR DESCRIPTION
## Summary

Fix capitalizations in Bot documentation and typo in on_raw_thread_update documentation.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
