### PR TITLE
Use `...` for `Command` and `Group` typing

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -1161,9 +1161,9 @@ class Client:
         event: Literal['app_command_completion'],
         /,
         *,
-        check: Optional[Callable[[Interaction[Self], Union[Command[Any, Any, Any], ContextMenu]], bool]],
+        check: Optional[Callable[[Interaction[Self], Union[Command[Any, ..., Any], ContextMenu]], bool]],
         timeout: Optional[float] = None,
-    ) -> Tuple[Interaction[Self], Union[Command[Any, Any, Any], ContextMenu]]:
+    ) -> Tuple[Interaction[Self], Union[Command[Any, ..., Any], ContextMenu]]:
         ...
 
     # AutoMod

--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -72,9 +72,9 @@ __all__ = (
 T = TypeVar('T')
 U = TypeVar('U')
 CogT = TypeVar('CogT', bound='Cog')
-CommandT = TypeVar('CommandT', bound='Command[Any, Any, Any]')
+CommandT = TypeVar('CommandT', bound='Command[Any, ..., Any]')
 # CHT = TypeVar('CHT', bound='Check')
-GroupT = TypeVar('GroupT', bound='Group[Any, Any, Any]')
+GroupT = TypeVar('GroupT', bound='Group[Any, ..., Any]')
 _NoneType = type(None)
 
 if TYPE_CHECKING:
@@ -297,7 +297,7 @@ def replace_parameters(
 
 
 class HybridAppCommand(discord.app_commands.Command[CogT, P, T]):
-    def __init__(self, wrapped: Union[HybridCommand[CogT, Any, T], HybridGroup[CogT, Any, T]]) -> None:
+    def __init__(self, wrapped: Union[HybridCommand[CogT, ..., T], HybridGroup[CogT, ..., T]]) -> None:
         signature = inspect.signature(wrapped.callback)
         params = replace_parameters(wrapped.params, wrapped.callback, signature)
         wrapped.callback.__signature__ = signature.replace(parameters=params)
@@ -312,7 +312,7 @@ class HybridAppCommand(discord.app_commands.Command[CogT, P, T]):
         finally:
             del wrapped.callback.__signature__
 
-        self.wrapped: Union[HybridCommand[CogT, Any, T], HybridGroup[CogT, Any, T]] = wrapped
+        self.wrapped: Union[HybridCommand[CogT, ..., T], HybridGroup[CogT, ..., T]] = wrapped
         self.binding: Optional[CogT] = wrapped.cog
         # This technically means only one flag converter is supported
         self.flag_converter: Optional[Tuple[str, Type[FlagConverter]]] = getattr(


### PR DESCRIPTION
## Summary

Fixes a few more typing things

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
