### PR TITLE
Fix Guild.ban docs

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3415,14 +3415,14 @@ class Guild(Hashable):
         delete_message_days: :class:`int`
             The number of days worth of messages to delete from the user
             in the guild. The minimum is 0 and the maximum is 7.
-            Defaults to 1 day if neither ``delete_message_days`` nor 
+            Defaults to 1 day if neither ``delete_message_days`` nor
             ``delete_message_seconds`` are passed.
 
             .. deprecated:: 2.1
         delete_message_seconds: :class:`int`
             The number of seconds worth of messages to delete from the user
             in the guild. The minimum is 0 and the maximum is 604800 (7 days).
-            Defaults to 1 day if neither ``delete_message_days`` nor 
+            Defaults to 1 day if neither ``delete_message_days`` nor
             ``delete_message_seconds`` are passed.
 
             .. versionadded:: 2.1

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3415,11 +3415,15 @@ class Guild(Hashable):
         delete_message_days: :class:`int`
             The number of days worth of messages to delete from the user
             in the guild. The minimum is 0 and the maximum is 7.
+            Defaults to 1 day if neither ``delete_message_days`` nor 
+            ``delete_message_seconds`` are passed.
 
             .. deprecated:: 2.1
-        delete_message_seconds: :class:`int`:
+        delete_message_seconds: :class:`int`
             The number of seconds worth of messages to delete from the user
             in the guild. The minimum is 0 and the maximum is 604800 (7 days).
+            Defaults to 1 day if neither ``delete_message_days`` nor 
+            ``delete_message_seconds`` are passed.
 
             .. versionadded:: 2.1
         reason: Optional[:class:`str`]


### PR DESCRIPTION
## Summary
The default of 1 day was inadvertently removed from the docs when #8391 was added

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
