### PR TITLE
Mark public callbacks as positional-only

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -1745,7 +1745,7 @@ class Group:
             if isinstance(command, Group):
                 yield from command.walk_commands()
 
-    async def on_error(self, interaction: Interaction, error: AppCommandError) -> None:
+    async def on_error(self, interaction: Interaction, error: AppCommandError, /) -> None:
         """|coro|
 
         A callback that is called when a child's command raises an :exc:`AppCommandError`.
@@ -1790,10 +1790,10 @@ class Group:
         if len(params) != 2:
             raise TypeError('The error handler must have 2 parameters.')
 
-        self.on_error = coro  # type: ignore
+        self.on_error = coro
         return coro
 
-    async def interaction_check(self, interaction: Interaction) -> bool:
+    async def interaction_check(self, interaction: Interaction, /) -> bool:
         """|coro|
 
         A callback that is called when an interaction happens within the group

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -167,7 +167,7 @@ class CommandParameter:
     def is_choice_annotation(self) -> bool:
         return getattr(self._annotation, '__discord_app_commands_is_choice__', False)
 
-    async def transform(self, interaction: Interaction, value: Any) -> Any:
+    async def transform(self, interaction: Interaction, value: Any, /) -> Any:
         if hasattr(self._annotation, '__discord_app_commands_transformer__'):
             # This one needs special handling for type safety reasons
             if self._annotation.__discord_app_commands_is_choice__:
@@ -305,7 +305,7 @@ class Transformer:
         else:
             return name
 
-    async def transform(self, interaction: Interaction, value: Any) -> Any:
+    async def transform(self, interaction: Interaction, value: Any, /) -> Any:
         """|maybecoro|
 
         Transforms the converted option value into another value.
@@ -325,7 +325,7 @@ class Transformer:
         raise NotImplementedError('Derived classes need to implement this.')
 
     async def autocomplete(
-        self, interaction: Interaction, value: Union[int, float, str]
+        self, interaction: Interaction, value: Union[int, float, str], /
     ) -> List[Choice[Union[int, float, str]]]:
         """|coro|
 
@@ -361,7 +361,7 @@ class IdentityTransformer(Transformer):
     def type(self) -> AppCommandOptionType:
         return self._type
 
-    async def transform(self, interaction: Interaction, value: Any) -> Any:
+    async def transform(self, interaction: Interaction, value: Any, /) -> Any:
         return value
 
 
@@ -459,7 +459,7 @@ class EnumValueTransformer(Transformer):
     def choices(self):
         return self._choices
 
-    async def transform(self, interaction: Interaction, value: Any) -> Any:
+    async def transform(self, interaction: Interaction, value: Any, /) -> Any:
         return self._enum(value)
 
 
@@ -486,7 +486,7 @@ class EnumNameTransformer(Transformer):
     def choices(self):
         return self._choices
 
-    async def transform(self, interaction: Interaction, value: Any) -> Any:
+    async def transform(self, interaction: Interaction, value: Any, /) -> Any:
         return self._enum[value]
 
 
@@ -503,7 +503,7 @@ class InlineTransformer(Transformer):
     def type(self) -> AppCommandOptionType:
         return AppCommandOptionType.string
 
-    async def transform(self, interaction: Interaction, value: Any) -> Any:
+    async def transform(self, interaction: Interaction, value: Any, /) -> Any:
         return await self.annotation.transform(interaction, value)
 
 
@@ -615,7 +615,7 @@ class MemberTransformer(Transformer):
     def type(self) -> AppCommandOptionType:
         return AppCommandOptionType.user
 
-    async def transform(self, interaction: Interaction, value: Any) -> Member:
+    async def transform(self, interaction: Interaction, value: Any, /) -> Member:
         if not isinstance(value, Member):
             raise TransformerError(value, self.type, self)
         return value
@@ -653,7 +653,7 @@ class BaseChannelTransformer(Transformer):
     def channel_types(self) -> List[ChannelType]:
         return self._channel_types
 
-    async def transform(self, interaction: Interaction, value: Any):
+    async def transform(self, interaction: Interaction, value: Any, /):
         resolved = value.resolve()
         if resolved is None or not isinstance(resolved, self._types):
             raise TransformerError(value, AppCommandOptionType.channel, self)
@@ -661,14 +661,14 @@ class BaseChannelTransformer(Transformer):
 
 
 class RawChannelTransformer(BaseChannelTransformer):
-    async def transform(self, interaction: Interaction, value: Any):
+    async def transform(self, interaction: Interaction, value: Any, /):
         if not isinstance(value, self._types):
             raise TransformerError(value, AppCommandOptionType.channel, self)
         return value
 
 
 class UnionChannelTransformer(BaseChannelTransformer):
-    async def transform(self, interaction: Interaction, value: Any):
+    async def transform(self, interaction: Interaction, value: Any, /):
         if isinstance(value, self._types):
             return value
 

--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -773,7 +773,7 @@ class CommandTree(Generic[ClientT]):
             for key in remove:
                 del mapping[key]
 
-    async def on_error(self, interaction: Interaction, error: AppCommandError) -> None:
+    async def on_error(self, interaction: Interaction, error: AppCommandError, /) -> None:
         """|coro|
 
         A callback that is called when any command raises an :exc:`AppCommandError`.
@@ -827,8 +827,7 @@ class CommandTree(Generic[ClientT]):
         if len(params) != 2:
             raise TypeError('error handler must have 2 parameters')
 
-        # Type checker doesn't like overriding methods like this
-        self.on_error = coro  # type: ignore
+        self.on_error = coro
         return coro
 
     def command(

--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -130,7 +130,7 @@ class ConverterTransformer(app_commands.Transformer):
             if module is not None and (module.startswith('discord.') and not module.endswith('converter')):
                 self.converter = CONVERTER_MAPPING.get(converter, converter)
 
-    async def transform(self, interaction: discord.Interaction, value: str) -> Any:
+    async def transform(self, interaction: discord.Interaction, value: str, /) -> Any:
         ctx = interaction._baton
         converter = self.converter
         ctx.current_parameter = self.parameter
@@ -154,7 +154,7 @@ class CallableTransformer(app_commands.Transformer):
         super().__init__()
         self.func: Callable[[str], Any] = func
 
-    async def transform(self, interaction: discord.Interaction, value: str) -> Any:
+    async def transform(self, interaction: discord.Interaction, value: str, /) -> Any:
         try:
             return self.func(value)
         except CommandError:
@@ -169,7 +169,7 @@ class GreedyTransformer(app_commands.Transformer):
         self.converter: Any = converter
         self.parameter: Parameter = parameter
 
-    async def transform(self, interaction: discord.Interaction, value: str) -> Any:
+    async def transform(self, interaction: discord.Interaction, value: str, /) -> Any:
         view = StringView(value)
         result = []
         ctx = interaction._baton

--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -134,7 +134,7 @@ class Modal(View):
 
         super().__init__(timeout=timeout)
 
-    async def on_submit(self, interaction: Interaction) -> None:
+    async def on_submit(self, interaction: Interaction, /) -> None:
         """|coro|
 
         Called when the modal is submitted.
@@ -146,7 +146,7 @@ class Modal(View):
         """
         pass
 
-    async def on_error(self, interaction: Interaction, error: Exception) -> None:
+    async def on_error(self, interaction: Interaction, error: Exception, /) -> None:
         """|coro|
 
         A callback that is called when :meth:`on_submit`

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -357,7 +357,7 @@ class View:
         self.__weights.clear()
         return self
 
-    async def interaction_check(self, interaction: Interaction) -> bool:
+    async def interaction_check(self, interaction: Interaction, /) -> bool:
         """|coro|
 
         A callback that is called when an interaction happens within the view
@@ -392,7 +392,7 @@ class View:
         """
         pass
 
-    async def on_error(self, interaction: Interaction, error: Exception, item: Item[Any]) -> None:
+    async def on_error(self, interaction: Interaction, error: Exception, item: Item[Any], /) -> None:
         """|coro|
 
         A callback that is called when an item's callback or :meth:`interaction_check`


### PR DESCRIPTION
## Summary

Marks several public-facing callbacks as positional-only. These methods are only ever called with positional arguments. This PR allows developers to use strict mode typing and name these parameters any name they would like.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
