### PR TITLE
Two minor patches to the doc

### DIFF
--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -286,7 +286,7 @@ class Transformer:
 
     @property
     def choices(self) -> Optional[List[Choice[Union[int, float, str]]]]:
-        """Optional[List[:class:`~discord.app_commands.Choice`]]: A list of choices that are allowed to this parameter.
+        """Optional[List[:class:`~discord.app_commands.Choice`]]: A list of choices that are allowed to this parameter, 25 maximum.
 
         Only valid if the :meth:`type` returns :attr:`~discord.AppCommandOptionType.number`
         :attr:`~discord.AppCommandOptionType.integer`, or :attr:`~discord.AppCommandOptionType.string`.

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -286,7 +286,7 @@ class Transformer:
 
     @property
     def choices(self) -> Optional[List[Choice[Union[int, float, str]]]]:
-        """Optional[List[:class:`~discord.app_commands.Choice`]]: A list of choices that are allowed to this parameter, 25 maximum.
+        """Optional[List[:class:`~discord.app_commands.Choice`]]: A list of up to 25 choices that are allowed to this parameter.
 
         Only valid if the :meth:`type` returns :attr:`~discord.AppCommandOptionType.number`
         :attr:`~discord.AppCommandOptionType.integer`, or :attr:`~discord.AppCommandOptionType.string`.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -497,4 +497,3 @@ My bot's commands are not showing up!
    ``https://discord.com/oauth2/authorize?client_id=<client id>&scope=applications.commands+bot``.
    Alternatively, if you use :func:`utils.oauth_url`, you can call the function as such:
    ``oauth_url(<other options>, scopes=("bot", "applications.commands"))``.
-3. You may need to change server to update the slash commands on the client side

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -497,3 +497,4 @@ My bot's commands are not showing up!
    ``https://discord.com/oauth2/authorize?client_id=<client id>&scope=applications.commands+bot``.
    Alternatively, if you use :func:`utils.oauth_url`, you can call the function as such:
    ``oauth_url(<other options>, scopes=("bot", "applications.commands"))``.
+3. You may need to change server to update the slash commands on the client side


### PR DESCRIPTION
## Summary

This pull request adds a possible solution when your slash commands don't show up in discord, and specifies that `Transformer.choices` cannot have more than 25 elements.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
