### PR TITLE
Fix typing error with CheckAnyFailure

### DIFF
--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -248,9 +248,9 @@ class CheckAnyFailure(CheckFailure):
         A list of check predicates that failed.
     """
 
-    def __init__(self, checks: List[CheckFailure], errors: List[Callable[[Context[BotT]], bool]]) -> None:
-        self.checks: List[CheckFailure] = checks
-        self.errors: List[Callable[[Context[BotT]], bool]] = errors
+    def __init__(self, checks: List[Callable[[Context[BotT]], bool]], errors: List[CheckFailure]) -> None:
+        self.checks: List[Callable[[Context[BotT]], bool]] = checks
+        self.errors: List[CheckFailure] = errors
         super().__init__('You do not have permission to run this command.')
 
 


### PR DESCRIPTION
## Summary

Fixes typing for ``CheckAnyFailure.__init__``.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- - Possibly? Probably not.
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
