### PR TITLE
Allow `Context.send` to use `delete_after` for ephemeral interactions

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -769,7 +769,7 @@ class Context(discord.abc.Messageable, Generic[BotT]):
         delete_after: :class:`float`
             If provided, the number of seconds to wait in the background
             before deleting the message we just sent. If the deletion fails,
-            then it is silently ignored. This is ignored for interaction based contexts.
+            then it is silently ignored.
         allowed_mentions: :class:`~discord.AllowedMentions`
             Controls the mentions being processed in this message. If this is
             passed, then the object is merged with :attr:`~discord.Client.allowed_mentions`.
@@ -876,6 +876,6 @@ class Context(discord.abc.Messageable, Generic[BotT]):
             await self.interaction.response.send_message(**kwargs)
             msg = await self.interaction.original_response()
 
-        if delete_after is not None and not (ephemeral and self.interaction is not None):
+        if delete_after is not None:
             await msg.delete(delay=delete_after)
         return msg


### PR DESCRIPTION
## Summary

Due to [Discord adding deletion of ephemeral messages](https://discord.com/developers/docs/change-log#delete-ephemeral-messages), this PR supports that functionality for `Context.send`.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
