### PR TITLE
Add better errors for incorrect items added to modal

### DIFF
--- a/discord/errors.py
+++ b/discord/errors.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     _ResponseType = Union[ClientResponse, Response]
 
     from .interactions import Interaction
+    from .ui.modal import Modal
 
 __all__ = (
     'DiscordException',
@@ -47,6 +48,7 @@ __all__ = (
     'ConnectionClosed',
     'PrivilegedIntentsRequired',
     'InteractionResponded',
+    'MissingRequiredItems',
 )
 
 
@@ -278,3 +280,19 @@ class InteractionResponded(ClientException):
     def __init__(self, interaction: Interaction):
         self.interaction: Interaction = interaction
         super().__init__('This interaction has already been responded to before')
+
+class MissingRequiredItems(ClientException):
+    """Exception that's raised when sending a modal using
+    :class:`InteractionResponse` when no items are added.
+
+    A modal requires at least one item.
+
+    Attributes
+    -----------
+    modal: :class:`ui.Modal`
+        The modal that's missing required items.
+    """
+
+    def __init__(self, modal: Modal):
+        self.modal: Modal = modal
+        super().__init__('This modal is missing required items.')

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -31,7 +31,7 @@ import datetime
 
 from . import utils
 from .enums import try_enum, Locale, InteractionType, InteractionResponseType
-from .errors import InteractionResponded, HTTPException, ClientException, DiscordException
+from .errors import InteractionResponded, HTTPException, ClientException, DiscordException, MissingRequiredItems
 from .flags import MessageFlags
 from .channel import PartialMessageable, ChannelType
 
@@ -843,12 +843,17 @@ class InteractionResponse:
         if self._response_type:
             raise InteractionResponded(self._parent)
 
+        modal_dict = modal.to_dict()
+
+        if not modal_dict["components"]:
+            raise MissingRequiredItems(modal)
+
         parent = self._parent
 
         adapter = async_context.get()
         http = parent._state.http
 
-        params = interaction_response_params(InteractionResponseType.modal.value, modal.to_dict())
+        params = interaction_response_params(InteractionResponseType.modal.value, modal_dict)
         await adapter.create_interaction_response(
             parent.id,
             parent.token,

--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -106,9 +106,8 @@ class Modal(View):
         children = {}
         for base in reversed(cls.__mro__):
             for name, member in base.__dict__.items():
-                if isinstance(member, Item):
-                    if isinstance(member, TextInput):
-                        children[name] = member
+                if isinstance(member, TextInput):
+                    children[name] = member
 
         cls.__modal_children_items__ = children
 

--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, ClassVar, List
 
 from ..utils import MISSING, find
 from .item import Item
+from .text_input import TextInput
 from .view import View
 
 if TYPE_CHECKING:
@@ -106,7 +107,8 @@ class Modal(View):
         for base in reversed(cls.__mro__):
             for name, member in base.__dict__.items():
                 if isinstance(member, Item):
-                    children[name] = member
+                    if isinstance(member, TextInput):
+                        children[name] = member
 
         cls.__modal_children_items__ = children
 
@@ -204,3 +206,28 @@ class Modal(View):
         }
 
         return payload
+
+    def add_item(self, item: TextInput) -> Self:
+        """Adds an item to the modal.
+
+        This function returns the class instance to allow for fluent-style
+        chaining.
+
+        Parameters
+        -----------
+        item: :class:`TextInput`
+            The text input to add to the modal.
+
+        Raises
+        --------
+        TypeError
+            A :class:`TextInput` was not passed.
+        ValueError
+            Maximum number of children has been exceeded (25)
+            or the row the item is trying to be added to is full.
+        """
+
+        if not isinstance(item, TextInput):
+            raise TypeError(f'expected TextInput not {item.__class__!r}')
+
+        super().add_item(item)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4723,6 +4723,8 @@ The following exceptions are thrown by the library.
 
 .. autoexception:: InteractionResponded
 
+.. autoexception:: MissingRequiredItems
+
 .. autoexception:: discord.opus.OpusError
 
 .. autoexception:: discord.opus.OpusNotLoaded
@@ -4740,6 +4742,7 @@ Exception Hierarchy
                 - :exc:`ConnectionClosed`
                 - :exc:`PrivilegedIntentsRequired`
                 - :exc:`InteractionResponded`
+                - :exc:`MissingRequiredItems`
             - :exc:`GatewayNotFound`
             - :exc:`HTTPException`
                 - :exc:`Forbidden`


### PR DESCRIPTION
## Summary

This PR adds better errors for incorrect adding of items to a modal. This includes adding an item other than `TextInput` or don't add an item at all.

### Incorrect item
**Class variables**: If the type of the class variable is not `TextInput` it won't get added to the `_children`.
**`add_item`**: Throws a `TypeError` if the given item is not a `TextInput`.

#### Example
```py
class TestModal(discord.ui.Modal, title='Test Modal'):
    name = ui.TextInput(label="Name")
    async def on_submit(self, interaction: discord.Interaction):
        await interaction.response.send_message(f'Thanks for your response!', ephemeral=True)

@bot.tree.command()
async def modal(interaction: discord.Interaction):
    m = TestModal()
    options = [
        discord.SelectOption(...),
        discord.SelectOption(...),
    ]
    dropdown = ui.Select(placeholder="Choose a section", options=options, min_values=1, max_values=1)
    
    # incorrect item passed
    m.add_item(dropdown)
    await interaction.response.send_modal(m)
```
**Error Before:** 
```
HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In data.components.0.components.0: Value of field "type" must be one of (4,).
```
**Error After:**
```
TypeError: expected TextInput not <class 'discord.ui.select.Select'>
```

### No items added
If no items are added to the modal (neither through class variables nor `add_item`) a new error is thrown: `MissingRequiredItems`.

#### Example
```py
class TestModal(discord.ui.Modal, title='Test Modal'):

    async def on_submit(self, interaction: discord.Interaction):
        await interaction.response.send_message(f'Thanks for your response!', ephemeral=True)


@bot.tree.command()
async def modal(interaction: discord.Interaction):
    m = TestModal()
    await interaction.response.send_modal(m)
```
**Error Before:**
```
HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In data.components: This field is required
```
**Error After:**
```
MissingRequiredItems: This modal is missing required items.
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
