### PR TITLE
Persistent views: Change to get_event_loop()

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -187,7 +187,7 @@ class View:
         self.__cancel_callback: Optional[Callable[[View], None]] = None
         self.__timeout_expiry: Optional[float] = None
         self.__timeout_task: Optional[asyncio.Task[None]] = None
-        self.__stopped: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
+        self.__stopped: asyncio.Future[bool] = asyncio.get_event_loop().create_future()
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} timeout={self.timeout} children={len(self._children)}>'


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

I've run into an issue on my bot where defining a persistent view caused an error saying no event loop was running, so while this may be an edge case on my bot causing it to fail, I changed it to use get_event_loop() instead of get_running_loop(), and it worked, and this should not introduce any breaking changes. So, I believe get_event_loop() is a better choice here.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
