### PR TITLE
Support unicode emojis in PartialEmojiConverter

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -771,8 +771,13 @@ class PartialEmojiConverter(Converter[discord.PartialEmoji]):
 
     This is done by extracting the animated flag, name and ID from the emoji.
 
+    If the emoji is a unicode emoji, then the name is the unicode character.
+
     .. versionchanged:: 1.5
          Raise :exc:`.PartialEmojiConversionFailure` instead of generic :exc:`.BadArgument`
+
+    .. versionchanged:: 2.0
+        Add support for converting unicode emojis
     """
 
     async def convert(self, ctx: Context[BotT], argument: str) -> discord.PartialEmoji:
@@ -786,6 +791,10 @@ class PartialEmojiConverter(Converter[discord.PartialEmoji]):
             return discord.PartialEmoji.with_state(
                 ctx.bot._connection, animated=emoji_animated, name=emoji_name, id=emoji_id
             )
+
+        # If the emoji is a unicode emoji, then the name is the unicode character.
+        if re.match(r'^[\u0023-\u0039]?[\u00ae\u00a9\U00002000-\U0010ffff]+$', argument):
+            return discord.PartialEmoji.with_state(ctx.bot._connection, name=argument)
 
         raise PartialEmojiConversionFailure(argument)
 

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -1445,6 +1445,7 @@ Miscellaneous Changes
 - :meth:`ext.commands.Cog.cog_load` has been added as part of the :ref:`migrating_2_0_commands_extension_cog_async` changes.
 - :meth:`ext.commands.Cog.cog_unload` may now be a :term:`coroutine` due to the :ref:`migrating_2_0_commands_extension_cog_async` changes.
 - :attr:`ext.commands.Command.clean_params` type now uses a custom :class:`inspect.Parameter` to handle defaults.
+- :class:`ext.commands.PartialEmojiConverter` can now return a :class:`PartialEmoji` representing a unicode emoji.
 
 .. _migrating_2_0_tasks:
 


### PR DESCRIPTION
## Summary

Previously only custom emojis worked with `PartialEmojiConverter`. An exception would be raised:

`discord.ext.commands.errors.PartialEmojiConversionFailure: Couldn't convert "⏹️" to PartialEmoji.`

This adds support for all kinds of unicode emojis.

Note: The regex is a bit loose but all emojis are covered by the regex.

Test code:

```py
@bot.command()
async def test(ctx: commands.Context[commands.Bot], emoji: discord.PartialEmoji):
    await ctx.message.add_reaction(emoji)
```

![image](https://user-images.githubusercontent.com/20955511/175830618-8e450a74-328c-4e8f-b2f9-b478b1324472.png)

The regex has been tested for correctness using a third-party [emoji](https://pypi.org/project/emoji/) package:

```py
from emoji import UNICODE_EMOJI
import re
# output should be empty
print(*["" if re.match(r"^[\u0023-\u0039]?[\u00ae\u00a9\U00002000-\U0010ffff]+$", argument) else f"{argument} {[hex(ord(c)) for c in argument]}\n" for argument in UNICODE_EMOJI['en']], sep="")
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
