### PR TITLE
Document accepted values for `auto_archive_duration` in `create_thread` methods

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -729,6 +729,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         auto_archive_duration: :class:`int`
             The duration in minutes before a thread is automatically archived for inactivity.
             If not provided, the channel's default auto archive duration is used.
+            Must be one of ``60``, ``1440``, ``4320``, or ``10080``, if provided.
         type: Optional[:class:`ChannelType`]
             The type of thread to create. If a ``message`` is passed then this parameter
             is ignored, as a thread created with a message is always a public thread.
@@ -2548,6 +2549,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         auto_archive_duration: :class:`int`
             The duration in minutes before a thread is automatically archived for inactivity.
             If not provided, the channel's default auto archive duration is used.
+            Must be one of ``60``, ``1440``, ``4320``, or ``10080``, if provided.
         slowmode_delay: Optional[:class:`int`]
             Specifies the slowmode rate limit for user in this channel, in seconds.
             The maximum value possible is ``21600``. By default no slowmode rate limit

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -729,6 +729,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         auto_archive_duration: :class:`int`
             The duration in minutes before a thread is automatically archived for inactivity.
             If not provided, the channel's default auto archive duration is used.
+
             Must be one of ``60``, ``1440``, ``4320``, or ``10080``, if provided.
         type: Optional[:class:`ChannelType`]
             The type of thread to create. If a ``message`` is passed then this parameter
@@ -2549,6 +2550,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         auto_archive_duration: :class:`int`
             The duration in minutes before a thread is automatically archived for inactivity.
             If not provided, the channel's default auto archive duration is used.
+
             Must be one of ``60``, ``1440``, ``4320``, or ``10080``, if provided.
         slowmode_delay: Optional[:class:`int`]
             Specifies the slowmode rate limit for user in this channel, in seconds.

--- a/discord/message.py
+++ b/discord/message.py
@@ -1215,6 +1215,7 @@ class PartialMessage(Hashable):
         auto_archive_duration: :class:`int`
             The duration in minutes before a thread is automatically archived for inactivity.
             If not provided, the channel's default auto archive duration is used.
+            Must be one of ``60``, ``1440``, ``4320``, or ``10080``, if provided.
         slowmode_delay: Optional[:class:`int`]
             Specifies the slowmode rate limit for user in this channel, in seconds.
             The maximum value possible is ``21600``. By default no slowmode rate limit

--- a/discord/message.py
+++ b/discord/message.py
@@ -1215,6 +1215,7 @@ class PartialMessage(Hashable):
         auto_archive_duration: :class:`int`
             The duration in minutes before a thread is automatically archived for inactivity.
             If not provided, the channel's default auto archive duration is used.
+
             Must be one of ``60``, ``1440``, ``4320``, or ``10080``, if provided.
         slowmode_delay: Optional[:class:`int`]
             Specifies the slowmode rate limit for user in this channel, in seconds.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Greetings,

Similar to commit https://github.com/Rapptz/discord.py/commit/26beabb74047a1cc506c3a6a1a496e1f221f95a4, this proposed PR aims to document the accepted values by Discord API for `auto_archive_duration` kw-arg of all `create_thread` methods.

If provided any other arbitrary integer value with said kw-arg, API sends error code `50035` instead:
```
HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In auto_archive_duration: Value must be one of (1440, 60, 4320, 10080).
```

I'm unsure if the newline I have added is needed in docs, please let me if any changes are required. Thank you for reading. :D

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
