### PR TITLE
Change View, Modal, and AudioPlayer to use logger instead of stderr

### DIFF
--- a/discord/player.py
+++ b/discord/player.py
@@ -24,7 +24,6 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import threading
-import traceback
 import subprocess
 import audioop
 import asyncio
@@ -709,14 +708,10 @@ class AudioPlayer(threading.Thread):
             try:
                 self.after(error)
             except Exception as exc:
-                _log.exception('Calling the after function failed.')
                 exc.__context__ = error
-                traceback.print_exception(type(exc), exc, exc.__traceback__)
+                _log.exception('Calling the after function failed.', exc_info=exc)
         elif error:
-            msg = f'Exception in voice thread {self.name}'
-            _log.exception(msg, exc_info=error)
-            print(msg, file=sys.stderr)
-            traceback.print_exception(type(error), error, error.__traceback__)
+            _log.exception('Exception in voice thread %s', self.name, exc_info=error)
 
     def stop(self) -> None:
         self._end.set()

--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -27,8 +27,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import sys
-import traceback
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, ClassVar, List
 
@@ -154,7 +152,7 @@ class Modal(View):
         A callback that is called when :meth:`on_submit`
         fails with an error.
 
-        The default implementation prints the traceback to stderr.
+        The default implementation logs to the library logger.
 
         Parameters
         -----------
@@ -163,8 +161,7 @@ class Modal(View):
         error: :class:`Exception`
             The exception that was raised.
         """
-        print(f'Ignoring exception in modal {self}:', file=sys.stderr)
-        traceback.print_exception(error.__class__, error, error.__traceback__, file=sys.stderr)
+        _log.error('Ignoring exception in modal %r:', self, exc_info=error)
 
     def _refresh(self, components: Sequence[ModalSubmitComponentInteractionDataPayload]) -> None:
         for component in components:

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -27,7 +27,6 @@ from typing import Any, Callable, ClassVar, Coroutine, Dict, Iterator, List, Opt
 from functools import partial
 from itertools import groupby
 
-import traceback
 import asyncio
 import logging
 import sys
@@ -388,7 +387,7 @@ class View:
         A callback that is called when an item's callback or :meth:`interaction_check`
         fails with an error.
 
-        The default implementation prints the traceback to stderr.
+        The default implementation logs to the library logger.
 
         Parameters
         -----------
@@ -399,8 +398,7 @@ class View:
         item: :class:`Item`
             The item that failed the dispatch.
         """
-        print(f'Ignoring exception in view {self} for item {item}:', file=sys.stderr)
-        traceback.print_exception(error.__class__, error, error.__traceback__, file=sys.stderr)
+        _log.error('Ignoring exception in view %r for item %r', self, item, exc_info=error)
 
     async def _scheduled_task(self, item: Item, interaction: Interaction):
         try:

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -572,7 +572,10 @@ class VoiceClient(VoiceProtocol):
 
         If an error happens while the audio player is running, the exception is
         caught and the audio player is then stopped.  If no after callback is
-        passed, any caught exception will be displayed as if it were raised.
+        passed, any caught exception will be logged using the library logger.
+
+        .. versionchanged:: 2.0
+            Instead of writing to ``sys.stderr``, the library's logger is used.
 
         Parameters
         -----------

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -941,6 +941,7 @@ The library now provides a default logging configuration if using :meth:`Client.
 - :meth:`Client.on_error`
 - :meth:`discord.ext.tasks.Loop.error`
 - :meth:`discord.ext.commands.Bot.on_command_error`
+- :meth:`VoiceClient.play`
 
 For more information, check :doc:`logging`.
 


### PR DESCRIPTION
## Summary

In 53685b9b86cbd56b5c53f0645d9e9893eb8cf69e on_error on various objects was changed to use logging instead of printing to stderr, but it seems like a couple places were forgotten.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
      - View and Modal were introduced in 2.0 so nothing to document there.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
