### PR TITLE
document relationship between AutoModRuleAction and its type

### DIFF
--- a/discord/automod.py
+++ b/discord/automod.py
@@ -65,11 +65,14 @@ class AutoModRuleAction:
     -----------
     type: :class:`AutoModRuleActionType`
         The type of action to take.
+        Defaults to :attr:`~AutoModRuleActionType.block_message`.
     channel_id: Optional[:class:`int`]
         The ID of the channel or thread to send the alert message to, if any.
+        Passing this sets :attr:`type` to :attr:`~AutoModRuleActionType.send_alert_message`.
     duration: Optional[:class:`datetime.timedelta`]
         The duration of the timeout to apply, if any.
         Has a maximum of 28 days.
+        Passing this sets :attr:`type` to :attr:`~AutoModRuleActionType.timeout`.
     """
 
     __slots__ = ('type', 'channel_id', 'duration')


### PR DESCRIPTION
## Summary

`AutoModRuleAction` has been a common point of confusion, this *should* clear up at least the unclear relationship between the parameters and `type`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
