### PR TITLE
Updated role mention property

### DIFF
--- a/discord/role.py
+++ b/discord/role.py
@@ -342,7 +342,7 @@ class Role(Hashable):
     @property
     def mention(self) -> str:
         """:class:`str`: Returns a string that allows you to mention a role."""
-        return f'<@&{self.id}>'
+        return "@everyone" if self.is_default() else f"<@&{self.id}>"
 
     @property
     def members(self) -> List[Member]:


### PR DESCRIPTION
## Summary

The [`mention`](https://discordpy.readthedocs.io/en/stable/api.html#discord.Role.mention) property of the [`discord.Role`](https://discordpy.readthedocs.io/en/stable/api.html#role) class returns `"@@everyone"` instead of `"@everyone"` when used with the default `@everyone` role.

This is a bug since mentionning the `@everyone` role does not work with an extra `@`.

This pull request fixes the bug.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
