### PR TITLE
Add :decorator: to ui.button and ui.select

### DIFF
--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -435,6 +435,7 @@ Button
     :inherited-members:
 
 .. autofunction:: discord.ui.button
+    :decorator:
 
 Select
 ~~~~~~~
@@ -446,6 +447,7 @@ Select
     :inherited-members:
 
 .. autofunction:: discord.ui.select
+    :decorator:
 
 TextInput
 ~~~~~~~~~~


### PR DESCRIPTION
## Summary
Since [`discord.ui.button`][1] and [`discord.ui.select`][2] are decorators, there should be the decorator-sign (`@`) in front of it in the docs.

## Checklist
- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)

[1]: https://discordpy.readthedocs.io/en/latest/interactions/api.html?%20modal#discord.ui.button
[2]: https://discordpy.readthedocs.io/en/latest/interactions/api.html?%20modal#discord.ui.select