### PR TITLE
[Docs] Fix member_prune extras attribute name

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2105,7 +2105,7 @@ of :class:`enum.Enum`.
         When this is the action, the type of :attr:`~AuditLogEntry.extra` is
         set to an unspecified proxy object with two attributes:
 
-        - ``delete_members_days``: An integer specifying how far the prune was.
+        - ``delete_member_days``: An integer specifying how far the prune was.
         - ``members_removed``: An integer specifying how many members were removed.
 
         When this is the action, :attr:`~AuditLogEntry.changes` is empty.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
The [current docs](https://discordpy.readthedocs.io/en/latest/api.html#discord.AuditLogAction.member_prune) for `AuditLogAction.member_prune` lists `delete_members_days` as an attribute of `.extras` for this action type. However, the [actual attribute name](https://github.com/Rapptz/discord.py/blob/master/discord/audit_logs.py#L495) is `delete_member_days`. This PR updates the docs to match the code.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
