### PR TITLE
Fix some __slots__

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -196,7 +196,6 @@ class Activity(BaseActivity):
     __slots__ = (
         'state',
         'details',
-        '_created_at',
         'timestamps',
         'assets',
         'party',

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -58,6 +58,7 @@ MISSING = utils.MISSING
 
 
 class AssetMixin:
+    __slots__ = ()
     url: str
     _state: Optional[Any]
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -1354,7 +1354,6 @@ class Message(PartialMessage, Hashable):
     """
 
     __slots__ = (
-        '_state',
         '_edited_timestamp',
         '_cs_channel_mentions',
         '_cs_raw_mentions',
@@ -1364,7 +1363,6 @@ class Message(PartialMessage, Hashable):
         '_cs_system_content',
         'tts',
         'content',
-        'channel',
         'webhook_id',
         'mention_everyone',
         'embeds',

--- a/discord/widget.py
+++ b/discord/widget.py
@@ -152,13 +152,9 @@ class WidgetMember(BaseUser):
     """
 
     __slots__ = (
-        'name',
         'status',
         'nick',
         'avatar',
-        'discriminator',
-        'id',
-        'bot',
         'activity',
         'deafened',
         'suppress',


### PR DESCRIPTION
## Summary

Fixes errors from slotscheck
```
ERROR: 'discord.activity:Activity' defines overlapping slots.
ERROR: 'discord.asset:Asset' has slots but superclass does not.
ERROR: 'discord.emoji:Emoji' has slots but superclass does not.
ERROR: 'discord.message:Message' defines overlapping slots.
ERROR: 'discord.partial_emoji:PartialEmoji' has slots but superclass does not.
ERROR: 'discord.sticker:_StickerTag' has slots but superclass does not.
ERROR: 'discord.widget:WidgetMember' defines overlapping slots.
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
