### PR TITLE
Add cog-level app command error special method

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -447,6 +447,7 @@ def _get_context_menu_parameter(func: ContextMenuCallback) -> Tuple[str, Any, Ap
     type = _context_menu_annotation(resolved)
     return (parameter.name, resolved, type)
 
+
 def _is_cog(obj: Any) -> TypeGuard[Cog]:
     return hasattr(obj, '__cog_commands__')
 

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -525,6 +525,25 @@ class Cog(metaclass=CogMeta):
         pass
 
     @_cog_special_method
+    async def cog_app_command_error(self, interaction: discord.Interaction, error: app_commands.AppCommandError) -> None:
+        """A special method that is called whenever an error within
+        an application command is dispatched inside this cog.
+
+        This is similar to :func:`discord.app_commands.CommandTree.on_error` except
+        only applying to the application commands inside this cog.
+
+        This **must** be a coroutine.
+
+        Parameters
+        -----------
+        interaction: :class:`~discord.Interaction`
+            The interaction that is being handled.
+        error: :exc:`~discord.app_commands.AppCommandError`
+            The exception that was raised.
+        """
+        pass
+
+    @_cog_special_method
     async def cog_before_invoke(self, ctx: Context[BotT]) -> None:
         """A special method that acts as a cog local pre-invoke hook.
 

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -28,7 +28,7 @@ import discord
 from discord import app_commands
 from discord.utils import maybe_coroutine
 
-from typing import Any, Callable, ClassVar, Dict, Generator, Iterable, List, Optional, TYPE_CHECKING, Tuple, TypeVar, Union
+from typing import Any, Callable, ClassVar, Coroutine, Dict, Generator, Iterable, List, Optional, TYPE_CHECKING, Tuple, TypeVar, Union
 
 from ._types import _BaseCommand, BotT
 
@@ -254,6 +254,7 @@ class Cog(metaclass=CogMeta):
     __cog_listeners__: List[Tuple[str, str]]
     __cog_is_app_commands_group__: ClassVar[bool] = False
     __cog_app_commands_group__: Optional[app_commands.Group]
+    __app_commands_error_handler__: Optional[Callable[[discord.Interaction, app_commands.AppCommandError], Coroutine[Any, Any, None]]]
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         # For issue 426, we need to store a copy of the command objects
@@ -328,6 +329,11 @@ class Cog(metaclass=CogMeta):
                 raise TypeError('maximum number of application command children exceeded')
 
             self.__cog_app_commands_group__._children = mapping  # type: ignore  # Variance issue
+
+        if Cog._get_overridden_method(self.cog_app_command_error) is not None:
+            self.__app_commands_error_handler__ = self.cog_app_command_error
+        else:
+            self.__app_commands_error_handler__ = None
 
         return self
 

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -28,7 +28,21 @@ import discord
 from discord import app_commands
 from discord.utils import maybe_coroutine
 
-from typing import Any, Callable, ClassVar, Coroutine, Dict, Generator, Iterable, List, Optional, TYPE_CHECKING, Tuple, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Coroutine,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    TYPE_CHECKING,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 from ._types import _BaseCommand, BotT
 
@@ -254,7 +268,9 @@ class Cog(metaclass=CogMeta):
     __cog_listeners__: List[Tuple[str, str]]
     __cog_is_app_commands_group__: ClassVar[bool] = False
     __cog_app_commands_group__: Optional[app_commands.Group]
-    __app_commands_error_handler__: Optional[Callable[[discord.Interaction, app_commands.AppCommandError], Coroutine[Any, Any, None]]]
+    __app_commands_error_handler__: Optional[
+        Callable[[discord.Interaction, app_commands.AppCommandError], Coroutine[Any, Any, None]]
+    ]
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         # For issue 426, we need to store a copy of the command objects


### PR DESCRIPTION
## Summary

Adds the `Cog.cog_app_command_error` method and resolves [card-83314413](https://github.com/Rapptz/discord.py/projects/3#card-83314413)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
