### PR TITLE
Fix audit log pagination logic

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3630,7 +3630,7 @@ class Guild(Hashable):
                 if limit is not None:
                     limit -= len(entries)
 
-                after = Object(id=int(entries[0]['id']))
+                after = Object(id=int(entries[-1]['id']))
 
             return data, entries, after, limit
 
@@ -3647,20 +3647,19 @@ class Guild(Hashable):
         if isinstance(after, datetime.datetime):
             after = Object(id=utils.time_snowflake(after, high=True))
 
-        if oldest_first is MISSING:
-            reverse = after is not MISSING
-        else:
-            reverse = oldest_first
+        if oldest_first:
+            if after is MISSING:
+                after = OLDEST_OBJECT
 
         predicate = None
 
-        if reverse:
+        if oldest_first:
             strategy, state = _after_strategy, after
             if before:
                 predicate = lambda m: int(m['id']) < before.id
         else:
             strategy, state = _before_strategy, before
-            if after and after != OLDEST_OBJECT:
+            if after:
                 predicate = lambda m: int(m['id']) > after.id
 
         # avoid circular import
@@ -3673,8 +3672,6 @@ class Guild(Hashable):
 
             data, raw_entries, state, limit = await strategy(retrieve, state, limit)
 
-            if reverse:
-                raw_entries = reversed(raw_entries)
             if predicate:
                 raw_entries = filter(predicate, raw_entries)
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -1717,7 +1717,7 @@ class HTTPClient:
         params: Dict[str, Any] = {'limit': limit}
         if before:
             params['before'] = before
-        if after:
+        if after is not None:
             params['after'] = after
         if user_id:
             params['user_id'] = user_id


### PR DESCRIPTION
## Summary

audit log requests with the `after` parameter are reversed on the discord side, we don't need to do it ourselves.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
