### PR TITLE
Fix grammar issue

### DIFF
--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -900,7 +900,7 @@ class CommandTree(Generic[ClientT]):
         guilds: Sequence[Snowflake] = MISSING,
         extras: Dict[Any, Any] = MISSING,
     ) -> Callable[[ContextMenuCallback], ContextMenu]:
-        """Creates a application command context menu from a regular function directly under this tree.
+        """Creates an application command context menu from a regular function directly under this tree.
 
         This function must have a signature of :class:`~discord.Interaction` as its first parameter
         and taking either a :class:`~discord.Member`, :class:`~discord.User`, or :class:`~discord.Message`,


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
I've changed the docstring for `CommandTree.context_menu`. Before this change it read "Creates **a** **application**". Application starts with a vowel, and that means that the "a" must be an "an".

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x ] This PR is **not** a code change (e.g. documentation, README, ...)
