### PR TITLE
Fix AutoModTrigger ignoring allow_list with type keyword

### DIFF
--- a/discord/automod.py
+++ b/discord/automod.py
@@ -121,7 +121,8 @@ class AutoModTrigger:
     +-----------------------------------------------+------------------------------------------------+
     |                    Type                       |                   Attributes                   |
     +===============================================+================================================+
-    | :attr:`AutoModRuleTriggerType.keyword`        | :attr:`keyword_filter`, :attr:`regex_patterns` |
+    | :attr:`AutoModRuleTriggerType.keyword`        | :attr:`keyword_filter`, :attr:`regex_patterns`,|
+    |                                               | :attr:`allow_list`                             |
     +-----------------------------------------------+------------------------------------------------+
     | :attr:`AutoModRuleTriggerType.spam`           |                                                |
     +-----------------------------------------------+------------------------------------------------+
@@ -146,7 +147,7 @@ class AutoModTrigger:
         `Rust's regex syntax <https://docs.rs/regex/latest/regex/#syntax>`_.
         Maximum of 10. Regex strings can only be up to 75 characters in length.
 
-        This could be combined with :attr:`keyword_filter`.
+        This may be combined with :attr:`keyword_filter` and :attr:`allow_list`
 
         .. versionadded:: 2.1
     presets: :class:`AutoModPresets`
@@ -225,7 +226,11 @@ class AutoModTrigger:
 
     def to_metadata_dict(self) -> Optional[Dict[str, Any]]:
         if self.type is AutoModRuleTriggerType.keyword:
-            return {'keyword_filter': self.keyword_filter, 'regex_patterns': self.regex_patterns}
+            return {
+                'keyword_filter': self.keyword_filter,
+                'regex_patterns': self.regex_patterns,
+                'allow_list': self.allow_list,
+            }
         elif self.type is AutoModRuleTriggerType.keyword_preset:
             return {'presets': self.presets.to_array(), 'allow_list': self.allow_list}
         elif self.type is AutoModRuleTriggerType.mention_spam:

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -147,7 +147,7 @@ class AutoModTrigger:
         `Rust's regex syntax <https://docs.rs/regex/latest/regex/#syntax>`_.
         Maximum of 10. Regex strings can only be up to 75 characters in length.
 
-        This may be combined with :attr:`keyword_filter` and :attr:`allow_list`
+        This could be combined with :attr:`keyword_filter` and/or :attr:`allow_list`
 
         .. versionadded:: 2.1
     presets: :class:`AutoModPresets`
@@ -214,7 +214,12 @@ class AutoModTrigger:
         if data is None:
             return cls(type=type_)
         elif type_ is AutoModRuleTriggerType.keyword:
-            return cls(type=type_, keyword_filter=data.get('keyword_filter'), regex_patterns=data.get('regex_patterns'))
+            return cls(
+                type=type_,
+                keyword_filter=data.get('keyword_filter'),
+                regex_patterns=data.get('regex_patterns'),
+                allow_list=data.get('allow_list'),
+            )
         elif type_ is AutoModRuleTriggerType.keyword_preset:
             return cls(
                 type=type_, presets=AutoModPresets._from_value(data.get('presets', [])), allow_list=data.get('allow_list')


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes a bug where `AutoModTrigger` ignores `allow_list` if type is `AutoModRuleTriggerType.keyword`


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
