### PR TITLE
docs: Guild add `afk_timeout` unit, changed `VIP_REGIONS` feature desc

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -181,7 +181,7 @@ class Guild(Hashable):
 
         .. versionadded:: 2.0
     afk_timeout: :class:`int`
-        The timeout to get sent to the AFK channel.
+        The number of seconds until someone is moved to the AFK channel.
     afk_channel: Optional[:class:`VoiceChannel`]
         The channel that denotes the AFK channel. ``None`` if it doesn't exist.
     id: :class:`int`
@@ -244,7 +244,7 @@ class Guild(Hashable):
         - ``TICKETED_EVENTS_ENABLED``: Guild has enabled ticketed events.
         - ``VANITY_URL``: Guild can have a vanity invite URL (e.g. discord.gg/discord-api).
         - ``VERIFIED``: Guild is a verified server.
-        - ``VIP_REGIONS``: Guild has VIP voice regions.
+        - ``VIP_REGIONS``: Guild can have 384kbps bitrate in voice channels.
         - ``WELCOME_SCREEN_ENABLED``: Guild has enabled the welcome screen.
 
     premium_tier: :class:`int`


### PR DESCRIPTION
## Summary

This PR changes documentation of `Guild`:
* Adds unit 'seconds' to the `afk_timeout` attribute for clarity. 
* Changes description of the `VIP_REGIONS` feature according to the official Discord Documentation: [Guild Features](https://discord.com/developers/docs/resources/guild#guild-object-guild-features)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
