### PR TITLE
Document get_thread not fetching archived threads

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -673,6 +673,11 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
     def get_thread(self, thread_id: int, /) -> Optional[Thread]:
         """Returns a thread with the given ID.
 
+        .. note::
+
+            This does not always retrieve archived threads, as they are not retained in the internal
+            cache. Use :func:`Guild.fetch_channel` instead.
+
         .. versionadded:: 2.0
 
         Parameters

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -739,6 +739,11 @@ class Guild(Hashable):
     def get_thread(self, thread_id: int, /) -> Optional[Thread]:
         """Returns a thread with the given ID.
 
+        .. note::
+
+            This does not always retrieve archived threads, as they are not retained in the internal
+            cache. Use :func:`fetch_channel` instead.
+
         .. versionadded:: 2.0
 
         Parameters


### PR DESCRIPTION
## Summary

The `get_thread` methods of `Guild` and `TextChannel` work inconsistently with archived threads, since threads [are evicted from the cache](https://discord.com/channels/336642139381301249/669155775700271126/1001354155824259082) once archived. As this is not stated in the documentation, this PR adds a note explaining this for those unaware of the internal workings of the library (like admittedly me until yesterday).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
