### PR TITLE
Add __int__ method to BaseFlags

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -159,6 +159,9 @@ class BaseFlags:
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} value={self.value}>'
+    
+    def __int__(self) -> int:
+        return self.value
 
     def __iter__(self) -> Iterator[Tuple[str, bool]]:
         for name, value in self.__class__.__dict__.items():
@@ -231,6 +234,10 @@ class SystemChannelFlags(BaseFlags):
         .. describe:: hash(x)
 
                Return the flag's hash.
+        
+        .. describe:: int(x)
+
+            Return the raw :attr:`value`.
 
         .. describe:: iter(x)
 
@@ -336,6 +343,11 @@ class MessageFlags(BaseFlags):
         .. describe:: hash(x)
 
                Return the flag's hash.
+
+        .. describe:: int(x)
+
+               Return the raw :attr:`value`.
+
         .. describe:: iter(x)
 
                Returns an iterator of ``(name, value)`` pairs. This allows it
@@ -459,6 +471,11 @@ class PublicUserFlags(BaseFlags):
         .. describe:: hash(x)
 
             Return the flag's hash.
+
+        .. describe:: int(x)
+
+               Return the raw :attr:`value`.
+
         .. describe:: iter(x)
 
             Returns an iterator of ``(name, value)`` pairs. This allows it
@@ -636,6 +653,11 @@ class Intents(BaseFlags):
         .. describe:: hash(x)
 
                Return the flag's hash.
+
+        .. describe:: int(x)
+
+               Return the raw :attr:`value`.
+
         .. describe:: iter(x)
 
                Returns an iterator of ``(name, value)`` pairs. This allows it
@@ -1211,6 +1233,11 @@ class MemberCacheFlags(BaseFlags):
         .. describe:: hash(x)
 
                Return the flag's hash.
+
+        .. describe:: int(x)
+
+               Return the raw :attr:`value`.
+
         .. describe:: iter(x)
 
                Returns an iterator of ``(name, value)`` pairs. This allows it
@@ -1353,6 +1380,11 @@ class ApplicationFlags(BaseFlags):
         .. describe:: hash(x)
 
             Return the flag's hash.
+        
+        .. describe:: int(x)
+
+            Return the raw :attr:`value`.
+
         .. describe:: iter(x)
 
             Returns an iterator of ``(name, value)`` pairs. This allows it
@@ -1470,6 +1502,11 @@ class ChannelFlags(BaseFlags):
         .. describe:: hash(x)
 
             Return the flag's hash.
+
+        .. describe:: int(x)
+
+               Return the raw :attr:`value`.
+
         .. describe:: iter(x)
 
             Returns an iterator of ``(name, value)`` pairs. This allows it
@@ -1558,6 +1595,11 @@ class AutoModPresets(ArrayFlags):
         .. describe:: hash(x)
 
             Return the flag's hash.
+
+        .. describe:: int(x)
+
+            Return the raw :attr:`value`.
+
         .. describe:: iter(x)
 
             Returns an iterator of ``(name, value)`` pairs. This allows it

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -88,7 +88,7 @@ def fill_with_flags(*, inverted: bool = False) -> Callable[[Type[BF]], Type[BF]]
 
         if inverted:
             max_bits = max(cls.VALID_FLAGS.values()).bit_length()
-            cls.DEFAULT_VALUE = -1 + (2**max_bits)
+            cls.DEFAULT_VALUE = -1 + (2 ** max_bits)
         else:
             cls.DEFAULT_VALUE = 0
 
@@ -142,7 +142,7 @@ class BaseFlags:
 
     def __invert__(self) -> Self:
         max_bits = max(self.VALID_FLAGS.values()).bit_length()
-        max_value = -1 + (2**max_bits)
+        max_value = -1 + (2 ** max_bits)
         return self._from_value(self.value ^ max_value)
 
     def __bool__(self) -> bool:
@@ -159,7 +159,7 @@ class BaseFlags:
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} value={self.value}>'
-    
+
     def __int__(self) -> int:
         return self.value
 
@@ -234,7 +234,7 @@ class SystemChannelFlags(BaseFlags):
         .. describe:: hash(x)
 
                Return the flag's hash.
-        
+
         .. describe:: int(x)
 
             Return the raw :attr:`value`.
@@ -1380,7 +1380,7 @@ class ApplicationFlags(BaseFlags):
         .. describe:: hash(x)
 
             Return the flag's hash.
-        
+
         .. describe:: int(x)
 
             Return the raw :attr:`value`.

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -88,7 +88,7 @@ def fill_with_flags(*, inverted: bool = False) -> Callable[[Type[BF]], Type[BF]]
 
         if inverted:
             max_bits = max(cls.VALID_FLAGS.values()).bit_length()
-            cls.DEFAULT_VALUE = -1 + (2 ** max_bits)
+            cls.DEFAULT_VALUE = -1 + (2**max_bits)
         else:
             cls.DEFAULT_VALUE = 0
 
@@ -142,7 +142,7 @@ class BaseFlags:
 
     def __invert__(self) -> Self:
         max_bits = max(self.VALID_FLAGS.values()).bit_length()
-        max_value = -1 + (2 ** max_bits)
+        max_value = -1 + (2**max_bits)
         return self._from_value(self.value ^ max_value)
 
     def __bool__(self) -> bool:

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -113,7 +113,7 @@ class Permissions(BaseFlags):
         .. describe:: hash(x)
 
                Return the permission's hash.
-        
+
         .. describe:: int(x)
 
                Return the raw :attr:`value`.

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -113,6 +113,11 @@ class Permissions(BaseFlags):
         .. describe:: hash(x)
 
                Return the permission's hash.
+        
+        .. describe:: int(x)
+
+               Return the raw :attr:`value`.
+
         .. describe:: iter(x)
 
                Returns an iterator of ``(perm, value)`` pairs. This allows it


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds a __int__ method to BaseFlags. Allows you to get the value using int(obj)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
