### PR TITLE
HybridCommand with_command not used + with_app_command docs adjustion

### DIFF
--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -500,12 +500,8 @@ class HybridCommand(Command[CogT, P, T]):
 
         super().__init__(func, **kwargs)
         self.with_app_command: bool = kwargs.pop('with_app_command', True)
-        self.with_command: bool = kwargs.pop('with_command', True)
         self._locale_name: Optional[app_commands.locale_str] = name_locale
         self._locale_description: Optional[app_commands.locale_str] = description_locale
-
-        if not self.with_command and not self.with_app_command:
-            raise TypeError('cannot set both with_command and with_app_command to False')
 
         self.app_command: Optional[HybridAppCommand[CogT, Any, T]] = (
             HybridAppCommand(self) if self.with_app_command else None

--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -868,7 +868,7 @@ def hybrid_command(
         The name to create the command with. By default this uses the
         function name unchanged.
     with_app_command: :class:`bool`
-        Whether to register the command as an application command.
+        Whether to register the command also as an application command.
     \*\*attrs
         Keyword arguments to pass into the construction of the
         hybrid command.
@@ -901,7 +901,7 @@ def hybrid_group(
     Parameters
     -----------
     with_app_command: :class:`bool`
-        Whether to register the command as an application command.
+        Whether to register the command also as an application command.
 
     Raises
     -------


### PR DESCRIPTION
## Summary

This pull request is for some changes for `with_command` and in addition `with_app_command`'s documentation.
At the moment `with_command` is an argument of `HybridCommand` but it's neither documented nor used in code. For that it got removed. 

In addition the documentation for the argument `with_app_command` got changed to a more understandable sentence. As I understand it right, the `HybridCommand` is basically a regular command with the feature through the argument `with_app_command` to **also** register it as an application command. The sentence has been adjusted accordingly.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes. -> `with_command` wasn't even in the docs.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
