### PR TITLE
Fix audit log for multiple app command permission updates

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -276,19 +276,17 @@ class AuditLogChanges:
             self.after.app_command_permissions = []
 
             for elem in data:
-                old_value = self._handle_app_command_permissions(
+                self._handle_app_command_permissions(
+                    self.before,
                     entry,
                     elem.get('old_value'),  # type: ignore # value will be an ApplicationCommandPermissions if present
                 )
-                if old_value is not None:
-                    self.before.app_command_permissions.append(old_value)
 
-                new_value = self._handle_app_command_permissions(
+                self._handle_app_command_permissions(
+                    self.after,
                     entry,
                     elem.get('new_value'),  # type: ignore # value will be an ApplicationCommandPermissions if present
                 )
-                if new_value is not None:
-                    self.after.app_command_permissions.append(new_value)
             return
 
         for elem in data:
@@ -364,18 +362,19 @@ class AuditLogChanges:
 
     def _handle_app_command_permissions(
         self,
+        diff: AuditLogDiff,
         entry: AuditLogEntry,
         data: Optional[ApplicationCommandPermissions],
-    ) -> Optional[AppCommandPermissions]:
+    ):
         if data is None:
-            return None
+            return
 
         # avoid circular import
         from discord.app_commands import AppCommandPermissions
 
         state = entry._state
         guild = entry.guild
-        return AppCommandPermissions(data=data, guild=guild, state=state)
+        diff.app_command_permissions.append(AppCommandPermissions(data=data, guild=guild, state=state))
 
 
 class _AuditLogProxy:

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -98,20 +98,6 @@ def _transform_snowflake(entry: AuditLogEntry, data: Snowflake) -> int:
     return int(data)
 
 
-def _transform_app_command_permissions(
-    entry: AuditLogEntry, data: ApplicationCommandPermissions
-) -> Optional[AppCommandPermissions]:
-    # avoid circular import
-    from discord.app_commands.models import AppCommandPermissions
-
-    if data is None:
-        return None
-
-    state = entry._state
-    guild = entry.guild
-    return AppCommandPermissions(data=data, guild=guild, state=state)
-
-
 def _transform_channel(entry: AuditLogEntry, data: Optional[Snowflake]) -> Optional[Union[abc.GuildChannel, Object]]:
     if data is None:
         return None
@@ -275,7 +261,6 @@ class AuditLogChanges:
         'entity_type':                   (None, _enum_transformer(enums.EntityType)),
         'preferred_locale':              (None, _enum_transformer(enums.Locale)),
         'image_hash':                    ('cover_image', _transform_cover_image),
-        'app_command_permission_update': ('app_command_permissions', _transform_app_command_permissions),
         'trigger_type':                  (None, _enum_transformer(enums.AutoModRuleTriggerType)),
     }
     # fmt: on
@@ -283,15 +268,31 @@ class AuditLogChanges:
     def __init__(self, entry: AuditLogEntry, data: List[AuditLogChangePayload]):
         self.before: AuditLogDiff = AuditLogDiff()
         self.after: AuditLogDiff = AuditLogDiff()
+        # special case entire process since each
+        # element in data is a different target
+        # key is the target id
+        if entry.action is enums.AuditLogAction.app_command_permission_update:
+            self.before.app_command_permissions = []
+            self.after.app_command_permissions = []
+
+            for elem in data:
+                old_value = self._handle_app_command_permissions(
+                    entry,
+                    elem.get('old_value'),  # type: ignore # value will be an ApplicationCommandPermissions if present
+                )
+                if old_value is not None:
+                    self.before.app_command_permissions.append(old_value)
+
+                new_value = self._handle_app_command_permissions(
+                    entry,
+                    elem.get('new_value'),  # type: ignore # value will be an ApplicationCommandPermissions if present
+                )
+                if new_value is not None:
+                    self.after.app_command_permissions.append(new_value)
+            return
 
         for elem in data:
-            # special case entire process since each
-            # element in data is a different target
-            # key is the target id
-            if entry.action is enums.AuditLogAction.app_command_permission_update:
-                attr = entry.action.name
-            else:
-                attr = elem['key']
+            attr = elem['key']
 
             # special cases for role add/remove
             if attr == '$add':
@@ -360,6 +361,21 @@ class AuditLogChanges:
             data.append(role)
 
         setattr(second, 'roles', data)
+
+    def _handle_app_command_permissions(
+        self,
+        entry: AuditLogEntry,
+        data: Optional[ApplicationCommandPermissions],
+    ) -> Optional[AppCommandPermissions]:
+        if data is None:
+            return None
+
+        # avoid circular import
+        from discord.app_commands import AppCommandPermissions
+
+        state = entry._state
+        guild = entry.guild
+        return AppCommandPermissions(data=data, guild=guild, state=state)
 
 
 class _AuditLogProxy:

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -67,7 +67,7 @@ if TYPE_CHECKING:
     from .sticker import GuildSticker
     from .threads import Thread
     from .integrations import PartialIntegration
-    from .app_commands import AppCommand, AppCommandPermissions
+    from .app_commands import AppCommand
 
     TargetType = Union[
         Guild,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3720,9 +3720,9 @@ AuditLogDiff
 
     .. attribute:: app_command_permissions
 
-        The permissions of the app command.
+        List of permissions for the app command.
 
-        :type: :class:`~discord.app_commands.AppCommandPermissions`
+        :type: List[:class:`~discord.app_commands.AppCommandPermissions`]
 
     .. attribute:: enabled
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fix `AuditLogDiff.app_command_permissions` being a single permission when multiple could have been updated
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
