### PR TITLE
Add `ignore_pynacl_warning` kwarg to `Client`

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -244,6 +244,11 @@ class Client:
         set to is ``30.0`` seconds.
 
         .. versionadded:: 2.0
+    ignore_pynacl_warning: :class:`bool`
+        An option to not log the PyNaCl warning. This is useful if you don't want to install 
+        the library just to silence the error and not for voice support. Defaults to ``False``.
+
+        .. versionadded:: 2.1
 
     Attributes
     -----------
@@ -292,7 +297,9 @@ class Client:
 
         if VoiceClient.warn_nacl:
             VoiceClient.warn_nacl = False
-            _log.warning("PyNaCl is not installed, voice will NOT be supported")
+            ignore_pynacl_warning: bool = options.pop('ignore_pynacl_warning', False)
+            if not ignore_pynacl_warning:
+              _log.warning("PyNaCl is not installed, voice will NOT be supported")
 
     async def __aenter__(self) -> Self:
         await self._async_setup_hook()


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

The only way to stop the PyNaCl warning is to install the library. However, some bots will never need voice support ever. This kwarg option will help silence the warning without having to install the library.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
