### PR TITLE
Add `translate` method to `Interaction`

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -505,11 +505,7 @@ class Interaction:
         )
 
     async def translate(
-        self,
-        string: Union[str, locale_str],
-        *,
-        locale: Locale = MISSING,
-        data: Optional[Any] = MISSING
+        self, string: Union[str, locale_str], *, locale: Locale = MISSING, data: Optional[Any] = MISSING
     ) -> Optional[Any]:
         """|coro| Translates a string using the set :class:`~discord.app_commands.Translator`.
 
@@ -519,16 +515,16 @@ class Interaction:
         ----------
         string: Union[:class:`str`, :class:`~discord.app_commands.locale_str`]
             The string to translate.
-            :class:`~discord.app_commands.locale_str` can be used to add more context, 
+            :class:`~discord.app_commands.locale_str` can be used to add more context,
             information, or any metadata necessary.
         locale: :class:`Locale`
-            The locale to use, this is handy if you want the 
+            The locale to use, this is handy if you want the
             translation for a specific locale.
             Defaults to the user's :attr:`.locale`.
         data: Optional[Any]
             The extraneous data that is being translated.
-            if not specified, either :attr:`.command` 
-            or :attr:`.message` will be passed, depending on which is 
+            if not specified, either :attr:`.command`
+            or :attr:`.message` will be passed, depending on which is
             available in the context.
             This can be ``None``.
         """
@@ -543,12 +539,8 @@ class Interaction:
         if data is MISSING:
             data = self.command or self.message
 
-        context = TranslationContext(
-            location=TranslationContextLocation.other,
-            data=data
-        )
+        context = TranslationContext(location=TranslationContextLocation.other, data=data)
         return await translator.translate(string, locale=locale, context=context)
-        
 
 
 class InteractionResponse:
@@ -958,6 +950,7 @@ class InteractionResponse:
         )
 
         self._response_type = InteractionResponseType.autocomplete_result
+
 
 class _InteractionMessageState:
     __slots__ = ('_parent', '_interaction')

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -528,6 +528,11 @@ class Interaction:
             If not specified, either :attr:`.command`
             or :attr:`.message` will be passed, depending on which is
             available in the context.
+
+        Returns
+        --------
+        Optional[:class:`str`]
+            The translated string, or ``None`` if a translator is not set.
         """
         translator = self._state._translator
         if not translator:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -525,10 +525,9 @@ class Interaction:
             Defaults to the user's :attr:`.locale`.
         data: Any
             The extraneous data that is being translated.
-            if not specified, either :attr:`.command`
+            If not specified, either :attr:`.command`
             or :attr:`.message` will be passed, depending on which is
             available in the context.
-            This can be ``None``.
         """
         translator = self._state._translator
         if not translator:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -42,6 +42,7 @@ from .permissions import Permissions
 from .http import handle_message_parameters
 from .webhook.async_ import async_context, Webhook, interaction_response_params, interaction_message_response_params
 from .app_commands.namespace import Namespace
+from .app_commands.translator import locale_str, TranslationContext, TranslationContextLocation
 
 __all__ = (
     'Interaction',
@@ -503,6 +504,52 @@ class Interaction:
             proxy_auth=http.proxy_auth,
         )
 
+    async def translate(
+        self,
+        string: Union[str, locale_str],
+        *,
+        locale: Locale = MISSING,
+        data: Optional[Any] = MISSING
+    ) -> Optional[Any]:
+        """|coro| Translates a string using the set :class:`~discord.app_commands.Translator`.
+
+        .. versionadded:: 2.1
+
+        Parameters
+        ----------
+        string: Union[:class:`str`, :class:`~discord.app_commands.locale_str`]
+            The string to translate.
+            :class:`~discord.app_commands.locale_str` can be used to add more context, 
+            information, or any metadata necessary.
+        locale: :class:`Locale`
+            The locale to use, this is handy if you want the 
+            translation for a specific locale.
+            Defaults to the user's :attr:`.locale`.
+        data: Optional[Any]
+            The extraneous data that is being translated.
+            if not specified, either :attr:`.command` 
+            or :attr:`.message` will be passed, depending on which is 
+            available in the context.
+            This can be ``None``.
+        """
+        translator = self._state._translator
+        if not translator:
+            return None
+
+        if not isinstance(string, locale_str):
+            string = locale_str(string)
+        if locale is MISSING:
+            locale = self.locale
+        if data is MISSING:
+            data = self.command or self.message
+
+        context = TranslationContext(
+            location=TranslationContextLocation.other,
+            data=data
+        )
+        return await translator.translate(string, locale=locale, context=context)
+        
+
 
 class InteractionResponse:
     """Represents a Discord interaction response.
@@ -911,7 +958,6 @@ class InteractionResponse:
         )
 
         self._response_type = InteractionResponseType.autocomplete_result
-
 
 class _InteractionMessageState:
     __slots__ = ('_parent', '_interaction')

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -506,7 +506,7 @@ class Interaction:
 
     async def translate(
         self, string: Union[str, locale_str], *, locale: Locale = MISSING, data: Any = MISSING
-    ) -> Optional[Any]:
+    ) -> Optional[str]:
         """|coro| Translates a string using the set :class:`~discord.app_commands.Translator`.
 
         .. versionadded:: 2.1

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -508,7 +508,7 @@ class Interaction:
         self, string: Union[str, locale_str], *, locale: Locale = MISSING, data: Any = MISSING
     ) -> Optional[str]:
         """|coro|
-        
+
         Translates a string using the set :class:`~discord.app_commands.Translator`.
 
         .. versionadded:: 2.1
@@ -520,19 +520,18 @@ class Interaction:
             :class:`~discord.app_commands.locale_str` can be used to add more context,
             information, or any metadata necessary.
         locale: :class:`Locale`
-            The locale to use, this is handy if you want the
-            translation for a specific locale.
+            The locale to use, this is handy if you want the translation
+            for a specific locale.
             Defaults to the user's :attr:`.locale`.
         data: Any
             The extraneous data that is being translated.
-            If not specified, either :attr:`.command`
-            or :attr:`.message` will be passed, depending on which is
-            available in the context.
+            If not specified, either :attr:`.command` or :attr:`.message` will be passed,
+            depending on which is available in the context.
 
         Returns
         --------
         Optional[:class:`str`]
-            The translated string, or ``None`` if a translator is not set.
+            The translated string, or ``None`` if a translator was not set.
         """
         translator = self._state._translator
         if not translator:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -507,7 +507,9 @@ class Interaction:
     async def translate(
         self, string: Union[str, locale_str], *, locale: Locale = MISSING, data: Any = MISSING
     ) -> Optional[str]:
-        """|coro| Translates a string using the set :class:`~discord.app_commands.Translator`.
+        """|coro|
+        
+        Translates a string using the set :class:`~discord.app_commands.Translator`.
 
         .. versionadded:: 2.1
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -505,7 +505,7 @@ class Interaction:
         )
 
     async def translate(
-        self, string: Union[str, locale_str], *, locale: Locale = MISSING, data: Optional[Any] = MISSING
+        self, string: Union[str, locale_str], *, locale: Locale = MISSING, data: Any = MISSING
     ) -> Optional[Any]:
         """|coro| Translates a string using the set :class:`~discord.app_commands.Translator`.
 
@@ -521,7 +521,7 @@ class Interaction:
             The locale to use, this is handy if you want the
             translation for a specific locale.
             Defaults to the user's :attr:`.locale`.
-        data: Optional[Any]
+        data: Any
             The extraneous data that is being translated.
             if not specified, either :attr:`.command`
             or :attr:`.message` will be passed, depending on which is


### PR DESCRIPTION
## Summary

This PR, as [discussed](https://discord.com/channels/336642139381301249/812600992116899861/1010223728933752905) on the [Discord server](https://discord.com/invites/dpy), adds a method called `translate` to `Interaction` that makes it easier to translate command responses and more.

```py
@tree.command()
async def foo(interaction: Interaction):
    response = "Hello, this is a test command!"

    # Before
    from discord.app_commands import TranslationContext, TranslationContextLocation, locale_str

    translator = tree.translator
    if not translator:
        await interaction.response.send_message(response)
        return

    context = TranslationContext(
        TranslationContextLocation.other,
        data=interaction.command
    )
    translated_response = await translator.translate(
        string=locale_str(response),
        locale=interaction.locale,
        context=context
    )

    # After
    translated_response = await interaction.translate(response) or response
    # .translate returns None if no translator is set or there was no translation returned
    # `or` handles that.


    await interaction.response.send_message(translated_response)
```
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
