### PR TITLE
remove redundant `VocalGuildChannel` from `Union`, as it's already part of `GuildChannel`

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -78,7 +78,7 @@ from .automod import AutoModRule, AutoModAction
 if TYPE_CHECKING:
     from .abc import PrivateChannel
     from .message import MessageableChannel
-    from .guild import GuildChannel, VocalGuildChannel
+    from .guild import GuildChannel
     from .http import HTTPClient
     from .voice_client import VoiceProtocol
     from .client import Client
@@ -98,7 +98,7 @@ if TYPE_CHECKING:
     from .types.command import GuildApplicationCommandPermissions as GuildApplicationCommandPermissionsPayload
 
     T = TypeVar('T')
-    Channel = Union[GuildChannel, VocalGuildChannel, PrivateChannel, PartialMessageable]
+    Channel = Union[GuildChannel, PrivateChannel, PartialMessageable]
 
 
 class ChunkRequest:


### PR DESCRIPTION
## Summary

no functional change as the removed code was redundant
guild.py#L134: `GuildChannel = Union[VocalGuildChannel, ForumChannel, TextChannel, CategoryChannel]`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
