### PR TITLE
Add custom_message to automod block_message aciton

### DIFF
--- a/discord/automod.py
+++ b/discord/automod.py
@@ -118,7 +118,9 @@ class AutoModRuleAction:
 
     def to_dict(self) -> Dict[str, Any]:
         ret = {'type': self.type.value, 'metadata': {}}
-        if self.type is AutoModRuleActionType.timeout:
+        if self.type is AutoModRuleActionType.block_message and self.custom_message is not None:
+            ret['metadata'] = {'custom_message': self.custom_message}
+        elif self.type is AutoModRuleActionType.timeout:
             ret['metadata'] = {'duration_seconds': int(self.duration.total_seconds())}  # type: ignore # duration cannot be None here
         elif self.type is AutoModRuleActionType.send_alert_message:
             ret['metadata'] = {'channel_id': str(self.channel_id)}

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -114,7 +114,7 @@ class AutoModRuleAction:
         elif data['type'] == AutoModRuleActionType.send_alert_message.value:
             channel_id = int(data['metadata']['channel_id'])
             return cls(channel_id=channel_id)
-        return cls(custom_message=data.get('metadata', {'custom_message': None})['custom_message'])
+        return cls(custom_message=data.get('metadata', {}).get('custom_message'))
 
     def to_dict(self) -> Dict[str, Any]:
         ret = {'type': self.type.value, 'metadata': {}}

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -27,7 +27,6 @@ import datetime
 
 from typing import TYPE_CHECKING, Any, Dict, Optional, List, Sequence, Set, Union, Sequence
 
-
 from .enums import AutoModRuleTriggerType, AutoModRuleActionType, AutoModRuleEventType, try_enum
 from .flags import AutoModPresets
 from . import utils
@@ -73,15 +72,28 @@ class AutoModRuleAction:
         The duration of the timeout to apply, if any.
         Has a maximum of 28 days.
         Passing this sets :attr:`type` to :attr:`~AutoModRuleActionType.timeout`.
+    custom_message: Optional[:class:`str`]
+        A custom message which will be shown to a user when their message is blocked.
+        Passing this sets :attr:`type` to :attr:`~AutoModRuleActionType.block_message`.
+
+        .. versionadded:: 2.2
     """
 
-    __slots__ = ('type', 'channel_id', 'duration')
+    __slots__ = ('type', 'channel_id', 'duration', 'custom_message')
 
-    def __init__(self, *, channel_id: Optional[int] = None, duration: Optional[datetime.timedelta] = None) -> None:
+    def __init__(
+        self,
+        *,
+        channel_id: Optional[int] = None,
+        duration: Optional[datetime.timedelta] = None,
+        custom_message: Optional[str] = None,
+    ) -> None:
         self.channel_id: Optional[int] = channel_id
         self.duration: Optional[datetime.timedelta] = duration
-        if channel_id and duration:
-            raise ValueError('Please provide only one of ``channel`` or ``duration``')
+        self.custom_message: Optional[str] = custom_message
+
+        if sum(v is None for v in (channel_id, duration, custom_message)) < 2:
+            raise ValueError('Only one of channel_id, duration, or custom_message can be passed.')
 
         if channel_id:
             self.type = AutoModRuleActionType.send_alert_message
@@ -102,7 +114,7 @@ class AutoModRuleAction:
         elif data['type'] == AutoModRuleActionType.send_alert_message.value:
             channel_id = int(data['metadata']['channel_id'])
             return cls(channel_id=channel_id)
-        return cls()
+        return cls(custom_message=data.get('metadata', {'custom_message': None})['custom_message'])
 
     def to_dict(self) -> Dict[str, Any]:
         ret = {'type': self.type.value, 'metadata': {}}

--- a/discord/types/automod.py
+++ b/discord/types/automod.py
@@ -45,9 +45,13 @@ class _AutoModerationActionMetadataTimeout(TypedDict):
     duration_seconds: int
 
 
+class _AutoModerationActionMetadataCustomMessage(TypedDict):
+    custom_message: str
+
+
 class _AutoModerationActionBlockMessage(TypedDict):
     type: Literal[1]
-    metadata: NotRequired[Empty]
+    metadata: NotRequired[_AutoModerationActionMetadataCustomMessage]
 
 
 class _AutoModerationActionAlert(TypedDict):


### PR DESCRIPTION
## Summary

Adds `custom_message` metadata field to the `block_message` `AutoModRuleAction`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
