### PR TITLE
(GitHub CI) Bump crowdin_download workflow versions

### DIFF
--- a/.github/workflows/crowdin_download.yml
+++ b/.github/workflows/crowdin_download.yml
@@ -26,7 +26,7 @@ jobs:
     environment: Crowdin
     name: download
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: master
@@ -48,7 +48,7 @@ jobs:
 
       - name: Create pull request
         id: cpr_crowdin
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Crowdin translations download
@@ -59,7 +59,7 @@ jobs:
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
 
       - name: Close and reopen the PR with different token to trigger CI
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         env:
           PR_NUMBER: ${{ steps.cpr_crowdin.outputs.pull-request-number }}
           PR_OPERATION: ${{ steps.cpr_crowdin.outputs.pull-request-operation }}


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This pull request will bump versions in the crowdin_download workflow file for example for actions/checkout from version 2 to version 3.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
