### PR TITLE
Add `warn_message_content` kwarg to `Bot`

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -185,6 +185,7 @@ class BotBase(GroupMixin[None]):
         self.owner_id: Optional[int] = options.get('owner_id')
         self.owner_ids: Optional[Collection[int]] = options.get('owner_ids', set())
         self.strip_after_prefix: bool = options.get('strip_after_prefix', False)
+        self.warn_message_content: bool = options.get('warn_message_content', True)
 
         if self.owner_id and self.owner_ids:
             raise TypeError('Both owner_id and owner_ids are set.')
@@ -212,7 +213,7 @@ class BotBase(GroupMixin[None]):
                 (callable(prefix) and prefix is not when_mentioned)
                 or isinstance(prefix, str)
                 or (isinstance(prefix, collections.abc.Iterable) and len(list(prefix)) >= 1)
-            )
+            ) and self.warn_message_content
             if trigger_warning:
                 _log.warning('Privileged message content intent is missing, commands may not work as expected.')
 
@@ -1479,6 +1480,11 @@ class Bot(BotBase, discord.Client):
         The type of application command tree to use. Defaults to :class:`~discord.app_commands.CommandTree`.
 
         .. versionadded:: 2.0
+        
+    warn_message_content: :class:`bool`
+        Whether to show the missing message_content warning. Defaults to ``True``.
+        
+        .. versionadded:: 2.2
     """
 
     pass


### PR DESCRIPTION
## Summary

There is no way to stop the missing message_content warning for the `when_mentioned_or` prefix. The warning is correct because non-mention prefixes do not work in servers but can be incorrect when the bot owner only intends to use the commands in DMs. This kwarg option will help silence the warning for the second use case.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)