### PR TITLE
Add support for toggling discoverable and invites_disabled features

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -245,6 +245,7 @@ class Guild(Hashable):
         - ``VERIFIED``: Guild is a verified server.
         - ``VIP_REGIONS``: Guild has VIP voice regions.
         - ``WELCOME_SCREEN_ENABLED``: Guild has enabled the welcome screen.
+        - ``INVITES_DISABLED``: Guild has disabled invites.
 
     premium_tier: :class:`int`
         The premium tier for this guild. Corresponds to "Nitro Server" in the official UI.
@@ -1698,6 +1699,7 @@ class Guild(Hashable):
         rules_channel: Optional[TextChannel] = MISSING,
         public_updates_channel: Optional[TextChannel] = MISSING,
         premium_progress_bar_enabled: bool = MISSING,
+        invites_disabled: bool = MISSING,
     ) -> Guild:
         r"""|coro|
 
@@ -1726,6 +1728,9 @@ class Guild(Hashable):
 
         .. versionchanged:: 2.0
             The ``premium_progress_bar_enabled`` keyword parameter was added.
+
+        .. versionchanged:: 2.1
+            The ``invites_disabled`` keyword parameter was added.
 
         Parameters
         ----------
@@ -1786,6 +1791,8 @@ class Guild(Hashable):
             public updates channel.
         premium_progress_bar_enabled: :class:`bool`
             Whether the premium AKA server boost level progress bar should be enabled for the guild.
+        invites_disabled: :class:`bool`
+            Whether joining via invites should be disabled for the guild.
         reason: Optional[:class:`str`]
             The reason for editing this guild. Shows up on the audit log.
 
@@ -1906,8 +1913,9 @@ class Guild(Hashable):
 
             fields['system_channel_flags'] = system_channel_flags.value
 
+        features = []
+
         if community is not MISSING:
-            features = []
             if community:
                 if 'rules_channel_id' in fields and 'public_updates_channel_id' in fields:
                     features.append('COMMUNITY')
@@ -1915,8 +1923,16 @@ class Guild(Hashable):
                     raise ValueError(
                         'community field requires both rules_channel and public_updates_channel fields to be provided'
                     )
+        elif 'COMMUNITY' in self.features:
+            features.append('COMMUNITY')
 
-            fields['features'] = features
+        if invites_disabled is not MISSING:
+            if invites_disabled:
+                features.append('INVITES_DISABLED')
+        elif 'INVITES_DISABLED' in self.features:
+            features.append('INVITES_DISABLED')
+
+        fields['features'] = features
 
         if premium_progress_bar_enabled is not MISSING:
             fields['premium_progress_bar_enabled'] = premium_progress_bar_enabled

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1916,32 +1916,34 @@ class Guild(Hashable):
 
             fields['system_channel_flags'] = system_channel_flags.value
 
-        features = set(self.features)
+        if any(feat is not MISSING for feat in (community, discoverable, invites_disabled)):
 
-        if community is not MISSING:
-            if community:
-                if 'rules_channel_id' in fields and 'public_updates_channel_id' in fields:
-                    features.add('COMMUNITY')
+            features = set(self.features)
+
+            if community is not MISSING:
+                if community:
+                    if 'rules_channel_id' in fields and 'public_updates_channel_id' in fields:
+                        features.add('COMMUNITY')
+                    else:
+                        raise ValueError(
+                            'community field requires both rules_channel and public_updates_channel fields to be provided'
+                        )
                 else:
-                    raise ValueError(
-                        'community field requires both rules_channel and public_updates_channel fields to be provided'
-                    )
-            else:
-                features.discard('COMMUNITY')
+                    features.discard('COMMUNITY')
 
-        if discoverable is not MISSING:
-            if discoverable:
-                features.add('DISCOVERABLE')
-            else:
-                features.discard('DISCOVERABLE')
+            if discoverable is not MISSING:
+                if discoverable:
+                    features.add('DISCOVERABLE')
+                else:
+                    features.discard('DISCOVERABLE')
 
-        if invites_disabled is not MISSING:
-            if invites_disabled:
-                features.add('INVITES_DISABLED')
-            else:
-                features.discard('INVITES_DISABLED')
+            if invites_disabled is not MISSING:
+                if invites_disabled:
+                    features.add('INVITES_DISABLED')
+                else:
+                    features.discard('INVITES_DISABLED')
 
-        fields['features'] = list(features)
+            fields['features'] = list(features)
 
         if premium_progress_bar_enabled is not MISSING:
             fields['premium_progress_bar_enabled'] = premium_progress_bar_enabled

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1699,6 +1699,7 @@ class Guild(Hashable):
         rules_channel: Optional[TextChannel] = MISSING,
         public_updates_channel: Optional[TextChannel] = MISSING,
         premium_progress_bar_enabled: bool = MISSING,
+        discoverable: bool = MISSING,
         invites_disabled: bool = MISSING,
     ) -> Guild:
         r"""|coro|
@@ -1730,7 +1731,7 @@ class Guild(Hashable):
             The ``premium_progress_bar_enabled`` keyword parameter was added.
 
         .. versionchanged:: 2.1
-            The ``invites_disabled`` keyword parameter was added.
+            The ``discoverable`` and ``invites_disabled`` keyword parameters were added.
 
         Parameters
         ----------
@@ -1791,6 +1792,8 @@ class Guild(Hashable):
             public updates channel.
         premium_progress_bar_enabled: :class:`bool`
             Whether the premium AKA server boost level progress bar should be enabled for the guild.
+        discoverable: :class:`bool`
+            Whether server discovery is enabled for this guild.
         invites_disabled: :class:`bool`
             Whether joining via invites should be disabled for the guild.
         reason: Optional[:class:`str`]
@@ -1925,6 +1928,12 @@ class Guild(Hashable):
                     )
         elif 'COMMUNITY' in self.features:
             features.append('COMMUNITY')
+
+        if discoverable is not MISSING:
+            if discoverable:
+                features.append('DISCOVERABLE')
+        elif 'DISCOVERABLE' in self.features:
+            features.append('DISCOVERABLE')
 
         if invites_disabled is not MISSING:
             if invites_disabled:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1916,32 +1916,32 @@ class Guild(Hashable):
 
             fields['system_channel_flags'] = system_channel_flags.value
 
-        features = []
+        features = set(self.features)
 
         if community is not MISSING:
             if community:
                 if 'rules_channel_id' in fields and 'public_updates_channel_id' in fields:
-                    features.append('COMMUNITY')
+                    features.add('COMMUNITY')
                 else:
                     raise ValueError(
                         'community field requires both rules_channel and public_updates_channel fields to be provided'
                     )
-        elif 'COMMUNITY' in self.features:
-            features.append('COMMUNITY')
+            else:
+                features.discard('COMMUNITY')
 
         if discoverable is not MISSING:
             if discoverable:
-                features.append('DISCOVERABLE')
-        elif 'DISCOVERABLE' in self.features:
-            features.append('DISCOVERABLE')
+                features.add('DISCOVERABLE')
+            else:
+                features.discard('DISCOVERABLE')
 
         if invites_disabled is not MISSING:
             if invites_disabled:
-                features.append('INVITES_DISABLED')
-        elif 'INVITES_DISABLED' in self.features:
-            features.append('INVITES_DISABLED')
+                features.add('INVITES_DISABLED')
+            else:
+                features.discard('INVITES_DISABLED')
 
-        fields['features'] = features
+        fields['features'] = list(features)
 
         if premium_progress_bar_enabled is not MISSING:
             fields['premium_progress_bar_enabled'] = premium_progress_bar_enabled

--- a/discord/types/guild.py
+++ b/discord/types/guild.py
@@ -77,6 +77,7 @@ GuildFeature = Literal[
     'VERIFIED',
     'VIP_REGIONS',
     'WELCOME_SCREEN_ENABLED',
+    'INVITES_DISABLED',
 ]
 
 


### PR DESCRIPTION
## Summary

This PR adds support for the DISCOVERABLE and INVITES_DISABLED guild feature.

Note, INVITES_DISABLED is not yet stable.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
