### PR TITLE
[commands] Add Cog.has_app_error_handler

### DIFF
--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -519,6 +519,13 @@ class Cog(metaclass=CogMeta):
         """
         return not hasattr(self.cog_command_error.__func__, '__cog_special_method__')
 
+    def has_app_error_handler(self) -> bool:
+        """:class:`bool`: Checks whether the cog has an app error handler.
+
+        .. versionadded:: 2.1
+        """
+        return not hasattr(self.cog_app_command_error.__func__, '__cog_special_method__')
+
     @_cog_special_method
     async def cog_load(self) -> None:
         """|maybecoro|


### PR DESCRIPTION
## Summary

This pull request adds `discord.ext.commands.Cog.has_app_error_handler` in order to know if the cog implements the method `cog_app_command_error`.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
