### PR TITLE
Implement AppCommand mentions

### DIFF
--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -874,7 +874,7 @@ class AppCommandGroup:
             base_command = self.parent
         else:
             base_command = self.parent.parent
-        return f'</{self.qualified_name}:{base_command.id}>'
+        return f'</{self.qualified_name}:{base_command.id}>' # type: ignore
 
     def _from_data(self, data: ApplicationCommandOption) -> None:
         self.type: AppCommandOptionType = try_enum(AppCommandOptionType, data['type'])

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -218,6 +218,11 @@ class AppCommand(Hashable):
         return f'<{self.__class__.__name__} id={self.id!r} name={self.name!r} type={self.type!r}>'
 
     @property
+    def mention(self) -> str:
+        """:class:`str`: Returns a string that allows you to mention the given AppCommand."""
+        return f'</{self.name}:{self.id}>'
+
+    @property
     def guild(self) -> Optional[Guild]:
         """Optional[:class:`~discord.Guild`]: Returns the guild this command is registered to
         if it exists.
@@ -844,6 +849,32 @@ class AppCommandGroup:
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} name={self.name!r} type={self.type!r}>'
+
+    @property
+    def qualified_name(self) -> str:
+        """:class:`str`: Returns the fully qualified command name.
+
+        The qualified name includes the parent name as well. For example,
+        in a command like ``/foo bar`` the qualified name is ``foo bar``.
+        """
+        # A B C
+        #     ^ self
+        #   ^ parent
+        # ^ grandparent
+        names = [self.name, self.parent.name]
+        if isinstance(self.parent, AppCommandGroup):
+            names.append(self.parent.parent.name)
+
+        return ' '.join(reversed(names))
+
+    @property
+    def mention(self) -> str:
+        """:class:`str`: Returns a string that allows you to mention the given AppCommandGroup."""
+        if isinstance(self.parent, AppCommandGroup):
+            base_command = self.parent.parent
+        else:
+            base_command = self.parent
+        return f'</{self.qualified_name}:{base_command.id}>'
 
     def _from_data(self, data: ApplicationCommandOption) -> None:
         self.type: AppCommandOptionType = try_enum(AppCommandOptionType, data['type'])

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -870,10 +870,10 @@ class AppCommandGroup:
     @property
     def mention(self) -> str:
         """:class:`str`: Returns a string that allows you to mention the given AppCommandGroup."""
-        if isinstance(self.parent, AppCommandGroup):
-            base_command = self.parent.parent
-        else:
+        if isinstance(self.parent, AppCommand):
             base_command = self.parent
+        else:
+            base_command = self.parent.parent
         return f'</{self.qualified_name}:{base_command.id}>'
 
     def _from_data(self, data: ApplicationCommandOption) -> None:

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -874,7 +874,7 @@ class AppCommandGroup:
             base_command = self.parent
         else:
             base_command = self.parent.parent
-        return f'</{self.qualified_name}:{base_command.id}>' # type: ignore
+        return f'</{self.qualified_name}:{base_command.id}>'  # type: ignore
 
     def _from_data(self, data: ApplicationCommandOption) -> None:
         self.type: AppCommandOptionType = try_enum(AppCommandOptionType, data['type'])


### PR DESCRIPTION
## Summary

This pr implements the upcoming slash command mentions into the `AppCommand` and `AppCommandGroup` models.

It also adds `AppCommandGroup.qualified_name` as it's used for the mention and could be useful for other use-cases.

Not sure when to ship this, as it currently doesn't work on mobile yet.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
