### PR TITLE
Make VoiceProtocol.on_voice_{state,server}_update pos-only

### DIFF
--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -115,7 +115,7 @@ class VoiceProtocol:
         self.client: Client = client
         self.channel: abc.Connectable = channel
 
-    async def on_voice_state_update(self, data: GuildVoiceStatePayload) -> None:
+    async def on_voice_state_update(self, data: GuildVoiceStatePayload, /) -> None:
         """|coro|
 
         An abstract method that is called when the client's voice state
@@ -128,7 +128,7 @@ class VoiceProtocol:
         """
         raise NotImplementedError
 
-    async def on_voice_server_update(self, data: VoiceServerUpdatePayload) -> None:
+    async def on_voice_server_update(self, data: VoiceServerUpdatePayload, /) -> None:
         """|coro|
 
         An abstract method that is called when initially connecting to voice.


### PR DESCRIPTION
## Summary

Similar to #8364 but for VoiceProtocol's on_voice_state_update and on_voice_server_update.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
