### PR TITLE
Changes to make command work in Python 3.11

### DIFF
--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -30,7 +30,7 @@ import sys
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Literal, Optional, Pattern, Set, Tuple, Type, Union
 
-from discord.utils import MISSING, maybe_coroutine, resolve_annotation
+from discord.utils import MISSING, MissingField, maybe_coroutine, resolve_annotation
 
 from .converter import run_converters
 from .errors import BadFlagArgument, MissingFlagArgument, MissingRequiredFlag, TooManyFlags, TooManyArguments
@@ -81,14 +81,14 @@ class Flag:
         used as application commands.
     """
 
-    name: str = MISSING
+    name: str = MissingField
     aliases: List[str] = field(default_factory=list)
-    attribute: str = MISSING
-    annotation: Any = MISSING
-    default: Any = MISSING
-    max_args: int = MISSING
-    override: bool = MISSING
-    description: str = MISSING
+    attribute: str = MissingField
+    annotation: Any = MissingField
+    default: Any = MissingField
+    max_args: int = MissingField
+    override: bool = MissingField
+    description: str = MissingField
     cast_to_dict: bool = False
 
     @property

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -119,7 +119,7 @@ class _MissingSentinel:
 
 
 MISSING: Any = _MissingSentinel()
-
+MissingField = field(default_factory=lambda: MISSING)
 
 class _cached_property:
     def __init__(self, function) -> None:


### PR DESCRIPTION
## Summary

In Python 3.11, if I specify MISSING directly, I will get a ValueError at startup, so I have changed to use default_factory.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
