### PR TITLE
[docs] Add missing and fix wrong docstrings

### DIFF
--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -908,6 +908,9 @@ def hybrid_group(
 
     Parameters
     -----------
+    name: Union[:class:`str`, :class:`~discord.app_commands.locale_str`]
+        The name to create the group with. By default this uses the
+        function name unchanged.
     with_app_command: :class:`bool`
         Whether to register the command also as an application command.
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1593,6 +1593,10 @@ class Guild(Hashable):
         -----------
         name: :class:`str`
             The channel's name.
+        overwrites: Dict[Union[:class:`Role`, :class:`Member`], :class:`PermissionOverwrite`]
+            A :class:`dict` of target (either a role or a member) to
+            :class:`PermissionOverwrite` to apply upon creation of a channel.
+            Useful for creating secret channels.
         topic: :class:`str`
             The channel's topic.
         category: Optional[:class:`CategoryChannel`]
@@ -2782,7 +2786,7 @@ class Guild(Hashable):
 
         Parameters
         ------------
-        id: :class:`int`
+        scheduled_event_id: :class:`int`
             The scheduled event ID.
         with_counts: :class:`bool`
             Whether to include the number of users that are subscribed to the event.
@@ -2846,6 +2850,8 @@ class Guild(Hashable):
             datetime object. Consider using :func:`utils.utcnow`.
 
             Required if the entity type is :attr:`EntityType.external`.
+        privacy_level: :class:`PrivacyLevel`
+            The privacy level of the scheduled event.
         entity_type: :class:`EntityType`
             The entity type of the scheduled event. If the channel is a
             :class:`StageInstance` or :class:`VoiceChannel` then this is


### PR DESCRIPTION
## Summary

Add missing docstrings of following items:
* `hybrid_group` decorator
* `Guild.create_forum` method
* `Guild.create_scheduled_event` method

Fix wrong docstrings of following items:
* `Guild.fetch_scheduled_event` method: `id` -> `scheduled_event_id`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
