### PR TITLE
update content parameter to not optional

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2515,9 +2515,9 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         self,
         *,
         name: str,
+        content: str,
         auto_archive_duration: ThreadArchiveDuration = MISSING,
         slowmode_delay: Optional[int] = None,
-        content: Optional[str] = None,
         tts: bool = False,
         embed: Embed = MISSING,
         embeds: Sequence[Embed] = MISSING,
@@ -2542,6 +2542,8 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         -----------
         name: :class:`str`
             The name of the thread.
+        content: :class:`str`
+            The content of the message to send with the thread.
         auto_archive_duration: :class:`int`
             The duration in minutes before a thread is automatically archived for inactivity.
             If not provided, the channel's default auto archive duration is used.
@@ -2549,8 +2551,6 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
             Specifies the slowmode rate limit for user in this channel, in seconds.
             The maximum value possible is ``21600``. By default no slowmode rate limit
             if this is ``None``.
-        content: Optional[:class:`str`]
-            The content of the message to send with the thread.
         tts: :class:`bool`
             Indicates if the message should be sent using text-to-speech.
         embed: :class:`~discord.Embed`


### PR DESCRIPTION
Server returns `discord.errors.HTTPException: 400 Bad Request (error code: 50006): Cannot send an empty message` if content parameter not supplied

## Summary

We found an issue when trying to implement forum capabilities in our bot. It turns out that you have to supply a string for the content parameter in order for the Discord API to accept the request. Otherwise a 400 Bad Request is returned. Once we began supplying the content parameter, the forum threads were created without issue.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
