### PR TITLE
Add min/max_length to Argument

### DIFF
--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -759,7 +759,7 @@ class Argument:
     min_length: Optional[:class:`int`]
         The minimum allowed length for this parameter.
     max_length: Optional[:class:`int`]
-        The maximum allowed length for this parameter.    
+        The maximum allowed length for this parameter.
     autocomplete: :class:`bool`
         Whether the argument has autocomplete.
     """

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -756,6 +756,10 @@ class Argument:
         The minimum supported value for this parameter.
     max_value: Optional[Union[:class:`int`, :class:`float`]]
         The maximum supported value for this parameter.
+    min_length: Optional[:class:`int`]
+        The minimum allowed length for this parameter.
+    max_length: Optional[:class:`int`]
+        The maximum allowed length for this parameter.    
     autocomplete: :class:`bool`
         Whether the argument has autocomplete.
     """
@@ -769,6 +773,8 @@ class Argument:
         'channel_types',
         'min_value',
         'max_value',
+        'min_length',
+        'max_length',
         'autocomplete',
         'parent',
         '_state',
@@ -791,6 +797,8 @@ class Argument:
         self.required: bool = data.get('required', False)
         self.min_value: Optional[Union[int, float]] = data.get('min_value')
         self.max_value: Optional[Union[int, float]] = data.get('max_value')
+        self.min_length: Optional[str] = data.get('min_length')
+        self.max_length: Optional[str] = data.get('max_length')
         self.autocomplete: bool = data.get('autocomplete', False)
         self.channel_types: List[ChannelType] = [try_enum(ChannelType, d) for d in data.get('channel_types', [])]
         self.choices: List[Choice[Union[int, float, str]]] = [
@@ -807,6 +815,8 @@ class Argument:
             'channel_types': [channel_type.value for channel_type in self.channel_types],
             'min_value': self.min_value,
             'max_value': self.max_value,
+            'min_length': self.min_length,
+            'max_length': self.max_length,
             'autocomplete': self.autocomplete,
             'options': [],
         }  # type: ignore # Type checker does not understand this literal.

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -797,8 +797,8 @@ class Argument:
         self.required: bool = data.get('required', False)
         self.min_value: Optional[Union[int, float]] = data.get('min_value')
         self.max_value: Optional[Union[int, float]] = data.get('max_value')
-        self.min_length: Optional[str] = data.get('min_length')
-        self.max_length: Optional[str] = data.get('max_length')
+        self.min_length: Optional[int] = data.get('min_length')
+        self.max_length: Optional[int] = data.get('max_length')
         self.autocomplete: bool = data.get('autocomplete', False)
         self.channel_types: List[ChannelType] = [try_enum(ChannelType, d) for d in data.get('channel_types', [])]
         self.choices: List[Choice[Union[int, float, str]]] = [

--- a/discord/types/command.py
+++ b/discord/types/command.py
@@ -61,8 +61,8 @@ class _StringApplicationCommandOptionChoice(TypedDict):
 class _StringApplicationCommandOption(_BaseApplicationCommandOption):
     type: Literal[3]
     choices: NotRequired[List[_StringApplicationCommandOptionChoice]]
-    min_length: int
-    max_length: int
+    min_length: NotRequired[int]
+    max_length: NotRequired[int]
     autocomplete: NotRequired[bool]
 
 

--- a/discord/types/command.py
+++ b/discord/types/command.py
@@ -61,6 +61,8 @@ class _StringApplicationCommandOptionChoice(TypedDict):
 class _StringApplicationCommandOption(_BaseApplicationCommandOption):
     type: Literal[3]
     choices: NotRequired[List[_StringApplicationCommandOptionChoice]]
+    min_length: int
+    max_length: int
     autocomplete: NotRequired[bool]
 
 


### PR DESCRIPTION
## Summary

Adds the missing `min_lenght` and `max_length` attributes to `app_commands.Argument`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
