### PR TITLE
[interactions] docs: Add missing decorator signs

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -1908,7 +1908,7 @@ class Group:
         auto_locale_strings: bool = True,
         extras: Dict[Any, Any] = MISSING,
     ) -> Callable[[CommandCallback[GroupT, P, T]], Command[GroupT, P, T]]:
-        """Creates an application command under this group.
+        """A decorator that creates an application command from a regular function under this group.
 
         Parameters
         ------------

--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -842,7 +842,7 @@ class CommandTree(Generic[ClientT]):
         auto_locale_strings: bool = True,
         extras: Dict[Any, Any] = MISSING,
     ) -> Callable[[CommandCallback[Group, P, T]], Command[Group, P, T]]:
-        """Creates an application command directly under this tree.
+        """A decorator that creates an application command from a regular function directly under this tree.
 
         Parameters
         ------------
@@ -911,7 +911,7 @@ class CommandTree(Generic[ClientT]):
         auto_locale_strings: bool = True,
         extras: Dict[Any, Any] = MISSING,
     ) -> Callable[[ContextMenuCallback], ContextMenu]:
-        """Creates an application command context menu from a regular function directly under this tree.
+        """A decorator that creates an application command context menu from a regular function directly under this tree.
 
         This function must have a signature of :class:`~discord.Interaction` as its first parameter
         and taking either a :class:`~discord.Member`, :class:`~discord.User`, or :class:`~discord.Message`,

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -493,6 +493,13 @@ Command
 
 .. autoclass:: discord.app_commands.Command
     :members:
+    :exclude-members: error, autocomplete
+
+    .. automethod:: Command.error(coro)
+        :decorator:
+
+    .. automethod:: Command.autocomplete(name)
+        :decorator:
 
 Parameter
 ++++++++++

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -474,13 +474,13 @@ CommandTree
     :members:
     :exclude-members: error, command, context_menu
 
-    .. automethod:: CommandTree.error(coro)
-        :decorator:
-
     .. automethod:: CommandTree.command(*, name=..., description=..., nsfw=False, guild=..., guilds=..., auto_locale_strings=True, extras=...)
         :decorator:
 
     .. automethod:: CommandTree.context_menu(*, name=..., nsfw=False, guild=..., guilds=..., auto_locale_strings=True, extras=...)
+        :decorator:
+
+    .. automethod:: CommandTree.error(coro)
         :decorator:
 
 Commands
@@ -495,10 +495,10 @@ Command
     :members:
     :exclude-members: error, autocomplete
 
-    .. automethod:: Command.error(coro)
+    .. automethod:: Command.autocomplete(name)
         :decorator:
 
-    .. automethod:: Command.autocomplete(name)
+    .. automethod:: Command.error(coro)
         :decorator:
 
 Parameter
@@ -530,12 +530,11 @@ Group
     :members:
     :exclude-members: error, command
 
-    .. automethod:: Group.error(coro)
-        :decorator:
-
     .. automethod:: Group.command(*, name=..., description=..., nsfw=False, auto_locale_strings=True, extras=...)
         :decorator:
 
+    .. automethod:: Group.error(coro)
+        :decorator:
 
 Decorators
 ~~~~~~~~~~~

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -516,6 +516,10 @@ ContextMenu
 
 .. autoclass:: discord.app_commands.ContextMenu
     :members:
+    :exclude-members: error
+
+    .. automethod:: ContextMenu.error(coro)
+        :decorator:
 
 Group
 ++++++

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -528,6 +528,14 @@ Group
 
 .. autoclass:: discord.app_commands.Group
     :members:
+    :exclude-members: error, command
+
+    .. automethod:: Group.error(coro)
+        :decorator:
+
+    .. automethod:: Group.command(*, name=..., description=..., nsfw=False, auto_locale_strings=True, extras=...)
+        :decorator:
+
 
 Decorators
 ~~~~~~~~~~~

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -472,6 +472,16 @@ CommandTree
 
 .. autoclass:: discord.app_commands.CommandTree
     :members:
+    :exclude-members: error, command, context_menu
+
+    .. automethod:: CommandTree.error(coro)
+        :decorator:
+
+    .. automethod:: CommandTree.command(*, name=..., description=..., nsfw=False, guild=..., guilds=..., auto_locale_strings=True, extras=...)
+        :decorator:
+
+    .. automethod:: CommandTree.context_menu(*, name=..., nsfw=False, guild=..., guilds=..., auto_locale_strings=True, extras=...)
+        :decorator:
 
 Commands
 ~~~~~~~~~


### PR DESCRIPTION
## Summary

This PR adds missing decorator signs in the docs. 

#### This includes:
* **`CommandTree`:** `command()`, `context_menu()`, `error()`
* **`Command`:** `autocomplete()`, `error()`
* **`ContextMenu`:** `error()`
* **`Group`:** `command()`, `error()`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
