### PR TITLE
Use ForwardRef and default to `Select` for unresolvable select annotations

### DIFF
--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -754,7 +754,8 @@ def select(
         Added the following keyword-arguments: ``cls``, ``channel_types``
 
     .. versionchanged:: 2.2
-        Now infers ``cls`` based on the callback if not supplied.
+        Now attempts to infer ``cls`` based on the callback if not supplied.
+        Unresolvable annotations still default to :class:`discord.ui.Select`.
 
     Example
     ---------
@@ -771,7 +772,7 @@ def select(
     cls: Union[Type[:class:`discord.ui.Select`], Type[:class:`discord.ui.UserSelect`], Type[:class:`discord.ui.RoleSelect`], \
         Type[:class:`discord.ui.MentionableSelect`], Type[:class:`discord.ui.ChannelSelect`]]
         The class to use for the select menu. Defaults to inferring the type from the
-        callback if available; otherwise defaults to :class:`discord.ui.Select`.
+        callback if available and resolvable; otherwise defaults to :class:`discord.ui.Select`.
         You can use other select types to display different select menus to the user.
         See the table above for the different values you can get from each select type.
         Subclasses work as well, however the callback in the subclass will get overridden.

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -690,7 +690,7 @@ def _get_select_callback_parameter(func: ItemCallbackType[V, BaseSelectT]) -> Ty
         globs = _ForwardRefDict(func.__globals__)
         try:
             resolved = eval(resolved, globs, globs)
-        except (TypeError, NameError):
+        except Exception:
             _log.debug(
                 "Unable to resolve annotation %r for callback %s: falling back to Select",
                 parameter.annotation,

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -31,7 +31,7 @@ from .item import Item, ItemCallbackType
 from ..enums import ChannelType, ComponentType
 from ..partial_emoji import PartialEmoji
 from ..emoji import Emoji
-from ..utils import MISSING, resolve_annotation
+from ..utils import MISSING
 from ..components import SelectOption, SelectMenu
 from ..app_commands.namespace import Namespace
 
@@ -692,7 +692,7 @@ def _get_select_callback_parameter(func: ItemCallbackType[V, BaseSelectT]) -> Ty
     if isinstance(resolved, str):
         globs = _ForwardRefDict(func.__globals__)
         try:
-            resolved = resolve_annotation(parameter.annotation, globs, globs, globs.cache)
+            resolved = eval(resolved, globs, globs)
         except (TypeError, NameError):
             raise TypeError(
                 f"Unable to resolve annotation {parameter.annotation!r} for callback {func.__qualname__}"

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -692,14 +692,14 @@ def _get_select_callback_parameter(func: ItemCallbackType[V, BaseSelectT]) -> Ty
             resolved = eval(resolved, globs, globs)
         except Exception:
             _log.debug(
-                "Unable to resolve annotation %r for callback %s: falling back to Select",
+                'Unable to resolve annotation %r for callback %s: falling back to Select',
                 parameter.annotation,
                 func.__qualname__,
             )
             return Select
         if isinstance(resolved, ForwardRef):
             _log.debug(
-                "Unable to resolve annotation %r for callback %s: falling back to Select",
+                'Unable to resolve annotation %r for callback %s: falling back to Select',
                 parameter.annotation,
                 func.__qualname__,
             )
@@ -707,7 +707,7 @@ def _get_select_callback_parameter(func: ItemCallbackType[V, BaseSelectT]) -> Ty
     origin = getattr(resolved, '__origin__', resolved)
     if origin is BaseSelect or not isinstance(origin, type) or not issubclass(origin, BaseSelect):
         _log.debug(
-            "Annotation %r for callback %s is unsupported: falling back to Select",
+            'Annotation %r for callback %s is unsupported: falling back to Select',
             parameter.annotation,
             func.__qualname__,
         )

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -22,7 +22,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 from __future__ import annotations
-from typing import Any, ForwardRef, List, Literal, Optional, TYPE_CHECKING, Tuple, Type, TypeVar, Callable, Union, Dict
+from typing import ForwardRef, List, Literal, Optional, TYPE_CHECKING, Tuple, Type, TypeVar, Callable, Union, Dict
 from contextvars import ContextVar
 import inspect
 import os
@@ -663,13 +663,8 @@ class ChannelSelect(BaseSelect[V]):
 
 
 class _ForwardRefDict(dict):
-    def __init__(self, *args, **kwargs):
-        self.cache: Dict[str, Any] = {}
-        super().__init__(*args, **kwargs)
-
     def __missing__(self, key):
-        self.cache[key] = ref = ForwardRef(key)
-        return ref
+        return ForwardRef(key)
 
 
 def _get_select_callback_parameter(func: ItemCallbackType[V, BaseSelectT]) -> Type[BaseSelect]:

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -675,10 +675,15 @@ def _get_select_callback_parameter(func: ItemCallbackType[V, BaseSelectT]) -> Ty
     for parameter in iterator:
         pass
 
-    if parameter.annotation is parameter.empty:
+    resolved = parameter.annotation
+    if resolved is parameter.empty:
         return Select
 
-    resolved = resolve_annotation(parameter.annotation, func.__globals__, func.__globals__, {})
+    if isinstance(resolved, str):
+        try:
+            resolved = resolve_annotation(parameter.annotation, func.__globals__, func.__globals__, {})
+        except NameError:
+            raise TypeError(f'Unable to resolve annotation {resolved!r} for select callback {func.__qualname__}') from None
     origin = getattr(resolved, '__origin__', resolved)
     if origin is BaseSelect or not isinstance(origin, type) or not issubclass(origin, BaseSelect):
         return Select


### PR DESCRIPTION
## Summary

Fixes #9136 (and closes #9141) by using to ForwardRefs as necessary and defaulting to `Select` if the annotation cannot be resolved.
As per that issue, this is only one solution to the issue - potentially the better solution would be to instead revert #9126, which is available in PR #9141.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
