### PR TITLE
Add built-in check for Interaction.app_permissions

### DIFF
--- a/discord/app_commands/checks.py
+++ b/discord/app_commands/checks.py
@@ -45,6 +45,7 @@ from .errors import (
     MissingAnyRole,
     MissingPermissions,
     BotMissingPermissions,
+    MissingInteractionPermissions,
     CommandOnCooldown,
 )
 

--- a/discord/app_commands/errors.py
+++ b/discord/app_commands/errors.py
@@ -271,6 +271,33 @@ class BotMissingPermissions(CheckFailure):
         super().__init__(message, *args)
 
 
+class MissingInteractionPermissions(CheckFailure):
+    """An exception raised when the application or bot lacks permissions for the current interaction to run a
+    command.
+
+    This inherits from :exc:`~discord.app_commands.CheckFailure`.
+
+    .. versionadded:: 2.0
+
+    Attributes
+    -----------
+    missing_permissions: List[:class:`str`]
+        The required permissions that are missing.
+    """
+
+    def __init__(self, missing_permissions: List[str], *args: Any) -> None:
+        self.missing_permissions: List[str] = missing_permissions
+
+        missing = [perm.replace('_', ' ').replace('guild', 'server').title() for perm in missing_permissions]
+
+        if len(missing) > 2:
+            fmt = '{}, and {}'.format(", ".join(missing[:-1]), missing[-1])
+        else:
+            fmt = ' and '.join(missing)
+        message = f'Application or Bot requires {fmt} permission(s) for the current interaction to run this command.'
+        super().__init__(message, *args)
+
+
 class CommandOnCooldown(CheckFailure):
     """An exception raised when the command being invoked is on cooldown.
 

--- a/discord/app_commands/errors.py
+++ b/discord/app_commands/errors.py
@@ -44,6 +44,7 @@ __all__ = (
     'MissingAnyRole',
     'MissingPermissions',
     'BotMissingPermissions',
+    'MissingInteractionPermissions',
     'CommandOnCooldown',
     'MissingApplicationID',
 )

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -625,6 +625,9 @@ Exceptions
 
 .. autoexception:: discord.app_commands.BotMissingPermissions
     :members:
+    
+.. autoexception:: discord.app_commands.MissingInteractionPermissions
+    :members:
 
 .. autoexception:: discord.app_commands.CommandOnCooldown
     :members:
@@ -659,6 +662,7 @@ Exception Hierarchy
                 - :exc:`~discord.app_commands.MissingAnyRole`
                 - :exc:`~discord.app_commands.MissingPermissions`
                 - :exc:`~discord.app_commands.BotMissingPermissions`
+                - :exc:`~discord.app_commands.MissingInteractionPermissions`
                 - :exc:`~discord.app_commands.CommandOnCooldown`
             - :exc:`~discord.app_commands.CommandLimitReached`
             - :exc:`~discord.app_commands.CommandAlreadyRegistered`


### PR DESCRIPTION
## Summary

This pr adds a check for the new `Interaction.app_permissions` attribute.

Am not sure about the naming. `app_has_permissions` was a bit weird and didn't stated the use-case clear enough. Feel free to suggest any changes related to naming.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
