### PR TITLE
Add async context manage to View

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -192,6 +192,12 @@ class View:
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} timeout={self.timeout} children={len(self._children)}>'
 
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.wait()
+
     async def __timeout_task_impl(self) -> None:
         while True:
             # Guard just in case someone changes the value of the timeout at runtime


### PR DESCRIPTION
## Summary

Adds an async context manager to views. This allows for a more coherency, without having to split simple flows into multiple classes and functions for simple tasks. For example in Confirm/Cancel buttons situations.

### Basic example
```python
class ConfimOrCancelView(discord.ui.View):
    def __init__(self, timeout: float = 60.0):
        super().__init__(ctx=ctx, timeout=timeout)
        self.confirmed: bool | None = None

    @discord.ui.button(label="Confirm", style=discord.ButtonStyle.green)
    async def confirm(
        self, interaction: discord.Interaction, button: discord.ui.Button[Self]
    ):
        self.confirmed = True
        self.stop()

    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.red)
    async def cancel(
        self, interaction: discord.Interaction, button: discord.ui.Button[Self]
    ):
        self.confirmed = False
        self.stop()

class AllianceSettings(commands.Cog):
    def __init__(self, bot: Bot):
        self.bot = bot
        
    @app_commands.command(name="command-1")
    async def my_command(self, interaction: discord.Interaction) -> None:
        async with ConfimOrCancelView(timeout=120) as view:
            # This context manager calls `view.wait()` on exit, so after everything in this block has 
            # finished running, it will wait for the interaction, or timeout before continuing.
            await interaction.response.send_message(content="Do you wish to proceed?", view=view")
            
        # This will only run after the interaction or timeout.
        if view.confirmed == None:
            await interaction.message.edit(content=f"Timed out!", view=None)
        if view.confirmed:
            await interaction.message.edit(content=f"You confirmed the action!", view=None)
        else:
            await interaction.message.edit(content=f"You canceled the action!", view=None)
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
