### PR TITLE
Remove documentation for on_group_join/leave

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -288,16 +288,6 @@ Channels
     :param after: The updated guild channel's new info.
     :type after: :class:`abc.GuildChannel`
 
-.. function:: on_group_join(channel, user)
-              on_group_remove(channel, user)
-
-    Called when someone joins or leaves a :class:`GroupChannel`.
-
-    :param channel: The group that the user joined or left.
-    :type channel: :class:`GroupChannel`
-    :param user: The user that joined or left.
-    :type user: :class:`User`
-
 .. function:: on_guild_channel_pins_update(channel, last_pin)
 
     Called whenever a message is pinned or unpinned from a guild channel.


### PR DESCRIPTION
## Summary
Remove group channel events that weren't removed with the deprecation of user-bot features.

## Checklist
- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
