### PR TITLE
Fix reactions with custom emojis breaking

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -120,9 +120,9 @@ def convert_emoji_reaction(emoji: Union[EmojiInputType, Reaction]) -> str:
     if isinstance(emoji, PartialEmoji):
         return emoji._as_reaction()
     if isinstance(emoji, str):
-        # Reactions can be in :name:id format, but not <:name:id>.
+        # Reactions can be in name:id format, but not <:name:id>.
         # No existing emojis have <> in them, so this should be okay.
-        return emoji.strip('<>')
+        return emoji.strip('<:>')
 
     raise TypeError(f'emoji argument must be str, Emoji, or Reaction not {emoji.__class__.__name__}.')
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Discord has changed the representation of custom emoji in reaction payloads, apparently. This commit strips the leading colon from reaction emoji strings to comply with this change.

Since this doesn't affect custom emojis sent as strings (`<:emoji:id>` works fine there), this internal fix is necessary.

fixes #9116 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
