### PR TITLE
Fix mention of ABC change and add change to commands.cooldown() to migration guide

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -2453,6 +2453,10 @@ def cooldown(
 
         .. versionchanged:: 1.7
             Callables are now supported for custom bucket types.
+
+        .. versionchanged:: 2.0
+            When passing a callable, it now needs to accept :class:`.Context`
+            rather than :class:`~discord.Message` as its only argument.
     """
 
     def decorator(func: Union[Command, CoroFunc]) -> Union[Command, CoroFunc]:

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -1472,6 +1472,8 @@ Miscellaneous Changes
 
     - To override a cog, the new ``override`` parameter can be used.
 
+- When passing a callable to ``type`` argument of :meth:`~ext.commands.cooldown`,
+  it now needs to accept :class:`~ext.commands.Context` rather than :class:`Message` as its only argument.
 - Metaclass of :class:`~ext.commands.Context` changed from :class:`abc.ABCMeta` to :class:`type`.
 - Changed type of :attr:`ext.commands.Command.clean_params` from :class:`collections.OrderedDict` to :class:`dict`.
   As the latter is guaranteed to preserve insertion order since Python 3.7.

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -153,7 +153,6 @@ The following have been changed to :func:`runtime-checkable <typing.runtime_chec
 
 - :class:`abc.Snowflake`
 - :class:`abc.User`
-- :class:`abc.PrivateChannel`
 
 The following have been changed to subclass :class:`~typing.Protocol`:
 
@@ -163,6 +162,7 @@ The following have been changed to subclass :class:`~typing.Protocol`:
 The following have been changed to use the default metaclass instead of :class:`abc.ABCMeta`:
 
 - :class:`abc.Messageable`
+- :class:`abc.PrivateChannel`
 
 ``datetime`` Objects Are Now UTC-Aware
 ----------------------------------------


### PR DESCRIPTION
## Summary

- Move PrivateChannel ABC change to a proper subsection in the migration guide as this has changed since that section was originally written: https://github.com/Rapptz/discord.py/commit/5de9287902ae3d4c1a9fc16ed6e7b3dcf204d6a0
- Add change to the accepted callables in cooldown()'s `type` argument to the migration guide as callable were already accepted in d.py 1.7 and the accepted callables have changed in 2.0 here: 311891912e2de597ed44abc959b74f6fb2059d3c

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
