### PR TITLE
Add slowmode_delay attribute

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -890,6 +890,7 @@ class VocalGuildChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hasha
         'rtc_region',
         'video_quality_mode',
         'last_message_id',
+		'slowmode_delay',
     )
 
     def __init__(self, *, state: ConnectionState, guild: Guild, data: Union[VoiceChannelPayload, StageChannelPayload]):
@@ -914,6 +915,7 @@ class VocalGuildChannel(discord.abc.Connectable, discord.abc.GuildChannel, Hasha
         self.position: int = data['position']
         self.bitrate: int = data['bitrate']
         self.user_limit: int = data['user_limit']
+		self.slowmode_delay: int = data.get('rate_limit_per_user', 0)
         self._fill_overwrites(data)
 
     @property
@@ -1321,7 +1323,7 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
 
     @utils.copy_doc(discord.abc.GuildChannel.clone)
     async def clone(self, *, name: Optional[str] = None, reason: Optional[str] = None) -> VoiceChannel:
-        return await self._clone_impl({'bitrate': self.bitrate, 'user_limit': self.user_limit}, name=name, reason=reason)
+        return await self._clone_impl({'bitrate': self.bitrate, 'user_limit': self.user_limit, "rate_limit_per_user": self.slowmode_delay}, name=name, reason=reason)
 
     @overload
     async def edit(self) -> None:
@@ -1340,6 +1342,7 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
         bitrate: int = ...,
         user_limit: int = ...,
         position: int = ...,
+        slowmode_delay: int = ...,
         sync_permissions: int = ...,
         category: Optional[CategoryChannel] = ...,
         overwrites: Mapping[OverwriteKeyT, PermissionOverwrite] = ...,
@@ -1381,6 +1384,8 @@ class VoiceChannel(discord.abc.Messageable, VocalGuildChannel):
             The new channel's user limit.
         position: :class:`int`
             The new channel's position.
+        slowmode_delay: :class:`int`
+            The new channel's slowmode interval in seconds.
         sync_permissions: :class:`bool`
             Whether to sync permissions with the channel's new or pre-existing
             category. Defaults to ``False``.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1370,6 +1370,8 @@ class Guild(Hashable):
         -----------
         name: :class:`str`
             The channel's name.
+        slowmode_delay: :class:`int`
+            The slowmode interval in seconds for the channel.
         overwrites: Dict[Union[:class:`Role`, :class:`Member`], :class:`PermissionOverwrite`]
             A :class:`dict` of target (either a role or a member) to
             :class:`PermissionOverwrite` to apply upon creation of a channel.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1353,6 +1353,7 @@ class Guild(Hashable):
         position: int = MISSING,
         bitrate: int = MISSING,
         user_limit: int = MISSING,
+        slowmode_delay: int = MISSING,
         rtc_region: Optional[str] = MISSING,
         video_quality_mode: VideoQualityMode = MISSING,
         overwrites: Mapping[Union[Role, Member], PermissionOverwrite] = MISSING,
@@ -1425,6 +1426,9 @@ class Guild(Hashable):
 
         if video_quality_mode is not MISSING:
             options['video_quality_mode'] = video_quality_mode.value
+
+        if slowmode_delay is not MISSING:
+            options['rate_limit_per_user'] = slowmode_delay
 
         data = await self._create_channel(
             name, overwrites=overwrites, channel_type=ChannelType.voice, category=category, reason=reason, **options

--- a/discord/types/channel.py
+++ b/discord/types/channel.py
@@ -87,7 +87,7 @@ class VoiceChannel(_BaseTextChannel):
     user_limit: int
     rtc_region: NotRequired[Optional[str]]
     video_quality_mode: NotRequired[VideoQualityMode]
-
+    rate_limit_per_user: int
 
 class CategoryChannel(_BaseGuildChannel):
     type: Literal[4]


### PR DESCRIPTION
Add `slowmode_delay` attributes to `channel.VoiceChannel` and related methods for creation and editing VoiceChannels

## Summary

The slowmode_delay attribute for `VoiceChannel` doesn't appear in the package, though it can be manually edited using keyword args (as seen in #9110). This adds the attribute to the VoiceChannel and allows the attribute to be accessed in a consistent way. Tests for cloning, deleting, and creating new VoiceChannels are successful.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
