### PR TITLE
Fix docstring for AppCommand.options and AppCommandGroup.options

### DIFF
--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -145,7 +145,7 @@ class AppCommand(Hashable):
         The application command's name.
     description: :class:`str`
         The application command's description.
-    options: List[Union[:class:`AppCommand`, :class:`AppCommandGroup`]]
+    options: List[Union[:class:`Argument`, :class:`AppCommandGroup`]]
         A list of options.
     default_member_permissions: Optional[:class:`~discord.Permissions`]
         The default member permissions that can run this command.
@@ -825,7 +825,7 @@ class AppCommandGroup:
         The name of the subcommand.
     description: :class:`str`
         The description of the subcommand.
-    options: List[Union[:class:`AppCommand`, :class:`AppCommandGroup`]]
+    options: List[Union[:class:`Argument`, :class:`AppCommandGroup`]]
         A list of options.
     parent: Union[:class:`AppCommand`, :class:`AppCommandGroup`]
         The parent application command.


### PR DESCRIPTION
## Summary

This pr fixes the docstrings for `AppCommand.options` and `AppCommandGroup.options`.

Context: https://ptb.discord.com/channels/336642139381301249/603069307286454290/1001050809661919232

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
