### PR TITLE
Add support for delete_message_seconds ban argument 

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3390,7 +3390,7 @@ class Guild(Hashable):
 
             .. deprecated:: 2.1
         delete_message_seconds: :class:`int`:
-            The number of seconds woorth of messages to delete from the user
+            The number of seconds worth of messages to delete from the user
             in the guild. The minimum is 0 and the maximum is 604800 (7 days).
 
             .. versionadded:: 2.1

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -46,6 +46,7 @@ from typing import (
     Union,
     overload,
 )
+import warnings
 
 from . import utils, abc
 from .role import Role
@@ -3412,6 +3413,8 @@ class Guild(Hashable):
             raise TypeError('Cannot mix delete_message_days and delete_message_seconds keyword arguments.')
 
         if delete_message_days is not MISSING:
+            msg = 'delete_message_days is deprecated, use delete_message_seconds instead'
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
             delete_message_seconds = delete_message_days * 86400  # one day
 
         if delete_message_seconds is MISSING:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3368,7 +3368,8 @@ class Guild(Hashable):
         user: Snowflake,
         *,
         reason: Optional[str] = None,
-        delete_message_days: int = 1,
+        delete_message_days: int = MISSING,
+        delete_message_seconds: int = MISSING,
     ) -> None:
         """|coro|
 
@@ -3386,6 +3387,13 @@ class Guild(Hashable):
         delete_message_days: :class:`int`
             The number of days worth of messages to delete from the user
             in the guild. The minimum is 0 and the maximum is 7.
+
+            .. deprecated:: 2.1
+        delete_message_seconds: :class:`int`:
+            The number of seconds woorth of messages to delete from the user
+            in the guild. The minimum is 0 and the maximum is 604800 (7 days).
+
+            .. versionadded:: 2.1
         reason: Optional[:class:`str`]
             The reason the user got banned.
 
@@ -3397,8 +3405,19 @@ class Guild(Hashable):
             You do not have the proper permissions to ban.
         HTTPException
             Banning failed.
+        TypeError
+            You specified both ``delete_message_days`` and ``delete_message_seconds``.
         """
-        await self._state.http.ban(user.id, self.id, delete_message_days, reason=reason)
+        if delete_message_days is not MISSING and delete_message_seconds is not MISSING:
+            raise TypeError('Cannot mix delete_message_days and delete_message_seconds keyword arguments.')
+
+        if delete_message_days is not MISSING:
+            delete_message_seconds = delete_message_days * 86400  # one day
+
+        if delete_message_seconds is MISSING:
+            delete_message_seconds = 86400  # one day
+
+        await self._state.http.ban(user.id, self.id, delete_message_seconds, reason=reason)
 
     async def unban(self, user: Snowflake, *, reason: Optional[str] = None) -> None:
         """|coro|

--- a/discord/http.py
+++ b/discord/http.py
@@ -1032,12 +1032,12 @@ class HTTPClient:
         self,
         user_id: Snowflake,
         guild_id: Snowflake,
-        delete_message_days: int = 1,
+        delete_message_seconds: int = 86400,  # one day
         reason: Optional[str] = None,
     ) -> Response[None]:
         r = Route('PUT', '/guilds/{guild_id}/bans/{user_id}', guild_id=guild_id, user_id=user_id)
         params = {
-            'delete_message_days': delete_message_days,
+            'delete_message_seconds': delete_message_seconds,
         }
 
         return self.request(r, params=params, reason=reason)

--- a/discord/member.py
+++ b/discord/member.py
@@ -711,14 +711,20 @@ class Member(discord.abc.Messageable, _UserTag):
     async def ban(
         self,
         *,
-        delete_message_days: int = 1,
+        delete_message_days: int = MISSING,
+        delete_message_seconds: int = MISSING,
         reason: Optional[str] = None,
     ) -> None:
         """|coro|
 
         Bans this member. Equivalent to :meth:`Guild.ban`.
         """
-        await self.guild.ban(self, reason=reason, delete_message_days=delete_message_days)
+        await self.guild.ban(
+            self,
+            reason=reason,
+            delete_message_days=delete_message_days,
+            delete_message_seconds=delete_message_seconds,
+        )
 
     async def unban(self, *, reason: Optional[str] = None) -> None:
         """|coro|

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -613,8 +613,9 @@ When mixed with the :data:`typing.Optional` converter you can provide simple and
                        delete_days: typing.Optional[int] = 0, *,
                        reason: str):
         """Mass bans members with an optional delete_days parameter"""
+        delete_seconds = delete_days * 86400 # one day
         for member in members:
-            await member.ban(delete_message_days=delete_days, reason=reason)
+            await member.ban(delete_message_seconds=delete_seconds, reason=reason)
 
 
 This command can be invoked any of the following ways:


### PR DESCRIPTION
## Summary

Adds `delete_message_seconds` to `Guild/Member.ban` also deprecates `delete_message_days`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
