### PR TITLE
Correct required permission for bypass_verification field in Member.edit

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -773,23 +773,23 @@ class Member(discord.abc.Messageable, _UserTag):
 
         Depending on the parameter passed, this requires different permissions listed below:
 
-        +---------------------+--------------------------------------+
-        |      Parameter      |              Permission              |
-        +---------------------+--------------------------------------+
-        | nick                | :attr:`Permissions.manage_nicknames` |
-        +---------------------+--------------------------------------+
-        | mute                | :attr:`Permissions.mute_members`     |
-        +---------------------+--------------------------------------+
-        | deafen              | :attr:`Permissions.deafen_members`   |
-        +---------------------+--------------------------------------+
-        | roles               | :attr:`Permissions.manage_roles`     |
-        +---------------------+--------------------------------------+
-        | voice_channel       | :attr:`Permissions.move_members`     |
-        +---------------------+--------------------------------------+
-        | timed_out_until     | :attr:`Permissions.moderate_members` |
-        +---------------------+--------------------------------------+
-        | bypass_verification | :attr:`Permissions.manage_guild`     |
-        +---------------------+--------------------------------------+
+        +---------------------+---------------------------------------+
+        |      Parameter      |              Permission               |
+        +---------------------+---------------------------------------+
+        | nick                | :attr:`Permissions.manage_nicknames`  |
+        +---------------------+---------------------------------------+
+        | mute                | :attr:`Permissions.mute_members`      |
+        +---------------------+---------------------------------------+
+        | deafen              | :attr:`Permissions.deafen_members`    |
+        +---------------------+---------------------------------------+
+        | roles               | :attr:`Permissions.manage_roles`      |
+        +---------------------+---------------------------------------+
+        | voice_channel       | :attr:`Permissions.move_members`      |
+        +---------------------+---------------------------------------+
+        | timed_out_until     | :attr:`Permissions.moderate_members`  |
+        +---------------------+---------------------------------------+
+        | bypass_verification | :attr:`Permissions.moderate_members`  |
+        +---------------------+---------------------------------------+
 
         All parameters are optional.
 


### PR DESCRIPTION
## Summary

title. Discord has clarified this in the API docs: https://github.com/discord/discord-api-docs/commit/c38ca4d817cde888c1a3d601aed98ffcea2a154a

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
