### PR TITLE
Add overloads to utils.sleep_until

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -690,6 +690,16 @@ def compute_timedelta(dt: datetime.datetime) -> float:
     return max((dt - now).total_seconds(), 0)
 
 
+@overload
+async def sleep_until(when: datetime.datetime, result: T) -> T:
+    ...
+
+
+@overload
+async def sleep_until(when: datetime.datetime) -> None:
+    ...
+
+
 async def sleep_until(when: datetime.datetime, result: Optional[T] = None) -> Optional[T]:
     """|coro|
 


### PR DESCRIPTION
## Summary

PR Adds overloads to utils.sleep_until to remove the unneccessary `| None` in return types.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
