### PR TITLE
Missing Generic specification on type alias

### DIFF
--- a/discord/ui/item.py
+++ b/discord/ui/item.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
 I = TypeVar('I', bound='Item')
 V = TypeVar('V', bound='View', covariant=True)
-ItemCallbackType = Callable[[V, Interaction, I], Coroutine[Any, Any, Any]]
+ItemCallbackType = Callable[[V, Interaction[Any], I], Coroutine[Any, Any, Any]]
 
 
 class Item(Generic[V]):


### PR DESCRIPTION
Seems this items was overlooked during the addition of Generics to Interaction in bf860b0b077683da98445fe4da6a693032fe0371.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

The type error is as follows:-
```py
Argument of type "(self: Self@MangaView, interaction: Interaction, item: Select[Self@MangaView]) -> Coroutine[Any, Any, None]" cannot be assigned to parameter of type "(V@select, Interaction[Client], SelectT@select) -> Coroutine[Any, Any, Any]"
  Type "(self: Self@MangaView, interaction: Interaction, item: Select[Self@MangaView]) -> Coroutine[Any, Any, None]" cannot be assigned to type "(V@select, Interaction[Client], SelectT@select) -> Coroutine[Any, Any, Any]"
    Parameter 2: type "Interaction[Client]" cannot be assigned to type "Interaction"
      "Interaction[Client]" is incompatible with "Interaction"
        TypeVar "ClientT@Interaction" is covariant
          "Client" is incompatible with "Mipha"
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
