### PR TITLE
Add missing param `send_start_notification` to `create_instance`

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1608,6 +1608,8 @@ class StageChannel(VocalGuildChannel):
         send_start_notification: :class:`bool`
             Whether to send a start notification. This sends a push notification to @everyone if ``True``. Defaults to ``False``.
             You must have :attr:`~Permissions.mention_everyone` to do this.
+            
+            .. versionadded:: 2.3
         reason: :class:`str`
             The reason the stage instance was created. Shows up on the audit log.
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1614,7 +1614,7 @@ class StageChannel(VocalGuildChannel):
         Raises
         ------
         TypeError
-            If the ``privacy_level`` or ``send_start_notification`` parameter is not the proper type.
+            If the ``privacy_level`` parameter is not the proper type.
         Forbidden
             You do not have permissions to create a stage instance.
         HTTPException

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1584,7 +1584,12 @@ class StageChannel(VocalGuildChannel):
         return utils.get(self.guild.stage_instances, channel_id=self.id)
 
     async def create_instance(
-        self, *, topic: str, privacy_level: PrivacyLevel = MISSING, reason: Optional[str] = None
+        self,
+        *,
+        topic: str,
+        privacy_level: PrivacyLevel = MISSING,
+        send_start_notification: bool = False,
+        reason: Optional[str] = None,
     ) -> StageInstance:
         """|coro|
 
@@ -1600,13 +1605,16 @@ class StageChannel(VocalGuildChannel):
             The stage instance's topic.
         privacy_level: :class:`PrivacyLevel`
             The stage instance's privacy level. Defaults to :attr:`PrivacyLevel.guild_only`.
+        send_start_notification: :class:`bool`
+            Whether to send a start notification. This sends a push notification to @everyone if ``True``. Defaults to ``False``.
+            You must have :attr:`~Permissions.mention_everyone` to do this.
         reason: :class:`str`
             The reason the stage instance was created. Shows up on the audit log.
 
         Raises
         ------
         TypeError
-            If the ``privacy_level`` parameter is not the proper type.
+            If the ``privacy_level`` or ``send_start_notification`` parameter is not the proper type.
         Forbidden
             You do not have permissions to create a stage instance.
         HTTPException
@@ -1625,6 +1633,12 @@ class StageChannel(VocalGuildChannel):
                 raise TypeError('privacy_level field must be of type PrivacyLevel')
 
             payload['privacy_level'] = privacy_level.value
+
+        if send_start_notification is not None:
+            if not isinstance(send_start_notification, bool):
+                raise TypeError('send_start_notification field must be of type bool')
+            else:
+                payload['send_start_notification'] = send_start_notification
 
         data = await self._state.http.create_stage_instance(**payload, reason=reason)
         return StageInstance(guild=self.guild, state=self._state, data=data)

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1634,11 +1634,7 @@ class StageChannel(VocalGuildChannel):
 
             payload['privacy_level'] = privacy_level.value
 
-        if send_start_notification is not None:
-            if not isinstance(send_start_notification, bool):
-                raise TypeError('send_start_notification field must be of type bool')
-            else:
-                payload['send_start_notification'] = send_start_notification
+        payload['send_start_notification'] = send_start_notification
 
         data = await self._state.http.create_stage_instance(**payload, reason=reason)
         return StageInstance(guild=self.guild, state=self._state, data=data)

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1608,7 +1608,7 @@ class StageChannel(VocalGuildChannel):
         send_start_notification: :class:`bool`
             Whether to send a start notification. This sends a push notification to @everyone if ``True``. Defaults to ``False``.
             You must have :attr:`~Permissions.mention_everyone` to do this.
-            
+
             .. versionadded:: 2.3
         reason: :class:`str`
             The reason the stage instance was created. Shows up on the audit log.

--- a/discord/http.py
+++ b/discord/http.py
@@ -1903,6 +1903,7 @@ class HTTPClient:
             'channel_id',
             'topic',
             'privacy_level',
+            'send_start_notification',
         )
         payload = {k: v for k, v in payload.items() if k in valid_keys}
 


### PR DESCRIPTION
## Summary

This PR adds the missing parameter `send_start_notification` to `StageChannel.create_instance`. 

Because the API doesn't send an HTTP error when the bot doesn't have `mention_everyone` permission, but the `send_start_notification` field is `True` , it's noted in the documentation.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
