### PR TITLE
Fix partially uknown typing errors

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -1161,9 +1161,9 @@ class Client:
         event: Literal['app_command_completion'],
         /,
         *,
-        check: Optional[Callable[[Interaction[Self], Union[Command, ContextMenu]], bool]],
+        check: Optional[Callable[[Interaction[Self], Union[Command[Any, Any, Any], ContextMenu]], bool]],
         timeout: Optional[float] = None,
-    ) -> Tuple[Interaction[Self], Union[Command, ContextMenu]]:
+    ) -> Tuple[Interaction[Self], Union[Command[Any, Any, Any], ContextMenu]]:
         ...
 
     # AutoMod
@@ -1816,9 +1816,9 @@ class Client:
         event: Literal["command", "command_completion"],
         /,
         *,
-        check: Optional[Callable[[Context], bool]] = None,
+        check: Optional[Callable[[Context[Any]], bool]] = None,
         timeout: Optional[float] = None,
-    ) -> Context:
+    ) -> Context[Any]:
         ...
 
     @overload
@@ -1827,9 +1827,9 @@ class Client:
         event: Literal["command_error"],
         /,
         *,
-        check: Optional[Callable[[Context, CommandError], bool]] = None,
+        check: Optional[Callable[[Context[Any], CommandError], bool]] = None,
         timeout: Optional[float] = None,
-    ) -> Tuple[Context, CommandError]:
+    ) -> Tuple[Context[Any], CommandError]:
         ...
 
     @overload

--- a/discord/ui/item.py
+++ b/discord/ui/item.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from .view import View
     from ..components import Component
 
-I = TypeVar('I', bound='Item')
+I = TypeVar('I', bound='Item[Any]')
 V = TypeVar('V', bound='View', covariant=True)
 ItemCallbackType = Callable[[V, Interaction[Any], I], Coroutine[Any, Any, Any]]
 

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -22,7 +22,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 from __future__ import annotations
-from typing import List, Literal, Optional, TYPE_CHECKING, Tuple, Type, TypeVar, Callable, Union, Dict, overload
+from typing import Any, List, Literal, Optional, TYPE_CHECKING, Tuple, Type, TypeVar, Callable, Union, Dict, overload
 from contextvars import ContextVar
 import inspect
 import os
@@ -71,12 +71,12 @@ if TYPE_CHECKING:
     ]
 
 V = TypeVar('V', bound='View', covariant=True)
-BaseSelectT = TypeVar('BaseSelectT', bound='BaseSelect')
-SelectT = TypeVar('SelectT', bound='Select')
-UserSelectT = TypeVar('UserSelectT', bound='UserSelect')
-RoleSelectT = TypeVar('RoleSelectT', bound='RoleSelect')
-ChannelSelectT = TypeVar('ChannelSelectT', bound='ChannelSelect')
-MentionableSelectT = TypeVar('MentionableSelectT', bound='MentionableSelect')
+BaseSelectT = TypeVar('BaseSelectT', bound='BaseSelect[Any]')
+SelectT = TypeVar('SelectT', bound='Select[Any]')
+UserSelectT = TypeVar('UserSelectT', bound='UserSelect[Any]')
+RoleSelectT = TypeVar('RoleSelectT', bound='RoleSelect[Any]')
+ChannelSelectT = TypeVar('ChannelSelectT', bound='ChannelSelect[Any]')
+MentionableSelectT = TypeVar('MentionableSelectT', bound='MentionableSelect[Any]')
 SelectCallbackDecorator: TypeAlias = Callable[[ItemCallbackType[V, BaseSelectT]], BaseSelectT]
 
 selected_values: ContextVar[Dict[str, List[PossibleValue]]] = ContextVar('selected_values')


### PR DESCRIPTION
## Summary

Fixes public APIs being reported as partially unknown by pyright in strict mode.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)