### PR TITLE
fix: add missing `required` property to `Parameter``

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -513,6 +513,10 @@ class Parameter:
         return self.__parent.display_name
 
     @property
+    def required(self) -> bool:
+        return self.__parent.required
+
+    @property
     def description(self) -> str:
         return str(self.__parent.description)
 


### PR DESCRIPTION
## Summary

The object `discord.app_commands.Parameter` is missing the property `required`.
This property was documented but missing.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
