### PR TITLE
update docs for abc.Messageable.pins()

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1614,7 +1614,7 @@ class Messageable:
         Raises
         -------
         ~discord.Forbidden
-            You do not have the permission to view this channel in order to retrieve its pinned messages.
+            You do not have the permission to retrieve pinned messages.
         ~discord.HTTPException
             Retrieving the pinned messages failed.
 

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1614,7 +1614,7 @@ class Messageable:
         Raises
         -------
         ~discord.Forbidden
-            You do not have the permission to view this channel in order to retrieve it's pinned messages.
+            You do not have the permission to view this channel in order to retrieve its pinned messages.
         ~discord.HTTPException
             Retrieving the pinned messages failed.
 

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1613,6 +1613,8 @@ class Messageable:
 
         Raises
         -------
+        ~discord.Forbidden
+            You do not have the permission to view this channel in order to retrieve it's pinned messages.
         ~discord.HTTPException
             Retrieving the pinned messages failed.
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This updates documentation for abc.Messageable.pins() method to account for `discord.Forbidden` error which is raised when the bot doesn't have permission to view the said channel in order to retrieve it's pins. Someone mentioned this in #bikeshedding in dpy server so I decided to make this PR. Please let me know your review!

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
