### PR TITLE
Type hint support for slices and __index__ in SequenceProxy

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -46,6 +46,7 @@ from typing import (
     Protocol,
     Set,
     Sequence,
+    SupportsIndex,
     Tuple,
     Type,
     TypeVar,
@@ -227,7 +228,15 @@ class SequenceProxy(Sequence[T_co]):
     def __repr__(self) -> str:
         return f"SequenceProxy({self.__proxied!r})"
 
-    def __getitem__(self, idx: int) -> T_co:
+    @overload
+    def __getitem__(self, idx: SupportsIndex) -> T_co:
+        ...
+
+    @overload
+    def __getitem__(self, idx: slice) -> List[T_co]:
+        ...
+
+    def __getitem__(self, idx: Union[SupportsIndex, slice]) -> Union[T_co, List[T_co]]:
         return self.__copied[idx]
 
     def __len__(self) -> int:


### PR DESCRIPTION
## Summary

Since SequenceProxy's `__getitem__` just calls the underlying list's `__getitem__`, it means that it supports slices and objects with `__index__` method as well.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
