### PR TITLE
update documentation of discord.user.avatar

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -153,7 +153,7 @@ class BaseUser(_UserTag):
     def avatar(self) -> Optional[Asset]:
         """Optional[:class:`Asset`]: Returns an :class:`Asset` for the avatar the user has.
 
-        If the user does not have a traditional avatar, ``None`` is returned.
+        If the user has a non-traditional avatar or a global default discord avatar, ``None`` is returned.
         If you want the avatar that a user has displayed, consider :attr:`display_avatar`.
         """
         if self._avatar is not None:

--- a/discord/user.py
+++ b/discord/user.py
@@ -153,7 +153,7 @@ class BaseUser(_UserTag):
     def avatar(self) -> Optional[Asset]:
         """Optional[:class:`Asset`]: Returns an :class:`Asset` for the avatar the user has.
 
-        If the user has a non-traditional avatar or a global default discord avatar, ``None`` is returned.
+        If the user has not uploaded a global avatar, ``None`` is returned.
         If you want the avatar that a user has displayed, consider :attr:`display_avatar`.
         """
         if self._avatar is not None:


### PR DESCRIPTION


## Summary

currently, discord.user.avatar has an ambiguous description leaving people confused as to why avatar is not returned. This PR makes it more clear that in case of default avatars, user.avatar returns None.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
