### PR TITLE
[docs] Change max values for AutoModTrigger attributes

### DIFF
--- a/discord/automod.py
+++ b/discord/automod.py
@@ -155,7 +155,6 @@ class AutoModTrigger:
     allow_list: List[:class:`str`]
         The list of words that are exempt from the commonly flagged words. Maximum of 100.
         Keywords can only be up to 60 characters in length.
-
     mention_limit: :class:`int`
         The total number of user and role mentions a message can contain.
         Has a maximum of 50.

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -153,7 +153,9 @@ class AutoModTrigger:
     presets: :class:`AutoModPresets`
         The presets used with the preset keyword filter.
     allow_list: List[:class:`str`]
-        The list of words that are exempt from the commonly flagged words.
+        The list of words that are exempt from the commonly flagged words. Maximum of 100.
+        Keywords can only be up to 60 characters in length.
+
     mention_limit: :class:`int`
         The total number of user and role mentions a message can contain.
         Has a maximum of 50.

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -139,13 +139,13 @@ class AutoModTrigger:
         The type of trigger.
     keyword_filter: List[:class:`str`]
         The list of strings that will trigger the keyword filter. Maximum of 1000.
-        Keywords can only be up to 30 characters in length.
+        Keywords can only be up to 60 characters in length.
 
         This could be combined with :attr:`regex_patterns`.
     regex_patterns: List[:class:`str`]
         The regex pattern that will trigger the filter. The syntax is based off of
         `Rust's regex syntax <https://docs.rs/regex/latest/regex/#syntax>`_.
-        Maximum of 10. Regex strings can only be up to 250 characters in length.
+        Maximum of 10. Regex strings can only be up to 260 characters in length.
 
         This could be combined with :attr:`keyword_filter` and/or :attr:`allow_list`
 


### PR DESCRIPTION
## Summary

Updates maximum values for `AutoModTrigger` attributes. 
This contains following attributes:
* `keyword_filter`: Changed max. chars per string from `30` to `60`
* `regex_patterns`: Changed max. chars per string from `250` to `260`
* `allow_list`: Added max. array length of `100` and max. chars per string of `60`

Reference: [Trigger Metadata Field Limits](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata-field-limits)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
