### PR TITLE
Add privacy_level to create_scheduled_event docstring

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2844,6 +2844,8 @@ class Guild(Hashable):
             automatically set to the appropriate entity type. If no channel
             is passed then the entity type is assumed to be
             :attr:`EntityType.external`
+        privacy_level: :class:`PrivacyLevel`
+            The privacy level of the scheduled event.
         image: :class:`bytes`
             The image of the scheduled event.
         location: :class:`str`


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Previously, the `privacy_level` kwarg was absent from the `Guild.create_scheduled_event` docstring. It is now added and described.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
