### PR TITLE
[commands] Add `.get_app_commands()` and `.walk_app_commands()` to Cog

### DIFF
--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -375,6 +375,17 @@ class Cog(metaclass=CogMeta):
         """
         return [c for c in self.__cog_commands__ if c.parent is None]
 
+    def get_app_commands(self) -> List[Union[app_commands.Command[Self, ..., Any], app_commands.Group]]:
+        r"""Returns the app commands that are defined inside this cog.
+
+        Returns
+        --------
+        List[Union[:class:`discord.app_commands.Command`, :class:`discord.app_commands.Group`]]
+            A :class:`list` of :class:`discord.app_commands.Command`\s and :class:`discord.app_commands.Group`\s that are
+            defined inside this cog, not including subcommands.
+        """
+        return [c for c in self.__cog_app_commands__ if c.parent is None]
+
     @property
     def qualified_name(self) -> str:
         """:class:`str`: Returns the cog's specified name, not the class name."""
@@ -388,6 +399,20 @@ class Cog(metaclass=CogMeta):
     @description.setter
     def description(self, description: str) -> None:
         self.__cog_description__ = description
+
+    def walk_app_commands(self) -> Generator[Union[app_commands.Command[Self, ..., Any], app_commands.Group], None, None]:
+        """An iterator that recursively walks through this cog's app (group)commands and subcommands.
+
+        Yields
+        ------
+        Union[:class:`discord.app_commands.Command`, :class:`discord.app_commands.Group`]
+            An app command or group from the cog.
+        """
+        for command in self.__cog_app_commands__:
+            if command.parent is None:
+                yield command
+                if isinstance(command, app_commands.Group):
+                    yield from command.walk_commands()
 
     def walk_commands(self) -> Generator[Command[Self, ..., Any], None, None]:
         """An iterator that recursively walks through this cog's commands and subcommands.

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -400,20 +400,6 @@ class Cog(metaclass=CogMeta):
     def description(self, description: str) -> None:
         self.__cog_description__ = description
 
-    def walk_app_commands(self) -> Generator[Union[app_commands.Command[Self, ..., Any], app_commands.Group], None, None]:
-        """An iterator that recursively walks through this cog's app (group)commands and subcommands.
-
-        Yields
-        ------
-        Union[:class:`discord.app_commands.Command`, :class:`discord.app_commands.Group`]
-            An app command or group from the cog.
-        """
-        for command in self.__cog_app_commands__:
-            if command.parent is None:
-                yield command
-                if isinstance(command, app_commands.Group):
-                    yield from command.walk_commands()
-
     def walk_commands(self) -> Generator[Command[Self, ..., Any], None, None]:
         """An iterator that recursively walks through this cog's commands and subcommands.
 
@@ -429,6 +415,19 @@ class Cog(metaclass=CogMeta):
                 yield command
                 if isinstance(command, GroupMixin):
                     yield from command.walk_commands()
+
+    def walk_app_commands(self) -> Generator[Union[app_commands.Command[Self, ..., Any], app_commands.Group], None, None]:
+        """An iterator that recursively walks through this cog's app commands and subcommands.
+
+        Yields
+        ------
+        Union[:class:`discord.app_commands.Command`, :class:`discord.app_commands.Group`]
+            An app command or group from the cog.
+        """
+        for command in self.__cog_app_commands__:
+            yield command
+            if isinstance(command, app_commands.Group):
+                yield from command.walk_commands()
 
     @property
     def app_command(self) -> Optional[app_commands.Group]:


### PR DESCRIPTION
## Summary

This PR adds two methods to `commands.Cog` that allows users to get the app commands defined in a Cog class.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
