### PR TITLE
Fix ui.Select.values in modals

### DIFF
--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -174,9 +174,11 @@ class Modal(View):
                     continue
                 item._refresh_state(component)  # type: ignore
 
-    async def _scheduled_task(self, interaction: Interaction):
+    async def _scheduled_task(self, interaction: Interaction, components: List[ModalSubmitComponentInteractionDataPayload]):
         try:
             self._refresh_timeout()
+            self._refresh(components)
+
             allow = await self.interaction_check(interaction)
             if not allow:
                 return
@@ -189,8 +191,10 @@ class Modal(View):
             # In the future, maybe this will require checking if we set an error response.
             self.stop()
 
-    def _dispatch_submit(self, interaction: Interaction) -> None:
-        asyncio.create_task(self._scheduled_task(interaction), name=f'discord-ui-modal-dispatch-{self.id}')
+    def _dispatch_submit(
+        self, interaction: Interaction, components: List[ModalSubmitComponentInteractionDataPayload]
+    ) -> None:
+        asyncio.create_task(self._scheduled_task(interaction, components), name=f'discord-ui-modal-dispatch-{self.id}')
 
     def to_dict(self) -> Dict[str, Any]:
         payload = {

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -23,7 +23,7 @@ DEALINGS IN THE SOFTWARE.
 """
 
 from __future__ import annotations
-from typing import List, Literal, Optional, TYPE_CHECKING, Tuple, TypeVar, Callable, Union
+from typing import List, Literal, Optional, TYPE_CHECKING, Tuple, TypeVar, Callable, Union, Dict
 from contextvars import ContextVar
 import inspect
 import os
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
 
 V = TypeVar('V', bound='View', covariant=True)
 
-selected_values: ContextVar[Optional[List[str]]] = ContextVar('selected_values', default=None)
+selected_values: ContextVar[Dict[str, list[str]]] = ContextVar('selected_values')
 
 
 class Select(Item[V]):
@@ -262,8 +262,8 @@ class Select(Item[V]):
     @property
     def values(self) -> List[str]:
         """List[:class:`str`]: A list of values that have been selected by the user."""
-        values = selected_values.get()
-        return values if values is not None else []
+        values = selected_values.get({})
+        return values.get(self.custom_id, [])
 
     @property
     def width(self) -> int:
@@ -276,7 +276,9 @@ class Select(Item[V]):
         self._underlying = component
 
     def _refresh_state(self, data: MessageComponentInteractionData) -> None:
-        selected_values.set(data.get('values', []))
+        values = selected_values.get({})
+        values[self.custom_id] = data.get('values', [])
+        selected_values.set(values)
 
     @classmethod
     def from_component(cls, component: SelectMenu) -> Self:

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
 
 V = TypeVar('V', bound='View', covariant=True)
 
-selected_values: ContextVar[Dict[str, list[str]]] = ContextVar('selected_values')
+selected_values: ContextVar[Dict[str, List[str]]] = ContextVar('selected_values')
 
 
 class Select(Item[V]):

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -126,6 +126,7 @@ class Select(Item[V]):
             disabled=disabled,
         )
         self.row = row
+        self._values: List[str] = []
 
     @property
     def custom_id(self) -> str:
@@ -262,8 +263,8 @@ class Select(Item[V]):
     @property
     def values(self) -> List[str]:
         """List[:class:`str`]: A list of values that have been selected by the user."""
-        values = selected_values.get({})
-        return values.get(self.custom_id, [])
+        values = selected_values.get(None)
+        return self._values if values is None else values.get(self.custom_id, [])
 
     @property
     def width(self) -> int:
@@ -277,7 +278,7 @@ class Select(Item[V]):
 
     def _refresh_state(self, data: MessageComponentInteractionData) -> None:
         values = selected_values.get({})
-        values[self.custom_id] = data.get('values', [])
+        self._values = values[self.custom_id] = data.get('values', [])
         selected_values.set(values)
 
     @classmethod

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -416,6 +416,8 @@ class View:
             if self.timeout:
                 self.__timeout_expiry = time.monotonic() + self.timeout
 
+            item._refresh_state(interaction.data)  # type: ignore
+
             allow = await self.interaction_check(interaction)
             if not allow:
                 return
@@ -615,7 +617,6 @@ class ViewStore:
         if item is None:
             return
 
-        item._refresh_state(interaction.data)  # type: ignore
         # Note, at this point the View is *not* None
         item.view._dispatch_item(item, interaction)  # type: ignore
 
@@ -630,8 +631,7 @@ class ViewStore:
             _log.debug("Modal interaction referencing unknown custom_id %s. Discarding", custom_id)
             return
 
-        modal._refresh(components)
-        modal._dispatch_submit(interaction)
+        modal._dispatch_submit(interaction, components)
 
     def remove_interaction_mapping(self, interaction_id: int) -> None:
         # This is called before re-adding the view


### PR DESCRIPTION
## Summary

This fixes a bug in #8136 where `.values` of every `Select` in a modal would return those of the last `Select`.
resolves #8319 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
