### PR TITLE
Fix async iterators with before/after limits requesting past their bounds

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1774,23 +1774,25 @@ class Messageable:
         channel = await self._get_channel()
 
         while True:
-            retrieve = min(100 if limit is None else limit, 100)
+            retrieve = 100 if limit is None else min(limit, 100)
             if retrieve < 1:
                 return
 
             data, state, limit = await strategy(retrieve, state, limit)
-
-            # Terminate loop on next iteration; there's no data left after this
-            if len(data) < 100:
-                limit = 0
 
             if reverse:
                 data = reversed(data)
             if predicate:
                 data = filter(predicate, data)
 
-            for raw_message in data:
+            count = 0
+
+            for count, raw_message in enumerate(data, 1):
                 yield self._state.create_message(channel=channel, data=raw_message)
+
+            if count < 100:
+                # There's no data left after this
+                break
 
 
 class Connectable(Protocol):

--- a/discord/client.py
+++ b/discord/client.py
@@ -1424,21 +1424,23 @@ class Client:
             predicate = lambda m: int(m['id']) > after.id
 
         while True:
-            retrieve = min(200 if limit is None else limit, 200)
+            retrieve = 200 if limit is None else min(limit, 200)
             if retrieve < 1:
                 return
 
             data, state, limit = await strategy(retrieve, state, limit)
 
-            # Terminate loop on next iteration; there's no data left after this
-            if len(data) < 200:
-                limit = 0
-
             if predicate:
                 data = filter(predicate, data)
 
-            for raw_guild in data:
+            count = 0
+
+            for count, raw_guild in enumerate(data, 1):
                 yield Guild(state=self._connection, data=raw_guild)
+
+            if count < 200:
+                # There's no data left after this
+                break
 
     async def fetch_template(self, code: Union[Template, str]) -> Template:
         """|coro|

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2079,7 +2079,7 @@ class Guild(Hashable):
             raise ClientException('Intents.members must be enabled to use this.')
 
         while True:
-            retrieve = min(1000 if limit is None else limit, 1000)
+            retrieve = 1000 if limit is None else min(limit, 1000)
             if retrieve < 1:
                 return
 
@@ -2304,7 +2304,7 @@ class Guild(Hashable):
             strategy, state = _after_strategy, after
 
         while True:
-            retrieve = min(1000 if limit is None else limit, 1000)
+            retrieve = 1000 if limit is None else min(limit, 1000)
             if retrieve < 1:
                 return
 
@@ -3660,15 +3660,11 @@ class Guild(Hashable):
         from .app_commands import AppCommand
 
         while True:
-            retrieve = min(100 if limit is None else limit, 100)
+            retrieve = 100 if limit is None else min(limit, 100)
             if retrieve < 1:
                 return
 
             data, raw_entries, state, limit = await strategy(retrieve, state, limit)
-
-            # Terminate loop on next iteration; there's no data left after this
-            if len(raw_entries) < 100:
-                limit = 0
 
             if reverse:
                 raw_entries = reversed(raw_entries)
@@ -3690,7 +3686,9 @@ class Guild(Hashable):
             )
             automod_rule_map = {rule.id: rule for rule in automod_rules}
 
-            for raw_entry in raw_entries:
+            count = 0
+
+            for count, raw_entry in enumerate(raw_entries, 1):
                 # Weird Discord quirk
                 if raw_entry['action_type'] is None:
                     continue
@@ -3703,6 +3701,10 @@ class Guild(Hashable):
                     automod_rules=automod_rule_map,
                     guild=self,
                 )
+
+            if count < 100:
+                # There's no data left after this
+                break
 
     async def widget(self) -> Widget:
         """|coro|


### PR DESCRIPTION
## Summary

This affects `Messageable.history`, `ScheduledEvent.users`, `Client.fetch_guilds`, and `Guild.audit_logs`.

To illustrate the problem, `Messageable.history` counted returned messages to tell when to stop iteration, but did so before filtering away those past the `before` or `after` boundaries. When both `oldest_first=False` and an `after` boundary were provided, this led to the history iterator continuing to retrieve messages older than the `after` boundary, which would then all be filtered away, continuing until the message limit or the beginning of the entire channel was reached. A similar situation would also occur with `oldest_first=True` and a `before` boundary provided.

This commit changes the logic in these methods to count items after filtering, so they stop requesting more as soon as the in-bounds items are exhausted.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
