### PR TITLE
Add str and float examples to app_commands.Range documentation

### DIFF
--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -553,10 +553,11 @@ else:
 
         Some example ranges limiting numeric input:
 
-        - ``Range[int, 10]`` means the input type is `int`, and the minimum is 10 with no maximum.
-        - ``Range[int, None, 10]`` means the input type is `int`, and the maximum is 10 with no minimum.
-        - ``Range[int, 1, 10]`` means the input type is `int`, and the minimum is 1 and the maximum is 10.
-        - ``Range[float, 1.0, 5.0]`` means the input type is `float`, and the minimum is 1.0 and the maximum is 5.0.
+        - ``Range[int, 10]`` means the minimum is 10 with no maximum.
+        - ``Range[int, None, 10]`` means the maximum is 10 with no minimum.
+        - ``Range[int, 1, 10]`` means the minimum is 1 and the maximum is 10.
+        - ``Range[float, 1.0, 5.0]`` means the minimum is 1.0 and the maximum is 5.0.
+        - ``Range[str, 1, 10]`` means the minimum length is 1 and the maximum length is 10.
 
         Some example ranges limiting string input:
 

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -559,12 +559,6 @@ else:
         - ``Range[float, 1.0, 5.0]`` means the minimum is 1.0 and the maximum is 5.0.
         - ``Range[str, 1, 10]`` means the minimum length is 1 and the maximum length is 10.
 
-        Some example ranges limiting string input:
-
-        - ``Range[str, 10]`` means the minimum length is 10 with no maximum length.
-        - ``Range[str, None, 10]`` means the maximum length is 10 with no minimum length.
-        - ``Range[str, 1, 10]`` means the minimum length is 1 and the maximum length is 10.
-
         .. versionadded:: 2.0
 
         Examples

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -567,6 +567,7 @@ else:
         .. code-block:: python3
 
             @app_commands.command()
+            async def range(interaction: discord.Interaction, value: app_commands.Range[int, 10, 12]):
                 await interaction.response.send_message(f'Your value is {value}', ephemeral=True)
         """
 

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -551,11 +551,18 @@ else:
         During type checking time this is equivalent to :obj:`typing.Annotated` so type checkers understand
         the intent of the code.
 
-        Some example ranges:
+        Some example ranges limiting numeric input:
 
-        - ``Range[int, 10]`` means the minimum is 10 with no maximum.
-        - ``Range[int, None, 10]`` means the maximum is 10 with no minimum.
-        - ``Range[int, 1, 10]`` means the minimum is 1 and the maximum is 10.
+        - ``Range[int, 10]`` means the input type is `int`, and the minimum is 10 with no maximum.
+        - ``Range[int, None, 10]`` means the input type is `int`, and the maximum is 10 with no minimum.
+        - ``Range[int, 1, 10]`` means the input type is `int`, and the minimum is 1 and the maximum is 10.
+        - ``Range[float, 1.0, 5.0]`` means the input type is `float`, and the minimum is 1.0 and the maximum is 5.0.
+
+        Some example ranges limiting string input:
+
+        - ``Range[str, 10]`` means the minimum length is 10 with no maximum length.
+        - ``Range[str, None, 10]`` means the maximum length is 10 with no minimum length.
+        - ``Range[str, 1, 10]`` means the minimum length is 1 and the maximum length is 10.
 
         .. versionadded:: 2.0
 
@@ -565,7 +572,11 @@ else:
         .. code-block:: python3
 
             @app_commands.command()
-            async def range(interaction: discord.Interaction, value: app_commands.Range[int, 10, 12]):
+            async def numeric_range(interaction: discord.Interaction, value: app_commands.Range[int, 10, 12]):
+                await interaction.response.send_message(f'Your value is {value}', ephemeral=True)
+                
+            @app_commands.command()
+            async def string_range(interaction: discord.Interaction, value: app_commands.Range[str, 5, 10]):
                 await interaction.response.send_message(f'Your value is {value}', ephemeral=True)
         """
 

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -551,7 +551,7 @@ else:
         During type checking time this is equivalent to :obj:`typing.Annotated` so type checkers understand
         the intent of the code.
 
-        Some example ranges limiting numeric input:
+        Some example ranges:
 
         - ``Range[int, 10]`` means the minimum is 10 with no maximum.
         - ``Range[int, None, 10]`` means the maximum is 10 with no minimum.

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -573,11 +573,6 @@ else:
         .. code-block:: python3
 
             @app_commands.command()
-            async def numeric_range(interaction: discord.Interaction, value: app_commands.Range[int, 10, 12]):
-                await interaction.response.send_message(f'Your value is {value}', ephemeral=True)
-                
-            @app_commands.command()
-            async def string_range(interaction: discord.Interaction, value: app_commands.Range[str, 5, 10]):
                 await interaction.response.send_message(f'Your value is {value}', ephemeral=True)
         """
 


### PR DESCRIPTION
## Summary

Add examples for str and float to the documentation for app_commands.Range transformer as it was not clear what types could be used before, other than int.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
