### PR TITLE
Normalize type formatting in Type Errors

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1513,7 +1513,7 @@ class Messageable:
             reference_dict = MISSING
 
         if view and not hasattr(view, '__discord_ui_view__'):
-            raise TypeError(f'view parameter must be View not {view.__class__!r}')
+            raise TypeError(f'view parameter must be View not {view.__class__.__name__}')
 
         if suppress_embeds:
             from .message import MessageFlags  # circular import

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -1850,7 +1850,7 @@ class Group:
         """
 
         if not isinstance(command, (Command, Group)):
-            raise TypeError(f'expected Command or Group not {command.__class__!r}')
+            raise TypeError(f'expected Command or Group not {command.__class__.__name__}')
 
         if isinstance(command, Group) and self.parent is not None:
             # In a tree like so:

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -468,7 +468,7 @@ class Choice(Generic[ChoiceT]):
             return AppCommandOptionType.string
         else:
             raise TypeError(
-                f'invalid Choice value type given, expected int, str, or float but received {self.value.__class__!r}'
+                f'invalid Choice value type given, expected int, str, or float but received {self.value.__class__.__name__}'
             )
 
     async def get_translated_payload(self, translator: Translator) -> Dict[str, Any]:

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -528,7 +528,7 @@ else:
 
         def __class_getitem__(cls, items) -> _TransformMetadata:
             if not isinstance(items, tuple):
-                raise TypeError(f'expected tuple for arguments, received {items.__class__!r} instead')
+                raise TypeError(f'expected tuple for arguments, received {items.__class__.__name__} instead')
 
             if len(items) != 2:
                 raise TypeError(f'Transform only accepts exactly two arguments')
@@ -540,7 +540,7 @@ else:
                     raise TypeError(f'second argument of Transform must be a Transformer class not {transformer!r}')
                 transformer = transformer()
             elif not isinstance(transformer, Transformer):
-                raise TypeError(f'second argument of Transform must be a Transformer not {transformer.__class__!r}')
+                raise TypeError(f'second argument of Transform must be a Transformer not {transformer.__class__.__name__}')
 
             return transformer
 
@@ -571,7 +571,7 @@ else:
 
         def __class_getitem__(cls, obj) -> _TransformMetadata:
             if not isinstance(obj, tuple):
-                raise TypeError(f'expected tuple for arguments, received {obj.__class__!r} instead')
+                raise TypeError(f'expected tuple for arguments, received {obj.__class__.__name__} instead')
 
             if len(obj) == 2:
                 obj = (*obj, None)

--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -346,7 +346,7 @@ class CommandTree(Generic[ClientT]):
                 self._context_menus.update(current)
             return
         elif not isinstance(command, (Command, Group)):
-            raise TypeError(f'Expected an application command, received {command.__class__!r} instead')
+            raise TypeError(f'Expected an application command, received {command.__class__.__name__} instead')
 
         # todo: validate application command groups having children (required)
 
@@ -1002,7 +1002,7 @@ class CommandTree(Generic[ClientT]):
         """
 
         if translator is not None and not isinstance(translator, Translator):
-            raise TypeError(f'expected None or Translator instance, received {translator.__class__!r} instead')
+            raise TypeError(f'expected None or Translator instance, received {translator.__class__.__name__} instead')
 
         old_translator = self._state._translator
         if old_translator is not None:

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2023,7 +2023,7 @@ class ForumTag(Hashable):
         elif isinstance(emoji, str):
             self.emoji = PartialEmoji.from_str(emoji)
         else:
-            raise TypeError(f'emoji must be a Emoji, PartialEmoji, or str not {emoji.__class__!r}')
+            raise TypeError(f'emoji must be a Emoji, PartialEmoji, or str not {emoji.__class__.__name__}')
 
     @classmethod
     def from_data(cls, *, state: ConnectionState, data: ForumTagPayload) -> Self:
@@ -2544,7 +2544,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
             sticker_ids: SnowflakeList = [s.id for s in stickers]
 
         if view and not hasattr(view, '__discord_ui_view__'):
-            raise TypeError(f'view parameter must be View not {view.__class__!r}')
+            raise TypeError(f'view parameter must be View not {view.__class__.__name__}')
 
         if suppress_embeds:
             from .message import MessageFlags  # circular import

--- a/discord/client.py
+++ b/discord/client.py
@@ -574,7 +574,7 @@ class Client:
             await self._async_setup_hook()
 
         if not isinstance(token, str):
-            raise TypeError(f'expected token to be a str, received {token.__class__!r} instead')
+            raise TypeError(f'expected token to be a str, received {token.__class__.__name__} instead')
         token = token.strip()
 
         data = await self.http.static_login(token)
@@ -888,7 +888,7 @@ class Client:
         if value is None or isinstance(value, AllowedMentions):
             self._connection.allowed_mentions = value
         else:
-            raise TypeError(f'allowed_mentions must be AllowedMentions not {value.__class__!r}')
+            raise TypeError(f'allowed_mentions must be AllowedMentions not {value.__class__.__name__}')
 
     @property
     def intents(self) -> Intents:
@@ -1964,7 +1964,7 @@ class Client:
         """
 
         if not isinstance(view, View):
-            raise TypeError(f'expected an instance of View not {view.__class__!r}')
+            raise TypeError(f'expected an instance of View not {view.__class__.__name__}')
 
         if not view.is_persistent():
             raise ValueError('View is not persistent. Items need to have a custom_id set and View must have no timeout')

--- a/discord/components.py
+++ b/discord/components.py
@@ -383,7 +383,7 @@ class SelectOption:
             elif isinstance(value, _EmojiTag):
                 self._emoji = value._to_partial()
             else:
-                raise TypeError(f'expected str, Emoji, or PartialEmoji, received {value.__class__} instead')
+                raise TypeError(f'expected str, Emoji, or PartialEmoji, received {value.__class__.__name__} instead')
         else:
             self._emoji = None
 

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -189,7 +189,7 @@ class BotBase(GroupMixin[None]):
             raise TypeError('Both owner_id and owner_ids are set.')
 
         if self.owner_ids and not isinstance(self.owner_ids, collections.abc.Collection):
-            raise TypeError(f'owner_ids must be a collection not {self.owner_ids.__class__!r}')
+            raise TypeError(f'owner_ids must be a collection not {self.owner_ids.__class__.__name__}')
 
         if help_command is _default:
             self.help_command = DefaultHelpCommand()

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -490,7 +490,7 @@ class Cog(metaclass=CogMeta):
         """
 
         if name is not MISSING and not isinstance(name, str):
-            raise TypeError(f'Cog.listener expected str but received {name.__class__.__name__!r} instead.')
+            raise TypeError(f'Cog.listener expected str but received {name.__class__.__name__} instead.')
 
         def decorator(func: FuncT) -> FuncT:
             actual = func

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -1117,7 +1117,7 @@ else:
 
         def __class_getitem__(cls, obj) -> Range:
             if not isinstance(obj, tuple):
-                raise TypeError(f'expected tuple for arguments, received {obj.__class__!r} instead')
+                raise TypeError(f'expected tuple for arguments, received {obj.__class__.__name__} instead')
 
             if len(obj) == 2:
                 obj = (*obj, None)

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -559,7 +559,7 @@ class Loop(Generic[LF]):
         """
 
         if not inspect.iscoroutinefunction(coro):
-            raise TypeError(f'Expected coroutine function, received {coro.__class__.__name__!r}.')
+            raise TypeError(f'Expected coroutine function, received {coro.__class__.__name__}.')
 
         self._before_loop = coro
         return coro
@@ -587,7 +587,7 @@ class Loop(Generic[LF]):
         """
 
         if not inspect.iscoroutinefunction(coro):
-            raise TypeError(f'Expected coroutine function, received {coro.__class__.__name__!r}.')
+            raise TypeError(f'Expected coroutine function, received {coro.__class__.__name__}.')
 
         self._after_loop = coro
         return coro
@@ -617,7 +617,7 @@ class Loop(Generic[LF]):
             The function was not a coroutine.
         """
         if not inspect.iscoroutinefunction(coro):
-            raise TypeError(f'Expected coroutine function, received {coro.__class__.__name__!r}.')
+            raise TypeError(f'Expected coroutine function, received {coro.__class__.__name__}.')
 
         self._error = coro
         return coro

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2902,7 +2902,8 @@ class Guild(Hashable):
                 _entity_type = getattr(channel, '_scheduled_event_entity_type', MISSING)
                 if _entity_type is None:
                     raise TypeError(
-                        f'invalid GuildChannel type passed, must be VoiceChannel or StageChannel not {channel.__class__!r}'
+                        'invalid GuildChannel type passed, must be VoiceChannel or StageChannel '
+                        f'not {channel.__class__.__name__}'
                     )
                 if _entity_type is MISSING:
                     raise TypeError('entity_type must be passed in when passing an ambiguous channel type')

--- a/discord/http.py
+++ b/discord/http.py
@@ -272,7 +272,7 @@ def _set_api_version(value: int):
     global INTERNAL_API_VERSION
 
     if not isinstance(value, int):
-        raise TypeError(f'expected int not {value.__class__!r}')
+        raise TypeError(f'expected int not {value.__class__.__name__}')
 
     if value not in (9, 10):
         raise ValueError(f'expected either 9 or 10 not {value}')

--- a/discord/member.py
+++ b/discord/member.py
@@ -976,7 +976,7 @@ class Member(discord.abc.Messageable, _UserTag):
         elif isinstance(until, datetime.datetime):
             timed_out_until = until
         else:
-            raise TypeError(f'expected None, datetime.datetime, or datetime.timedelta not {until.__class__!r}')
+            raise TypeError(f'expected None, datetime.datetime, or datetime.timedelta not {until.__class__.__name__}')
 
         await self.edit(timed_out_until=timed_out_until, reason=reason)
 

--- a/discord/object.py
+++ b/discord/object.py
@@ -94,7 +94,7 @@ class Object(Hashable):
         try:
             id = int(id)
         except ValueError:
-            raise TypeError(f'id parameter must be convertible to int not {id.__class__!r}') from None
+            raise TypeError(f'id parameter must be convertible to int not {id.__class__.__name__}') from None
         self.id: int = id
         self.type: Type[abc.Snowflake] = type or self.__class__
 

--- a/discord/scheduled_event.py
+++ b/discord/scheduled_event.py
@@ -414,7 +414,7 @@ class ScheduledEvent(Hashable):
         entity_type = entity_type or getattr(channel, '_scheduled_event_entity_type', MISSING)
         if entity_type is None:
             raise TypeError(
-                f'invalid GuildChannel type passed, must be VoiceChannel or StageChannel not {channel.__class__!r}'
+                f'invalid GuildChannel type passed, must be VoiceChannel or StageChannel not {channel.__class__.__name__}'
             )
 
         if entity_type is not MISSING:

--- a/discord/ui/button.py
+++ b/discord/ui/button.py
@@ -106,7 +106,7 @@ class Button(Item[V]):
             custom_id = os.urandom(16).hex()
 
         if custom_id is not None and not isinstance(custom_id, str):
-            raise TypeError(f'expected custom_id to be str not {custom_id.__class__!r}')
+            raise TypeError(f'expected custom_id to be str not {custom_id.__class__.__name__}')
 
         if url is not None:
             style = ButtonStyle.link
@@ -117,7 +117,7 @@ class Button(Item[V]):
             elif isinstance(emoji, _EmojiTag):
                 emoji = emoji._to_partial()
             else:
-                raise TypeError(f'expected emoji to be str, Emoji, or PartialEmoji not {emoji.__class__}')
+                raise TypeError(f'expected emoji to be str, Emoji, or PartialEmoji not {emoji.__class__.__name__}')
 
         self._underlying = ButtonComponent._raw_construct(
             custom_id=custom_id,
@@ -196,7 +196,7 @@ class Button(Item[V]):
             elif isinstance(value, _EmojiTag):
                 self._underlying.emoji = value._to_partial()
             else:
-                raise TypeError(f'expected str, Emoji, or PartialEmoji, received {value.__class__} instead')
+                raise TypeError(f'expected str, Emoji, or PartialEmoji, received {value.__class__.__name__} instead')
         else:
             self._underlying.emoji = None
 

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -114,7 +114,7 @@ class Select(Item[V]):
         self._provided_custom_id = custom_id is not MISSING
         custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
         if not isinstance(custom_id, str):
-            raise TypeError(f'expected custom_id to be str not {custom_id.__class__!r}')
+            raise TypeError(f'expected custom_id to be str not {custom_id.__class__.__name__}')
 
         options = [] if options is MISSING else options
         self._underlying = SelectMenu._raw_construct(

--- a/discord/ui/text_input.py
+++ b/discord/ui/text_input.py
@@ -111,7 +111,7 @@ class TextInput(Item[V]):
         self._provided_custom_id = custom_id is not MISSING
         custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
         if not isinstance(custom_id, str):
-            raise TypeError(f'expected custom_id to be str not {custom_id.__class__!r}')
+            raise TypeError(f'expected custom_id to be str not {custom_id.__class__.__name__}')
 
         self._underlying = TextInputComponent._raw_construct(
             label=label,

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -319,7 +319,7 @@ class View:
             raise ValueError('maximum number of children exceeded')
 
         if not isinstance(item, Item):
-            raise TypeError(f'expected Item not {item.__class__!r}')
+            raise TypeError(f'expected Item not {item.__class__.__name__}')
 
         self.__weights.add_item(item)
 

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1694,7 +1694,7 @@ class Webhook(BaseWebhook):
                 raise ValueError('Webhook views require an associated state with the webhook')
 
             if not hasattr(view, '__discord_ui_view__'):
-                raise TypeError(f'expected view parameter to be of type View not {view.__class__!r}')
+                raise TypeError(f'expected view parameter to be of type View not {view.__class__.__name__}')
 
             if ephemeral is True and view.timeout is None:
                 view.timeout = 15 * 60.0

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -649,7 +649,7 @@ class SyncWebhook(BaseWebhook):
 
         if session is not MISSING:
             if not isinstance(session, requests.Session):
-                raise TypeError(f'expected requests.Session not {session.__class__!r}')
+                raise TypeError(f'expected requests.Session not {session.__class__.__name__}')
         else:
             session = requests  # type: ignore
         return cls(data, session, token=bot_token)
@@ -692,7 +692,7 @@ class SyncWebhook(BaseWebhook):
 
         if session is not MISSING:
             if not isinstance(session, requests.Session):
-                raise TypeError(f'expected requests.Session not {session.__class__!r}')
+                raise TypeError(f'expected requests.Session not {session.__class__.__name__}')
         else:
             session = requests  # type: ignore
         return cls(data, session, token=bot_token)  # type: ignore


### PR DESCRIPTION
Currently, there remain some mixed usages of `obj.__class__` in reporting TypeErrors which results in unnecessary angled brackets and formatting:
```py
[Bot] TypeError: expected token to be a str, received <class 'NoneType'> instead
```
whereas, if sticking with the standard form of `obj.__class__.__name__`, as used by most Python standard library TypeErrors:
```py
[Bot] TypeError: expected token to be a str, received NoneType instead
```
## Summary

Whilst most Type Errors within the project already use this form; there remain a few instances where this is not the case. This PR normalizes print formatting of incorrect types in TypeErrors to use `{obj.__class__.__name__}` 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
