### PR TITLE
added setter method for ChannelSelect.channel_types

### DIFF
--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -657,6 +657,11 @@ class ChannelSelect(BaseSelect[V]):
 
     @channel_types.setter
     def channel_types(self, value: List[ChannelType]) -> None:
+        if not isinstance(value, list): 
+            raise TypeError('channel_types must be a list of ChannelType')
+        if not all(isinstance(obj, ChannelType) for obj in value):
+            raise TypeError('all list items must be a ChannelType')
+            
         self._underlying.channel_types = value
     
     @property

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -657,13 +657,13 @@ class ChannelSelect(BaseSelect[V]):
 
     @channel_types.setter
     def channel_types(self, value: List[ChannelType]) -> None:
-        if not isinstance(value, list): 
+        if not isinstance(value, list):
             raise TypeError('channel_types must be a list of ChannelType')
         if not all(isinstance(obj, ChannelType) for obj in value):
             raise TypeError('all list items must be a ChannelType')
-            
+
         self._underlying.channel_types = value
-    
+
     @property
     def values(self) -> List[Union[AppCommandChannel, AppCommandThread]]:
         """List[Union[:class:`~discord.app_commands.AppCommandChannel`, :class:`~discord.app_commands.AppCommandThread`]]: A list of channels selected by the user."""

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -655,6 +655,10 @@ class ChannelSelect(BaseSelect[V]):
         """List[:class:`~discord.ChannelType`]: A list of channel types that can be selected."""
         return self._underlying.channel_types
 
+    @channel_types.setter
+    def channel_types(self, value: List[ChannelType]) -> None:
+        self._underlying.channel_types = value
+    
     @property
     def values(self) -> List[Union[AppCommandChannel, AppCommandThread]]:
         """List[Union[:class:`~discord.app_commands.AppCommandChannel`, :class:`~discord.app_commands.AppCommandThread`]]: A list of channels selected by the user."""


### PR DESCRIPTION
## Summary

When ##9013 was added, it brought the new select menus that discord added. Though ChannelSelect.channel_types did not have a setter method while Select.options does, so I've added the setter method to it 

## Checklist

- [ x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x ] This PR fixes an issue.
- [x ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
