### PR TITLE
[tasks] docs: Add missing decorator sign

### DIFF
--- a/docs/ext/tasks/index.rst
+++ b/docs/ext/tasks/index.rst
@@ -152,3 +152,4 @@ API Reference
         :decorator:
 
 .. autofunction:: discord.ext.tasks.loop
+    :decorator:


### PR DESCRIPTION
## Summary

This PR adds missing decorator signs in the docs.

#### This includes:
* `tasks.loop`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
