### PR TITLE
Add support for harmful_link automod triggers

### DIFF
--- a/discord/automod.py
+++ b/discord/automod.py
@@ -130,6 +130,7 @@ class AutoModTrigger:
     def __init__(
         self,
         *,
+        type: Optional[AutoModRuleTriggerType] = None,
         keyword_filter: Optional[List[str]] = None,
         presets: Optional[AutoModPresets] = None,
     ) -> None:
@@ -138,18 +139,24 @@ class AutoModTrigger:
         if keyword_filter and presets:
             raise ValueError('Please pass only one of keyword_filter or presets.')
 
-        if self.keyword_filter is not None:
+        if type is not None:
+            self.type = type
+        elif self.keyword_filter is not None:
             self.type = AutoModRuleTriggerType.keyword
-        else:
+        elif self.presets is not None:
             self.type = AutoModRuleTriggerType.keyword_preset
+        else:
+            raise ValueError('Please pass the trigger type explicitly if not using keyword_filter or presets.')
 
     @classmethod
     def from_data(cls, type: int, data: Optional[AutoModerationTriggerMetadataPayload]) -> Self:
         type_ = try_enum(AutoModRuleTriggerType, type)
         if type_ is AutoModRuleTriggerType.keyword:
             return cls(keyword_filter=data['keyword_filter'])  # type: ignore # unable to typeguard due to outer payload
-        else:
+        elif type_ is AutoModRuleTriggerType.keyword_preset:
             return cls(presets=AutoModPresets._from_value(data['presets']))  # type: ignore # unable to typeguard due to outer payload
+        else:
+            return cls(type=type_)
 
     def to_metadata_dict(self) -> Dict[str, Any]:
         if self.keyword_filter is not None:


### PR DESCRIPTION
## Summary

Previously, when `guild.fetch_automod_rules()` was used in a guild with a 'harmful link' automod rule, it raised this exception:

```
  File "/tmp/nqn_common/nqn_common/stores/blocked_emotes.py", line 114, in _get_automod_rule
    automod_rules = await guild.fetch_automod_rules()
  File "/usr/local/lib/python3.9/site-packages/discord/guild.py", line 3891, in fetch_automod_rules
    return [AutoModRule(data=d, guild=self, state=self._state) for d in data]
  File "/usr/local/lib/python3.9/site-packages/discord/guild.py", line 3891, in <listcomp>
    return [AutoModRule(data=d, guild=self, state=self._state) for d in data]
  File "/usr/local/lib/python3.9/site-packages/discord/automod.py", line 212, in __init__
    self.trigger: AutoModTrigger = AutoModTrigger.from_data(data['trigger_type'], data=data.get('trigger_metadata'))
  File "/usr/local/lib/python3.9/site-packages/discord/automod.py", line 152, in from_data
    return cls(presets=AutoModPresets._from_value(data['presets']))  # type: ignore # unable to typeguard due to outer payload
KeyError: 'presets'
```

 This PR adds an explicit `type` parameter to `AutoModTrigger`, which is used to deserialise automod rules without any keyword_filter or presets. It can also be used to create harmful_link and spam trigger types, but I've only tested harmful_link creation. (I don't have access to a guild with spam enabled)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. 
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
