### PR TITLE
ForumTag.emoji initialization fix

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2023,7 +2023,7 @@ class ForumTag(Hashable):
         elif isinstance(emoji, str):
             self.emoji = PartialEmoji.from_str(emoji)
         elif emoji is not None:
-            raise TypeError(f'emoji must be a Emoji, PartialEmoji, or str not {emoji.__class__.__name__}')
+            raise TypeError(f'emoji must be a Emoji, PartialEmoji, str or None not {emoji.__class__.__name__}')
 
     @classmethod
     def from_data(cls, *, state: ConnectionState, data: ForumTagPayload) -> Self:

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2013,7 +2013,7 @@ class ForumTag(Hashable):
 
     __slots__ = ('name', 'id', 'moderated', 'emoji')
 
-    def __init__(self, *, name: str, emoji: Optional[EmojiInputType], moderated: bool = False) -> None:
+    def __init__(self, *, name: str, emoji: Optional[EmojiInputType] = None, moderated: bool = False) -> None:
         self.name: str = name
         self.id: int = 0
         self.moderated: bool = moderated
@@ -2022,7 +2022,7 @@ class ForumTag(Hashable):
             self.emoji = emoji._to_partial()
         elif isinstance(emoji, str):
             self.emoji = PartialEmoji.from_str(emoji)
-        else:
+        elif emoji is not None:
             raise TypeError(f'emoji must be a Emoji, PartialEmoji, or str not {emoji.__class__.__name__}')
 
     @classmethod


### PR DESCRIPTION
This fixes a bug that makes it so that one can't assign None to a Forum Tag

## Summary

Currently users can't create tags which only have name, and manually using None, just makes it error. So this PR fixes that issue.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
