### PR TITLE
Stop using deprecated set-output GH Actions command

### DIFF
--- a/.github/workflows/crowdin_download.yml
+++ b/.github/workflows/crowdin_download.yml
@@ -15,7 +15,7 @@ jobs:
       - id: check
         if: env.CROWDIN_API_KEY != null
         run: |
-          echo "::set-output name=available::true"
+          echo "available=true" >> $GITHUB_OUTPUT
         env:
           CROWDIN_API_KEY: ${{ secrets.CROWDIN_API_KEY }}
 

--- a/.github/workflows/crowdin_download.yml
+++ b/.github/workflows/crowdin_download.yml
@@ -22,6 +22,7 @@ jobs:
   download:
     runs-on: ubuntu-latest
     needs: [ check-environment ]
+    # secrets cannot be accessed inside an `if` so this needs to be checked in separate job
     if: needs.check-environment.outputs.available == 'true'
     environment: Crowdin
     name: download


### PR DESCRIPTION
## Summary

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
