### PR TITLE
Correct how CroupCog handles "extras" parameter

### DIFF
--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -147,6 +147,7 @@ class CogMeta(type):
         .. versionadded:: 2.0
     group_extras: :class:`dict`
         A dictionary that can be used to store extraneous data.
+        This is only applicable for :class:`GroupCog` instances.
         The library will not touch any values or keys within this dictionary.
 
         .. versionadded:: 2.1

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -149,7 +149,7 @@ class CogMeta(type):
         A dictionary that can be used to store extraneous data.
         The library will not touch any values or keys within this dictionary. Alternatively,
         you can also set this as a class variable.
-        
+
         .. versionadded:: 2.1
     """
 
@@ -730,8 +730,8 @@ class GroupCog(Cog):
     the application commands defined within it.
 
     This inherits from :class:`Cog` and the options in :class:`CogMeta` also apply to this.
-    See the :class:`Cog` documentation for methods. 
-    
+    See the :class:`Cog` documentation for methods.
+
     Decorators such as :func:`~discord.app_commands.guild_only`, :func:`~discord.app_commands.guilds`,
     and :func:`~discord.app_commands.default_permissions` will apply to the group if used on top of the
     cog.

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -308,7 +308,7 @@ class Cog(metaclass=CogMeta):
                 guild_ids=getattr(cls, '__discord_app_commands_default_guilds__', None),
                 guild_only=getattr(cls, '__discord_app_commands_guild_only__', False),
                 default_permissions=getattr(cls, '__discord_app_commands_default_permissions__', None),
-                extras=cls.__cog_group_extras__
+                extras=cls.__cog_group_extras__,
             )
         else:
             group = None

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -147,8 +147,7 @@ class CogMeta(type):
         .. versionadded:: 2.0
     group_extras: :class:`dict`
         A dictionary that can be used to store extraneous data.
-        The library will not touch any values or keys within this dictionary. Alternatively,
-        you can also set this as a class variable.
+        The library will not touch any values or keys within this dictionary.
 
         .. versionadded:: 2.1
     """
@@ -190,7 +189,7 @@ class CogMeta(type):
         attrs['__cog_group_name__'] = group_name
         attrs['__cog_group_nsfw__'] = kwargs.pop('group_nsfw', False)
         attrs['__cog_group_auto_locale_strings__'] = kwargs.pop('group_auto_locale_strings', True)
-        attrs['__cog_group_extras__'] = attrs.get('group_extras', kwargs.pop('group_extras', {}))
+        attrs['__cog_group_extras__'] = kwargs.pop('group_extras', {})
 
         description = kwargs.pop('description', None)
         if description is None:

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -184,7 +184,7 @@ class CogMeta(type):
         attrs['__cog_group_name__'] = group_name
         attrs['__cog_group_nsfw__'] = kwargs.pop('group_nsfw', False)
         attrs['__cog_group_auto_locale_strings__'] = kwargs.pop('group_auto_locale_strings', True)
-        attrs['__cog_group_extras__'] = attrs.get('extras', kwargs.pop('extras', {}))
+        attrs['__cog_group_extras__'] = attrs.get('group_extras', kwargs.pop('group_extras', {}))
 
         description = kwargs.pop('description', None)
         if description is None:

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -153,6 +153,7 @@ class CogMeta(type):
     __cog_group_description__: Union[str, app_commands.locale_str]
     __cog_group_nsfw__: bool
     __cog_group_auto_locale_strings__: bool
+    __cog_group_extras__: Dict[Any, Any]
     __cog_settings__: Dict[str, Any]
     __cog_commands__: List[Command[Any, ..., Any]]
     __cog_app_commands__: List[Union[app_commands.Group, app_commands.Command[Any, ..., Any]]]
@@ -183,6 +184,7 @@ class CogMeta(type):
         attrs['__cog_group_name__'] = group_name
         attrs['__cog_group_nsfw__'] = kwargs.pop('group_nsfw', False)
         attrs['__cog_group_auto_locale_strings__'] = kwargs.pop('group_auto_locale_strings', True)
+        attrs['__cog_group_extras__'] = attrs.get('extras', kwargs.pop('extras', {}))
 
         description = kwargs.pop('description', None)
         if description is None:
@@ -306,6 +308,7 @@ class Cog(metaclass=CogMeta):
                 guild_ids=getattr(cls, '__discord_app_commands_default_guilds__', None),
                 guild_only=getattr(cls, '__discord_app_commands_guild_only__', False),
                 default_permissions=getattr(cls, '__discord_app_commands_default_permissions__', None),
+                extras=cls.__cog_group_extras__
             )
         else:
             group = None

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -145,6 +145,12 @@ class CogMeta(type):
         than :class:`str`. Defaults to ``True``.
 
         .. versionadded:: 2.0
+    group_extras: :class:`dict`
+        A dictionary that can be used to store extraneous data.
+        The library will not touch any values or keys within this dictionary. Alternatively,
+        you can also set this as a class variable.
+        
+        .. versionadded:: 2.1
     """
 
     __cog_name__: str
@@ -724,8 +730,8 @@ class GroupCog(Cog):
     the application commands defined within it.
 
     This inherits from :class:`Cog` and the options in :class:`CogMeta` also apply to this.
-    See the :class:`Cog` documentation for methods.
-
+    See the :class:`Cog` documentation for methods. 
+    
     Decorators such as :func:`~discord.app_commands.guild_only`, :func:`~discord.app_commands.guilds`,
     and :func:`~discord.app_commands.default_permissions` will apply to the group if used on top of the
     cog.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

### The issue
Previously, setting `extras` on a GroupCog was impossible due to how the lib handled them.

```python
import discord
from discord.ext import commands
import asyncio

class MyGroupCog(
    commands.GroupCog,
    group_name='group_cog'
    # NOTE: you cant pass extras = {'custom_id': '6c51e12d7e22389d653cc1a36a13d1'} here
):
    extras = {'custom_id': '6c51e12d7e22389d653cc1a36a13d1'}
    
bot = commands.Bot(command_prefix='None', intents=discord.Intents.default())

# Simulated setup hook
async def main() -> None:
    cog = MyGroupCog()
    await bot.add_cog(cog)
    
    print(cog.extras)

    group = bot.tree.get_command('group_cog')
    assert group
    print(group.extras)
    
asyncio.run(main())
```
```python
>>> {'custom_id': '6c51e12d7e22389d653cc1a36a13d1'}
>>> {}
```

### Solution
This pr adjusts for the passing of both `extras=xxx` as a "class parameter" and as a classvar.

```python
import discord
from discord.ext import commands
import asyncio

# NOTE: Can pass extras=xxx in class parameter or set
# as a classvar as shown below
class MyGroupCog(
    commands.GroupCog,
    group_name='group_cog'
    extras = {'custom_id': '6c51e12d7e22389d653cc1a36a13d1'}
):
    extras = {'custom_id': '6c51e12d7e22389d653cc1a36a13d1'}
    
bot = commands.Bot(command_prefix='None', intents=discord.Intents.default())

# Simulated setup hook
async def main() -> None:
    cog = MyGroupCog()
    await bot.add_cog(cog)
    
    print(cog.extras)

    group = bot.tree.get_command('group_cog')
    assert group
    print(group.extras)
    
asyncio.run(main())
```
```python
>>> {'custom_id': '6c51e12d7e22389d653cc1a36a13d1'}
>>> {'custom_id': '6c51e12d7e22389d653cc1a36a13d1'}
```

### Side note
In this line: 
```py
attrs['__cog_group_extras__'] = attrs.get('extras', kwargs.pop('extras', {}))
```
The nesting of `.get()` was used instead of `or` because if the user explicitly passed something that was evaluated incorrectly, `or` would be called overriding their passed variable. If you feel this should be changed to `or` let me know.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
