### PR TITLE
make app_commands.describe examples consistent

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -2089,7 +2089,7 @@ def describe(**parameters: Union[str, locale_str]) -> Callable[[T], T]:
 
     .. code-block:: python3
 
-        @app_commands.command()
+        @app_commands.command(description='Bans a member')
         @app_commands.describe(member='the member to ban')
         async def ban(interaction: discord.Interaction, member: discord.Member):
             await interaction.response.send_message(f'Banned {member}')


### PR DESCRIPTION
## Summary

This makes the examples for `app_commands.describe` result in the same command and documentation.
The old example only made a description for the arg, not the command. The new docstring example made a description for both.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
