### PR TITLE
[docs] document missing AuditLogDiff attributes for AuditLogAction.guild_update

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1975,6 +1975,8 @@ of :class:`enum.Enum`.
         - :attr:`~AuditLogDiff.verification_level`
         - :attr:`~AuditLogDiff.widget_channel`
         - :attr:`~AuditLogDiff.widget_enabled`
+        - :attr:`~AuditLogDiff.premium_progress_bar_enabled`
+        - :attr:`~AuditLogDiff.system_channel_flags`
 
     .. attribute:: channel_create
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3939,6 +3939,20 @@ AuditLogDiff
 
         :type: List[:class:`abc.GuildChannel`, :class:`Thread`, :class:`Object`]
 
+    .. attribute:: premium_progress_bar_enabled
+
+        The guild’s display setting to show boost progress sidebar
+
+        :type: :class:`bool`
+
+    .. attribute:: system_channel_flags
+
+        The guild’s system channel settings.
+
+        See also :attr:`Guild.system_channel_flags`
+
+        :type: :class:`SystemChannelFlags`
+
 .. this is currently missing the following keys: reason and application_id
    I'm not sure how to port these
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Greetings,

This PR documents these two possible attributes as they are present in `before` and `after` AuditLogDiff changes for `guild_update` audit log action type, when the respective setting is toggled in server settings by a moderator.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
