### PR TITLE
Add `description` kwarg to command.Parameter and show in help command

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -149,6 +149,7 @@ def get_signature_parameters(
                     parameter._annotation = default.annotation
 
             parameter._default = default.default
+            parameter._description = default._description
             parameter._displayed_default = default._displayed_default
 
         annotation = parameter.annotation

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -1148,8 +1148,8 @@ class DefaultHelpCommand(HelpCommand):
         :attr:`indent` spaces, padded to ``max_size`` using :meth:`~HelpCommand.get_max_size`
         followed by the argument's :attr:`~.commands.Parameter.description` or
         :attr:`.default_argument_description` and then shortened
-        to fit into the :attr:`width` and  then the
-        :attr:`~.commands.Parameter.displayed_default` between () if one is present.
+        to fit into the :attr:`width` and then :attr:`~.commands.Parameter.displayed_default`
+        between () if one is present after that.
 
         .. versionadded:: 2.0
 

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -1038,7 +1038,7 @@ class DefaultHelpCommand(HelpCommand):
         self.dm_help_threshold: int = options.pop('dm_help_threshold', 1000)
         self.arguments_heading: str = options.pop('arguments_heading', "Arguments:")
         self.commands_heading: str = options.pop('commands_heading', 'Commands:')
-        self.default_argument_description: str = options.pop('default_argument_description', 'No description given.')
+        self.default_argument_description: str = options.pop('default_argument_description', 'No description given')
         self.no_category: str = options.pop('no_category', 'No Category')
         self.paginator: Paginator = options.pop('paginator', None)
         self.show_parameter_descriptions: bool = options.pop('show_parameter_descriptions', True)
@@ -1164,15 +1164,9 @@ class DefaultHelpCommand(HelpCommand):
         for argument in arguments:
             name = argument.name
             width = max_size - (get_width(name) - len(name))
-            entry = f'{self.indent * " "}{name:<{width}}'
-            if argument.description is not None:
-                entry += f' - {argument.description}'
-            else:
-                entry += f' - {self.default_argument_description}'
-
+            entry = f'{self.indent * " "}{name:<{width}} {argument.description or self.default_argument_description}'
             # we do not want to shorten the default value, if any.
             entry = self.shorten_text(entry)
-
             if argument.displayed_default is not None:
                 entry += f' (default: {argument.displayed_default})'
 

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -1068,6 +1068,23 @@ class DefaultHelpCommand(HelpCommand):
         )
 
     def get_command_signature(self, command: Command[Any, ..., Any], /) -> str:
+        """Retrieves the signature portion of the help page.
+
+        Calls :meth:`~.HelpCommand.get_command_signature` if :attr:`show_parameter_descriptions` is ``False`` 
+        else returns a modified signature where the command parameters are not shown.
+
+        .. versionadded:: 2.0
+
+        Parameters
+        ------------
+        command: :class:`Command`
+            The command to get the signature of.
+
+        Returns
+        --------
+        :class:`str`
+            The signature for the command.
+        """
         if self.show_parameter_descriptions is False:
             return super().get_command_signature(command)
 
@@ -1125,7 +1142,7 @@ class DefaultHelpCommand(HelpCommand):
             self.paginator.add_line(self.shorten_text(entry))
 
     def add_command_arguments(self, command: Command[Any, ..., Any], /) -> None:
-        """Indents a list of command arguments after :attr:`.arguments_heading`.
+        """Indents a list of command arguments after the :attr:`.arguments_heading`.
 
         The default implementation is the argument :attr:`~.commands.Parameter.name` indented by
         :attr:`indent` spaces, padded to ``max_size`` using :meth:`~HelpCommand.get_max_size`

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -1007,7 +1007,7 @@ class DefaultHelpCommand(HelpCommand):
         How much to indent the commands from a heading. Defaults to ``2``.
     arguments_heading: :class:`str`
         The arguments list's heading string used when the help command is invoked with a command name.
-        Useful for i18n. Defaults to ``"Arguments:"``
+        Useful for i18n. Defaults to ``"Arguments:"``. 
         Shown when :attr:`.show_parameter_descriptions` is ``True``.
 
         .. versionadded:: 2.0
@@ -1095,7 +1095,7 @@ class DefaultHelpCommand(HelpCommand):
             ``commands`` parameter is now positional-only.
 
         .. versionchanged:: 2.0
-            A `-` is added between the command name and short_doc.
+            A ``-`` is added between the command name and short_doc.
 
         Parameters
         -----------
@@ -1120,23 +1120,26 @@ class DefaultHelpCommand(HelpCommand):
         for command in commands:
             name = command.name
             width = max_size - (get_width(name) - len(name))
-            entry = f'{self.indent * " "}{name:<{width}} - {command.short_doc}'
+            entry = f'{self.indent * " "}{name:<{width}}'
+            if command.short_doc:
+                entry += f' - {command.short_doc}'
             self.paginator.add_line(self.shorten_text(entry))
 
     def add_command_arguments(self, command: Command[Any, ..., Any], /) -> None:
-        """Indents a list of command arguments after the specified heading.
+        """Indents a list of command arguments after :attr:`.arguments_heading`.
 
         The default implementation is the argument :attr:`~.commands.Parameter.name` indented by
-        :attr:`indent` spaces, padded to ``max_size`` followed by
-        the argument's :attr:`~.commands.Parameter.description` or :attr:`.default_argument_description` and then shortened
-        to fit into the :attr:`width` and then the :attr:`~.commands.Parameter.displayed_default` between () if argument
-        has a default value.
+        :attr:`indent` spaces, padded to ``max_size`` using :meth:`~HelpCommand.get_max_size` 
+        followed by the argument's :attr:`~.commands.Parameter.description` or 
+        :attr:`.default_argument_description` and then shortened
+        to fit into the :attr:`width` and  then the 
+        :attr:`~.commands.Parameter.displayed_default` between () if one is present.
 
         .. versionadded:: 2.0
 
         Parameters
         -----------
-        commands: :class:`Command`
+        command: :class:`Command`
             The command to list the arguments for.
         """
         arguments = command.clean_params.values()
@@ -1176,6 +1179,9 @@ class DefaultHelpCommand(HelpCommand):
         .. versionchanged:: 2.0
 
             ``command`` parameter is now positional-only.
+
+        .. versionchanged:: 2.0
+            :meth:`.add_command_arguments` is now called if :attr:`.show_parameter_descriptions` is ``True``.
 
         Parameters
         ------------

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -1097,10 +1097,11 @@ class DefaultHelpCommand(HelpCommand):
 
         The formatting is added to the :attr:`paginator`.
 
-        The default implementation is the argument name indented by
+        The default implementation is the argument :attr:`~.commands.Parameter.name` indented by
         :attr:`indent` spaces, padded to ``max_size`` followed by
-        the argument's :attr:`~.commands.Parameter.description` or "No description provided." and then shortened
-        to fit into the :attr:`width`.
+        the argument's :attr:`~.commands.Parameter.description` or :attr:`.default_argument_description` and then shortened
+        to fit into the :attr:`width` and then the :attr:`~.commands.Parameter.displayed_default` between () if argument
+        has a default value.
 
         .. versionadded:: 2.0
 

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -480,7 +480,6 @@ class HelpCommand:
             if parent_sig:
                 fmt = parent_sig + ' ' + fmt
             alias = fmt
-            alias = f'[{command.name}|{aliases}]'
         else:
             alias = command.name if not parent_sig else parent_sig + ' ' + command.name
 

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -995,12 +995,16 @@ class DefaultHelpCommand(HelpCommand):
     arguments_heading: :class:`str`
         The arguments list's heading string used when the help command is invoked with a command name.
         Useful for i18n. Defaults to ``"Arguments:"``
+
+        .. versionadded:: 2.0
     commands_heading: :class:`str`
         The command list's heading string used when the help command is invoked with a category name.
         Useful for i18n. Defaults to ``"Commands:"``
     default_argument_description: :class:`str`
         The default argument description string used when the argument's :attr:`~.commands.Parameter.description` is ``None``.
         Useful for i18n. Defaults to ``"No description given."``
+
+        .. versionadded:: 2.0
     no_category: :class:`str`
         The string used when there is a command which does not belong to any category(cog).
         Useful for i18n. Defaults to ``"No Category"``

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -483,7 +483,7 @@ class HelpCommand:
             alias = f'[{command.name}|{aliases}]'
         else:
             alias = command.name if not parent_sig else parent_sig + ' ' + command.name
-        
+
         return f'{self.context.clean_prefix}{alias} {command.signature}'
 
     def remove_mentions(self, string: str, /) -> str:
@@ -1007,7 +1007,7 @@ class DefaultHelpCommand(HelpCommand):
         How much to indent the commands from a heading. Defaults to ``2``.
     arguments_heading: :class:`str`
         The arguments list's heading string used when the help command is invoked with a command name.
-        Useful for i18n. Defaults to ``"Arguments:"``. 
+        Useful for i18n. Defaults to ``"Arguments:"``.
         Shown when :attr:`.show_parameter_descriptions` is ``True``.
 
         .. versionadded:: 2.0
@@ -1071,7 +1071,7 @@ class DefaultHelpCommand(HelpCommand):
     def get_command_signature(self, command: Command[Any, ..., Any], /) -> str:
         if self.show_parameter_descriptions is False:
             return super().get_command_signature(command)
-        
+
         name = command.name
         if len(command.aliases) > 0:
             aliases = '|'.join(command.aliases)
@@ -1129,10 +1129,10 @@ class DefaultHelpCommand(HelpCommand):
         """Indents a list of command arguments after :attr:`.arguments_heading`.
 
         The default implementation is the argument :attr:`~.commands.Parameter.name` indented by
-        :attr:`indent` spaces, padded to ``max_size`` using :meth:`~HelpCommand.get_max_size` 
-        followed by the argument's :attr:`~.commands.Parameter.description` or 
+        :attr:`indent` spaces, padded to ``max_size`` using :meth:`~HelpCommand.get_max_size`
+        followed by the argument's :attr:`~.commands.Parameter.description` or
         :attr:`.default_argument_description` and then shortened
-        to fit into the :attr:`width` and  then the 
+        to fit into the :attr:`width` and  then the
         :attr:`~.commands.Parameter.displayed_default` between () if one is present.
 
         .. versionadded:: 2.0

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -1070,7 +1070,7 @@ class DefaultHelpCommand(HelpCommand):
     def get_command_signature(self, command: Command[Any, ..., Any], /) -> str:
         """Retrieves the signature portion of the help page.
 
-        Calls :meth:`~.HelpCommand.get_command_signature` if :attr:`show_parameter_descriptions` is ``False`` 
+        Calls :meth:`~.HelpCommand.get_command_signature` if :attr:`show_parameter_descriptions` is ``False``
         else returns a modified signature where the command parameters are not shown.
 
         .. versionadded:: 2.0

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -1090,12 +1090,8 @@ class DefaultHelpCommand(HelpCommand):
             entry = f'{self.indent * " "}{name:<{width}} - {command.short_doc}'
             self.paginator.add_line(self.shorten_text(entry))
 
-    def add_command_arguments(
-        self, command: Command[Any, ..., Any], /, *, heading: str, max_size: Optional[int] = None
-    ) -> None:
+    def add_command_arguments(self, command: Command[Any, ..., Any], /) -> None:
         """Indents a list of command arguments after the specified heading.
-
-        The formatting is added to the :attr:`paginator`.
 
         The default implementation is the argument :attr:`~.commands.Parameter.name` indented by
         :attr:`indent` spaces, padded to ``max_size`` followed by
@@ -1109,19 +1105,13 @@ class DefaultHelpCommand(HelpCommand):
         -----------
         commands: :class:`Command`
             The command to list the arguments for.
-        heading: :class:`str`
-            The heading to add to the output. This is only added
-            if the list of arguments is greater than 0.
-        max_size: Optional[:class:`int`]
-            The max size to use for the gap between indents.
-            If unspecified, calls :meth:`~HelpCommand.get_max_size` on all arguments.
         """
         arguments = command.clean_params.values()
         if not arguments:
             return
 
-        self.paginator.add_line(heading)
-        max_size = max_size or self.get_max_size(arguments)  # type: ignore # not a command
+        self.paginator.add_line(self.arguments_heading)
+        max_size = self.get_max_size(arguments)  # type: ignore # not a command
 
         get_width = discord.utils._string_width
         for argument in arguments:

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -1085,7 +1085,7 @@ class DefaultHelpCommand(HelpCommand):
         :class:`str`
             The signature for the command.
         """
-        if self.show_parameter_descriptions is False:
+        if not self.show_parameter_descriptions:
             return super().get_command_signature(command)
 
         name = command.name
@@ -1208,7 +1208,7 @@ class DefaultHelpCommand(HelpCommand):
                     self.paginator.add_line(line)
                 self.paginator.add_line()
 
-        if self.show_parameter_descriptions is True:
+        if self.show_parameter_descriptions:
             self.add_command_arguments(command)
 
     def get_destination(self) -> discord.abc.Messageable:

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -1110,9 +1110,6 @@ class DefaultHelpCommand(HelpCommand):
         .. versionchanged:: 2.0
             ``commands`` parameter is now positional-only.
 
-        .. versionchanged:: 2.0
-            A ``-`` is added between the command name and short_doc.
-
         Parameters
         -----------
         commands: Sequence[:class:`Command`]
@@ -1136,9 +1133,7 @@ class DefaultHelpCommand(HelpCommand):
         for command in commands:
             name = command.name
             width = max_size - (get_width(name) - len(name))
-            entry = f'{self.indent * " "}{name:<{width}}'
-            if command.short_doc:
-                entry += f' - {command.short_doc}'
+            entry = f'{self.indent * " "}{name:<{width}} {command.short_doc}'
             self.paginator.add_line(self.shorten_text(entry))
 
     def add_command_arguments(self, command: Command[Any, ..., Any], /) -> None:

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -470,8 +470,8 @@ class HelpCommand:
             alias = f'[{command.name}|{aliases}]'
         else:
             alias = command.name
-        
-        return f"{self.context.clean_prefix}{name}"
+
+        return f'{self.context.clean_prefix}{alias}'
 
     def remove_mentions(self, string: str, /) -> str:
         """Removes mentions from the string to prevent abuse.
@@ -1116,7 +1116,7 @@ class DefaultHelpCommand(HelpCommand):
             return
 
         self.paginator.add_line(heading)
-        max_size = max_size or self.get_max_size(arguments) # type: ignore # not a command
+        max_size = max_size or self.get_max_size(arguments)  # type: ignore # not a command
 
         get_width = discord.utils._string_width
         for argument in arguments:

--- a/discord/ext/commands/parameters.py
+++ b/discord/ext/commands/parameters.py
@@ -87,7 +87,7 @@ class Parameter(inspect.Parameter):
     .. versionadded:: 2.0
     """
 
-    __slots__ = ('_displayed_default', '_fallback')
+    __slots__ = ('_displayed_default', '_description', '_fallback')
 
     def __init__(
         self,
@@ -95,11 +95,13 @@ class Parameter(inspect.Parameter):
         kind: ParamKinds,
         default: Any = empty,
         annotation: Any = empty,
+        description: str = empty,
         displayed_default: str = empty,
     ) -> None:
         super().__init__(name=name, kind=kind, default=default, annotation=annotation)
         self._name = name
         self._kind = kind
+        self._description = description
         self._default = default
         self._annotation = annotation
         self._displayed_default = displayed_default
@@ -112,6 +114,7 @@ class Parameter(inspect.Parameter):
         kind: ParamKinds = MISSING,
         default: Any = MISSING,
         annotation: Any = MISSING,
+        description: str = MISSING,
         displayed_default: Any = MISSING,
     ) -> Self:
         if name is MISSING:
@@ -122,6 +125,8 @@ class Parameter(inspect.Parameter):
             default = self._default
         if annotation is MISSING:
             annotation = self._annotation
+        if description is MISSING:
+            description = self._description
         if displayed_default is MISSING:
             displayed_default = self._displayed_default
 
@@ -130,6 +135,7 @@ class Parameter(inspect.Parameter):
             kind=kind,
             default=default,
             annotation=annotation,
+            description=description,
             displayed_default=displayed_default,
         )
 
@@ -152,6 +158,11 @@ class Parameter(inspect.Parameter):
 
         return self.annotation
 
+    @property
+    def description(self) -> Optional[str]:
+        """Optional[:class:`str`]: The description of this parameter."""
+        return self._description if self._description is not empty else None
+        
     @property
     def displayed_default(self) -> Optional[str]:
         """Optional[:class:`str`]: The displayed default in :class:`Command.signature`."""
@@ -180,6 +191,7 @@ def parameter(
     *,
     converter: Any = empty,
     default: Any = empty,
+    description: str = empty,
     displayed_default: str = empty,
 ) -> Any:
     r"""parameter(\*, converter=..., default=..., displayed_default=...)
@@ -205,6 +217,8 @@ def parameter(
     default: Any
         The default value for the parameter, if this is a :term:`callable` or a |coroutine_link|_ it is called with a
         positional :class:`Context` argument.
+    description: :class:`str`
+        The description of this parameter.
     displayed_default: :class:`str`
         The displayed default in :attr:`Command.signature`.
     """
@@ -213,6 +227,7 @@ def parameter(
         kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
         annotation=converter,
         default=default,
+        description=description,
         displayed_default=displayed_default,
     )
 
@@ -223,13 +238,14 @@ class ParameterAlias(Protocol):
         *,
         converter: Any = empty,
         default: Any = empty,
+        description: str = empty,
         displayed_default: str = empty,
     ) -> Any:
         ...
 
 
 param: ParameterAlias = parameter
-r"""param(\*, converter=..., default=..., displayed_default=...)
+r"""param(\*, converter=..., default=..., description=..., displayed_default=...)
 
 An alias for :func:`parameter`.
 

--- a/discord/ext/commands/parameters.py
+++ b/discord/ext/commands/parameters.py
@@ -162,7 +162,7 @@ class Parameter(inspect.Parameter):
     def description(self) -> Optional[str]:
         """Optional[:class:`str`]: The description of this parameter."""
         return self._description if self._description is not empty else None
-        
+
     @property
     def displayed_default(self) -> Optional[str]:
         """Optional[:class:`str`]: The displayed default in :class:`Command.signature`."""


### PR DESCRIPTION
## Summary

This PR adds a way to set a description for an ext.commands/hybrid command argument.
and reformats the `DefaultHelpCommand` to show that description, MinimalHelpCommand is left unchanged.

Also added `arguments_heading` and `default_argument_description` keyword arguments to `DefaultHelpCommand`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
