### PR TITLE
[commands] fix Range to allow 3.10 Union syntax

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -1109,6 +1109,9 @@ else:
             # Trick to allow it inside typing.Union
             pass
 
+        def __or__(self, rhs) -> Any:
+            return Union[self, rhs]
+
         def __class_getitem__(cls, obj) -> Range:
             if not isinstance(obj, tuple):
                 raise TypeError(f'expected tuple for arguments, received {obj.__class__!r} instead')


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR adds the `__or__` method to `Range` to make 3.10 unions work. Fixes #8445 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
