### PR TITLE
Fix small type in Guild.edit docstring

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1698,14 +1698,13 @@ class Guild(Hashable):
 
         Edits the guild.
 
-        You must have the :attr:`~Permissions.manage_guild` permission
-        to edit the guild.
+        You must have the :attr:`~Permissions.manage_guild` permission to edit the guild.
 
         .. versionchanged:: 1.4
-            The `rules_channel` and `public_updates_channel` keyword-only parameters were added.
+            The ``rules_channel`` and ``public_updates_channel`` keyword parameters were added.
 
         .. versionchanged:: 2.0
-            The `discovery_splash` and `community` keyword-only parameters were added.
+            The ``discovery_splash`` and `community` keyword parameters were added.
 
         .. versionchanged:: 2.0
             The newly updated guild is returned.
@@ -1721,7 +1720,7 @@ class Guild(Hashable):
             The ``preferred_locale`` keyword parameter now accepts an enum instead of :class:`str`.
 
         .. versionchanged:: 2.0
-            The `premium_progress_bar_enabled` keyword-only parameter were added.
+            The ``premium_progress_bar_enabled`` keyword parameter was added.
 
         Parameters
         ----------


### PR DESCRIPTION
## Summary

Added some missing `"``"` and "keyword-only" is not used this way anywhere in the docs so also corrected that.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
