### PR TITLE
Fix Type-Hint for TextChannel.delete_messages()

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -389,7 +389,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             {'topic': self.topic, 'nsfw': self.nsfw, 'rate_limit_per_user': self.slowmode_delay}, name=name, reason=reason
         )
 
-    async def delete_messages(self, messages: Iterable[Snowflake], *, reason: Optional[str] = None) -> None:
+    async def delete_messages(self, messages: Iterable[Message], *, reason: Optional[str] = None) -> None:
         """|coro|
 
         Deletes a list of messages. This is similar to :meth:`Message.delete`
@@ -413,7 +413,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
 
         Parameters
         -----------
-        messages: Iterable[:class:`abc.Snowflake`]
+        messages: Iterable[:class:`Message`]
             An iterable of messages denoting which ones to bulk delete.
         reason: Optional[:class:`str`]
             The reason for deleting the messages. Shows up on the audit log.


### PR DESCRIPTION
Fixed incorrect type hints.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixed method type hints.  
Fixes prevent incorrect usage of methods.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
