### PR TITLE
Add overload for TypeGuards to wait_for

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -1120,7 +1120,7 @@ class Client:
         *,
         check: Optional[Callable[..., TypeGuard[T]]] = None,
         timeout: Optional[float] = None,
-    ) -> Coro[T]:
+    ) -> Coroutine[Any, Any, T]:
         ...
 
     @overload
@@ -1131,7 +1131,7 @@ class Client:
         *,
         check: Optional[Callable[..., bool]] = None,
         timeout: Optional[float] = None,
-    ) -> Coro[Any]:
+    ) -> Coroutine[Any, Any, Any]:
         ...
 
     def wait_for(
@@ -1141,7 +1141,7 @@ class Client:
         *,
         check: Optional[Callable[..., bool]] = None,
         timeout: Optional[float] = None,
-    ) -> Coro[Any]:
+    ) -> Coroutine[Any, Any, Any]:
         """|coro|
 
         Waits for a WebSocket event to be dispatched.

--- a/discord/client.py
+++ b/discord/client.py
@@ -92,6 +92,7 @@ __all__ = (
 )
 # fmt: on
 
+T = TypeVar("T")
 Coro = TypeVar('Coro', bound=Callable[..., Coroutine[Any, Any, Any]])
 
 _log = logging.getLogger(__name__)
@@ -1119,7 +1120,7 @@ class Client:
         *,
         check: Optional[Callable[..., TypeGuard[T]]] = None,
         timeout: Optional[float] = None,
-    ) -> asyncio.Future[T]:
+    ) -> Coro[T]:
         ...
 
     @overload
@@ -1130,7 +1131,7 @@ class Client:
         *,
         check: Optional[Callable[..., bool]] = None,
         timeout: Optional[float] = None,
-    ) -> asyncio.Future[Any]:
+    ) -> Coro[Any]:
         ...
 
     def wait_for(
@@ -1140,7 +1141,7 @@ class Client:
         *,
         check: Optional[Callable[..., bool]] = None,
         timeout: Optional[float] = None,
-    ) -> asyncio.Future[Any]:
+    ) -> Coro[Any]:
         """|coro|
 
         Waits for a WebSocket event to be dispatched.

--- a/discord/client.py
+++ b/discord/client.py
@@ -36,6 +36,7 @@ from typing import (
     Generator,
     List,
     Optional,
+    overload,
     Sequence,
     TYPE_CHECKING,
     Tuple,
@@ -75,7 +76,7 @@ from .threads import Thread
 from .sticker import GuildSticker, StandardSticker, StickerPack, _sticker_factory
 
 if TYPE_CHECKING:
-    from typing_extensions import Self
+    from typing_extensions import Self, TypeGuard
     from types import TracebackType
     from .types.guild import Guild as GuildPayload
     from .abc import SnowflakeTime, Snowflake, PrivateChannel
@@ -1110,6 +1111,18 @@ class Client:
                 'Please use the login method or asynchronous context manager before calling this method'
             )
 
+    @overload
+    def wait_for(
+        self,
+        event: str,
+        /,
+        *,
+        check: Optional[Callable[..., TypeGuard[T]]] = None,
+        timeout: Optional[float] = None,
+    ) -> asyncio.Future[T]:
+        ...
+
+    @overload
     def wait_for(
         self,
         event: str,
@@ -1117,7 +1130,17 @@ class Client:
         *,
         check: Optional[Callable[..., bool]] = None,
         timeout: Optional[float] = None,
-    ) -> Any:
+    ) -> asyncio.Future[Any]:
+        ...
+
+    def wait_for(
+        self,
+        event: str,
+        /,
+        *,
+        check: Optional[Callable[..., bool]] = None,
+        timeout: Optional[float] = None,
+    ) -> asyncio.Future[Any]:
         """|coro|
 
         Waits for a WebSocket event to be dispatched.


### PR DESCRIPTION
## Summary

Adds an additional overload to Client.wait_for for TypeGuards to improve type safety a little

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
