### PR TITLE
Fix embed edge cases

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -228,9 +228,15 @@ class Embed:
         # try to fill in the more rich fields
 
         try:
-            self._colour = Colour(value=data['color'])
+            color = data['color']
         except KeyError:
-            pass
+            try:
+                color = data['colour']
+            except KeyError:
+                color = None
+
+        if color is not None:
+            self._colour = Colour(value=color)
 
         try:
             self._timestamp = utils.parse_time(data['timestamp'])
@@ -742,16 +748,16 @@ class Embed:
                     result['timestamp'] = timestamp.replace(tzinfo=datetime.timezone.utc).isoformat()
 
         # add in the non raw attribute ones
-        if self.type:
+        if self.type is not None:
             result['type'] = self.type
 
-        if self.description:
+        if self.description is not None:
             result['description'] = self.description
 
-        if self.url:
+        if self.url is not None:
             result['url'] = self.url
 
-        if self.title:
+        if self.title is not None:
             result['title'] = self.title
 
         return result  # type: ignore # This payload is equivalent to the EmbedData type

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -228,15 +228,9 @@ class Embed:
         # try to fill in the more rich fields
 
         try:
-            color = data['color']
+            self._colour = Colour(value=data['color'])
         except KeyError:
-            try:
-                color = data['colour']
-            except KeyError:
-                color = None
-
-        if color is not None:
-            self._colour = Colour(value=color)
+            pass
 
         try:
             self._timestamp = utils.parse_time(data['timestamp'])


### PR DESCRIPTION
## Summary

This PR fixes 2 things about `Embed`:

1. `.copy()` not including the following keys if any were assigned to an empty value (`""` for example): `type, title, description, url`.
Discussed in the bikeshedding thread ["Potential edge case for Embed.copy()"](https://canary.discord.com/channels/336642139381301249/1048902326586445886) in the server
~~2. `.from_dict()` not supporting `"colour"` as a key in the dict.
Reported by `Jack#7382` in the server [here](https://canary.discord.com/channels/336642139381301249/336642776609456130/1049371481576058880) (#general)~~ Reverted per [this comment](https://github.com/Rapptz/discord.py/pull/9128#issuecomment-1343495059)

I'm unsure if this is a breaking change or needs a `versionadded` string. Discord does not care about empty fields, so no errors are thrown.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
