### PR TITLE
Document that docstrings can be used to document parameters

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -2102,7 +2102,8 @@ def describe(**parameters: Union[str, locale_str]) -> Callable[[T], T]:
 
         @app_commands.command()
         async def ban(interaction: discord.Interaction, member: discord.Member):
-            '''
+            """Bans a member
+
             Parameters
             -----------
             member: discord.Member

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -2102,13 +2102,13 @@ def describe(**parameters: Union[str, locale_str]) -> Callable[[T], T]:
 
         @app_commands.command()
         async def ban(interaction: discord.Interaction, member: discord.Member):
-            '''Bans a member
+            \"\"\"Bans a member
 
             Parameters
             -----------
             member: discord.Member
                 the member to ban
-            '''
+            \"\"\"
             await interaction.response.send_message(f'Banned {member}')
 
     Parameters

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -2102,7 +2102,7 @@ def describe(**parameters: Union[str, locale_str]) -> Callable[[T], T]:
 
         @app_commands.command()
         async def ban(interaction: discord.Interaction, member: discord.Member):
-            """Bans a member
+            '''Bans a member
 
             Parameters
             -----------

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -2094,6 +2094,22 @@ def describe(**parameters: Union[str, locale_str]) -> Callable[[T], T]:
         async def ban(interaction: discord.Interaction, member: discord.Member):
             await interaction.response.send_message(f'Banned {member}')
 
+    Alternatively, you can describe parameters using Google, Sphinx, or Numpy style docstrings.
+
+    Example:
+
+    .. code-block:: python3
+
+        @app_commands.command()
+        async def ban(interaction: discord.Interaction, member: discord.Member):
+            '''
+            Parameters
+            -----------
+            member: discord.Member
+                the member to ban
+            '''
+            await interaction.response.send_message(f'Banned {member}')
+
     Parameters
     -----------
     \*\*parameters: Union[:class:`str`, :class:`locale_str`]


### PR DESCRIPTION
## Summary

Currently it is not documented that Google, Sphinx, or Numpy style docstrings can be used instead of the `app_commands.describe` decorator. This changes that.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
