### PR TITLE
Remove redundant int cast

### DIFF
--- a/discord/role.py
+++ b/discord/role.py
@@ -251,7 +251,7 @@ class Role(Hashable):
             return True
 
         if self.position == other.position:
-            return int(self.id) > int(other.id)
+            return self.id > other.id
 
         return False
 


### PR DESCRIPTION
## Summary
This int cast was added when IDs were still string. Should no longer be needed since all IDs are int already

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
