### PR TITLE
Make Paginator.pages not finalize the paginator

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -206,7 +206,9 @@ class Paginator:
         # we have more than just the prefix in our current page
         if len(self._current_page) > (0 if self.prefix is None else 1):
             # Render and include current page without closing
-            current_page = self.linesep.join([*self._current_page, self.suffix] if self.suffix is not None else self._current_page)
+            current_page = self.linesep.join(
+                [*self._current_page, self.suffix] if self.suffix is not None else self._current_page
+            )
             return [*self._pages, current_page]
 
         return self._pages

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -205,7 +205,10 @@ class Paginator:
         """List[:class:`str`]: Returns the rendered list of pages."""
         # we have more than just the prefix in our current page
         if len(self._current_page) > (0 if self.prefix is None else 1):
-            self.close_page()
+            # Render and include current page without closing
+            current_page = self.linesep.join([*self._current_page, self.suffix] if self.suffix is not None else self._current_page)
+            return [*self._pages, current_page]
+
         return self._pages
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## Summary

In the current implementation of Paginator, accessing the `pages` property has the side effect of closing the open page. While this doesn't cause problems in most use cases (where it is used as a disposable part of a formatting pipeline), it's still technically undocumented behavior. I happen to know about it because jishaku has been [strategically avoiding it for 4 years](https://github.com/Gorialis/jishaku/blob/350b5176703790dded51280acd97e767a7fa4591/jishaku/paginators.py#L71), but I think properties just shouldn't be allowed to mutate state like this.

In my eyes this means one of two things:
- `Paginator.pages` should be upgraded to a function to make it more obvious that it can have side effects (`Paginator.render()`?)
- `Paginator.pages` should be adjusted to not have a mutating side effect.

Even if you were to go with the first option, either you'd have to go to the trouble of removing `.pages` (breaking change for near to no reason) or adjust it to not mutate in comparison anyway, so I think it just makes sense to make it not mutate and call it a day.

The worst downside of the impl proposed I can think of is that it has to use new memory for up to two new PyLists and the rendered current page, but all other pages are just extended into the list so their text content will be the same reference and thus won't be using any extra memory, which quells the biggest concern if your paginator contains e.g. several megabytes of log files or something.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
