### PR TITLE
Allow creation of allow lists in automod word filter rules

### DIFF
--- a/discord/automod.py
+++ b/discord/automod.py
@@ -127,7 +127,12 @@ class AutoModTrigger:
         The list of words that are exempt from the commonly flagged words.
     """
 
-    __slots__ = ('type', 'keyword_filter', 'presets', 'allow_list',)
+    __slots__ = (
+        'type',
+        'keyword_filter',
+        'presets',
+        'allow_list',
+    )
 
     def __init__(
         self,
@@ -170,7 +175,6 @@ class AutoModTrigger:
             if self.allow_list:
                 ret['allow_list'] = self.allow_list
             return ret
-
 
         return {}
 

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -123,9 +123,11 @@ class AutoModTrigger:
         The list of strings that will trigger the keyword filter.
     presets: Optional[:class:`AutoModPresets`]
         The presets used with the preset keyword filter.
+    allow_list: Optional[List[:class:`str`]]
+        The list of words that are exempt from the commonly flagged words.
     """
 
-    __slots__ = ('type', 'keyword_filter', 'presets')
+    __slots__ = ('type', 'keyword_filter', 'presets', 'allow_list',)
 
     def __init__(
         self,
@@ -133,9 +135,11 @@ class AutoModTrigger:
         type: Optional[AutoModRuleTriggerType] = None,
         keyword_filter: Optional[List[str]] = None,
         presets: Optional[AutoModPresets] = None,
+        allow_list: Optional[List[str]] = None,
     ) -> None:
         self.keyword_filter: Optional[List[str]] = keyword_filter
         self.presets: Optional[AutoModPresets] = presets
+        self.allow_list: Optional[List[str]] = allow_list
         if keyword_filter and presets:
             raise ValueError('Please pass only one of keyword_filter or presets.')
 
@@ -143,7 +147,7 @@ class AutoModTrigger:
             self.type = type
         elif self.keyword_filter is not None:
             self.type = AutoModRuleTriggerType.keyword
-        elif self.presets is not None:
+        elif self.presets is not None or self.allow_list is not None:
             self.type = AutoModRuleTriggerType.keyword_preset
         else:
             raise ValueError('Please pass the trigger type explicitly if not using keyword_filter or presets.')
@@ -162,7 +166,11 @@ class AutoModTrigger:
         if self.keyword_filter is not None:
             return {'keyword_filter': self.keyword_filter}
         elif self.presets is not None:
-            return {'presets': self.presets.to_array()}
+            ret: Dict[str, Any] = {'presets': self.presets.to_array()}
+            if self.allow_list:
+                ret['allow_list'] = self.allow_list
+            return ret
+
 
         return {}
 

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -147,7 +147,7 @@ class AutoModTrigger:
             self.type = type
         elif self.keyword_filter is not None:
             self.type = AutoModRuleTriggerType.keyword
-        elif self.presets is not None or self.allow_list is not None:
+        elif self.presets is not None:
             self.type = AutoModRuleTriggerType.keyword_preset
         else:
             raise ValueError('Please pass the trigger type explicitly if not using keyword_filter or presets.')


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR adds the capability to pass an allowed list of words to the automod word filters.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
