### PR TITLE
Reformat code with black and use single quotes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import re
 
 requirements = []
 with open('requirements.txt') as f:
-  requirements = f.read().splitlines()
+    requirements = f.read().splitlines()
 
 version = ''
 with open('discord/__init__.py') as f:
@@ -16,13 +16,12 @@ if version.endswith(('a', 'b', 'rc')):
     # append version identifier based on commit count
     try:
         import subprocess
-        p = subprocess.Popen(['git', 'rev-list', '--count', 'HEAD'],
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        p = subprocess.Popen(['git', 'rev-list', '--count', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate()
         if out:
             version += out.decode('utf-8').strip()
-        p = subprocess.Popen(['git', 'rev-parse', '--short', 'HEAD'],
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(['git', 'rev-parse', '--short', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate()
         if out:
             version += '+g' + out.decode('utf-8').strip()
@@ -54,7 +53,7 @@ extras_require = {
         'pytest-cov',
         'pytest-mock',
         'typing-extensions>=4.3,<5',
-    ]
+    ],
 }
 
 packages = [
@@ -67,24 +66,25 @@ packages = [
     'discord.ext.tasks',
 ]
 
-setup(name='discord.py',
-      author='Rapptz',
-      url='https://github.com/Rapptz/discord.py',
-      project_urls={
-        "Documentation": "https://discordpy.readthedocs.io/en/latest/",
-        "Issue tracker": "https://github.com/Rapptz/discord.py/issues",
-      },
-      version=version,
-      packages=packages,
-      license='MIT',
-      description='A Python wrapper for the Discord API',
-      long_description=readme,
-      long_description_content_type="text/x-rst",
-      include_package_data=True,
-      install_requires=requirements,
-      extras_require=extras_require,
-      python_requires='>=3.8.0',
-      classifiers=[
+setup(
+    name='discord.py',
+    author='Rapptz',
+    url='https://github.com/Rapptz/discord.py',
+    project_urls={
+        'Documentation': 'https://discordpy.readthedocs.io/en/latest/',
+        'Issue tracker': 'https://github.com/Rapptz/discord.py/issues',
+    },
+    version=version,
+    packages=packages,
+    license='MIT',
+    description='A Python wrapper for the Discord API',
+    long_description=readme,
+    long_description_content_type='text/x-rst',
+    include_package_data=True,
+    install_requires=requirements,
+    extras_require=extras_require,
+    python_requires='>=3.8.0',
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: MIT License',
         'Intended Audience :: Developers',
@@ -98,5 +98,5 @@ setup(name='discord.py',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Utilities',
         'Typing :: Typed',
-      ]
+    ],
 )


### PR DESCRIPTION
## Summary
Fix setup.py not being black compliant and make the string quotes consistent.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
