### PR TITLE
Fix uneccessary arguments needed for edit scheduled event

### DIFF
--- a/discord/scheduled_event.py
+++ b/discord/scheduled_event.py
@@ -326,9 +326,7 @@ class ScheduledEvent(Hashable):
         description: :class:`str`
             The description of the scheduled event.
         channel: Optional[:class:`~discord.abc.Snowflake`]
-            The channel to put the scheduled event in. If the channel is
-            a :class:`StageInstance` or :class:`VoiceChannel` then
-            it automatically sets the entity type.
+            The channel to put the scheduled event in. This will automatically set the entity type.
 
             Required if the entity type is either :attr:`EntityType.voice` or
             :attr:`EntityType.stage_instance`.

--- a/discord/scheduled_event.py
+++ b/discord/scheduled_event.py
@@ -426,38 +426,37 @@ class ScheduledEvent(Hashable):
             payload['entity_type'] = entity_type.value
 
         _entity_type = entity_type or self.entity_type
+        _channel = channel or self.channel
+        _location = location or self.location
+        _end_time = end_time or self.end_time
 
         if _entity_type in (EntityType.stage_instance, EntityType.voice):
-            if channel is MISSING or channel is None:
+            if _channel in (MISSING, None):
                 raise TypeError('channel must be set when entity_type is voice or stage_instance')
+            payload['channel_id'] = _channel.id
 
-            payload['channel_id'] = channel.id
-
-            if location not in (MISSING, None):
+            if _location not in (MISSING, None):
                 raise TypeError('location cannot be set when entity_type is voice or stage_instance')
             payload['entity_metadata'] = None
         else:
-            if channel not in (MISSING, None):
-                raise TypeError('channel cannot be set when entity_type is external')
             payload['channel_id'] = None
 
-            if location is MISSING or location is None:
+            if _location in (MISSING, None):
                 raise TypeError('location must be set when entity_type is external')
+            metadata['location'] = _location
 
-            metadata['location'] = location
-
-            if end_time is MISSING or end_time is None:
+            if _end_time in (MISSING, None):
                 raise TypeError('end_time must be set when entity_type is external')
 
-        if end_time is not MISSING:
-            if end_time is not None:
-                if end_time.tzinfo is None:
+        if _end_time is not MISSING:
+            if _end_time is not None:
+                if _end_time.tzinfo is None:
                     raise ValueError(
                         'end_time must be an aware datetime. Consider using discord.utils.utcnow() or datetime.datetime.now().astimezone() for local time.'
                     )
-                payload['scheduled_end_time'] = end_time.isoformat()
+                payload['scheduled_end_time'] = _end_time.isoformat()
             else:
-                payload['scheduled_end_time'] = end_time
+                payload['scheduled_end_time'] = _end_time
 
         if metadata:
             payload['entity_metadata'] = metadata


### PR DESCRIPTION
## Summary

This fixes errors which occurre when the event type is `external` and you use [`ScheduledEvent.edit`](https://discordpy.readthedocs.io/en/latest/api.html?highlight=create_scheduled_event#discord.ScheduledEvent.edit) because no `location` or `end_time` is given, even you provided those already in `create_scheduled_event`.
The updated code will check if `location` and `end_time` are already set in the event object. Only if it's not set there, it raises an error.

This fix will also automatically set `payload['channel_id']` to `None` if the `EntityType` is `external`.

This error fixes an existing issue: https://github.com/Rapptz/discord.py/issues/9261

### Testing

**Code**
```python
@bot.command()
async def edit_event(ctx: commands.Context):
    guild = ctx.guild
    channel = bot.get_channel(1007623668433682492)

    start_time = discord.utils.utcnow() + datetime.timedelta(600)
    end_time = discord.utils.utcnow() + datetime.timedelta(1200)
    type_external = discord.EntityType.external
    privacy = discord.PrivacyLevel.guild_only
    location = "https://example.com"

    for i in range(0, 5):
        try:
            if i == 0:
                # Edit name only; PASS
                event = await guild.create_scheduled_event(name="Before 0", start_time=start_time, end_time=end_time,
                                                           entity_type=type_external, privacy_level=privacy,
                                                           location=location)
                await event.edit(name="After 0")
            elif i == 1:
                # Edit to external and all required arguments; PASS
                event = await guild.create_scheduled_event(name="Before 1", channel=channel, start_time=start_time,
                                                           privacy_level=privacy)
                await event.edit(name="After 1", entity_type=type_external, end_time=end_time, location=location)

            elif i == 2:
                # Edit to external and end_time; FAIL
                event = await guild.create_scheduled_event(name="Before 2", channel=channel, start_time=start_time,
                                                           privacy_level=privacy)
                await event.edit(name="After 2", entity_type=type_external, end_time=end_time)

            elif i == 3:
                # Edit to external and location; FAIL
                event = await guild.create_scheduled_event(name="Before 3", channel=channel, start_time=start_time,
                                                           privacy_level=privacy)
                await event.edit(name="After 3", entity_type=type_external, location=location)

            elif i == 4:
                # Edit to external and only end_time is already set; FAIL
                event = await guild.create_scheduled_event(name="Before 4", channel=channel, end_time=end_time,
                                                           start_time=start_time, privacy_level=privacy)
                await event.edit(name="After 4", entity_type=type_external)

        except Exception as e:
            tb = e.__traceback__
            _, _, funcname, _ = traceback.extract_tb(tb)[-1]

            print(f"{i}  Failed in {funcname}: {e}")
        else:
            print(f"{i}  Pass")
```
**Output**
```
0  Pass
1  Pass
2  Failed in edit: location must be set when entity_type is external
3  Failed in edit: end_time must be set when entity_type is external
4  Failed in edit: location must be set when entity_type is external
```
The output looks as expected.


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
