### PR TITLE
Improve TranslationContext type narrowing using a tagged union

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -52,7 +52,7 @@ from ..enums import AppCommandOptionType, AppCommandType, ChannelType, Locale
 from .models import Choice
 from .transformers import annotation_to_parameter, CommandParameter, NoneType
 from .errors import AppCommandError, CheckFailure, CommandInvokeError, CommandSignatureMismatch, CommandAlreadyRegistered
-from .translator import TranslationContextLocation, TranslationContextObject, Translator, locale_str
+from .translator import TranslationContextLocation, TranslationContext, Translator, locale_str
 from ..message import Message
 from ..user import User
 from ..member import Member
@@ -739,8 +739,8 @@ class Command(Generic[GroupT, P, T]):
         description_localizations: Dict[str, str] = {}
 
         # Prevent creating these objects in a heavy loop
-        name_context = TranslationContextObject(location=TranslationContextLocation.command_name, data=self)
-        description_context = TranslationContextObject(location=TranslationContextLocation.command_description, data=self)
+        name_context = TranslationContext(location=TranslationContextLocation.command_name, data=self)
+        description_context = TranslationContext(location=TranslationContextLocation.command_description, data=self)
 
         for locale in Locale:
             if self._locale_name:
@@ -1230,7 +1230,7 @@ class ContextMenu:
 
     async def get_translated_payload(self, translator: Translator) -> Dict[str, Any]:
         base = self.to_dict()
-        context = TranslationContextObject(location=TranslationContextLocation.command_name, data=self)
+        context = TranslationContext(location=TranslationContextLocation.command_name, data=self)
         if self._locale_name:
             name_localizations: Dict[str, str] = {}
             for locale in Locale:
@@ -1646,8 +1646,8 @@ class Group:
         description_localizations: Dict[str, str] = {}
 
         # Prevent creating these objects in a heavy loop
-        name_context = TranslationContextObject(location=TranslationContextLocation.group_name, data=self)
-        description_context = TranslationContextObject(location=TranslationContextLocation.group_description, data=self)
+        name_context = TranslationContext(location=TranslationContextLocation.group_name, data=self)
+        description_context = TranslationContext(location=TranslationContextLocation.group_description, data=self)
         for locale in Locale:
             if self._locale_name:
                 translation = await translator._checked_translate(self._locale_name, locale, name_context)

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -52,7 +52,7 @@ from ..enums import AppCommandOptionType, AppCommandType, ChannelType, Locale
 from .models import Choice
 from .transformers import annotation_to_parameter, CommandParameter, NoneType
 from .errors import AppCommandError, CheckFailure, CommandInvokeError, CommandSignatureMismatch, CommandAlreadyRegistered
-from .translator import TranslationContext, TranslationContextLocation, Translator, locale_str
+from .translator import TranslationContextLocation, TranslationContextObject, Translator, locale_str
 from ..message import Message
 from ..user import User
 from ..member import Member
@@ -739,8 +739,8 @@ class Command(Generic[GroupT, P, T]):
         description_localizations: Dict[str, str] = {}
 
         # Prevent creating these objects in a heavy loop
-        name_context = TranslationContext(location=TranslationContextLocation.command_name, data=self)
-        description_context = TranslationContext(location=TranslationContextLocation.command_description, data=self)
+        name_context = TranslationContextObject(location=TranslationContextLocation.command_name, data=self)
+        description_context = TranslationContextObject(location=TranslationContextLocation.command_description, data=self)
 
         for locale in Locale:
             if self._locale_name:
@@ -1230,7 +1230,7 @@ class ContextMenu:
 
     async def get_translated_payload(self, translator: Translator) -> Dict[str, Any]:
         base = self.to_dict()
-        context = TranslationContext(location=TranslationContextLocation.command_name, data=self)
+        context = TranslationContextObject(location=TranslationContextLocation.command_name, data=self)
         if self._locale_name:
             name_localizations: Dict[str, str] = {}
             for locale in Locale:
@@ -1646,8 +1646,8 @@ class Group:
         description_localizations: Dict[str, str] = {}
 
         # Prevent creating these objects in a heavy loop
-        name_context = TranslationContext(location=TranslationContextLocation.group_name, data=self)
-        description_context = TranslationContext(location=TranslationContextLocation.group_description, data=self)
+        name_context = TranslationContextObject(location=TranslationContextLocation.group_name, data=self)
+        description_context = TranslationContextObject(location=TranslationContextLocation.group_description, data=self)
         for locale in Locale:
             if self._locale_name:
                 translation = await translator._checked_translate(self._locale_name, locale, name_context)

--- a/discord/app_commands/errors.py
+++ b/discord/app_commands/errors.py
@@ -52,7 +52,7 @@ __all__ = (
 if TYPE_CHECKING:
     from .commands import Command, Group, ContextMenu
     from .transformers import Transformer
-    from .translator import TranslationContext, locale_str
+    from .translator import TranslationContextTypes, locale_str
     from ..types.snowflake import Snowflake, SnowflakeList
     from .checks import Cooldown
 
@@ -162,11 +162,11 @@ class TranslationError(AppCommandError):
         *msg: str,
         string: Optional[Union[str, locale_str]] = None,
         locale: Optional[Locale] = None,
-        context: TranslationContext,
+        context: TranslationContextTypes,
     ) -> None:
         self.string: Optional[Union[str, locale_str]] = string
         self.locale: Optional[Locale] = locale
-        self.context: TranslationContext = context
+        self.context: TranslationContextTypes = context
 
         if msg:
             super().__init__(*msg)

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from .errors import MissingApplicationID
-from .translator import TranslationContextLocation, TranslationContextObject, locale_str, Translator
+from .translator import TranslationContextLocation, TranslationContext, locale_str, Translator
 from ..permissions import Permissions
 from ..enums import AppCommandOptionType, AppCommandType, AppCommandPermissionType, ChannelType, Locale, try_enum
 from ..mixins import Hashable
@@ -463,7 +463,7 @@ class Choice(Generic[ChoiceT]):
     async def get_translated_payload(self, translator: Translator) -> Dict[str, Any]:
         base = self.to_dict()
         name_localizations: Dict[str, str] = {}
-        context = TranslationContextObject(location=TranslationContextLocation.choice_name, data=self)
+        context = TranslationContext(location=TranslationContextLocation.choice_name, data=self)
         if self._locale_name:
             for locale in Locale:
                 translation = await translator._checked_translate(self._locale_name, locale, context)

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from .errors import MissingApplicationID
-from .translator import TranslationContextLocation, Translator, TranslationContext, locale_str
+from .translator import TranslationContextLocation, TranslationContextObject, locale_str, Translator
 from ..permissions import Permissions
 from ..enums import AppCommandOptionType, AppCommandType, AppCommandPermissionType, ChannelType, Locale, try_enum
 from ..mixins import Hashable
@@ -463,7 +463,7 @@ class Choice(Generic[ChoiceT]):
     async def get_translated_payload(self, translator: Translator) -> Dict[str, Any]:
         base = self.to_dict()
         name_localizations: Dict[str, str] = {}
-        context = TranslationContext(location=TranslationContextLocation.choice_name, data=self)
+        context = TranslationContextObject(location=TranslationContextLocation.choice_name, data=self)
         if self._locale_name:
             for locale in Locale:
                 translation = await translator._checked_translate(self._locale_name, locale, context)

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -46,7 +46,7 @@ from typing import (
 
 from .errors import AppCommandError, TransformerError
 from .models import AppCommandChannel, AppCommandThread, Choice
-from .translator import TranslationContextLocation, locale_str, Translator, TranslationContext
+from .translator import TranslationContextLocation, TranslationContextObject, Translator, locale_str
 from ..channel import StageChannel, VoiceChannel, TextChannel, CategoryChannel
 from ..abc import GuildChannel
 from ..threads import Thread
@@ -101,8 +101,8 @@ class CommandParameter:
         description_localizations: Dict[str, str] = {}
 
         # Prevent creating these objects in a heavy loop
-        name_context = TranslationContext(location=TranslationContextLocation.parameter_name, data=data)
-        description_context = TranslationContext(location=TranslationContextLocation.parameter_description, data=data)
+        name_context = TranslationContextObject(location=TranslationContextLocation.parameter_name, data=data)
+        description_context = TranslationContextObject(location=TranslationContextLocation.parameter_description, data=data)
         for locale in Locale:
             if needs_name_translations:
                 translation = await translator._checked_translate(rename, locale, name_context)

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -46,7 +46,7 @@ from typing import (
 
 from .errors import AppCommandError, TransformerError
 from .models import AppCommandChannel, AppCommandThread, Choice
-from .translator import TranslationContextLocation, TranslationContextObject, Translator, locale_str
+from .translator import TranslationContextLocation, TranslationContext, Translator, locale_str
 from ..channel import StageChannel, VoiceChannel, TextChannel, CategoryChannel
 from ..abc import GuildChannel
 from ..threads import Thread
@@ -101,8 +101,8 @@ class CommandParameter:
         description_localizations: Dict[str, str] = {}
 
         # Prevent creating these objects in a heavy loop
-        name_context = TranslationContextObject(location=TranslationContextLocation.parameter_name, data=data)
-        description_context = TranslationContextObject(location=TranslationContextLocation.parameter_description, data=data)
+        name_context = TranslationContext(location=TranslationContextLocation.parameter_name, data=data)
+        description_context = TranslationContext(location=TranslationContextLocation.parameter_description, data=data)
         for locale in Locale:
             if needs_name_translations:
                 translation = await translator._checked_translate(rename, locale, name_context)

--- a/discord/app_commands/translator.py
+++ b/discord/app_commands/translator.py
@@ -28,6 +28,12 @@ from .errors import TranslationError
 from ..enums import Enum, Locale
 
 
+if TYPE_CHECKING:
+    from typing import Protocol
+    from .commands import Command, ContextMenu, Group, Parameter
+    from .models import Choice
+
+
 __all__ = (
     'TranslationContextLocation',
     'TranslationContext',
@@ -47,7 +53,7 @@ class TranslationContextLocation(Enum):
     other = 7
 
 
-class TranslationContext:  # type: ignore  # See below
+class TranslationContextObject:
     """A class that provides context for the :class:`locale_str` being translated.
 
     This is useful to determine where exactly the string is located and aid in looking
@@ -71,52 +77,46 @@ class TranslationContext:  # type: ignore  # See below
 if TYPE_CHECKING:
     # For type checking purposes, it makes sense to allow the user to leverage type narrowing
     # So code like this works as expected:
+    #
     # if context.type is TranslationContextLocation.command_name:
     #    reveal_type(context.data)  # Revealed type is Command | ContextMenu
     #
-    # Unfortunately doing a trick like this requires lying to the type checker so
-    # this is what the code below enables.
-    #
-    # Should this trick stop working then it might be fair to remove this code.
-    # It's purely here for convenience.
+    # This requires a union of types
 
-    from .commands import Command, ContextMenu, Group, Parameter
-    from .models import Choice
-
-    class _CommandNameTranslationContext:
+    class _CommandNameTranslationContext(Protocol):
         location: Literal[TranslationContextLocation.command_name]
         data: Union[Command[Any, ..., Any], ContextMenu]
 
-    class _CommandDescriptionTranslationContext:
+    class _CommandDescriptionTranslationContext(Protocol):
         location: Literal[TranslationContextLocation.command_description]
         data: Command[Any, ..., Any]
 
-    class _GroupTranslationContext:
+    class _GroupTranslationContext(Protocol):
         location: Literal[TranslationContextLocation.group_name, TranslationContextLocation.group_description]
         data: Group
 
-    class _ParameterTranslationContext:
+    class _ParameterTranslationContext(Protocol):
         location: Literal[TranslationContextLocation.parameter_description, TranslationContextLocation.parameter_name]
         data: Parameter
 
-    class _ChoiceTranslationContext:
+    class _ChoiceTranslationContext(Protocol):
         location: Literal[TranslationContextLocation.choice_name]
         data: Choice[Union[int, str, float]]
 
-    class _OtherTranslationContext:
+    class _OtherTranslationContext(Protocol):
         location: Literal[TranslationContextLocation.other]
         data: Any
 
-    class TranslationContext(
+    TranslationContext = Union[
         _CommandNameTranslationContext,
         _CommandDescriptionTranslationContext,
         _GroupTranslationContext,
         _ParameterTranslationContext,
         _ChoiceTranslationContext,
         _OtherTranslationContext,
-    ):
-        def __init__(self, location: TranslationContextLocation, data: Any) -> None:
-            ...
+    ]
+else:
+    TranslationContext = TranslationContextObject
 
 
 class Translator:
@@ -162,13 +162,15 @@ class Translator:
         """
         pass
 
-    async def _checked_translate(self, string: locale_str, locale: Locale, context: TranslationContext) -> Optional[str]:
+    async def _checked_translate(
+        self, string: locale_str, locale: Locale, context: TranslationContextObject
+    ) -> Optional[str]:
         try:
-            return await self.translate(string, locale, context)
+            return await self.translate(string, locale, context)  # type: ignore
         except TranslationError:
             raise
         except Exception as e:
-            raise TranslationError(string=string, locale=locale, context=context) from e
+            raise TranslationError(string=string, locale=locale, context=context) from e  # type: ignore
 
     async def translate(self, string: locale_str, locale: Locale, context: TranslationContext) -> Optional[str]:
         """|coro|

--- a/discord/app_commands/translator.py
+++ b/discord/app_commands/translator.py
@@ -219,11 +219,9 @@ class Translator:
             The locale being requested for translation.
         context: :class:`TranslationContext`
             The translation context where the string originated from.
-
-            .. note::
-                For better type checking ergonomics, the ``TranslationContextTypes``
-                type can be used instead to aid with type narrowing. It is functionally
-                equivalent to :class:`TranslationContext`.
+            For better type checking ergonomics, the ``TranslationContextTypes``
+            type can be used instead to aid with type narrowing. It is functionally
+            equivalent to :class:`TranslationContext`.
         """
 
         return None

--- a/discord/app_commands/translator.py
+++ b/discord/app_commands/translator.py
@@ -219,6 +219,11 @@ class Translator:
             The locale being requested for translation.
         context: :class:`TranslationContext`
             The translation context where the string originated from.
+
+            .. note::
+                For better type checking ergonomics, the ``TranslationContextTypes``
+                type can be used instead to aid with type narrowing. It is functionally
+                equivalent to :class:`TranslationContext`.
         """
 
         return None


### PR DESCRIPTION
## Summary

This fixes type narrowing for TranslationContext. Previously, conditions other than `command_name` weren't narrowing correctly.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
