### PR TITLE
Make View initialize other subclasses.

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -156,8 +156,8 @@ class View:
     __discord_ui_modal__: ClassVar[bool] = False
     __view_children_items__: ClassVar[List[ItemCallbackType[Any, Any]]] = []
 
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        super().__init_subclass__(**kwargs)
+    def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
 
         children: Dict[str, ItemCallbackType[Any, Any]] = {}
         for base in reversed(cls.__mro__):

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -156,7 +156,9 @@ class View:
     __discord_ui_modal__: ClassVar[bool] = False
     __view_children_items__: ClassVar[List[ItemCallbackType[Any, Any]]] = []
 
-    def __init_subclass__(cls) -> None:
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+
         children: Dict[str, ItemCallbackType[Any, Any]] = {}
         for base in reversed(cls.__mro__):
             for name, member in base.__dict__.items():


### PR DESCRIPTION
## Summary
The following code throws an AttributeError (shown in code) because `View`'s `__init_subclass__` doesn't call to `super()`, resulting in `Generic.__init_subclass__` never being called. Since it is responsible for setting `__parameters__`, when a type is given to specialize the resulting generic class, `__class_getitem__` throws an error.
```python
from typing import TypeVar, Generic
from discord.ui import View

T = TypeVar("T")

class SomeBaseView(View, Generic[T]):
  ...

class SomeView(SomeBaseView[int]):
  ...
# AttributeError: type object 'SomeBaseView' has no attribute '__parameters__'
# If you change the order of inheritance, this works fine. e.g. `class SomeBaseView(Generic[T], View):`
```
So, this pull request make `.ui.View` initialize other subclasses.

## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)