### PR TITLE
Switch quotes to make docs example render properly

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -2082,7 +2082,7 @@ def context_menu(
 
 
 def describe(**parameters: Union[str, locale_str]) -> Callable[[T], T]:
-    r"""Describes the given parameters by their name using the key of the keyword argument
+    r'''Describes the given parameters by their name using the key of the keyword argument
     as the name.
 
     Example:
@@ -2102,13 +2102,13 @@ def describe(**parameters: Union[str, locale_str]) -> Callable[[T], T]:
 
         @app_commands.command()
         async def ban(interaction: discord.Interaction, member: discord.Member):
-            \"\"\"Bans a member
+            """Bans a member
 
             Parameters
             -----------
             member: discord.Member
                 the member to ban
-            \"\"\"
+            """
             await interaction.response.send_message(f'Banned {member}')
 
     Parameters
@@ -2120,7 +2120,7 @@ def describe(**parameters: Union[str, locale_str]) -> Callable[[T], T]:
     --------
     TypeError
         The parameter name is not found.
-    """
+    '''
 
     def decorator(inner: T) -> T:
         if isinstance(inner, Command):


### PR DESCRIPTION
## Summary

Fixes the issue raised by @sgtlaggy in this comment: https://github.com/Rapptz/discord.py/pull/8345#issuecomment-1217248422 by changing `app_commands.describe` docstring to use single quotes so the example docstring can use double quotes.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
