### PR TITLE
[commands] docs: Add missing decorator signs

### DIFF
--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -216,9 +216,12 @@ HybridGroup
 .. autoclass:: discord.ext.commands.HybridGroup
     :members:
     :inherited-members:
-    :exclude-members: after_invoke, before_invoke, command, error, group
+    :exclude-members: after_invoke, autocomplete, before_invoke, command, error, group
 
     .. automethod:: HybridGroup.after_invoke()
+        :decorator:
+
+    .. automethod:: HybridGroup.autocomplete(name)
         :decorator:
 
     .. automethod:: HybridGroup.before_invoke()

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -18,7 +18,7 @@ Bot
 .. autoclass:: discord.ext.commands.Bot
     :members:
     :inherited-members:
-    :exclude-members: after_invoke, before_invoke, check, check_once, command, event, group, listen
+    :exclude-members: after_invoke, before_invoke, check, check_once, command, event, group, hybrid_command, hybrid_group, listen
 
     .. automethod:: Bot.after_invoke()
         :decorator:
@@ -39,6 +39,12 @@ Bot
         :decorator:
 
     .. automethod:: Bot.group(*args, **kwargs)
+        :decorator:
+
+    .. automethod:: Bot.hybrid_command(name=..., with_app_command=True, *args, **kwargs)
+        :decorator:
+
+    .. automethod:: Bot.hybrid_group(name=..., with_app_command=True, *args, **kwargs)
         :decorator:
 
     .. automethod:: Bot.listen(name=None)

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -194,9 +194,12 @@ HybridCommand
 .. autoclass:: discord.ext.commands.HybridCommand
     :members:
     :special-members: __call__
-    :exclude-members: after_invoke, before_invoke, error
+    :exclude-members: after_invoke, autocomplete, before_invoke, error
 
     .. automethod:: HybridCommand.after_invoke()
+        :decorator:
+
+    .. automethod:: HybridCommand.autocomplete(name)
         :decorator:
 
     .. automethod:: HybridCommand.before_invoke()


### PR DESCRIPTION
## Summary

This PR adds missing decorator signs in the docs.

#### This includes:
* **`Bot`**: `hybrid_command()`, `hybrid_group()`
* **`HybridCommand`**: `autocomplete()`
* **`HybridGroup`**: `autocomplete()`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
