### PR TITLE
Correct app command decorators that use Interaction

### DIFF
--- a/discord/app_commands/checks.py
+++ b/discord/app_commands/checks.py
@@ -59,8 +59,8 @@ if TYPE_CHECKING:
     from ..interactions import Interaction
 
     CooldownFunction = Union[
-        Callable[[Interaction], Coroutine[Any, Any, T]],
-        Callable[[Interaction], T],
+        Callable[[Interaction[Any]], Coroutine[Any, Any, T]],
+        Callable[[Interaction[Any]], T],
     ]
 
 __all__ = (

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -99,19 +99,19 @@ T = TypeVar('T')
 F = TypeVar('F', bound=Callable[..., Any])
 GroupT = TypeVar('GroupT', bound='Binding')
 Coro = Coroutine[Any, Any, T]
-UnboundError = Callable[['Interaction', AppCommandError], Coro[Any]]
+UnboundError = Callable[['Interaction[Any]', AppCommandError], Coro[Any]]
 Error = Union[
-    Callable[[GroupT, 'Interaction', AppCommandError], Coro[Any]],
+    Callable[[GroupT, 'Interaction[Any]', AppCommandError], Coro[Any]],
     UnboundError,
 ]
-Check = Callable[['Interaction'], Union[bool, Coro[bool]]]
+Check = Callable[['Interaction[Any]'], Union[bool, Coro[bool]]]
 Binding = Union['Group', 'commands.Cog']
 
 
 if TYPE_CHECKING:
     CommandCallback = Union[
-        Callable[Concatenate[GroupT, 'Interaction', P], Coro[T]],
-        Callable[Concatenate['Interaction', P], Coro[T]],
+        Callable[Concatenate[GroupT, 'Interaction[Any]', P], Coro[T]],
+        Callable[Concatenate['Interaction[Any]', P], Coro[T]],
     ]
 
     ContextMenuCallback = Union[
@@ -120,15 +120,15 @@ if TYPE_CHECKING:
         # Callable[[GroupT, 'Interaction', User], Coro[Any]],
         # Callable[[GroupT, 'Interaction', Message], Coro[Any]],
         # Callable[[GroupT, 'Interaction', Union[Member, User]], Coro[Any]],
-        Callable[['Interaction', Member], Coro[Any]],
-        Callable[['Interaction', User], Coro[Any]],
-        Callable[['Interaction', Message], Coro[Any]],
-        Callable[['Interaction', Union[Member, User]], Coro[Any]],
+        Callable[['Interaction[Any]', Member], Coro[Any]],
+        Callable[['Interaction[Any]', User], Coro[Any]],
+        Callable[['Interaction[Any]', Message], Coro[Any]],
+        Callable[['Interaction[Any]', Union[Member, User]], Coro[Any]],
     ]
 
     AutocompleteCallback = Union[
-        Callable[[GroupT, 'Interaction', str], Coro[List[Choice[ChoiceT]]]],
-        Callable[['Interaction', str], Coro[List[Choice[ChoiceT]]]],
+        Callable[[GroupT, 'Interaction[Any]', str], Coro[List[Choice[ChoiceT]]]],
+        Callable[['Interaction[Any]', str], Coro[List[Choice[ChoiceT]]]],
     ]
 else:
     CommandCallback = Callable[..., Coro[T]]


### PR DESCRIPTION
## Summary

Corrects the type aliases used on the `@app_commands.command`, `@app_commands.context_menu`, `@app_commands.Command.error`, `@app_commands.Command.check`, app commands cooldown functions, and `@app_commands.Command.autocomplete` decorators so when specifying `ClientT` on `Interaction[ClientT]` it doesn't error.

<img width="475" alt="image" src="https://user-images.githubusercontent.com/75498301/213275685-0b05c639-b934-46cb-bc42-31fdc8a8f019.png">

### Currently
Specifying the generic on `Interaction` would give [type errors](https://mystb.in/EdgarElectricAug). Although not shown in the following image, the error and autocomplete decorators would give similar type errors.

![image](https://user-images.githubusercontent.com/75498301/213274888-78346332-0f4b-4548-a32c-57f500c128d0.png)

### The Fix
Adding `Any` on the type aliases fixes this. I briefly looked into specifying `ClientT` instead of `Any` but I got complaints that `P` (ParamSpec) also needed a default. This was the easiest patch to the issue.

## Checklist

- [x] If code changes were made, they were tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
