### PR TITLE
Update colour constants

### DIFF
--- a/discord/colour.py
+++ b/discord/colour.py
@@ -455,11 +455,14 @@ class Colour:
 
         This will appear transparent on Discord's dark theme.
 
-        .. colour:: #36393F
+        .. colour:: #313338
 
         .. versionadded:: 1.5
+
+        .. versionchanged:: 2.2
+            Updated colour from previous ``0x36393F`` to reflect discord theme changes.
         """
-        return cls(0x36393F)
+        return cls(0x313338)
 
     @classmethod
     def fuchsia(cls) -> Self:
@@ -483,23 +486,23 @@ class Colour:
 
     @classmethod
     def dark_embed(cls) -> Self:
-        """A factory method that returns a :class:`Colour` with a value of ``0x2F3136``.
+        """A factory method that returns a :class:`Colour` with a value of ``0x2B2D31``.
 
-        .. colour:: #2F3136
+        .. colour:: #2B2D31
 
         .. versionadded:: 2.2
         """
-        return cls(0x2F3136)
+        return cls(0x2B2D31)
 
     @classmethod
     def light_embed(cls) -> Self:
-        """A factory method that returns a :class:`Colour` with a value of ``0xF2F3F5``.
+        """A factory method that returns a :class:`Colour` with a value of ``0xEEEFF1``.
 
-        .. colour:: #F2F3F5
+        .. colour:: #EEEFF1
 
         .. versionadded:: 2.2
         """
-        return cls(0xF2F3F5)
+        return cls(0xEEEFF1)
 
 
 Color = Colour

--- a/discord/colour.py
+++ b/discord/colour.py
@@ -451,7 +451,7 @@ class Colour:
 
     @classmethod
     def dark_theme(cls) -> Self:
-        """A factory method that returns a :class:`Colour` with a value of ``0x36393F``.
+        """A factory method that returns a :class:`Colour` with a value of ``0x313338``.
 
         This will appear transparent on Discord's dark theme.
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Update the colour constant to reflect discord's changes to the user interface.

These are the colours:

![DiscordCanary_Oa7OWC2TFH](https://user-images.githubusercontent.com/13399568/220673602-75cd6f3e-8f79-4715-92c6-994747e36914.png)

![DiscordCanary_3voW8Ld91F](https://user-images.githubusercontent.com/13399568/220673698-c15aac84-1144-4ac1-9c0b-fc0e5118d8f0.png)

![DiscordCanary_Hl9DOKEWUQ](https://user-images.githubusercontent.com/13399568/220673711-7d259ba4-1af9-4831-95d6-518437ba54cb.png)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
