### PR TITLE
Add info to docs on how `py -3` ignores virtualenv

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -88,6 +88,11 @@ However, for the quick and dirty:
 
 Congratulations. You now have a virtual environment all set up.
 
+.. note::
+
+    Scripts executed with ``py -3`` will ignore any currently active virtual
+    environment, as the ``-3`` specifies a global scope.
+
 Basic Concepts
 ---------------
 


### PR DESCRIPTION
## Summary

Add info to docs on how `py -3` ignores virtualenv. Tried to be concise, could include more info such as suggesting use of `py` or `python` to take current virtualenv into account.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
