### PR TITLE
fix docstring for create_invite

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1213,12 +1213,12 @@ class GuildChannel:
             .. versionadded:: 2.0
 
         target_user: Optional[:class:`User`]
-            The user whose stream to display for this invite, required if `target_type` is `TargetType.stream`. The user must be streaming in the channel.
+            The user whose stream to display for this invite, required if ``target_type`` is :attr:`.InviteTarget.stream`. The user must be streaming in the channel.
 
             .. versionadded:: 2.0
 
         target_application_id:: Optional[:class:`int`]
-            The id of the embedded application for the invite, required if `target_type` is `TargetType.embedded_application`.
+            The id of the embedded application for the invite, required if ``target_type`` is :attr:`.InviteTarget.embedded_application`.
 
             .. versionadded:: 2.0
 


### PR DESCRIPTION
## Summary

- Fixes the backticks to make mentioning of other parameters actually codeblocked
- Fixes mention of `InviteTarget` attributes

Before:
<img width="1020" alt="image" src="https://user-images.githubusercontent.com/44045823/192203143-4c7ee77a-0d7b-4947-b0a7-d6dbef732c79.png">
After:
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/44045823/192203190-7482078f-39db-4b12-9c45-9fde64e579d5.png">


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
