### PR TITLE
Added `voice_state` property

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -626,6 +626,18 @@ class Guild(Hashable):
         return self._state._get_voice_client(self.id)
 
     @property
+    def voice_state(self) -> Optional[VoiceState]:
+        """Optional[:class:`VoiceState`]: Returns the client's :class:`VoiceState` associated with this guild, if any.
+
+        .. versionadded:: 2.0
+        """
+        key = self.me.id
+        value = self._voice_state_for(key)
+        if not value or not value.channel:
+            return None
+        return value
+
+    @property
     def text_channels(self) -> List[TextChannel]:
         """List[:class:`TextChannel`]: A list of text channels that belongs to this guild.
 


### PR DESCRIPTION
## Summary

Added `voice_state` property in `discord.Guild` to quickly access the `discord.VoiceState` of the client, if any.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
