### PR TITLE
Add support for `default_sort_order` in `ForumChannel`

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2354,6 +2354,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         default_thread_slowmode_delay: int = ...,
         default_reaction_emoji: Optional[EmojiInputType] = ...,
         default_layout: ForumLayoutType = ...,
+        default_sort_order: ForumOrderType = ...,
         require_tag: bool = ...,
     ) -> ForumChannel:
         ...
@@ -2412,6 +2413,10 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
             The new default layout for posts in this forum.
 
             .. versionadded:: 2.2
+        default_sort_order: Optional[:class:`ForumOrderType`]
+            The new default sort order for posts in this forum.
+
+            .. versionadded:: 2.3
         require_tag: :class:`bool`
             Whether to require a tag for threads in this channel or not.
 
@@ -2473,6 +2478,21 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
                 raise TypeError(f'default_layout parameter must be a ForumLayoutType not {layout.__class__.__name__}')
 
             options['default_forum_layout'] = layout.value
+
+        try:
+            sort_order = options.pop('default_sort_order')
+        except KeyError:
+            pass
+        else:
+            if sort_order is None:
+                options['default_sort_order'] = None
+            else:
+                if not isinstance(sort_order, ForumOrderType):
+                    raise TypeError(
+                        f'default_sort_order parameter must be a ForumOrderType not {sort_order.__class__.__name__}'
+                    )
+
+                options['default_sort_order'] = sort_order.value
 
         payload = await self._edit(options, reason=reason)
         if payload is not None:

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -47,7 +47,7 @@ import datetime
 import discord.abc
 from .scheduled_event import ScheduledEvent
 from .permissions import PermissionOverwrite, Permissions
-from .enums import ChannelType, ForumLayoutType, PrivacyLevel, try_enum, VideoQualityMode, EntityType
+from .enums import ChannelType, ForumLayoutType, ForumOrderType, PrivacyLevel, try_enum, VideoQualityMode, EntityType
 from .mixins import Hashable
 from . import utils
 from .utils import MISSING
@@ -2154,6 +2154,10 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         Defaults to :attr:`ForumLayoutType.not_set`.
 
         .. versionadded:: 2.2
+    default_sort_order: Optional[:class:`ForumOrderType`]
+        The default sort order for posts in this forum channel.
+
+        .. versionadded:: 2.3
     """
 
     __slots__ = (
@@ -2173,6 +2177,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         'default_thread_slowmode_delay',
         'default_reaction_emoji',
         'default_layout',
+        'default_sort_order',
         '_available_tags',
         '_flags',
     )
@@ -2217,6 +2222,11 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
                 id=utils._get_as_snowflake(default_reaction_emoji, 'emoji_id') or None,  # Coerce 0 -> None
                 name=default_reaction_emoji.get('emoji_name') or '',
             )
+
+        self.default_sort_order: Optional[ForumOrderType] = None
+        default_sort_order = data.get('default_sort_order')
+        if default_sort_order is not None:
+            self.default_sort_order = try_enum(ForumOrderType, default_sort_order)
 
         self._flags: int = data.get('flags', 0)
         self._fill_overwrites(data)

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -67,6 +67,7 @@ __all__ = (
     'AutoModRuleEventType',
     'AutoModRuleActionType',
     'ForumLayoutType',
+    'ForumOrderType',
 )
 
 if TYPE_CHECKING:
@@ -749,6 +750,11 @@ class ForumLayoutType(Enum):
     not_set = 0
     list_view = 1
     gallery_view = 2
+
+
+class ForumOrderType(Enum):
+    latest_activity = 0
+    creation_date = 1
 
 
 def create_unknown_value(cls: Type[E], val: Any) -> E:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -73,6 +73,7 @@ from .enums import (
     MFALevel,
     Locale,
     AutoModRuleEventType,
+    ForumOrderType,
 )
 from .mixins import Hashable
 from .user import User
@@ -1576,6 +1577,7 @@ class Guild(Hashable):
         reason: Optional[str] = None,
         default_auto_archive_duration: int = MISSING,
         default_thread_slowmode_delay: int = MISSING,
+        default_sort_order: Optional[ForumOrderType] = None,
         available_tags: Sequence[ForumTag] = MISSING,
     ) -> ForumChannel:
         """|coro|
@@ -1620,6 +1622,10 @@ class Guild(Hashable):
             The default slowmode delay in seconds for threads created in this forum.
 
             .. versionadded:: 2.1
+        default_sort_order: Optional[:class:`ForumOrderType`]
+            The default sort order for posts in this forum channel.
+
+            .. versionadded:: 2.3
         available_tags: Sequence[:class:`ForumTag`]
             The available tags for this forum channel.
 
@@ -1658,6 +1664,16 @@ class Guild(Hashable):
 
         if default_thread_slowmode_delay is not MISSING:
             options['default_thread_rate_limit_per_user'] = default_thread_slowmode_delay
+
+        if default_sort_order is None:
+            options['default_sort_order'] = None
+        else:
+            if not isinstance(default_sort_order, ForumOrderType):
+                raise TypeError(
+                    f'default_sort_order parameter must be a ForumOrderType not {default_sort_order.__class__.__name__}'
+                )
+
+            options['default_sort_order'] = default_sort_order.value
 
         if available_tags is not MISSING:
             options['available_tags'] = [t.to_dict() for t in available_tags]

--- a/discord/http.py
+++ b/discord/http.py
@@ -1148,6 +1148,7 @@ class HTTPClient:
             'available_tags',
             'applied_tags',
             'default_forum_layout',
+            'default_sort_order',
         )
 
         payload = {k: v for k, v in options.items() if k in valid_keys}

--- a/discord/http.py
+++ b/discord/http.py
@@ -1190,6 +1190,7 @@ class HTTPClient:
             'video_quality_mode',
             'default_auto_archive_duration',
             'default_thread_rate_limit_per_user',
+            'default_sort_order',
             'available_tags',
         )
         payload.update({k: v for k, v in options.items() if k in valid_keys and v is not None})

--- a/discord/types/channel.py
+++ b/discord/types/channel.py
@@ -134,6 +134,7 @@ class ForumTag(TypedDict):
     emoji_name: Optional[str]
 
 
+ForumOrderType = Literal[0, 1]
 ForumLayoutType = Literal[0, 1, 2]
 
 
@@ -141,6 +142,7 @@ class ForumChannel(_BaseTextChannel):
     type: Literal[15]
     available_tags: List[ForumTag]
     default_reaction_emoji: Optional[DefaultReaction]
+    default_sort_order: Optional[ForumOrderType]
     default_forum_layout: NotRequired[ForumLayoutType]
     flags: NotRequired[int]
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3310,6 +3310,21 @@ of :class:`enum.Enum`.
         Displays posts as a collection of tiles.
 
 
+.. class:: ForumOrderType
+
+    Represents how a forum's posts are sorted in the client.
+
+    .. versionadded:: 2.3
+
+    .. attribute:: latest_activity
+
+        Sort forum posts by activity.
+
+    .. attribute:: creation_date
+
+        Sort forum posts by creation time (from most recent to oldest).
+
+
 .. _discord-api-audit-logs:
 
 Audit Log Data


### PR DESCRIPTION
## Summary

This PR adds support for `default_sort_order` in `ForumChannel`. This includes:
* `ForumChannel`
* `ForumChannel.edit`
* `Guild.create_forum`

**Note: At the moment you're not able to set `default_sort_order` to `0` due of a bug in the API. Therefore the API responds with `default_sort_order: None` when creating a forum. See the related issue: https://github.com/discord/discord-api-docs/issues/5979**

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
