### PR TITLE
Set thread related perms in private channels to False

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2812,10 +2812,18 @@ class DMChannel(discord.abc.Messageable, discord.abc.PrivateChannel, Hashable):
 
         - :attr:`~Permissions.send_tts_messages`: You cannot send TTS messages in a DM.
         - :attr:`~Permissions.manage_messages`: You cannot delete others messages in a DM.
+        - :attr:`~Permissions.create_private_threads`: There are no threads in a DM.
+        - :attr:`~Permissions.create_public_threads`: There are no threads in a DM.
+        - :attr:`~Permissions.manage_threads`: There are no threads in a DM.
+        - :attr:`~Permissions.send_messages_in_threads`: There are no threads in a DM.
 
         .. versionchanged:: 2.0
 
             ``obj`` parameter is now positional-only.
+
+        .. versionchanged:: 2.1
+
+            Thread related permissions are now set to ``False``.
 
         Parameters
         -----------
@@ -2978,12 +2986,20 @@ class GroupChannel(discord.abc.Messageable, discord.abc.PrivateChannel, Hashable
 
         - :attr:`~Permissions.send_tts_messages`: You cannot send TTS messages in a DM.
         - :attr:`~Permissions.manage_messages`: You cannot delete others messages in a DM.
+        - :attr:`~Permissions.create_private_threads`: There are no threads in a DM.
+        - :attr:`~Permissions.create_public_threads`: There are no threads in a DM.
+        - :attr:`~Permissions.manage_threads`: There are no threads in a DM.
+        - :attr:`~Permissions.send_messages_in_threads`: There are no threads in a DM.
 
         This also checks the kick_members permission if the user is the owner.
 
         .. versionchanged:: 2.0
 
             ``obj`` parameter is now positional-only.
+
+        .. versionchanged:: 2.1
+
+            Thread related permissions are now set to ``False``.
 
         Parameters
         -----------

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -192,6 +192,10 @@ class Permissions(BaseFlags):
         base.read_messages = True
         base.send_tts_messages = False
         base.manage_messages = False
+        base.create_private_threads = False
+        base.create_public_threads = False
+        base.manage_threads = False
+        base.send_messages_in_threads = False
         return base
 
     @classmethod


### PR DESCRIPTION
## Summary

Threads can only be created in guilds so this updates `Permissions._dm_permissions()` to set thread-related perms to False.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
