### PR TITLE
Raise TypeError when token is None

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -630,10 +630,9 @@ class Client:
         if self.loop is _loop:
             await self._async_setup_hook()
 
-        try:
-            token = token.strip()
-        except AttributeError as exc:
-            raise TypeError('Token must be of type str.') from exc
+        if not isinstance(token, str):
+            raise TypeError(f'expected token to be a str, received {token.__class__!r} instead')
+        token = token.strip()
 
         data = await self.http.static_login(token)
         self._connection.user = ClientUser(state=self._connection, data=data)

--- a/discord/client.py
+++ b/discord/client.py
@@ -633,7 +633,7 @@ class Client:
         try:
             token = token.strip()
         except AttributeError as exc:
-            raise LoginFailure('Token must be of type str.') from exc
+            raise TypeError('Token must be of type str.') from exc
 
         data = await self.http.static_login(token)
         self._connection.user = ClientUser(state=self._connection, data=data)

--- a/discord/client.py
+++ b/discord/client.py
@@ -630,7 +630,12 @@ class Client:
         if self.loop is _loop:
             await self._async_setup_hook()
 
-        data = await self.http.static_login(token.strip())
+        try:
+            token = token.strip()
+        except AttributeError as exc:
+            raise LoginFailure('Token must be of type str.') from exc
+
+        data = await self.http.static_login(token)
         self._connection.user = ClientUser(state=self._connection, data=data)
         self._application = await self.application_info()
         if self._connection.application_id is None:


### PR DESCRIPTION
## Summary

Raises a `TypeError`, if token can't get stripped with `strip()`, which means that token is not of type `str`. 
E.g. this happens when your environment variable can't be found with `os.getenv()`. It allows users to know what exactly causes the error (especially for beginners in discord.py).

**Now**
```
Traceback (most recent call last):
  File "C:/Users/andri/Documents/GitHub/Testing-Py/Discord.py/v2.0/main.py", line 171, in <module>
    bot.run(os.getenv("WRONG_ENV"))
  File "C:\Users\andri\Documents\GitHub\Testing-Py\Discord.py\v2.0\venv\lib\site-packages\discord\client.py", line 890, in run
    asyncio.run(runner())
  File "C:\Users\andri\AppData\Local\Programs\Python\Python38\lib\asyncio\runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "C:\Users\andri\AppData\Local\Programs\Python\Python38\lib\asyncio\base_events.py", line 616, in run_until_complete
    return future.result()
  File "C:\Users\andri\Documents\GitHub\Testing-Py\Discord.py\v2.0\venv\lib\site-packages\discord\client.py", line 865, in runner
    await self.start(token, reconnect=reconnect)
  File "C:\Users\andri\Documents\GitHub\Testing-Py\Discord.py\v2.0\venv\lib\site-packages\discord\client.py", line 798, in start
    await self.login(token)
  File "C:\Users\andri\Documents\GitHub\Testing-Py\Discord.py\v2.0\venv\lib\site-packages\discord\client.py", line 633, in login
    data = await self.http.static_login(token.strip())
AttributeError: 'NoneType' object has no attribute 'strip'
```

**After**
```
Traceback (most recent call last):
  File "C:\Users\andri\Documents\GitHub\Testing-Py\Discord.py\fork\venv\lib\site-packages\discord\client.py", line 634, in login
    token = token.strip()
AttributeError: 'NoneType' object has no attribute 'strip'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:/Users/andri/Documents/GitHub/Testing-Py/Discord.py/fork/main.py", line 125, in <module>
    bot.run(os.getenv("WRONG_ENV"))
  File "C:\Users\andri\Documents\GitHub\Testing-Py\Discord.py\fork\venv\lib\site-packages\discord\client.py", line 895, in run
    asyncio.run(runner())
  File "C:\Users\andri\AppData\Local\Programs\Python\Python38\lib\asyncio\runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "C:\Users\andri\AppData\Local\Programs\Python\Python38\lib\asyncio\base_events.py", line 616, in run_until_complete
    return future.result()
  File "C:\Users\andri\Documents\GitHub\Testing-Py\Discord.py\fork\venv\lib\site-packages\discord\client.py", line 870, in runner
    await self.start(token, reconnect=reconnect)
  File "C:\Users\andri\Documents\GitHub\Testing-Py\Discord.py\fork\venv\lib\site-packages\discord\client.py", line 803, in start
    await self.login(token)
  File "C:\Users\andri\Documents\GitHub\Testing-Py\Discord.py\fork\venv\lib\site-packages\discord\client.py", line 636, in login
    raise TypeError('Token must be of type str.') from exc
TypeError: Token must be of type str.
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes. (already exists: `LoginFailure – The wrong credentials are passed.`)
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
