### PR TITLE
Add automod types to audit log

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -63,11 +63,7 @@ if TYPE_CHECKING:
     from .types.role import Role as RolePayload
     from .types.snowflake import Snowflake
     from .types.command import ApplicationCommandPermissions
-    from .types.automod import (
-        AutoModerationTriggerMetadata,
-        AutoModerationAction,
-        _AutoModerationTriggerMetadataKeywordPreset,
-    )
+    from .types.automod import AutoModerationTriggerMetadata, AutoModerationAction
     from .user import User
     from .stage_instance import StageInstance
     from .sticker import GuildSticker
@@ -89,6 +85,7 @@ if TYPE_CHECKING:
         Thread,
         Object,
         PartialIntegration,
+        AutoModRule,
         None,
     ]
 

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -33,6 +33,7 @@ from .invite import Invite
 from .mixins import Hashable
 from .object import Object
 from .permissions import PermissionOverwrite, Permissions
+from .automod import AutoModTrigger, AutoModRuleAction, AutoModPresets
 
 __all__ = (
     'AuditLogDiff',
@@ -62,12 +63,18 @@ if TYPE_CHECKING:
     from .types.role import Role as RolePayload
     from .types.snowflake import Snowflake
     from .types.command import ApplicationCommandPermissions
+    from .types.automod import (
+        AutoModerationTriggerMetadata,
+        AutoModerationAction,
+        _AutoModerationTriggerMetadataKeywordPreset,
+    )
     from .user import User
     from .stage_instance import StageInstance
     from .sticker import GuildSticker
     from .threads import Thread
     from .integrations import PartialIntegration
     from .app_commands import AppCommand
+    from .automod import AutoModRule, AutoModTrigger
 
     TargetType = Union[
         Guild,
@@ -104,6 +111,12 @@ def _transform_channel(entry: AuditLogEntry, data: Optional[Snowflake]) -> Optio
     return entry.guild.get_channel(int(data)) or Object(id=data)
 
 
+def _transform_channels_or_threads(
+    entry: AuditLogEntry, data: List[Snowflake]
+) -> List[Union[abc.GuildChannel, Thread, Object]]:
+    return [entry.guild.get_channel_or_thread(int(data)) or Object(id=data) for data in data]
+
+
 def _transform_member_id(entry: AuditLogEntry, data: Optional[Snowflake]) -> Union[Member, User, None]:
     if data is None:
         return None
@@ -114,6 +127,10 @@ def _transform_guild_id(entry: AuditLogEntry, data: Optional[Snowflake]) -> Opti
     if data is None:
         return None
     return entry._state._get_guild(int(data))
+
+
+def _transform_roles(entry: AuditLogEntry, data: List[Snowflake]) -> List[Union[Role, Object]]:
+    return [entry.guild.get_role(int(role_id)) or Object(role_id) for role_id in data]
 
 
 def _transform_overwrites(
@@ -169,6 +186,24 @@ def _guild_hash_transformer(path: str) -> Callable[[AuditLogEntry, Optional[str]
         return Asset._from_guild_image(entry._state, entry.guild.id, data, path=path)
 
     return _transform
+
+
+def _transform_automod_trigger_metadata(
+    entry: AuditLogEntry, data: AutoModerationTriggerMetadata
+) -> Optional[AutoModTrigger]:
+    if data is None:
+        return None
+
+    # discord doesn't provide the type of the trigger
+    # have to infer from the data and present keys
+    if 'presets' in data:
+        return AutoModTrigger(presets=AutoModPresets._from_value(data['presets']))  # type: ignore
+
+    return AutoModTrigger(**data)
+
+
+def _transform_automod_actions(entry: AuditLogEntry, data: List[AutoModerationAction]) -> List[AutoModRuleAction]:
+    return [AutoModRuleAction.from_data(action) for action in data]
 
 
 E = TypeVar('E', bound=enums.Enum)
@@ -262,6 +297,11 @@ class AuditLogChanges:
         'preferred_locale':              (None, _enum_transformer(enums.Locale)),
         'image_hash':                    ('cover_image', _transform_cover_image),
         'trigger_type':                  (None, _enum_transformer(enums.AutoModRuleTriggerType)),
+        'event_type':                    (None, _enum_transformer(enums.AutoModRuleEventType)),
+        'trigger_metadata':              ('trigger', _transform_automod_trigger_metadata),
+        'actions':                       (None, _transform_automod_actions),
+        'exempt_channels':               (None, _transform_channels_or_threads),
+        'exempt_roles':                  (None, _transform_roles),
     }
     # fmt: on
 
@@ -465,6 +505,7 @@ class AuditLogEntry(Hashable):
         users: Dict[int, User],
         integrations: Dict[int, PartialIntegration],
         app_commands: Dict[int, AppCommand],
+        automod_rules: Dict[int, AutoModRule],
         data: AuditLogEntryPayload,
         guild: Guild,
     ):
@@ -473,6 +514,7 @@ class AuditLogEntry(Hashable):
         self._users: Dict[int, User] = users
         self._integrations: Dict[int, PartialIntegration] = integrations
         self._app_commands: Dict[int, AppCommand] = app_commands
+        self._automod_rules: Dict[int, AutoModRule] = automod_rules
         self._from_data(data)
 
     def _from_data(self, data: AuditLogEntryPayload) -> None:
@@ -694,5 +736,5 @@ class AuditLogEntry(Hashable):
     def _convert_target_integration_or_app_command(self, target_id: int) -> Union[PartialIntegration, AppCommand, Object]:
         return self._get_integration_by_app_id(target_id) or self._get_app_command(target_id) or Object(target_id)
 
-    def _convert_target_auto_moderation(self, target_id: int) -> Union[Member, Object]:
-        return self.guild.get_member(target_id) or Object(target_id)
+    def _convert_target_auto_moderation(self, target_id: int) -> Union[AutoModRule, Object]:
+        return self._automod_rules.get(target_id) or Object(target_id)

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -463,7 +463,7 @@ class AutoModAction:
     def channel(self) -> Optional[Union[GuildChannel, Thread]]:
         """Optional[Union[:class:`abc.GuildChannel`, :class:`Thread`]]: The channel this action was taken in."""
         if self.channel_id:
-            return self.guild.get_channel(self.channel_id)
+            return self.guild.get_channel_or_thread(self.channel_id)
         return None
 
     @property

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -66,7 +66,7 @@ class AutoModRuleAction:
     type: :class:`AutoModRuleActionType`
         The type of action to take.
     channel_id: Optional[:class:`int`]
-        The ID of the channel to send the alert message to, if any.
+        The ID of the channel or thread to send the alert message to, if any.
     duration: Optional[:class:`datetime.timedelta`]
         The duration of the timeout to apply, if any.
         Has a maximum of 28 days.

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -452,8 +452,10 @@ class AuditLogAction(Enum):
             return 'thread'
         elif v < 122:
             return 'integration_or_app_command'
-        elif v < 144:
+        elif v < 143:
             return 'auto_moderation'
+        elif v == 143:
+            return 'user'
 
 
 class UserFlags(Enum):

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3627,6 +3627,12 @@ class Guild(Hashable):
             app_commands = (AppCommand(data=raw_cmd, state=self._state) for raw_cmd in data.get('application_commands', []))
             app_command_map = {app_command.id: app_command for app_command in app_commands}
 
+            automod_rules = (
+                AutoModRule(data=raw_rule, guild=self, state=self._state)
+                for raw_rule in data.get('auto_moderation_rules', [])
+            )
+            automod_rule_map = {rule.id: rule for rule in automod_rules}
+
             for raw_entry in raw_entries:
                 # Weird Discord quirk
                 if raw_entry['action_type'] is None:
@@ -3637,6 +3643,7 @@ class Guild(Hashable):
                     users=user_map,
                     integrations=integration_map,
                     app_commands=app_command_map,
+                    automod_rules=automod_rule_map,
                     guild=self,
                 )
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2583,7 +2583,8 @@ of :class:`enum.Enum`.
         An automod rule was created.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        a :class:`Object` with the ID of the automod rule that was created.
+        a :class:`AutoModRule` or :class:`Object` with the ID of the automod
+        rule that was created.
 
         Possible attributes for :class:`AuditLogDiff`:
 
@@ -2591,7 +2592,7 @@ of :class:`enum.Enum`.
         - :attr:`~AuditLogDiff.enabled`
         - :attr:`~AuditLogDiff.event_type`
         - :attr:`~AuditLogDiff.trigger_type`
-        - :attr:`~AuditLogDiff.trigger_metadata`
+        - :attr:`~AuditLogDiff.trigger`
         - :attr:`~AuditLogDiff.actions`
         - :attr:`~AuditLogDiff.exempt_roles`
         - :attr:`~AuditLogDiff.exempt_channels`
@@ -2603,7 +2604,8 @@ of :class:`enum.Enum`.
         An automod rule was updated.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        a :class:`Object` with the ID of the automod rule that was updated.
+        a :class:`AutoModRule` or :class:`Object` with the ID of the automod
+        rule that was created.
 
         Possible attributes for :class:`AuditLogDiff`:
 
@@ -2611,7 +2613,7 @@ of :class:`enum.Enum`.
         - :attr:`~AuditLogDiff.enabled`
         - :attr:`~AuditLogDiff.event_type`
         - :attr:`~AuditLogDiff.trigger_type`
-        - :attr:`~AuditLogDiff.trigger_metadata`
+        - :attr:`~AuditLogDiff.trigger`
         - :attr:`~AuditLogDiff.actions`
         - :attr:`~AuditLogDiff.exempt_roles`
         - :attr:`~AuditLogDiff.exempt_channels`
@@ -2623,7 +2625,8 @@ of :class:`enum.Enum`.
         An automod rule was deleted.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        a :class:`Object` with the ID of the automod rule that was deleted.
+        a :class:`AutoModRule` or :class:`Object` with the ID of the automod
+        rule that was created.
 
         Possible attributes for :class:`AuditLogDiff`:
 
@@ -2631,7 +2634,7 @@ of :class:`enum.Enum`.
         - :attr:`~AuditLogDiff.enabled`
         - :attr:`~AuditLogDiff.event_type`
         - :attr:`~AuditLogDiff.trigger_type`
-        - :attr:`~AuditLogDiff.trigger_metadata`
+        - :attr:`~AuditLogDiff.trigger`
         - :attr:`~AuditLogDiff.actions`
         - :attr:`~AuditLogDiff.exempt_roles`
         - :attr:`~AuditLogDiff.exempt_channels`
@@ -3734,7 +3737,7 @@ AuditLogDiff
 
         The event type for triggering the automod rule.
 
-        :type: :class:`str`
+        :type: :class:`AutoModRuleEventType`
 
     .. attribute:: trigger_type
 
@@ -3742,29 +3745,29 @@ AuditLogDiff
 
         :type: :class:`AutoModRuleTriggerType`
 
-    .. attribute:: trigger_metadata
+    .. attribute:: trigger
 
-        The trigger metadata for the automod rule.
+        The trigger for the automod rule.
 
-        :type: Dict[:class:`str`, Any]
+        :type: :class:`AutoModTrigger`
 
     .. attribute:: actions
 
         The actions to take when an automod rule is triggered.
 
-        :type: List[Dict[:class:`str`, Any]]
+        :type: List[AutoModRuleAction]
 
     .. attribute:: exempt_roles
 
         The list of roles that are exempt from the automod rule.
 
-        :type: List[:class:`str`]
+        :type: List[Union[:class:`Role`, :class:`Object`]]
 
     .. attribute:: exempt_channels
 
-        The list of channels that are exempt from the automod rule.
+        The list of channels or threads that are exempt from the automod rule.
 
-        :type: List[:class:`str`]
+        :type: List[:class:`abc.GuildChannel`, :class:`Thread`, :class:`Object`]
 
 .. this is currently missing the following keys: reason and application_id
    I'm not sure how to port these


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Change automod_block_message action target type to user to match docs
Change target to the full AutoModRule object from resolved data in the auditlog entry
Changed auditlog diff attributes:
-  event_type > AutoModRuleEventType enum
-  trigger_metadata > trigger: AutoModTrigger
-  exempt_roles/exempt_channels > list[Role]/list[Union[GuildChannel, Thread]]
-  actions > list[AutoModRuleAction]


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
