### PR TITLE
[Docs] Update channel.pins() exceptions

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1615,6 +1615,8 @@ class Messageable:
         -------
         ~discord.HTTPException
             Retrieving the pinned messages failed.
+        ~discord.Forbidden
+            You do not have the permissions required to get the pinned messages.
 
         Returns
         --------


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR aims to update the doccumentation for `channel.pins()`. Currently, if a bot does not have access to a channel and tries to request that channel's pins, `discord.Forbidden` is raised. This is not currently reflected in the doccumenation and so I've updated it.
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
