### PR TITLE
Add additional audit log types for auto mod

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -578,7 +578,11 @@ class AuditLogEntry(Hashable):
                     channel=self.guild.get_channel_or_thread(channel_id) or Object(id=channel_id),
                     message_id=int(extra['message_id']),
                 )
-            elif self.action is enums.AuditLogAction.automod_block_message:
+            elif (
+                self.action is enums.AuditLogAction.automod_block_message
+                or self.action is enums.AuditLogAction.automod_flag_message
+                or self.action is enums.AuditLogAction.automod_timeout_member
+            ):
                 channel_id = int(extra['channel_id'])
                 self.extra = _AuditLogProxyAutoModAction(
                     automod_rule_name=extra['auto_moderation_rule_name'],

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -355,6 +355,8 @@ class AuditLogAction(Enum):
     automod_rule_update           = 141
     automod_rule_delete           = 142
     automod_block_message         = 143
+    automod_flag_message          = 144
+    automod_timeout_member        = 145
     # fmt: on
 
     @property
@@ -413,6 +415,8 @@ class AuditLogAction(Enum):
             AuditLogAction.automod_rule_update:           AuditLogActionCategory.update,
             AuditLogAction.automod_rule_delete:           AuditLogActionCategory.delete,
             AuditLogAction.automod_block_message:         None,
+            AuditLogAction.automod_flag_message:          None,
+            AuditLogAction.automod_timeout_member:        None,
         }
         # fmt: on
         return lookup[self]
@@ -454,7 +458,7 @@ class AuditLogAction(Enum):
             return 'integration_or_app_command'
         elif v < 143:
             return 'auto_moderation'
-        elif v == 143:
+        elif v < 146:
             return 'user'
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2678,6 +2678,42 @@ of :class:`enum.Enum`.
 
         .. versionadded:: 2.0
 
+    .. attribute:: automod_flag_message
+
+        An automod rule flagged a message.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.target` is
+        a :class:`Member` with the ID of the person who triggered the automod rule.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
+        set to an unspecified proxy object with 3 attributes:
+
+        - ``automod_rule_name``: The name of the automod rule that was triggered.
+        - ``automod_rule_trigger``: A :class:`AutoModRuleTriggerType` representation of the rule type that was triggered.
+        - ``channel``: The channel in which the automod rule was triggered.
+
+        When this is the action, :attr:`AuditLogEntry.changes` is empty.
+
+        .. versionadded:: 2.1
+
+    .. attribute:: automod_timeout_member
+
+        An automod rule timed-out a member.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.target` is
+        a :class:`Member` with the ID of the person who triggered the automod rule.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
+        set to an unspecified proxy object with 3 attributes:
+
+        - ``automod_rule_name``: The name of the automod rule that was triggered.
+        - ``automod_rule_trigger``: A :class:`AutoModRuleTriggerType` representation of the rule type that was triggered.
+        - ``channel``: The channel in which the automod rule was triggered.
+
+        When this is the action, :attr:`AuditLogEntry.changes` is empty.
+
+        .. versionadded:: 2.1
+
 .. class:: AuditLogActionCategory
 
     Represents the category that the :class:`AuditLogAction` belongs to.


### PR DESCRIPTION
## Summary

This PR adds additional `AuditLogAction` types `automod_flag_message` (`AUTO_MODERATION_FLAG_TO_CHANNEL`) and `automod_timeout_member` (`AUTO_MODERATION_USER_COMMUNICATION_DISABLED`)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
