### PR TITLE
Change ambiguous Loop.stop description

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -415,7 +415,7 @@ class Loop(Generic[LF]):
             use :meth:`cancel` instead.
 
         .. versionchanged:: 2.0
-            Calling this method in :meth:`before_loop` will stop the first iteration from running.
+            Calling this method in :meth:`before_loop` will stop the loop before the initial iteration is run.
 
         .. versionadded:: 1.2
         """
@@ -545,7 +545,7 @@ class Loop(Generic[LF]):
         The coroutine must take no arguments (except ``self`` in a class context).
 
         .. versionchanged:: 2.0
-            Calling :meth:`stop` in this coroutine will stop the initial iteration from running.
+            Calling :meth:`stop` in this coroutine will stop the loop before the initial iteration is run.
 
         Parameters
         ------------


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Changes ambiguous wording describing the behavior of Loop.stop inside of Loop.before_loop

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
