### PR TITLE
fix variance issues in `Bot.add_cog` with `List[Snowflake]`

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -41,6 +41,7 @@ from typing import (
     Dict,
     TYPE_CHECKING,
     Optional,
+    Sequence,
     TypeVar,
     Type,
     Union,
@@ -703,7 +704,7 @@ class BotBase(GroupMixin[None]):
         *,
         override: bool = False,
         guild: Optional[Snowflake] = MISSING,
-        guilds: List[Snowflake] = MISSING,
+        guilds: Sequence[Snowflake] = MISSING,
     ) -> None:
         """|coro|
 
@@ -811,7 +812,7 @@ class BotBase(GroupMixin[None]):
         /,
         *,
         guild: Optional[Snowflake] = MISSING,
-        guilds: List[Snowflake] = MISSING,
+        guilds: Sequence[Snowflake] = MISSING,
     ) -> Optional[Cog]:
         """|coro|
 

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -39,6 +39,7 @@ from typing import (
     List,
     Optional,
     TYPE_CHECKING,
+    Sequence,
     Tuple,
     TypeVar,
     Union,
@@ -660,7 +661,7 @@ class Cog(metaclass=CogMeta):
         """
         pass
 
-    async def _inject(self, bot: BotBase, override: bool, guild: Optional[Snowflake], guilds: List[Snowflake]) -> Self:
+    async def _inject(self, bot: BotBase, override: bool, guild: Optional[Snowflake], guilds: Sequence[Snowflake]) -> Self:
         cls = self.__class__
 
         # we'll call this first so that errors can propagate without


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR fixes that variances issues presented with `typing.List / list` for `commands.Bot.add_cog`'s `guilds=` parameter.

<details open>
<summary>Example repro code</summary>
<br>

```python
from typing import List

import discord

GUILDS: List[discord.Object] = [discord.Object(id=...), ...]

# Add a Cog definition

Bot.add_cog(Cog(...), guilds=GUILDS)  # <-- This will type fail due to list invariance.
```

</br>
</details>

## Checklist

I did not update docs due to a previous discussion relating to Sequence types and List documentation within the d.py server.

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
