### PR TITLE
Fixed state.py, connection dispatch bug.

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -571,6 +571,8 @@ class ConnectionState:
 
         except asyncio.CancelledError:
             pass
+        except ConnectionResetError:
+            pass
         else:
             # dispatch the event
             self.call_handlers('ready')


### PR DESCRIPTION
```bash
future: <Task finished name='Task-10' coro=<ConnectionState._delay_ready() done, defined at /usr/local/lib/python3.10/site-packages/discord/state.py:533> exception=ConnectionResetError('Cannot write to closing transport')>
```

Has been fixed

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
