### PR TITLE
Add documetation for auto_moderation_action MessageType enum

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1589,6 +1589,12 @@ of :class:`enum.Enum`.
         The system message denoting that a context menu command was executed.
 
         .. versionadded:: 2.0
+    .. attribute:: auto_moderation_action
+
+        The system message sent when an AutoMod rule is triggered. This is only
+        sent if the rule is configured to sent an alert when triggered.
+
+        .. versionadded:: 2.0
 
 .. class:: UserFlags
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This adds documentation for the auto_moderation_action MessageType enum that was added in https://github.com/Rapptz/discord.py/pull/8159

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
