### PR TITLE
[commands] Pass failed argument's value to BadLiteralArgument

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -1330,7 +1330,7 @@ async def run_converters(ctx: Context[BotT], converter: Any, argument: str, para
                 return value
 
         # if we're here, then we failed to match all the literals
-        raise BadLiteralArgument(param, literal_args, errors)
+        raise BadLiteralArgument(param, literal_args, errors, argument)
 
     # This must be the last if-clause in the chain of origin checking
     # Nearly every type is a generic type within the typing library

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -912,9 +912,6 @@ class BadLiteralArgument(UserInputError):
 
     .. versionadded:: 2.0
 
-    .. versionchanged:: 2.3
-        Added the ``argument`` parameter and matching attribute.
-
     Attributes
     -----------
     param: :class:`inspect.Parameter`
@@ -924,7 +921,7 @@ class BadLiteralArgument(UserInputError):
     errors: List[:class:`CommandError`]
         A list of errors that were caught from failing the conversion.
     argument: :class:`str`
-        The argument's value that failed to be converted. Defaults to an empty string for a non-breaking change.
+        The argument's value that failed to be converted. Defaults to an empty string.
 
         .. versionadded:: 2.3
     """

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -912,6 +912,9 @@ class BadLiteralArgument(UserInputError):
 
     .. versionadded:: 2.0
 
+    .. versionchanged:: 2.3
+        Added the ``argument`` parameter and matching attribute.
+
     Attributes
     -----------
     param: :class:`inspect.Parameter`
@@ -922,6 +925,8 @@ class BadLiteralArgument(UserInputError):
         A list of errors that were caught from failing the conversion.
     argument: :class:`str`
         The argument's value that failed to be converted. Defaults to an empty string for a non-breaking change.
+
+        .. versionadded:: 2.3
     """
 
     def __init__(self, param: Parameter, literals: Tuple[Any, ...], errors: List[CommandError], argument: str = "") -> None:

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -920,12 +920,15 @@ class BadLiteralArgument(UserInputError):
         A tuple of values compared against in conversion, in order of failure.
     errors: List[:class:`CommandError`]
         A list of errors that were caught from failing the conversion.
+    argument: :class:`str`
+        The argument's value that failed to be converted. Defaults to an empty string for a non-breaking change.
     """
 
-    def __init__(self, param: Parameter, literals: Tuple[Any, ...], errors: List[CommandError]) -> None:
+    def __init__(self, param: Parameter, literals: Tuple[Any, ...], errors: List[CommandError], argument: str = "") -> None:
         self.param: Parameter = param
         self.literals: Tuple[Any, ...] = literals
         self.errors: List[CommandError] = errors
+        self.argument: str = argument
 
         to_string = [repr(l) for l in literals]
         if len(to_string) > 2:


### PR DESCRIPTION
## Summary

This PR adds an `argument` attribute and parameter to `BadLiteralArgument`. This way, users can include the failed argument's value in their custom errors.

The parameter defaults to an empty string to make this a non-breaking change. Defaulting to `None` and typing as `Optional[]` would mark it as Optional for everything when that's never the case when the library raises it.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
