### PR TITLE
Add async def convert to RangeTransformer for compatability with classic/hybrid Converters

### DIFF
--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -411,7 +411,7 @@ class RangeTransformer(IdentityTransformer):
                 argument = converterfunc(argument)
             except ValueError:
                 raise TransformerError(
-                    f'Converting to "{converterfunc.annotation.__name__}" failed for parameter "{ctx.current_parameter.name}".',
+                    f'Converting to "{"int" if self._opt_type == AppCommandOptionType.integer else "float"}" failed for parameter "{ctx.current_parameter.name}".'
                     self._opt_type,
                     self
                 )

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -390,7 +390,7 @@ class RangeTransformer(IdentityTransformer):
         return self._max
     
     async def convert(self, ctx, argument):
-        # compatability with classic converters for hybrid command usage
+        # Compatability with classic converters for hybrid command usage
         # TransformerError used because i cant import BadArgument
         if self._opt_type == AppCommandOptionType.string:
             if self._min and len(argument) < self._min:

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -378,6 +378,7 @@ class RangeTransformer(IdentityTransformer):
 
         self._min: Optional[Union[int, float]] = min
         self._max: Optional[Union[int, float]] = max
+        self._opt_type: AppCommandOptionType = opt_type
         super().__init__(opt_type)
 
     @property

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -391,7 +391,7 @@ class RangeTransformer(IdentityTransformer):
     
     async def convert(self, ctx, argument):
         # Compatability with classic converters for hybrid command usage
-        # TransformerError used because i cant import BadArgument
+        # TransformerError used because I can't import BadArgument
         if self._opt_type == AppCommandOptionType.string:
             if self._min and len(argument) < self._min:
                 raise TransformerError(

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -409,12 +409,12 @@ class RangeTransformer(IdentityTransformer):
             converterfunc = int if self._opt_type == AppCommandOptionType.integer else float
             try:
                 argument = converterfunc(argument)
-            except ValueError:
+            except ValueError as exc:
                 raise TransformerError(
                     f'Converting to "{"int" if self._opt_type == AppCommandOptionType.integer else "float"}" failed for parameter "{ctx.current_parameter.name}".'
                     self._opt_type,
                     self
-                )
+                ) from exc
             if self._min and argument < self._min:
                 raise TransformerError(
                     f'Parameter "{ctx.current_parameter.name}" must be greater than {self._min}.',


### PR DESCRIPTION
## Summary

I added an `async def convert` method to `RangeTransformer` so that when used in a classic/hybrid command, the expected range value is enforced. However, I wasn't able to import `discord.ext.commands.errors.BadArgument` so I raise `discord.app_commands.errors.TransformerError` instead. I'm not sure how to fix this without making more changes than I'm comfortable making so I'm submitting the pull as-is for yall to look at and maybe make your own changes so it can work properly.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
