### PR TITLE
Document AuditLogEntry.guild

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -553,6 +553,8 @@ class AuditLogEntry(Hashable):
         .. versionadded:: 2.2
     id: :class:`int`
         The entry ID.
+    guild: :class:`Guild`
+        the guild that the action belongs to.
     target: Any
         The target that got changed. The exact type of this depends on
         the action being done.

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -555,6 +555,8 @@ class AuditLogEntry(Hashable):
         The entry ID.
     guild: :class:`Guild`
         the guild that the action belongs to.
+
+        .. versionadded:: 2.2
     target: Any
         The target that got changed. The exact type of this depends on
         the action being done.


### PR DESCRIPTION
## Summary

Documents AuditLogEntry.guild. This is because ``on_audit_log_entry`` event.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
