### PR TITLE
Added `self_mute` and `self_deaf` methods inside `VoiceClient`

### DIFF
--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -280,6 +280,29 @@ class VoiceClient(VoiceProtocol):
         """:class:`ClientUser`: The user connected to voice (i.e. ourselves)."""
         return self._state.user  # type: ignore
 
+    @property
+    def voice_state(self):
+        """:class:`Optional[VoiceState]`: The voice state associated with the voice client.
+
+        .. versionadded:: 2.0"""
+        return self.channel.guild.me.voice
+
+    async def self_mute(self, value: bool = True, /) -> None:
+        """Self mutes the client.
+
+        .. versionadded:: 2.0"""
+        vs = self.voice_state
+        if vs:
+            await self.voice_connect(self_deaf=vs.self_deaf, self_mute=value)
+
+    async def self_deaf(self, value: bool = True, /) -> None:
+        """Self deafens the client.
+
+        .. versionadded:: 2.0"""
+        vs = self.voice_state
+        if vs:
+            await self.voice_connect(self_deaf=value, self_mute=vs.self_mute)
+
     def checked_add(self, attr: str, value: int, limit: int) -> None:
         val = getattr(self, attr)
         if val + value > limit:


### PR DESCRIPTION
## Summary

Added an easier way to mute and deafen the voice client.

Before:
```python3
vc: discord.VoiceClient = …
deafened = vc.guild.me.voice.self_deaf  # Keep the current self deafened state
await vc.guild.change_voice_state(channel=vc.channel, self_mute=True, self_deaf=deafened)
```

After:
```python3
vc: discord.VoiceClient = …
await vc.self_mute()
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
