### PR TITLE
[commands] Add option to process a certain command_str

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -1358,7 +1358,7 @@ class BotBase(GroupMixin[None]):
             exc = errors.CommandNotFound(f'Command "{ctx.invoked_with}" is not found')
             self.dispatch('command_error', ctx, exc)
 
-    async def process_commands(self, message: Message, /) -> None:
+    async def process_commands(self, message: Message, *, command_str: Optional[str] = MISSING) -> None:
         """|coro|
 
         This function processes the commands that have been registered
@@ -1383,11 +1383,20 @@ class BotBase(GroupMixin[None]):
         -----------
         message: :class:`discord.Message`
             The message to process commands for.
+        command_str: Optional[:class:`str`]
+            The command string which should be processed.
+            This can be useful to process multiple commands.
         """
         if message.author.bot:
             return
 
+        before_content = message.content
+        if command_str not in (MISSING, None):
+            message.content = command_str
+
         ctx = await self.get_context(message)
+        message.content = before_content
+
         # the type of the invocation context's bot attribute will be correct
         await self.invoke(ctx)  # type: ignore
 


### PR DESCRIPTION
## Summary

This adds the feature requested here: https://github.com/Rapptz/discord.py/issues/7067
It's worth mentioning that this is not useful when processing *one* command, but processing multiple commands or a certain part of `message.content`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
