### PR TITLE
[commands] Fix HybridCommandGroup._update_copy to update fallback

### DIFF
--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -706,6 +706,11 @@ class HybridGroup(Group[CogT, P, T]):
             # This is a very lazy copy because the CogMeta will properly copy it
             # with bindings and all later
             copy.app_command._children = self.app_command._children.copy()
+
+        # Ensure the copy's fallback wraps the copy
+        if copy._fallback_command and self._fallback_command:
+            copy._fallback_command.wrapped = copy
+
         return copy
 
     def autocomplete(


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR fixes #8461 by updating the hybrid group's fallback when it is copied.
If the fallback is not updated, the fallback continues to wrap the original command from before the copy, causing any future changes to the command (e.g. setting the cog) to be lost. This is why only the Context is passed to the before_invoke hook as seen in the original issue.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
