### PR TITLE
[commands] Raise CheckFailure when cog check fails

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -1270,7 +1270,9 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
                 if local_check is not None:
                     ret = await discord.utils.maybe_coroutine(local_check, ctx)
                     if not ret:
-                        return False
+                        raise CheckFailure(
+                            f'The check on cog {cog.qualified_name} failed for command {self.qualified_name}.'
+                        )
 
             predicates = self.checks
             if not predicates:


### PR DESCRIPTION
## Summary

Raise a `CheckFailure` when `cog_check`s fail, with its own error message. The original error message implied an issue related to the checks on the command itself and not the entire cog, so this just to easier differentiate between cog check and command check.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
