### PR TITLE
[docs] add missing AuditLogDiff attrs for `channel_update` & `channel_delete` audit log actions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2018,6 +2018,9 @@ of :class:`enum.Enum`.
         - :attr:`~AuditLogDiff.rtc_region`
         - :attr:`~AuditLogDiff.video_quality_mode`
         - :attr:`~AuditLogDiff.default_auto_archive_duration`
+        - :attr:`~AuditLogDiff.nsfw`
+        - :attr:`~AuditLogDiff.slowmode_delay`
+        - :attr:`~AuditLogDiff.user_limit`
 
     .. attribute:: channel_delete
 
@@ -2034,6 +2037,9 @@ of :class:`enum.Enum`.
         - :attr:`~AuditLogDiff.name`
         - :attr:`~AuditLogDiff.type`
         - :attr:`~AuditLogDiff.overwrites`
+        - :attr:`~AuditLogDiff.flags`
+        - :attr:`~AuditLogDiff.nsfw`
+        - :attr:`~AuditLogDiff.slowmode_delay`
 
     .. attribute:: overwrite_create
 
@@ -3941,7 +3947,7 @@ AuditLogDiff
 
     .. attribute:: premium_progress_bar_enabled
 
-        The guild’s display setting to show boost progress sidebar
+        The guild’s display setting to show boost progress bar.
 
         :type: :class:`bool`
 
@@ -3952,6 +3958,28 @@ AuditLogDiff
         See also :attr:`Guild.system_channel_flags`
 
         :type: :class:`SystemChannelFlags`
+
+    .. attribute:: nsfw
+
+        Whether the channel is marked as “not safe for work” or “age restricted”.
+
+        :type: :class:`bool`
+
+    .. attribute:: user_limit
+
+        The channel’s limit for number of members that can be in a voice or stage channel.
+
+        See also :attr:`VoiceChannel.user_limit` and :attr:`StageChannel.user_limit`
+
+        :type: :class:`int`
+
+    .. attribute:: flags
+
+        The channel flags associated with this thread or forum post.
+
+        See also :attr:`ForumChannel.flags` and :attr:`Thread.flags`
+
+        :type: :class:`ChannelFlags`
 
 .. this is currently missing the following keys: reason and application_id
    I'm not sure how to port these


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Greetings,

This PR documents missing AuditLogDiff attributes for `channel_update` and `channel_delete` audit log actions. I also corrected minor typo I did in my last PR in `AuditLogDiff.premium_progress_bar_enabled` since thats how it's worded in client UI. Please let me know in case you want me to undo it.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
