### PR TITLE
Fixed an error in creating a new `commands.Cog` class instance.

### DIFF
--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -338,7 +338,7 @@ class Cog(metaclass=CogMeta):
                 app_command: Optional[Union[app_commands.Group, app_commands.Command[Self, ..., Any]]] = getattr(
                     command, 'app_command', None
                 )
-                if app_command is not None:
+                if app_command:
                     group_parent = self.__cog_app_commands_group__
                     app_command = app_command._copy_with(parent=group_parent, binding=self)
                     # The type checker does not see the app_command attribute even though it exists


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Hello,

I am using a development bot running dpy2.2.0a (on the `master` branch).
Some of my cogs are using `commands.HybridGroup` commands and can't load since I cloned this repo again.

Here is the error:
```
[23:04:36] ERROR    [red] Package loading failed
╭───────────────────────────────────────────────────────────────────── Traceback (most recent call last) ─────────────────────────────────────────────────────────────────────╮
│ C:\Users\Username\redenv\lib\site-packages\discord\ext\commands\cog.py:343 in __new__                                                                                         │
│ ❱ 343                     app_command = app_command._copy_with(parent=group_parent,                                                                                         │
│       binding=self)                                                                                                                                                         │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: '_MissingSentinel' object has no attribute '_copy_with'
```
Or in a "pure" dpy bot, tested by another person:
```
Traceback (most recent call last):
  File "C:\Users\Flame\Desktop\dpybot\cogs\dev.py", line 104, in eval_command
    ret = await func()
  File "<string>", line 7, in func
  File "C:\Users\Flame\VENV\DEV\lib\site-packages\discord\ext\commands\cog.py", line 343, in __new__
    app_command = app_command._copy_with(parent=group_parent, binding=self)
AttributeError: '_MissingSentinel' object has no attribute '_copy_with'
```
This can be reproduced with this eval or this code as a package:
```
class Cog(discord.ext.commands.Cog):
    @discord.ext.commands.hybrid_group(with_app_command=False)
    async def test(self, ctx: commands.Context):
        pass
return Cog()
```
- `commands.HybridGroup.app_command` is set to `discord.utils.MISSING`.
https://github.com/Rapptz/discord.py/blob/master/discord/ext/commands/hybrid.py#L630-L634
- `commands.Cog.__new__` checks if `commands.HybridGroup.app_command` is set to `None` and not to `discord.utils.MISSING`.
https://github.com/Rapptz/discord.py/blob/master/discord/ext/commands/cog.py#L338-L348
- The cause of this error is this PR, not yet present in a dpy release:
https://github.com/Rapptz/discord.py/commit/3ff88db768c5e4272350484ba1398ca77f04ab68#diff-98c3111f0e1f1387b8148868881cf00be840555e17f3a685fbccf7b9a19d1bb2R341

Thank you in advance,
AAA3A

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
