### PR TITLE
Add support for member flags

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -42,6 +42,7 @@ __all__ = (
     'ApplicationFlags',
     'ChannelFlags',
     'AutoModPresets',
+    'MemberFlags',
 )
 
 BF = TypeVar('BF', bound='BaseFlags')
@@ -1646,3 +1647,74 @@ class AutoModPresets(ArrayFlags):
         self = cls.__new__(cls)
         self.value = self.DEFAULT_VALUE
         return self
+
+
+@fill_with_flags()
+class MemberFlags(BaseFlags):
+    r"""Wraps up the Discord Guild Member flags
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two MemberFlags are equal.
+        .. describe:: x != y
+
+            Checks if two MemberFlags are not equal.
+
+        .. describe:: x | y, x |= y
+
+            Returns an MemberFlags instance with all enabled flags from
+            both x and y.
+
+        .. describe:: x & y, x &= y
+
+            Returns an MemberFlags instance with only flags enabled on
+            both x and y.
+
+        .. describe:: x ^ y, x ^= y
+
+            Returns an MemberFlags instance with only flags enabled on
+            only one of x or y, not on both.
+
+        .. describe:: ~x
+
+            Returns an MemberFlags instance with all flags inverted from x.
+
+        .. describe:: hash(x)
+
+            Return the flag's hash.
+        .. describe:: iter(x)
+
+            Returns an iterator of ``(name, value)`` pairs. This allows it
+            to be, for example, constructed as a dict or a list of pairs.
+            Note that aliases are not shown.
+
+    .. versionadded:: 2.2
+
+    Attributes
+    -----------
+    value: :class:`int`
+        The raw value. You should query flags via the properties
+        rather than using this raw value.
+    """
+
+    @flag_value
+    def did_rejoin(self):
+        """:class:`bool`: Returns ``True`` if the member left and rejoined the :attr:`~discord.Member.guild`."""
+        return 1 << 0
+
+    @flag_value
+    def completed_onboarding(self):
+        """:class:`bool`: Returns ``True`` if the member has completed onboarding."""
+        return 1 << 1
+
+    @flag_value
+    def bypasses_verification(self):
+        """:class:`bool`: Returns ``True`` if the member can bypass the guild verification requirements."""
+        return 1 << 2
+
+    @flag_value
+    def started_onboarding(self):
+        """:class:`bool`: Returns ``True`` if the member has started onboarding."""
+        return 1 << 3

--- a/discord/member.py
+++ b/discord/member.py
@@ -42,6 +42,7 @@ from .enums import Status, try_enum
 from .errors import ClientException
 from .colour import Colour
 from .object import Object
+from .flags import MemberFlags
 
 __all__ = (
     'VoiceState',
@@ -321,6 +322,7 @@ class Member(discord.abc.Messageable, _UserTag):
         '_user',
         '_state',
         '_avatar',
+        '_flags',
     )
 
     if TYPE_CHECKING:
@@ -353,6 +355,7 @@ class Member(discord.abc.Messageable, _UserTag):
         self.pending: bool = data.get('pending', False)
         self._avatar: Optional[str] = data.get('avatar')
         self._permissions: Optional[int]
+        self._flags: int = data['flags']
         try:
             self._permissions = int(data['permissions'])
         except KeyError:
@@ -366,7 +369,7 @@ class Member(discord.abc.Messageable, _UserTag):
     def __repr__(self) -> str:
         return (
             f'<Member id={self._user.id} name={self._user.name!r} discriminator={self._user.discriminator!r}'
-            f' bot={self._user.bot} nick={self.nick!r} guild={self.guild!r}>'
+            f' bot={self._user.bot} nick={self.nick!r} guild={self.guild!r} flags={self.flags!r}>'
         )
 
     def __eq__(self, other: object) -> bool:
@@ -391,6 +394,7 @@ class Member(discord.abc.Messageable, _UserTag):
         self.nick = data.get('nick', None)
         self.pending = data.get('pending', False)
         self.timed_out_until = utils.parse_time(data.get('communication_disabled_until'))
+        self._flags = data.get('flags', 0)
 
     @classmethod
     def _try_upgrade(cls, *, data: UserWithMemberPayload, guild: Guild, state: ConnectionState) -> Union[User, Self]:
@@ -416,6 +420,7 @@ class Member(discord.abc.Messageable, _UserTag):
         self.pending = member.pending
         self.activities = member.activities
         self.timed_out_until = member.timed_out_until
+        self._flags = member._flags
         self._permissions = member._permissions
         self._state = member._state
         self._avatar = member._avatar
@@ -446,6 +451,7 @@ class Member(discord.abc.Messageable, _UserTag):
         self.timed_out_until = utils.parse_time(data.get('communication_disabled_until'))
         self._roles = utils.SnowflakeList(map(int, data['roles']))
         self._avatar = data.get('avatar')
+        self._flags = data.get('flags', 0)
 
     def _presence_update(self, data: PartialPresenceUpdate, user: UserPayload) -> Optional[Tuple[User, User]]:
         self.activities = tuple(create_activity(d, self._state) for d in data['activities'])
@@ -708,6 +714,11 @@ class Member(discord.abc.Messageable, _UserTag):
         """Optional[:class:`VoiceState`]: Returns the member's current voice state."""
         return self.guild._voice_state_for(self._user.id)
 
+    @property
+    def flags(self) -> MemberFlags:
+        """:class:`MemberFlags`: Returns the member's flags."""
+        return MemberFlags._from_value(self._flags)
+
     async def ban(
         self,
         *,
@@ -750,6 +761,7 @@ class Member(discord.abc.Messageable, _UserTag):
         roles: Collection[discord.abc.Snowflake] = MISSING,
         voice_channel: Optional[VocalGuildChannel] = MISSING,
         timed_out_until: Optional[datetime.datetime] = MISSING,
+        bypasses_verification: bool = MISSING,
         reason: Optional[str] = None,
     ) -> Optional[Member]:
         """|coro|
@@ -758,21 +770,23 @@ class Member(discord.abc.Messageable, _UserTag):
 
         Depending on the parameter passed, this requires different permissions listed below:
 
-        +-----------------+--------------------------------------+
-        |   Parameter     |              Permission              |
-        +-----------------+--------------------------------------+
-        | nick            | :attr:`Permissions.manage_nicknames` |
-        +-----------------+--------------------------------------+
-        | mute            | :attr:`Permissions.mute_members`     |
-        +-----------------+--------------------------------------+
-        | deafen          | :attr:`Permissions.deafen_members`   |
-        +-----------------+--------------------------------------+
-        | roles           | :attr:`Permissions.manage_roles`     |
-        +-----------------+--------------------------------------+
-        | voice_channel   | :attr:`Permissions.move_members`     |
-        +-----------------+--------------------------------------+
-        | timed_out_until | :attr:`Permissions.moderate_members` |
-        +-----------------+--------------------------------------+
+        +-----------------------+--------------------------------------+
+        |   Parameter           |              Permission              |
+        +-----------------------+--------------------------------------+
+        | nick                  | :attr:`Permissions.manage_nicknames` |
+        +-----------------------+--------------------------------------+
+        | mute                  | :attr:`Permissions.mute_members`     |
+        +-----------------------+--------------------------------------+
+        | deafen                | :attr:`Permissions.deafen_members`   |
+        +-----------------------+--------------------------------------+
+        | roles                 | :attr:`Permissions.manage_roles`     |
+        +-----------------------+--------------------------------------+
+        | voice_channel         | :attr:`Permissions.move_members`     |
+        +-----------------------+--------------------------------------+
+        | timed_out_until       | :attr:`Permissions.moderate_members` |
+        +-----------------------+--------------------------------------+
+        | bypasses_verification | :attr:`Permissions.manage_guild`     |
+        +-----------------------+--------------------------------------+
 
         All parameters are optional.
 
@@ -805,6 +819,10 @@ class Member(discord.abc.Messageable, _UserTag):
             This must be a timezone-aware datetime object. Consider using :func:`utils.utcnow`.
 
             .. versionadded:: 2.0
+        bypasses_verification: :class:`bool`
+            Indicates if the member should be allowed to bypass the guild verification requirements.
+
+            .. versionadded:: 2.2
 
         reason: Optional[:class:`str`]
             The reason for editing this member. Shows up on the audit log.
@@ -875,6 +893,11 @@ class Member(discord.abc.Messageable, _UserTag):
                         'timed_out_until must be an aware datetime. Consider using discord.utils.utcnow() or datetime.datetime.now().astimezone() for local time.'
                     )
                 payload['communication_disabled_until'] = timed_out_until.isoformat()
+
+        if bypasses_verification is not MISSING:
+            flags = MemberFlags._from_value(self._flags)
+            flags.bypasses_verification = bypasses_verification
+            payload['flags'] = flags.value
 
         if payload:
             data = await http.edit_member(guild_id, self.id, reason=reason, **payload)

--- a/discord/types/gateway.py
+++ b/discord/types/gateway.py
@@ -216,6 +216,7 @@ class GuildMemberUpdateEvent(TypedDict):
     user: User
     avatar: Optional[str]
     joined_at: Optional[str]
+    flags: int
     nick: NotRequired[str]
     premium_since: NotRequired[Optional[str]]
     deaf: NotRequired[bool]

--- a/discord/types/member.py
+++ b/discord/types/member.py
@@ -36,6 +36,7 @@ class PartialMember(TypedDict):
     joined_at: str
     deaf: bool
     mute: bool
+    flags: int
 
 
 class Member(PartialMember, total=False):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -804,6 +804,7 @@ Members
     - pending
     - timeout
     - guild avatar
+    - flags
 
     Due to a Discord limitation, this event is not dispatched when a member's timeout expires.
 
@@ -4832,6 +4833,13 @@ PublicUserFlags
 .. autoclass:: PublicUserFlags
     :members:
 
+MemberFlags
+~~~~~~~~~~~~
+
+.. attributetable:: MemberFlags
+
+.. autoclass:: MemberFlags
+    :members:
 
 ForumTag
 ~~~~~~~~~


### PR DESCRIPTION
## Summary

This PR adds support for the `flags` field on members.

Adds the following:
- `MemberFlags`
- `Member._flags`
- (property) `Member.flags`
- `bypasses_verification` kwarg in `Member.edit`
Note: I assumed the permission for this is `manage_guild`.
- `- flags` to the list of reasons `on_member_update` can be called
- `flags: int` to relevant typedicts


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
