### PR TITLE
fixes:#8285

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -911,7 +911,9 @@ class Member(discord.abc.Messageable, _UserTag):
         else:
             await self._state.http.edit_my_voice_state(self.guild.id, payload)
 
-    async def move_to(self, channel: Optional[VocalGuildChannel], *, reason: Optional[str] = None) -> None:
+    async def move_to(
+            self, channel: Optional[Union[VocalGuildChannel, StageChannel]], *, reason: Optional[str] = None
+    ) -> None:
         """|coro|
 
         Moves a member to a new voice channel (they must be connected first).


### PR DESCRIPTION
## Summary

The allowed type for move_to says StageChannel in the documentation, but wasn't actually added to the coroutine. This is purely a cosmetic change as the original already accepted StageChannel. For issue #8285

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
