### PR TITLE
docs: Add missing attributetable to classes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3988,8 +3988,12 @@ User
 AutoMod
 ~~~~~~~
 
+.. attributetable:: AutoModRule
+
 .. autoclass:: AutoModRule()
     :members:
+
+.. attributetable:: AutoModAction
 
 .. autoclass:: AutoModAction()
     :members:
@@ -4073,20 +4077,32 @@ ScheduledEvent
 Integration
 ~~~~~~~~~~~~
 
+.. attributetable:: Integration
+
 .. autoclass:: Integration()
     :members:
+
+.. attributetable:: IntegrationAccount
 
 .. autoclass:: IntegrationAccount()
     :members:
 
+.. attributetable:: BotIntegration
+
 .. autoclass:: BotIntegration()
     :members:
+
+.. attributetable:: IntegrationApplication
 
 .. autoclass:: IntegrationApplication()
     :members:
 
+.. attributetable:: StreamIntegration
+
 .. autoclass:: StreamIntegration()
     :members:
+
+.. attributetable:: PartialIntegration
 
 .. autoclass:: PartialIntegration()
     :members:


### PR DESCRIPTION
## Summary

This PR adds missing `.. attributetable::` to classes including:
* `AutoModRule`, `AutoModAction`
* `Integration`, `IntegrationAccount`, `BotIntegration`, `IntegrationApplication`, `StreamIntegration`, `PartialIntegration`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
