### PR TITLE
Don't store finished views/modals

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1552,7 +1552,7 @@ class Messageable:
             data = await state.http.send_message(channel.id, params=params)
 
         ret = state.create_message(channel=channel, data=data)
-        if view:
+        if view and not view.is_finished():
             state.store_view(view, ret.id)
 
         if delete_after is not None:

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2653,7 +2653,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
             data = await state.http.start_thread_in_forum(self.id, params=params, reason=reason)
             thread = Thread(guild=self.guild, state=self._state, data=data)
             message = Message(state=self._state, channel=thread, data=data['message'])
-            if view:
+            if view and not view.is_finished():
                 self._state.store_view(view, message.id)
 
             return ThreadWithMessage(thread=thread, message=message)

--- a/discord/client.py
+++ b/discord/client.py
@@ -2694,7 +2694,7 @@ class Client:
         TypeError
             A view was not passed.
         ValueError
-            The view is not persistent. A persistent view has no timeout
+            The view is not persistent or is already finished. A persistent view has no timeout
             and all their components have an explicitly provided custom_id.
         """
 
@@ -2703,6 +2703,9 @@ class Client:
 
         if not view.is_persistent():
             raise ValueError('View is not persistent. Items need to have a custom_id set and View must have no timeout')
+
+        if view.is_finished():
+            raise ValueError('View is already finished.')
 
         self._connection.store_view(view, message_id)
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -784,7 +784,7 @@ class InteractionResponse(Generic[ClientT]):
             params=params,
         )
 
-        if view is not MISSING:
+        if view is not MISSING and not view.is_finished():
             if ephemeral and view.timeout is None:
                 view.timeout = 15 * 60.0
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -954,8 +954,8 @@ class InteractionResponse(Generic[ClientT]):
             proxy_auth=http.proxy_auth,
             params=params,
         )
-
-        self._parent._state.store_view(modal)
+        if not modal.is_finished():
+            self._parent._state.store_view(modal)
         self._response_type = InteractionResponseType.modal
 
     async def autocomplete(self, choices: Sequence[Choice[ChoiceT]]) -> None:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Finished views are stored and never removed since they would not properly time out/stop a second time. 
Consistent with other methods like edit that check if the view is finished before storing.
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
