### PR TITLE
Fix default guild parameter in tree.clear_commands

### DIFF
--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -458,7 +458,12 @@ class CommandTree(Generic[ClientT]):
             key = (command, guild_id, type.value)
             return self._context_menus.pop(key, None)
 
-    def clear_commands(self, *, guild: Optional[Snowflake], type: Optional[AppCommandType] = None) -> None:
+    def clear_commands(
+        self,
+        *,
+        guild: Optional[Snowflake] = None,
+        type: Optional[AppCommandType] = None
+    ) -> None:
         """Clears all application commands from the tree.
 
         This only removes the commands locally -- in order to sync the commands


### PR DESCRIPTION
## Summary

This fixes the default `guild` argument in `CommandTree.clear_commands`. It's an optional, but didn't have a `= None` default.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
