### PR TITLE
Add Pycharm support to coloured logging; Check for Vscode/Pycharm on all platforms

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1208,14 +1208,17 @@ def format_dt(dt: datetime.datetime, /, style: Optional[TimestampStyle] = None) 
 
 
 def stream_supports_colour(stream: Any) -> bool:
+    # Pycharm and Vscode support colour in their inbuilt editors
+    if "PYCHARM_HOSTED" in os.environ or os.environ.get("TERM_PROGRAM") == "vscode":
+        return True
+
     is_a_tty = hasattr(stream, 'isatty') and stream.isatty()
     if sys.platform != 'win32':
         return is_a_tty
 
     # ANSICON checks for things like ConEmu
     # WT_SESSION checks if this is Windows Terminal
-    # VSCode built-in terminal supports colour too
-    return is_a_tty and ('ANSICON' in os.environ or 'WT_SESSION' in os.environ or os.environ.get('TERM_PROGRAM') == 'vscode')
+    return is_a_tty and ('ANSICON' in os.environ or 'WT_SESSION' in os.environ)
 
 
 class _ColourFormatter(logging.Formatter):

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1209,7 +1209,7 @@ def format_dt(dt: datetime.datetime, /, style: Optional[TimestampStyle] = None) 
 
 def stream_supports_colour(stream: Any) -> bool:
     # Pycharm and Vscode support colour in their inbuilt editors
-    if "PYCHARM_HOSTED" in os.environ or os.environ.get("TERM_PROGRAM") == "vscode":
+    if 'PYCHARM_HOSTED' in os.environ or os.environ.get('TERM_PROGRAM') == 'vscode':
         return True
 
     is_a_tty = hasattr(stream, 'isatty') and stream.isatty()


### PR DESCRIPTION
## Summary

This PR adjusts `utils.stream_supports_colour` to check for Pycharm's terminal in addition to Vscode, as both support colour. It also changes order of checks so that platforms other than windows can have coloured text in their editor as well.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
