### PR TITLE
Fall back to Object for AuditLogEntry.target

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -719,7 +719,10 @@ class AuditLogEntry(Hashable):
                 return None
             return Object(id=self._target_id)
         else:
-            return converter(self._target_id)
+            converted = converter(self._target_id)
+            if self._target_id is not None and converted is None:
+                return Object(id=self._target_id)
+            return converted
 
     @utils.cached_property
     def category(self) -> Optional[enums.AuditLogActionCategory]:

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -719,10 +719,7 @@ class AuditLogEntry(Hashable):
                 return None
             return Object(id=self._target_id)
         else:
-            converted = converter(self._target_id)
-            if self._target_id is not None and converted is None:
-                return Object(id=self._target_id)
-            return converted
+            return converter(self._target_id)
 
     @utils.cached_property
     def category(self) -> Optional[enums.AuditLogActionCategory]:
@@ -752,8 +749,8 @@ class AuditLogEntry(Hashable):
     def _convert_target_channel(self, target_id: int) -> Union[abc.GuildChannel, Object]:
         return self.guild.get_channel(target_id) or Object(id=target_id)
 
-    def _convert_target_user(self, target_id: int) -> Union[Member, User, None]:
-        return self._get_member(target_id)
+    def _convert_target_user(self, target_id: int) -> Union[Member, User, Object, None]:
+        return self._get_member(target_id) or Object(id=target_id, type=Member)
 
     def _convert_target_role(self, target_id: int) -> Union[Role, Object]:
         return self.guild.get_role(target_id) or Object(id=target_id, type=Role)
@@ -782,8 +779,8 @@ class AuditLogEntry(Hashable):
     def _convert_target_emoji(self, target_id: int) -> Union[Emoji, Object]:
         return self._state.get_emoji(target_id) or Object(id=target_id, type=Emoji)
 
-    def _convert_target_message(self, target_id: int) -> Union[Member, User, None]:
-        return self._get_member(target_id)
+    def _convert_target_message(self, target_id: int) -> Union[Member, User, Object, None]:
+        return self._get_member(target_id) or Object(id=target_id, type=Member)
 
     def _convert_target_stage_instance(self, target_id: int) -> Union[StageInstance, Object]:
         return self.guild.get_stage_instance(target_id) or Object(id=target_id, type=StageInstance)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2061,7 +2061,7 @@ of :class:`enum.Enum`.
         A member was kicked.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`User` who got kicked.
+        the :class:`User` or :class:`Object` who got kicked.
 
         When this is the action, :attr:`~AuditLogEntry.changes` is empty.
 
@@ -2085,7 +2085,7 @@ of :class:`enum.Enum`.
         A member was banned.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`User` who got banned.
+        the :class:`User` or :class:`Object` who got banned.
 
         When this is the action, :attr:`~AuditLogEntry.changes` is empty.
 
@@ -2094,7 +2094,7 @@ of :class:`enum.Enum`.
         A member was unbanned.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`User` who got unbanned.
+        the :class:`User` or :class:`Object` who got unbanned.
 
         When this is the action, :attr:`~AuditLogEntry.changes` is empty.
 
@@ -2106,7 +2106,7 @@ of :class:`enum.Enum`.
         - They were server muted or deafened (or it was undo'd)
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Member` or :class:`User` who got updated.
+        the :class:`Member`, :class:`User`, or :class:`Object` who got updated.
 
         Possible attributes for :class:`AuditLogDiff`:
 
@@ -2121,7 +2121,7 @@ of :class:`enum.Enum`.
         either gains a role or loses a role.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Member` or :class:`User` who got the role.
+        the :class:`Member`, :class:`User`, or :class:`Object` who got the role.
 
         Possible attributes for :class:`AuditLogDiff`:
 
@@ -2157,7 +2157,7 @@ of :class:`enum.Enum`.
         A bot was added to the guild.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Member` or :class:`User` which was added to the guild.
+        the :class:`Member`, :class:`User`, or :class:`Object` which was added to the guild.
 
         .. versionadded:: 1.3
 
@@ -2338,7 +2338,7 @@ of :class:`enum.Enum`.
         only triggers if the message was deleted by someone other than the author.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Member` or :class:`User` who had their message deleted.
+        the :class:`Member`, :class:`User`, or :class:`Object` who had their message deleted.
 
         When this is the action, the type of :attr:`~AuditLogEntry.extra` is
         set to an unspecified proxy object with two attributes:
@@ -2365,7 +2365,7 @@ of :class:`enum.Enum`.
         A message was pinned in a channel.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Member` or :class:`User` who had their message pinned.
+        the :class:`Member`, :class:`User`, or :class:`Object` who had their message pinned.
 
         When this is the action, the type of :attr:`~AuditLogEntry.extra` is
         set to an unspecified proxy object with two attributes:
@@ -2380,7 +2380,7 @@ of :class:`enum.Enum`.
         A message was unpinned in a channel.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Member` or :class:`User` who had their message unpinned.
+        the :class:`Member`, :class:`User`, or :class:`Object` who had their message unpinned.
 
         When this is the action, the type of :attr:`~AuditLogEntry.extra` is
         set to an unspecified proxy object with two attributes:


### PR DESCRIPTION
## Summary

Fixes `AuditLogEntry.target` sometimes being `None` despite there being a valid `_target_id` due to cache misses. Instead it'll return `Object` under this PR.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
