### PR TITLE
Fix create_scheduled_event param handling

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2974,14 +2974,14 @@ class Guild(Hashable):
         else:
             if not isinstance(entity_type, EntityType):
                 raise TypeError('entity_type must be of type EntityType')
+                
+            payload['entity_type'] = entity_type.value
 
         if entity_type is None:
             raise TypeError(
                 'invalid GuildChannel type passed, must be VoiceChannel or StageChannel '
                 f'not {channel.__class__.__name__}'
             )
-
-        payload['entity_type'] = entity_type.value
 
         if privacy_level is not MISSING:
             if not isinstance(privacy_level, PrivacyLevel):

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2974,7 +2974,7 @@ class Guild(Hashable):
         else:
             if not isinstance(entity_type, EntityType):
                 raise TypeError('entity_type must be of type EntityType')
-                
+
             payload['entity_type'] = entity_type.value
 
         if entity_type is None:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2983,7 +2983,11 @@ class Guild(Hashable):
 
         payload['entity_type'] = entity_type.value
 
-        payload['privacy_level'] = PrivacyLevel.guild_only.value
+        if privacy_level is not MISSING:
+            if not isinstance(privacy_level, PrivacyLevel):
+                raise TypeError('privacy_level must be of type PrivacyLevel.')
+
+            payload['privacy_level'] = privacy_level.value
 
         if description is not MISSING:
             payload['description'] = description

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3014,12 +3014,13 @@ class Guild(Hashable):
 
             if end_time in (MISSING, None):
                 raise TypeError('end_time must be set when entity_type is external')
-            else:
-                if end_time.tzinfo is None:
-                    raise ValueError(
-                        'end_time must be an aware datetime. Consider using discord.utils.utcnow() or datetime.datetime.now().astimezone() for local time.'
-                    )
-                payload['scheduled_end_time'] = end_time.isoformat()
+
+        if end_time not in (MISSING, None):
+            if end_time.tzinfo is None:
+                raise ValueError(
+                    'end_time must be an aware datetime. Consider using discord.utils.utcnow() or datetime.datetime.now().astimezone() for local time.'
+                )
+            payload['scheduled_end_time'] = end_time.isoformat()
 
         if metadata:
             payload['entity_metadata'] = metadata

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3013,7 +3013,9 @@ class Guild(Hashable):
 
             metadata['location'] = location
 
-            if end_time is not MISSING:
+            if end_time in (MISSING, None):
+                raise TypeError('end_time must be set when entity_type is external')
+            else:
                 if end_time.tzinfo is None:
                     raise ValueError(
                         'end_time must be an aware datetime. Consider using discord.utils.utcnow() or datetime.datetime.now().astimezone() for local time.'

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2979,8 +2979,7 @@ class Guild(Hashable):
 
         if entity_type is None:
             raise TypeError(
-                'invalid GuildChannel type passed, must be VoiceChannel or StageChannel '
-                f'not {channel.__class__.__name__}'
+                'invalid GuildChannel type passed, must be VoiceChannel or StageChannel ' f'not {channel.__class__.__name__}'
             )
 
         if privacy_level is not MISSING:
@@ -2998,16 +2997,12 @@ class Guild(Hashable):
 
         if entity_type in (EntityType.stage_instance, EntityType.voice):
             if channel in (MISSING, None):
-                raise TypeError(
-                    'channel must be set when entity_type is voice or stage_instance'
-                )
+                raise TypeError('channel must be set when entity_type is voice or stage_instance')
 
             payload['channel_id'] = channel.id
 
             if location is not MISSING:
-                raise TypeError(
-                    'location cannot be set when entity_type is voice or stage_instance'
-                )
+                raise TypeError('location cannot be set when entity_type is voice or stage_instance')
         else:
             if channel is not MISSING:
                 raise TypeError('channel cannot be set when entity_type is external')

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2998,12 +2998,16 @@ class Guild(Hashable):
 
         if entity_type in (EntityType.stage_instance, EntityType.voice):
             if channel in (MISSING, None):
-                raise TypeError('channel must be set when entity_type is voice or stage_instance')
+                raise TypeError(
+                    'channel must be set when entity_type is voice or stage_instance'
+                )
 
             payload['channel_id'] = channel.id
 
             if location is not MISSING:
-                raise TypeError('location cannot be set when entity_type is voice or stage_instance')
+                raise TypeError(
+                    'location cannot be set when entity_type is voice or stage_instance'
+                )
         else:
             if channel is not MISSING:
                 raise TypeError('channel cannot be set when entity_type is external')

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2964,9 +2964,9 @@ class Guild(Hashable):
         entity_type = entity_type or getattr(channel, '_scheduled_event_entity_type', MISSING)
         if entity_type is MISSING:
             if channel and isinstance(channel, Object):
-                if channel.type == VoiceChannel:
+                if channel.type is VoiceChannel:
                     entity_type = EntityType.voice
-                elif channel.type == StageChannel:
+                elif channel.type is StageChannel:
                     entity_type = EntityType.stage_instance
 
             elif location not in (MISSING, None):

--- a/discord/scheduled_event.py
+++ b/discord/scheduled_event.py
@@ -503,17 +503,16 @@ class ScheduledEvent(Hashable):
                     entity_type = EntityType.stage_instance
             elif location not in (MISSING, None):
                 entity_type = EntityType.external
+        else:
+            if not isinstance(entity_type, EntityType):
+                raise TypeError('entity_type must be of type EntityType')
 
         if entity_type is None:
             raise TypeError(
                 f'invalid GuildChannel type passed, must be VoiceChannel or StageChannel not {channel.__class__.__name__}'
             )
 
-        if entity_type is not MISSING:
-            if not isinstance(entity_type, EntityType):
-                raise TypeError('entity_type must be of type EntityType')
-
-            payload['entity_type'] = entity_type.value
+        payload['entity_type'] = entity_type.value
 
         _entity_type = entity_type or self.entity_type
         _entity_type_changed = _entity_type is not self.entity_type

--- a/discord/scheduled_event.py
+++ b/discord/scheduled_event.py
@@ -506,13 +506,13 @@ class ScheduledEvent(Hashable):
         else:
             if not isinstance(entity_type, EntityType):
                 raise TypeError('entity_type must be of type EntityType')
+            
+            payload['entity_type'] = entity_type.value
 
         if entity_type is None:
             raise TypeError(
                 f'invalid GuildChannel type passed, must be VoiceChannel or StageChannel not {channel.__class__.__name__}'
             )
-
-        payload['entity_type'] = entity_type.value
 
         _entity_type = entity_type or self.entity_type
         _entity_type_changed = _entity_type is not self.entity_type

--- a/discord/scheduled_event.py
+++ b/discord/scheduled_event.py
@@ -506,7 +506,7 @@ class ScheduledEvent(Hashable):
         else:
             if not isinstance(entity_type, EntityType):
                 raise TypeError('entity_type must be of type EntityType')
-            
+
             payload['entity_type'] = entity_type.value
 
         if entity_type is None:


### PR DESCRIPTION
## Summary

**This fix includes following:**
* overloads for `Guild.create_scheduled_event` + not requiring some args
* `end_time` is required now when `entity_type` is `external` in `Guild.create_scheduled_event` 
* `privacy_level` isn't static anymore in `Guild.create_scheduled_event`
* better readability when `entity_type` is not missing for both `Guild.create_scheduled_event` and `ScheduledEvent.edit`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
