### PR TITLE
Fix Guild.afk_channel and VoiceState.channel being None at startup

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -520,10 +520,6 @@ class Guild(Hashable):
             self._scheduled_events[scheduled_event.id] = scheduled_event
 
         self.owner_id: Optional[int] = utils._get_as_snowflake(guild, 'owner_id')
-        self.afk_channel: Optional[VocalGuildChannel] = self.get_channel(utils._get_as_snowflake(guild, 'afk_channel_id'))  # type: ignore
-
-        for obj in guild.get('voice_states', []):
-            self._update_voice_state(obj, int(obj['channel_id']))
 
         cache_joined = self._state.member_cache_flags.joined
         cache_voice = self._state.member_cache_flags.voice
@@ -535,6 +531,11 @@ class Guild(Hashable):
 
         self._sync(guild)
         self._large: Optional[bool] = None if self._member_count is None else self._member_count >= 250
+
+        self.afk_channel: Optional[VocalGuildChannel] = self.get_channel(utils._get_as_snowflake(guild, 'afk_channel_id'))  # type: ignore
+
+        for obj in guild.get('voice_states', []):
+            self._update_voice_state(obj, int(obj['channel_id']))
 
     # TODO: refactor/remove?
     def _sync(self, data: GuildPayload) -> None:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
voice states and afk_channel were created/set before guild channels were populated

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
