### PR TITLE
Add ForumChannel to Webhook's documentation

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -68,7 +68,7 @@ if TYPE_CHECKING:
     from ..http import Response
     from ..guild import Guild
     from ..emoji import Emoji
-    from ..channel import VoiceChannel
+    from ..channel import ForumChannel, VoiceChannel
     from ..abc import Snowflake
     from ..ui.view import View
     import datetime
@@ -1006,8 +1006,8 @@ class BaseWebhook(Hashable):
         return self._state and self._state._get_guild(self.guild_id)
 
     @property
-    def channel(self) -> Optional[Union[VoiceChannel, TextChannel]]:
-        """Optional[Union[:class:`VoiceChannel`, :class:`TextChannel`]]: The channel this webhook belongs to.
+    def channel(self) -> Optional[Union[ForumChannel, VoiceChannel, TextChannel]]:
+        """Optional[Union[:class:`ForumChannel`, :class:`VoiceChannel`, :class:`TextChannel`]]: The channel this webhook belongs to.
 
         If this is a partial webhook, then this will always return ``None``.
         """
@@ -1059,7 +1059,8 @@ class Webhook(BaseWebhook):
 
     There are two main ways to use Webhooks. The first is through the ones
     received by the library such as :meth:`.Guild.webhooks`,
-    :meth:`.TextChannel.webhooks` and :meth:`.VoiceChannel.webhooks`.
+    :meth:`.TextChannel.webhooks`, :meth:`.VoiceChannel.webhooks`
+    and :meth:`.ForumChannel.webhooks`.
     The ones received by the library will automatically be
     bound using the library's internal HTTP session.
 


### PR DESCRIPTION
## Summary

Update documentation and type hint of `BaseWebhook.channel` to include `ForumChannel` type and mention `ForumChannel.webhooks` in the docstring of the `Webhook` class.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
