### PR TITLE
Fixed typo in 'discord.Status.invisible'

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1858,7 +1858,7 @@ of :class:`enum.Enum`.
     .. attribute:: invisible
 
         The member is "invisible". In reality, this is only used in sending
-        a presence a la :meth:`Client.change_presence`. When you receive a
+        a presence update to :meth:`Client.change_presence`. When you receive a
         user's presence this will be :attr:`offline` instead.
 
 


### PR DESCRIPTION
## Summary

The current docs have:
```
The member is “invisible”. In reality, this is only used in sending a presence a la Client.change_presence(). When you receive a user’s presence this will be offline instead.
```
though there is a typo with `a la`. I changed `a la` to `update to` in this PR


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
