### PR TITLE
Fix typo in hybrid commands documentation

### DIFF
--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -1239,7 +1239,6 @@ Following are currently **not supported** by hybrid commands:
 Apart from that, all other features such as converters, checks, autocomplete, flags etc.
 are supported on hybrid commands. Note that due to a design constraint, decorators related to application commands
 such as :func:`discord.app_commands.autocomplete` should be placed below the :func:`~ext.commands.hybrid_command` decorator.
-decorator.
 
 For convenience and ease in writing code, The :class:`~ext.commands.Context` class implements
 some behavioural changes for various methods and attributes:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
