### PR TITLE
fix Range and Transform to allow 3.10 Union syntax

### DIFF
--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -544,6 +544,9 @@ else:
 
             return transformer
 
+        def __or__(self, rhs) -> Any:
+            return Union[self, rhs]
+
     class Range:
         """A type annotation that can be applied to a parameter to require a numeric or string
         type to fit within the range provided.
@@ -608,6 +611,9 @@ else:
                 max=cast(max) if max is not None else None,
             )
             return transformer
+
+        def __or__(self, rhs) -> Any:
+            return Union[self, rhs]
 
 
 class MemberTransformer(Transformer):


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR allows 3.10 Union syntax to work for `app_commands.Range` and `app_commands.Transform` as was done in #8446

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
