### PR TITLE
Fix minor grammatical error

### DIFF
--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -108,7 +108,7 @@ class AllChannels:
 
 
 class AppCommand(Hashable):
-    """Represents a application command.
+    """Represents an application command.
 
     In common parlance this is referred to as a "Slash Command" or a
     "Context Menu Command".
@@ -732,7 +732,7 @@ class AppCommandThread(Hashable):
 
 
 class Argument:
-    """Represents a application command argument.
+    """Represents an application command argument.
 
     .. versionadded:: 2.0
 


### PR DESCRIPTION
## Summary

Fixed two small grammatical errors, both inside two separate comments in `discord/app_commands/models.py`. These comments were within classes `AppCommand` and `Argument` respectively.

In these two comments, `a` was used along with `application`, a noun that begins with a vowel. In such cases, the article `an` should be used instead. 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
