### PR TITLE
Fix AuditLogDiff.type for webhooks

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -283,11 +283,15 @@ def _flag_transformer(cls: Type[F]) -> Callable[[AuditLogEntry, Union[int, str]]
     return _transform
 
 
-def _transform_type(entry: AuditLogEntry, data: Union[int, str]) -> Union[enums.ChannelType, enums.StickerType, str]:
+def _transform_type(
+    entry: AuditLogEntry, data: Union[int, str]
+) -> Union[enums.ChannelType, enums.StickerType, enums.WebhookType, str]:
     if entry.action.name.startswith('sticker_'):
         return enums.try_enum(enums.StickerType, data)
     elif entry.action.name.startswith('integration_'):
         return data  # type: ignore  # integration type is str
+    elif entry.action.name.startswith('webhook_'):
+        return enums.try_enum(enums.WebhookType, data)
     else:
         return enums.try_enum(enums.ChannelType, data)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3517,9 +3517,9 @@ AuditLogDiff
 
     .. attribute:: type
 
-        The type of channel, sticker or integration.
+        The type of channel, sticker, webhook or integration.
 
-        :type: Union[:class:`ChannelType`, :class:`StickerType`, :class:`str`]
+        :type: Union[:class:`ChannelType`, :class:`StickerType`, :class:`WebhookType`, :class:`str`]
 
     .. attribute:: topic
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes the `type` for `AuditLogDiff` for webhook related audit logs events.
Prior to this proposed change, the transformer converted webhook type to channel type.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
