### PR TITLE
fix: library stub not found

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:
     # Generally, these two libraries are supposed to be separate from each other.
     # However, for type hinting purposes it's unfortunately necessary for one to
     # reference the other to prevent type checking errors in callbacks
-    from discord.ext.commands import Cog
+    from discord.ext import commands
 
     ErrorFunc = Callable[[Interaction, AppCommandError], Coroutine[Any, Any, None]]
 
@@ -105,7 +105,7 @@ Error = Union[
     UnboundError,
 ]
 Check = Callable[['Interaction'], Union[bool, Coro[bool]]]
-Binding = Union['Group', 'Cog']
+Binding = Union['Group', 'commands.Cog']
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Summary

```py
# sample.py
from discord import app_commands

app_commands.command()
```
When I check the file with mypy, it says that the stub cannot be found.

``discord\app_commands\commands.py:89: error: Cannot find implementation or library stub for module named "discord.ext.commands"``

https://github.com/Rapptz/discord.py/pull/7743#issuecomment-1074682871
Perhaps it has something to do with the issue comment.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
