### PR TITLE
Fix permissions-based docstrings to be more consistent

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -790,7 +790,7 @@ class GuildChannel:
 
         Deletes the channel.
 
-        You must have :attr:`~discord.Permissions.manage_channels` permission to use this.
+        You must have the :attr:`~discord.Permissions.manage_channels` permission to use this.
 
         Parameters
         -----------
@@ -1257,7 +1257,7 @@ class GuildChannel:
 
         Returns a list of all active instant invites from this channel.
 
-        You must have :attr:`~discord.Permissions.manage_channels` to get this information.
+        You must have the :attr:`~discord.Permissions.manage_channels` permission to get this information.
 
         Raises
         -------
@@ -1644,7 +1644,7 @@ class Messageable:
     ) -> AsyncIterator[Message]:
         """Returns an :term:`asynchronous iterator` that enables receiving the destination's message history.
 
-        You must have :attr:`~discord.Permissions.read_message_history` permissions to use this.
+        You must have the :attr:`~discord.Permissions.read_message_history` permission to use this.
 
         Examples
         ---------

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -790,7 +790,7 @@ class GuildChannel:
 
         Deletes the channel.
 
-        You must have the :attr:`~discord.Permissions.manage_channels` permission to use this.
+        You must have :attr:`~discord.Permissions.manage_channels` to do this.
 
         Parameters
         -----------
@@ -854,7 +854,7 @@ class GuildChannel:
         If the ``overwrite`` parameter is ``None``, then the permission
         overwrites are deleted.
 
-        You must have the :attr:`~discord.Permissions.manage_roles` permission to use this.
+        You must have :attr:`~discord.Permissions.manage_roles` to do this.
 
         .. note::
 
@@ -970,8 +970,7 @@ class GuildChannel:
         Clones this channel. This creates a channel with the same properties
         as this channel.
 
-        You must have the :attr:`~discord.Permissions.manage_channels` permission to
-        do this.
+        You must have :attr:`~discord.Permissions.manage_channels` to do this.
 
         .. versionadded:: 1.1
 
@@ -1052,8 +1051,7 @@ class GuildChannel:
 
         If exact position movement is required, ``edit`` should be used instead.
 
-        You must have the :attr:`~discord.Permissions.manage_channels` permission to
-        do this.
+        You must have :attr:`~discord.Permissions.manage_channels` to do this.
 
         .. note::
 
@@ -1190,8 +1188,7 @@ class GuildChannel:
 
         Creates an instant invite from a text or voice channel.
 
-        You must have the :attr:`~discord.Permissions.create_instant_invite` permission to
-        do this.
+        You must have :attr:`~discord.Permissions.create_instant_invite` to do this.
 
         Parameters
         ------------
@@ -1257,7 +1254,7 @@ class GuildChannel:
 
         Returns a list of all active instant invites from this channel.
 
-        You must have the :attr:`~discord.Permissions.manage_channels` permission to get this information.
+        You must have :attr:`~discord.Permissions.manage_channels` to get this information.
 
         Raises
         -------
@@ -1644,7 +1641,7 @@ class Messageable:
     ) -> AsyncIterator[Message]:
         """Returns an :term:`asynchronous iterator` that enables receiving the destination's message history.
 
-        You must have the :attr:`~discord.Permissions.read_message_history` permission to use this.
+        You must have :attr:`~discord.Permissions.read_message_history` to do this.
 
         Examples
         ---------

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -344,7 +344,7 @@ class AutoModRule:
 
         Edits this auto moderation rule.
 
-        You must have the :attr:`Permissions.manage_guild` permission to edit rules.
+        You must have :attr:`Permissions.manage_guild` to edit rules.
 
         Parameters
         -----------
@@ -416,7 +416,7 @@ class AutoModRule:
 
         Deletes the auto moderation rule.
 
-        You must have the :attr:`Permissions.manage_guild` permission to delete rules.
+        You must have :attr:`Permissions.manage_guild` to delete rules.
 
         Parameters
         -----------
@@ -521,7 +521,7 @@ class AutoModAction:
 
         Fetch the rule whose action was taken.
 
-        You must have the :attr:`Permissions.manage_guild` permission to use this.
+        You must have :attr:`Permissions.manage_guild` to do this.
 
         Raises
         -------

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -344,7 +344,7 @@ class AutoModRule:
 
         Edits this auto moderation rule.
 
-        You must have :attr:`Permissions.manage_guild` to edit rules.
+        You must have the :attr:`Permissions.manage_guild` permission to edit rules.
 
         Parameters
         -----------
@@ -416,7 +416,7 @@ class AutoModRule:
 
         Deletes the auto moderation rule.
 
-        You must have :attr:`Permissions.manage_guild` to delete rules.
+        You must have the :attr:`Permissions.manage_guild` permission to delete rules.
 
         Parameters
         -----------

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -713,7 +713,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
 
         Creates a thread in this text channel.
 
-        To create a public thread, you must have :attr:`~discord.Permissions.create_public_threads`.
+        To create a public thread, you must have the :attr:`~discord.Permissions.create_public_threads` permission.
         For a private thread, :attr:`~discord.Permissions.create_private_threads` is needed instead.
 
         .. versionadded:: 2.0
@@ -792,7 +792,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         """Returns an :term:`asynchronous iterator` that iterates over all archived threads in this text channel,
         in order of decreasing ID for joined threads, and decreasing :attr:`Thread.archive_timestamp` otherwise.
 
-        You must have :attr:`~Permissions.read_message_history` to use this. If iterating over private threads
+        You must have the :attr:`~Permissions.read_message_history` permission to use this. If iterating over private threads
         then :attr:`~Permissions.manage_threads` is also required.
 
         .. versionadded:: 2.0

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -310,8 +310,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
 
         Edits the channel.
 
-        You must have the :attr:`~Permissions.manage_channels` permission to
-        use this.
+        You must have :attr:`~Permissions.manage_channels` to do this.
 
         .. versionchanged:: 1.3
             The ``overwrites`` keyword-only parameter was added.
@@ -402,8 +401,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         You cannot bulk delete more than 100 messages or messages that
         are older than 14 days old.
 
-        You must have the :attr:`~Permissions.manage_messages` permission to
-        use this.
+        You must have :attr:`~Permissions.manage_messages` to do this.
 
         .. versionchanged:: 2.0
 
@@ -464,9 +462,9 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         ``check``. If a ``check`` is not provided then all messages are deleted
         without discrimination.
 
-        You must have the :attr:`~Permissions.manage_messages` permission to
+        You must have :attr:`~Permissions.manage_messages` to
         delete messages even if they are your own.
-        The :attr:`~Permissions.read_message_history` permission is
+        Having :attr:`~Permissions.read_message_history` is
         also needed to retrieve message history.
 
         .. versionchanged:: 2.0
@@ -536,7 +534,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
 
         Gets the list of webhooks from this channel.
 
-        Requires :attr:`~.Permissions.manage_webhooks` permissions.
+        You must have :attr:`~.Permissions.manage_webhooks` to do this.
 
         Raises
         -------
@@ -559,7 +557,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
 
         Creates a webhook for this channel.
 
-        Requires :attr:`~.Permissions.manage_webhooks` permissions.
+        You must have :attr:`~.Permissions.manage_webhooks` to do this.
 
         .. versionchanged:: 1.1
             Added the ``reason`` keyword-only parameter.
@@ -713,7 +711,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
 
         Creates a thread in this text channel.
 
-        To create a public thread, you must have the :attr:`~discord.Permissions.create_public_threads` permission.
+        To create a public thread, you must have :attr:`~discord.Permissions.create_public_threads`.
         For a private thread, :attr:`~discord.Permissions.create_private_threads` is needed instead.
 
         .. versionadded:: 2.0
@@ -792,7 +790,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         """Returns an :term:`asynchronous iterator` that iterates over all archived threads in this text channel,
         in order of decreasing ID for joined threads, and decreasing :attr:`Thread.archive_timestamp` otherwise.
 
-        You must have the :attr:`~Permissions.read_message_history` permission to use this. If iterating over private threads
+        You must have :attr:`~Permissions.read_message_history` to do this. If iterating over private threads
         then :attr:`~Permissions.manage_threads` is also required.
 
         .. versionadded:: 2.0
@@ -1132,8 +1130,7 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
         You cannot bulk delete more than 100 messages or messages that
         are older than 14 days old.
 
-        You must have the :attr:`~Permissions.manage_messages` permission to
-        use this.
+        You must have :attr:`~Permissions.manage_messages` to do this.
 
         .. versionadded:: 2.0
 
@@ -1190,9 +1187,9 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
         ``check``. If a ``check`` is not provided then all messages are deleted
         without discrimination.
 
-        You must have the :attr:`~Permissions.manage_messages` permission to
+        You must have :attr:`~Permissions.manage_messages` to
         delete messages even if they are your own.
-        The :attr:`~Permissions.read_message_history` permission is
+        Having :attr:`~Permissions.read_message_history` is
         also needed to retrieve message history.
 
         .. versionadded:: 2.0
@@ -1261,7 +1258,7 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
 
         Gets the list of webhooks from this channel.
 
-        Requires :attr:`~.Permissions.manage_webhooks` permissions.
+        You must have :attr:`~.Permissions.manage_webhooks` to do this.
 
         .. versionadded:: 2.0
 
@@ -1286,7 +1283,7 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
 
         Creates a webhook for this channel.
 
-        Requires :attr:`~.Permissions.manage_webhooks` permissions.
+        You must have :attr:`~.Permissions.manage_webhooks` to do this.
 
         .. versionadded:: 2.0
 
@@ -1356,8 +1353,7 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
 
         Edits the channel.
 
-        You must have the :attr:`~Permissions.manage_channels` permission to
-        use this.
+        You must have :attr:`~Permissions.manage_channels` to do this.
 
         .. versionchanged:: 1.3
             The ``overwrites`` keyword-only parameter was added.
@@ -1565,8 +1561,7 @@ class StageChannel(VocalGuildChannel):
 
         Create a stage instance.
 
-        You must have the :attr:`~Permissions.manage_channels` permission to
-        use this.
+        You must have :attr:`~Permissions.manage_channels` to do this.
 
         .. versionadded:: 2.0
 
@@ -1656,8 +1651,7 @@ class StageChannel(VocalGuildChannel):
 
         Edits the channel.
 
-        You must have the :attr:`~Permissions.manage_channels` permission to
-        use this.
+        You must have :attr:`~Permissions.manage_channels` to do this.
 
         .. versionchanged:: 2.0
             The ``topic`` parameter must now be set via :attr:`create_instance`.
@@ -1827,8 +1821,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
 
         Edits the channel.
 
-        You must have the :attr:`~Permissions.manage_channels` permission to
-        use this.
+        You must have :attr:`~Permissions.manage_channels` to do this.
 
         .. versionchanged:: 1.3
             The ``overwrites`` keyword-only parameter was added.
@@ -2293,8 +2286,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
 
         Edits the forum.
 
-        You must have the :attr:`~Permissions.manage_channels` permission to
-        use this.
+        You must have :attr:`~Permissions.manage_channels` to do this.
 
         Parameters
         ----------
@@ -2407,8 +2399,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
 
         Creates a new tag in this forum.
 
-        You must have the :attr:`~Permissions.manage_channels` permission to
-        use this.
+        You must have :attr:`~Permissions.manage_channels` to do this.
 
         Parameters
         ----------
@@ -2596,7 +2587,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
 
         Gets the list of webhooks from this channel.
 
-        Requires :attr:`~.Permissions.manage_webhooks` permissions.
+        You must have :attr:`~.Permissions.manage_webhooks` to do this.
 
         Raises
         -------
@@ -2619,7 +2610,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
 
         Creates a webhook for this channel.
 
-        Requires :attr:`~.Permissions.manage_webhooks` permissions.
+        You must have :attr:`~.Permissions.manage_webhooks` to do this.
 
         Parameters
         -------------

--- a/discord/client.py
+++ b/discord/client.py
@@ -1674,7 +1674,7 @@ class Client:
 
         Revokes an :class:`.Invite`, URL, or ID to an invite.
 
-        You must have the :attr:`~.Permissions.manage_channels` permission in
+        You must have :attr:`~.Permissions.manage_channels` in
         the associated guild to do this.
 
         .. versionchanged:: 2.0

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -196,7 +196,7 @@ class Emoji(_EmojiTag, AssetMixin):
 
         Deletes the custom emoji.
 
-        You must have :attr:`~Permissions.manage_emojis` permission to
+        You must have the :attr:`~Permissions.manage_emojis` permission to
         do this.
 
         Parameters
@@ -221,7 +221,7 @@ class Emoji(_EmojiTag, AssetMixin):
 
         Edits the custom emoji.
 
-        You must have :attr:`~Permissions.manage_emojis` permission to
+        You must have the :attr:`~Permissions.manage_emojis` permission to
         do this.
 
         .. versionchanged:: 2.0

--- a/discord/emoji.py
+++ b/discord/emoji.py
@@ -92,7 +92,7 @@ class Emoji(_EmojiTag, AssetMixin):
         Whether the emoji is available for use.
     user: Optional[:class:`User`]
         The user that created the emoji. This can only be retrieved using :meth:`Guild.fetch_emoji` and
-        having the :attr:`~Permissions.manage_emojis` permission.
+        having :attr:`~Permissions.manage_emojis`.
     """
 
     __slots__: Tuple[str, ...] = (
@@ -196,8 +196,7 @@ class Emoji(_EmojiTag, AssetMixin):
 
         Deletes the custom emoji.
 
-        You must have the :attr:`~Permissions.manage_emojis` permission to
-        do this.
+        You must have :attr:`~Permissions.manage_emojis` to do this.
 
         Parameters
         -----------
@@ -221,8 +220,7 @@ class Emoji(_EmojiTag, AssetMixin):
 
         Edits the custom emoji.
 
-        You must have the :attr:`~Permissions.manage_emojis` permission to
-        do this.
+        You must have :attr:`~Permissions.manage_emojis` to do this.
 
         .. versionchanged:: 2.0
             The newly updated emoji is returned.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1229,8 +1229,7 @@ class Guild(Hashable):
 
         Creates a :class:`TextChannel` for the guild.
 
-        Note that you need the :attr:`~Permissions.manage_channels` permission
-        to create the channel.
+        Note that you must have :attr:`~Permissions.manage_channels` to create the channel.
 
         The ``overwrites`` parameter can be used to create a 'secret'
         channel upon creation. This parameter expects a :class:`dict` of
@@ -1724,7 +1723,7 @@ class Guild(Hashable):
 
         Edits the guild.
 
-        You must have the :attr:`~Permissions.manage_guild` permission to edit the guild.
+        You must have :attr:`~Permissions.manage_guild` to edit the guild.
 
         .. versionchanged:: 1.4
             The ``rules_channel`` and ``public_updates_channel`` keyword parameters were added.
@@ -2144,8 +2143,7 @@ class Guild(Hashable):
 
         Retrieves the :class:`BanEntry` for a user.
 
-        You must have the :attr:`~Permissions.ban_members` permission
-        to get this information.
+        You must have :attr:`~Permissions.ban_members` to get this information.
 
         Parameters
         -----------
@@ -2223,8 +2221,7 @@ class Guild(Hashable):
     ) -> AsyncIterator[BanEntry]:
         """Retrieves an :term:`asynchronous iterator` of the users that are banned from the guild as a :class:`BanEntry`.
 
-        You must have the :attr:`~Permissions.ban_members` permission
-        to get this information.
+        You must have :attr:`~Permissions.ban_members` to get this information.
 
         .. versionchanged:: 2.0
             Due to a breaking change in Discord's API, this now returns a paginated iterator instead of a list.
@@ -2335,8 +2332,7 @@ class Guild(Hashable):
         The inactive members are denoted if they have not logged on in
         ``days`` number of days and they have no roles.
 
-        You must have the :attr:`~Permissions.kick_members` permission
-        to use this.
+        You must have :attr:`~Permissions.kick_members` to do this.
 
         To check how many members you would prune without actually pruning,
         see the :meth:`estimate_pruned_members` function.
@@ -2399,7 +2395,7 @@ class Guild(Hashable):
 
         Gets the list of templates from this guild.
 
-        Requires :attr:`~.Permissions.manage_guild` permissions.
+        You must have :attr:`~.Permissions.manage_guild` to do this.
 
         .. versionadded:: 1.7
 
@@ -2423,7 +2419,7 @@ class Guild(Hashable):
 
         Gets the list of webhooks from this guild.
 
-        Requires :attr:`~.Permissions.manage_webhooks` permissions.
+        You must have :attr:`~.Permissions.manage_webhooks` to do this.
 
         Raises
         -------
@@ -2496,8 +2492,7 @@ class Guild(Hashable):
 
         Returns a list of all active instant invites from the guild.
 
-        You must have the :attr:`~Permissions.manage_guild` permission to get
-        this information.
+        You must have :attr:`~Permissions.manage_guild` to get this information.
 
         Raises
         -------
@@ -2525,8 +2520,7 @@ class Guild(Hashable):
 
         Creates a template for the guild.
 
-        You must have the :attr:`~Permissions.manage_guild` permission to
-        do this.
+        You must have :attr:`~Permissions.manage_guild` to do this.
 
         .. versionadded:: 1.7
 
@@ -2553,8 +2547,7 @@ class Guild(Hashable):
 
         Attaches an integration to the guild.
 
-        You must have the :attr:`~Permissions.manage_guild` permission to
-        do this.
+        You must have :attr:`~Permissions.manage_guild` to do this.
 
         .. versionadded:: 1.4
 
@@ -2579,8 +2572,7 @@ class Guild(Hashable):
 
         Returns a list of all integrations attached to the guild.
 
-        You must have the :attr:`~Permissions.manage_guild` permission to
-        do this.
+        You must have :attr:`~Permissions.manage_guild` to do this.
 
         .. versionadded:: 1.4
 
@@ -2675,8 +2667,7 @@ class Guild(Hashable):
 
         Creates a :class:`Sticker` for the guild.
 
-        You must have the :attr:`~Permissions.manage_emojis_and_stickers` permission to
-        do this.
+        You must have :attr:`~Permissions.manage_emojis_and_stickers` to do this.
 
         .. versionadded:: 2.0
 
@@ -2728,8 +2719,7 @@ class Guild(Hashable):
 
         Deletes the custom :class:`Sticker` from the guild.
 
-        You must have the :attr:`~Permissions.manage_emojis_and_stickers` permission to
-        do this.
+        You must have :attr:`~Permissions.manage_emojis_and_stickers` to do this.
 
         .. versionadded:: 2.0
 
@@ -2823,7 +2813,7 @@ class Guild(Hashable):
 
         Creates a scheduled event for the guild.
 
-        Requires :attr:`~Permissions.manage_events` permissions.
+        You must have :attr:`~Permissions.manage_events` to do this.
 
         .. versionadded:: 2.0
 
@@ -3025,8 +3015,7 @@ class Guild(Hashable):
         There is currently a limit of 50 static and animated emojis respectively per guild,
         unless the guild has the ``MORE_EMOJI`` feature which extends the limit to 200.
 
-        You must have the :attr:`~Permissions.manage_emojis` permission to
-        do this.
+        You must have :attr:`~Permissions.manage_emojis` to do this.
 
         Parameters
         -----------
@@ -3067,8 +3056,7 @@ class Guild(Hashable):
 
         Deletes the custom :class:`Emoji` from the guild.
 
-        You must have the :attr:`~Permissions.manage_emojis` permission to
-        do this.
+        You must have :attr:`~Permissions.manage_emojis` to do this.
 
         .. versionchanged:: 2.0
 
@@ -3161,8 +3149,7 @@ class Guild(Hashable):
 
         All fields are optional.
 
-        You must have the :attr:`~Permissions.manage_roles` permission to
-        do this.
+        You must have :attr:`~Permissions.manage_roles` to do this.
 
         .. versionchanged:: 1.6
             Can now pass ``int`` to ``colour`` keyword-only parameter.
@@ -3249,8 +3236,7 @@ class Guild(Hashable):
 
         Bulk edits a list of :class:`Role` in the guild.
 
-        You must have the :attr:`~Permissions.manage_roles` permission to
-        do this.
+        You must have :attr:`~Permissions.manage_roles` to do this.
 
         .. versionadded:: 1.4
 
@@ -3319,8 +3305,7 @@ class Guild(Hashable):
 
         The guild must have ``COMMUNITY`` in :attr:`~Guild.features`.
 
-        You must have the :attr:`~Permissions.manage_guild` permission to use
-        this as well.
+        You must have :attr:`~Permissions.manage_guild` to do this.as well.
 
         .. versionadded:: 2.0
 
@@ -3354,8 +3339,7 @@ class Guild(Hashable):
 
         The guild must have ``COMMUNITY`` in :attr:`~Guild.features`.
 
-        You must have the :attr:`~Permissions.manage_guild` permission to use
-        this as well.
+        You must have :attr:`~Permissions.manage_guild` to do this.as well.
 
         .. versionadded:: 2.0
 
@@ -3390,8 +3374,7 @@ class Guild(Hashable):
 
         The user must meet the :class:`abc.Snowflake` abc.
 
-        You must have the :attr:`~Permissions.kick_members` permission to
-        do this.
+        You must have :attr:`~Permissions.kick_members` to do this.
 
         Parameters
         -----------
@@ -3423,8 +3406,7 @@ class Guild(Hashable):
 
         The user must meet the :class:`abc.Snowflake` abc.
 
-        You must have the :attr:`~Permissions.ban_members` permission to
-        do this.
+        You must have :attr:`~Permissions.ban_members` to do this.
 
         Parameters
         -----------
@@ -3474,8 +3456,7 @@ class Guild(Hashable):
 
         The user must meet the :class:`abc.Snowflake` abc.
 
-        You must have the :attr:`~Permissions.ban_members` permission to
-        do this.
+        You must have :attr:`~Permissions.ban_members` to do this.
 
         Parameters
         -----------
@@ -3512,8 +3493,7 @@ class Guild(Hashable):
 
         The guild must have ``VANITY_URL`` in :attr:`~Guild.features`.
 
-        You must have the :attr:`~Permissions.manage_guild` permission to use
-        this as well.
+        You must have :attr:`~Permissions.manage_guild` to do this.as well.
 
         Raises
         -------
@@ -3558,7 +3538,7 @@ class Guild(Hashable):
     ) -> AsyncIterator[AuditLogEntry]:
         """Returns an :term:`asynchronous iterator` that enables receiving the guild's audit logs.
 
-        You must have the :attr:`~Permissions.view_audit_log` permission to use this.
+        You must have :attr:`~Permissions.view_audit_log` to do this.
 
         Examples
         ----------
@@ -3756,8 +3736,7 @@ class Guild(Hashable):
 
         Edits the widget of the guild.
 
-        You must have the :attr:`~Permissions.manage_guild` permission to
-        use this
+        You must have :attr:`~Permissions.manage_guild` to do this.
 
         .. versionadded:: 2.0
 
@@ -3921,7 +3900,7 @@ class Guild(Hashable):
 
         Fetches an active automod rule from the guild.
 
-        You must have the :attr:`Permissions.manage_guild` permission to use this.
+        You must have :attr:`Permissions.manage_guild` to do this.
 
         .. versionadded:: 2.0
 
@@ -3950,7 +3929,7 @@ class Guild(Hashable):
 
         Fetches all automod rules from the guild.
 
-        You must have the :attr:`Permissions.manage_guild` permission to use this.
+        You must have :attr:`Permissions.manage_guild` to do this.
 
         .. versionadded:: 2.0
 
@@ -3986,7 +3965,7 @@ class Guild(Hashable):
 
         Create an automod rule.
 
-        You must have the :attr:`Permissions.manage_guild` permission to use this.
+        You must have :attr:`Permissions.manage_guild` to do this.
 
         .. versionadded:: 2.0
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2675,7 +2675,7 @@ class Guild(Hashable):
 
         Creates a :class:`Sticker` for the guild.
 
-        You must have :attr:`~Permissions.manage_emojis_and_stickers` permission to
+        You must have the :attr:`~Permissions.manage_emojis_and_stickers` permission to
         do this.
 
         .. versionadded:: 2.0
@@ -2728,7 +2728,7 @@ class Guild(Hashable):
 
         Deletes the custom :class:`Sticker` from the guild.
 
-        You must have :attr:`~Permissions.manage_emojis_and_stickers` permission to
+        You must have the :attr:`~Permissions.manage_emojis_and_stickers` permission to
         do this.
 
         .. versionadded:: 2.0
@@ -3067,7 +3067,7 @@ class Guild(Hashable):
 
         Deletes the custom :class:`Emoji` from the guild.
 
-        You must have :attr:`~Permissions.manage_emojis` permission to
+        You must have the :attr:`~Permissions.manage_emojis` permission to
         do this.
 
         .. versionchanged:: 2.0
@@ -3921,7 +3921,7 @@ class Guild(Hashable):
 
         Fetches an active automod rule from the guild.
 
-        You must have the :attr:`Permissions.manage_guild` to use this.
+        You must have the :attr:`Permissions.manage_guild` permission to use this.
 
         .. versionadded:: 2.0
 
@@ -3950,7 +3950,7 @@ class Guild(Hashable):
 
         Fetches all automod rules from the guild.
 
-        You must have the :attr:`Permissions.manage_guild` to use this.
+        You must have the :attr:`Permissions.manage_guild` permission to use this.
 
         .. versionadded:: 2.0
 

--- a/discord/integrations.py
+++ b/discord/integrations.py
@@ -134,8 +134,7 @@ class Integration:
 
         Deletes the integration.
 
-        You must have the :attr:`~Permissions.manage_guild` permission to
-        do this.
+        You must have :attr:`~Permissions.manage_guild` to do this.
 
         Parameters
         -----------
@@ -231,8 +230,7 @@ class StreamIntegration(Integration):
 
         Edits the integration.
 
-        You must have the :attr:`~Permissions.manage_guild` permission to
-        do this.
+        You must have :attr:`~Permissions.manage_guild` to do this.
 
         .. versionchanged:: 2.0
             This function will now raise :exc:`TypeError` instead of
@@ -278,8 +276,7 @@ class StreamIntegration(Integration):
 
         Syncs the integration.
 
-        You must have the :attr:`~Permissions.manage_guild` permission to
-        do this.
+        You must have :attr:`~Permissions.manage_guild` to do this.
 
         Raises
         -------

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -544,7 +544,7 @@ class Invite(Hashable):
 
         Revokes the instant invite.
 
-        You must have the :attr:`~Permissions.manage_channels` permission to do this.
+        You must have :attr:`~Permissions.manage_channels` to do this.
 
         Parameters
         -----------

--- a/discord/member.py
+++ b/discord/member.py
@@ -922,8 +922,7 @@ class Member(discord.abc.Messageable, _UserTag):
 
         Moves a member to a new voice channel (they must be connected first).
 
-        You must have the :attr:`~Permissions.move_members` permission to
-        use this.
+        You must have :attr:`~Permissions.move_members` to do this.
 
         This raises the same exceptions as :meth:`edit`.
 
@@ -948,8 +947,7 @@ class Member(discord.abc.Messageable, _UserTag):
         Applies a time out to a member until the specified date time or for the
         given :class:`datetime.timedelta`.
 
-        You must have the :attr:`~Permissions.moderate_members` permission to
-        use this.
+        You must have :attr:`~Permissions.moderate_members` to do this.
 
         This raises the same exceptions as :meth:`edit`.
 
@@ -985,7 +983,7 @@ class Member(discord.abc.Messageable, _UserTag):
 
         Gives the member a number of :class:`Role`\s.
 
-        You must have the :attr:`~Permissions.manage_roles` permission to
+        You must have :attr:`~Permissions.manage_roles` to
         use this, and the added :class:`Role`\s must appear lower in the list
         of roles than the highest role of the member.
 
@@ -1024,7 +1022,7 @@ class Member(discord.abc.Messageable, _UserTag):
 
         Removes :class:`Role`\s from this member.
 
-        You must have the :attr:`~Permissions.manage_roles` permission to
+        You must have :attr:`~Permissions.manage_roles` to
         use this, and the removed :class:`Role`\s must appear lower in the list
         of roles than the highest role of the member.
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -771,8 +771,7 @@ class PartialMessage(Hashable):
         Deletes the message.
 
         Your own messages could be deleted without any proper permissions. However to
-        delete other people's messages, you need the :attr:`~Permissions.manage_messages`
-        permission.
+        delete other people's messages, you must have :attr:`~Permissions.manage_messages`.
 
         .. versionchanged:: 1.1
             Added the new ``delay`` keyword-only parameter.
@@ -947,10 +946,10 @@ class PartialMessage(Hashable):
 
         Publishes this message to your announcement channel.
 
-        You must have the :attr:`~Permissions.send_messages` permission to do this.
+        You must have :attr:`~Permissions.send_messages` to do this.
 
-        If the message is not your own then the :attr:`~Permissions.manage_messages`
-        permission is also needed.
+        If the message is not your own then :attr:`~Permissions.manage_messages`
+        is also needed.
 
         Raises
         -------
@@ -967,7 +966,7 @@ class PartialMessage(Hashable):
 
         Pins the message.
 
-        You must have the :attr:`~Permissions.manage_messages` permission to do
+        You must have :attr:`~Permissions.manage_messages` to do
         this in a non-private channel context.
 
         Parameters
@@ -997,7 +996,7 @@ class PartialMessage(Hashable):
 
         Unpins the message.
 
-        You must have the :attr:`~Permissions.manage_messages` permission to do
+        You must have :attr:`~Permissions.manage_messages` to do
         this in a non-private channel context.
 
         Parameters
@@ -1028,9 +1027,9 @@ class PartialMessage(Hashable):
 
         The emoji may be a unicode emoji or a custom guild :class:`Emoji`.
 
-        You must have the :attr:`~Permissions.read_message_history` permission
-        to use this. If nobody else has reacted to the message using this
-        emoji, the :attr:`~Permissions.add_reactions` permission is required.
+        You must have :attr:`~Permissions.read_message_history`
+        to do this. If nobody else has reacted to the message using this
+        emoji, :attr:`~Permissions.add_reactions` is required.
 
         .. versionchanged:: 2.0
 
@@ -1068,7 +1067,7 @@ class PartialMessage(Hashable):
         The emoji may be a unicode emoji or a custom guild :class:`Emoji`.
 
         If the reaction is not your own (i.e. ``member`` parameter is not you) then
-        the :attr:`~Permissions.manage_messages` permission is needed.
+        :attr:`~Permissions.manage_messages` is needed.
 
         The ``member`` parameter must represent a member and meet
         the :class:`abc.Snowflake` abc.
@@ -1110,7 +1109,7 @@ class PartialMessage(Hashable):
 
         The emoji may be a unicode emoji or a custom guild :class:`Emoji`.
 
-        You need the :attr:`~Permissions.manage_messages` permission to use this.
+        You must have :attr:`~Permissions.manage_messages` to do this.
 
         .. versionadded:: 1.3
 
@@ -1143,7 +1142,7 @@ class PartialMessage(Hashable):
 
         Removes all the reactions from the message.
 
-        You need the :attr:`~Permissions.manage_messages` permission to use this.
+        You must have :attr:`~Permissions.manage_messages` to do this.
 
         Raises
         --------
@@ -1166,7 +1165,7 @@ class PartialMessage(Hashable):
 
         Creates a public thread from this message.
 
-        You must have the :attr:`~discord.Permissions.create_public_threads` permission in order to
+        You must have :attr:`~discord.Permissions.create_public_threads` in order to
         create a public thread from a message.
 
         The channel this message belongs in must be a :class:`TextChannel`.

--- a/discord/message.py
+++ b/discord/message.py
@@ -1166,7 +1166,7 @@ class PartialMessage(Hashable):
 
         Creates a public thread from this message.
 
-        You must have :attr:`~discord.Permissions.create_public_threads` in order to
+        You must have the :attr:`~discord.Permissions.create_public_threads` permission in order to
         create a public thread from a message.
 
         The channel this message belongs in must be a :class:`TextChannel`.

--- a/discord/reaction.py
+++ b/discord/reaction.py
@@ -117,7 +117,7 @@ class Reaction:
         Remove the reaction by the provided :class:`User` from the message.
 
         If the reaction is not your own (i.e. ``user`` parameter is not you) then
-        the :attr:`~Permissions.manage_messages` permission is needed.
+        :attr:`~Permissions.manage_messages` is needed.
 
         The ``user`` parameter must represent a user or member and meet
         the :class:`abc.Snowflake` abc.
@@ -144,7 +144,7 @@ class Reaction:
 
         Clears this reaction from the message.
 
-        You need the :attr:`~Permissions.manage_messages` permission to use this.
+        You must have :attr:`~Permissions.manage_messages` to do this.
 
         .. versionadded:: 1.3
 

--- a/discord/role.py
+++ b/discord/role.py
@@ -394,8 +394,7 @@ class Role(Hashable):
 
         Edits the role.
 
-        You must have the :attr:`~Permissions.manage_roles` permission to
-        use this.
+        You must have :attr:`~Permissions.manage_roles` to do this.
 
         All fields are optional.
 
@@ -492,8 +491,7 @@ class Role(Hashable):
 
         Deletes the role.
 
-        You must have the :attr:`~Permissions.manage_roles` permission to
-        use this.
+        You must have :attr:`~Permissions.manage_roles` to do this.
 
         Parameters
         -----------

--- a/discord/scheduled_event.py
+++ b/discord/scheduled_event.py
@@ -315,7 +315,7 @@ class ScheduledEvent(Hashable):
 
         Edits the scheduled event.
 
-        Requires :attr:`~Permissions.manage_events` permissions.
+        You must have :attr:`~Permissions.manage_events` to do this.
 
         Parameters
         -----------
@@ -470,7 +470,7 @@ class ScheduledEvent(Hashable):
 
         Deletes the scheduled event.
 
-        Requires :attr:`~Permissions.manage_events` permissions.
+        You must have :attr:`~Permissions.manage_events` to do this.
 
         Parameters
         -----------

--- a/discord/stage_instance.py
+++ b/discord/stage_instance.py
@@ -135,8 +135,7 @@ class StageInstance(Hashable):
 
         Edits the stage instance.
 
-        You must have the :attr:`~Permissions.manage_channels` permission to
-        use this.
+        You must have :attr:`~Permissions.manage_channels` to do this.
 
         Parameters
         -----------
@@ -176,8 +175,7 @@ class StageInstance(Hashable):
 
         Deletes the stage instance.
 
-        You must have the :attr:`~Permissions.manage_channels` permission to
-        use this.
+        You must have :attr:`~Permissions.manage_channels` to do this.
 
         Parameters
         -----------

--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -405,7 +405,7 @@ class GuildSticker(Sticker):
         The ID of the guild that this sticker is from.
     user: Optional[:class:`User`]
         The user that created this sticker. This can only be retrieved using :meth:`Guild.fetch_sticker` and
-        having the :attr:`~Permissions.manage_emojis_and_stickers` permission.
+        having :attr:`~Permissions.manage_emojis_and_stickers`.
     emoji: :class:`str`
         The name of a unicode emoji that represents this sticker.
     """
@@ -494,8 +494,7 @@ class GuildSticker(Sticker):
 
         Deletes the custom :class:`Sticker` from the guild.
 
-        You must have the :attr:`~Permissions.manage_emojis_and_stickers` permission to
-        do this.
+        You must have :attr:`~Permissions.manage_emojis_and_stickers` to do this.
 
         Parameters
         -----------

--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -494,7 +494,7 @@ class GuildSticker(Sticker):
 
         Deletes the custom :class:`Sticker` from the guild.
 
-        You must have :attr:`~Permissions.manage_emojis_and_stickers` permission to
+        You must have the :attr:`~Permissions.manage_emojis_and_stickers` permission to
         do this.
 
         Parameters

--- a/discord/template.py
+++ b/discord/template.py
@@ -214,8 +214,7 @@ class Template:
 
         Sync the template to the guild's current state.
 
-        You must have the :attr:`~Permissions.manage_guild` permission in the
-        source guild to do this.
+        You must have :attr:`~Permissions.manage_guild` in the source guild to do this.
 
         .. versionadded:: 1.7
 
@@ -250,8 +249,7 @@ class Template:
 
         Edit the template metadata.
 
-        You must have the :attr:`~Permissions.manage_guild` permission in the
-        source guild to do this.
+        You must have :attr:`~Permissions.manage_guild` in the source guild to do this.
 
         .. versionadded:: 1.7
 
@@ -294,8 +292,7 @@ class Template:
 
         Delete the template.
 
-        You must have the :attr:`~Permissions.manage_guild` permission in the
-        source guild to do this.
+        You must have :attr:`~Permissions.manage_guild` in the source guild to do this.
 
         .. versionadded:: 1.7
 

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -721,7 +721,7 @@ class Thread(Messageable, Hashable):
 
         Joins this thread.
 
-        You must have :attr:`~Permissions.send_messages_in_threads` to join a thread.
+        You must have the :attr:`~Permissions.send_messages_in_threads` permission to join a thread.
         If the thread is private, :attr:`~Permissions.manage_threads` is also needed.
 
         Raises
@@ -750,7 +750,7 @@ class Thread(Messageable, Hashable):
 
         Adds a user to this thread.
 
-        You must have :attr:`~Permissions.send_messages_in_threads` to add a user to a thread.
+        You must have the :attr:`~Permissions.send_messages_in_threads` permission to add a user to a thread.
         If the thread is private then and :attr:`invitable` is ``False`` then :attr:`~Permissions.manage_messages`
         is required to add a user to the thread.
 
@@ -773,7 +773,7 @@ class Thread(Messageable, Hashable):
 
         Removes a user from this thread.
 
-        You must have :attr:`~Permissions.manage_threads` or be the creator of the thread to remove a user.
+        You must have the :attr:`~Permissions.manage_threads` permission or be the creator of the thread to remove a user.
 
         Parameters
         -----------
@@ -837,7 +837,7 @@ class Thread(Messageable, Hashable):
 
         Deletes this thread.
 
-        You must have :attr:`~Permissions.manage_threads` to delete threads.
+        You must have the :attr:`~Permissions.manage_threads` permission to delete threads.
 
         Raises
         -------

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -435,8 +435,7 @@ class Thread(Messageable, Hashable):
         You cannot bulk delete more than 100 messages or messages that
         are older than 14 days old.
 
-        You must have the :attr:`~Permissions.manage_messages` permission to
-        use this.
+        You must have :attr:`~Permissions.manage_messages` to do this.
 
         Parameters
         -----------
@@ -492,9 +491,9 @@ class Thread(Messageable, Hashable):
         ``check``. If a ``check`` is not provided then all messages are deleted
         without discrimination.
 
-        You must have the :attr:`~Permissions.manage_messages` permission to
+        You must have :attr:`~Permissions.manage_messages` to
         delete messages even if they are your own.
-        The :attr:`~Permissions.read_message_history` permission is
+        Having :attr:`~Permissions.read_message_history` is
         also needed to retrieve message history.
 
         Examples
@@ -647,11 +646,11 @@ class Thread(Messageable, Hashable):
 
         Adds the given forum tags to a thread.
 
-        You must have the :attr:`~Permissions.manage_threads` permission to
+        You must have :attr:`~Permissions.manage_threads` to
         use this or the thread must be owned by you.
 
-        Tags that have :attr:`ForumTag.moderated` set to ``True`` require the
-        :attr:`~Permissions.manage_threads` permissions to be added.
+        Tags that have :attr:`ForumTag.moderated` set to ``True`` require
+        :attr:`~Permissions.manage_threads` to be added.
 
         The maximum number of tags that can be added to a thread is 5.
 
@@ -685,7 +684,7 @@ class Thread(Messageable, Hashable):
 
         Remove the given forum tags to a thread.
 
-        You must have the :attr:`~Permissions.manage_threads` permission to
+        You must have :attr:`~Permissions.manage_threads` to
         use this or the thread must be owned by you.
 
         The parent channel must be a :class:`ForumChannel`.
@@ -721,7 +720,7 @@ class Thread(Messageable, Hashable):
 
         Joins this thread.
 
-        You must have the :attr:`~Permissions.send_messages_in_threads` permission to join a thread.
+        You must have :attr:`~Permissions.send_messages_in_threads` to join a thread.
         If the thread is private, :attr:`~Permissions.manage_threads` is also needed.
 
         Raises
@@ -750,8 +749,8 @@ class Thread(Messageable, Hashable):
 
         Adds a user to this thread.
 
-        You must have the :attr:`~Permissions.send_messages_in_threads` permission to add a user to a thread.
-        If the thread is private then and :attr:`invitable` is ``False`` then :attr:`~Permissions.manage_messages`
+        You must have :attr:`~Permissions.send_messages_in_threads` to add a user to a thread.
+        If the thread is private and :attr:`invitable` is ``False`` then :attr:`~Permissions.manage_messages`
         is required to add a user to the thread.
 
         Parameters
@@ -773,7 +772,7 @@ class Thread(Messageable, Hashable):
 
         Removes a user from this thread.
 
-        You must have the :attr:`~Permissions.manage_threads` permission or be the creator of the thread to remove a user.
+        You must have :attr:`~Permissions.manage_threads` or be the creator of the thread to remove a user.
 
         Parameters
         -----------
@@ -837,7 +836,7 @@ class Thread(Messageable, Hashable):
 
         Deletes this thread.
 
-        You must have the :attr:`~Permissions.manage_threads` permission to delete threads.
+        You must have :attr:`~Permissions.manage_threads` to delete threads.
 
         Raises
         -------

--- a/discord/welcome_screen.py
+++ b/discord/welcome_screen.py
@@ -160,8 +160,7 @@ class WelcomeScreen:
 
         Welcome channels can only accept custom emojis if :attr:`Guild.premium_tier` is level 2 or above.
 
-        You must have the :attr:`~Permissions.manage_guild` permission in the
-        guild to do this.
+        You must have :attr:`~Permissions.manage_guild` in the guild to do this.
 
         Usage: ::
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -618,7 +618,7 @@ Guilds
 .. function:: on_invite_create(invite)
 
     Called when an :class:`Invite` is created.
-    You must have the :attr:`~Permissions.manage_channels` permission to receive this.
+    You must have :attr:`~Permissions.manage_channels` to receive this.
 
     .. versionadded:: 1.3
 
@@ -635,7 +635,7 @@ Guilds
 .. function:: on_invite_delete(invite)
 
     Called when an :class:`Invite` is deleted.
-    You must have the :attr:`~Permissions.manage_channels` permission to receive this.
+    You must have :attr:`~Permissions.manage_channels` to receive this.
 
     .. versionadded:: 1.3
 


### PR DESCRIPTION
## Summary

Buncha permission inconsistencies in the docstrings, fixed 'em up!

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
