### PR TITLE
Fix incorrect docs in select menu min_values

### DIFF
--- a/discord/components.py
+++ b/discord/components.py
@@ -240,7 +240,7 @@ class SelectMenu(Component):
         The placeholder text that is shown if nothing is selected, if any.
     min_values: :class:`int`
         The minimum number of items that must be chosen for this select menu.
-        Defaults to 1 and must be between 1 and 25.
+        Defaults to 1 and must be between 0 and 25.
     max_values: :class:`int`
         The maximum number of items that must be chosen for this select menu.
         Defaults to 1 and must be between 1 and 25.

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -75,7 +75,7 @@ class Select(Item[V]):
         The placeholder text that is shown if nothing is selected, if any.
     min_values: :class:`int`
         The minimum number of items that must be chosen for this select menu.
-        Defaults to 1 and must be between 1 and 25.
+        Defaults to 1 and must be between 0 and 25.
     max_values: :class:`int`
         The maximum number of items that must be chosen for this select menu.
         Defaults to 1 and must be between 1 and 25.
@@ -335,7 +335,7 @@ def select(
         ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     min_values: :class:`int`
         The minimum number of items that must be chosen for this select menu.
-        Defaults to 1 and must be between 1 and 25.
+        Defaults to 1 and must be between 0 and 25.
     max_values: :class:`int`
         The maximum number of items that must be chosen for this select menu.
         Defaults to 1 and must be between 1 and 25.


### PR DESCRIPTION
## Summary

The [documentation](https://discordpy.readthedocs.io/en/stable/interactions/api.html#discord.SelectMenu.min_values) for `min_values` in a select menu states that it must be between 1 and 25. However, in the [Discord API docs](https://discord.com/developers/docs/interactions/message-components#select-menus) it says that `min_values` can be from 0 to 25.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
