### PR TITLE
Fix MISSING error for `enabled` param

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3970,7 +3970,7 @@ class Guild(Hashable):
         event_type: AutoModRuleEventType,
         trigger: AutoModTrigger,
         actions: List[AutoModRuleAction],
-        enabled: bool = MISSING,
+        enabled: bool = False,
         exempt_roles: Sequence[Snowflake] = MISSING,
         exempt_channels: Sequence[Snowflake] = MISSING,
         reason: str = MISSING,
@@ -3995,7 +3995,7 @@ class Guild(Hashable):
             The actions that will be taken when the automod rule is triggered.
         enabled: :class:`bool`
             Whether the automod rule is enabled.
-            Discord will default to ``False``.
+            Defaults to ``False``.
         exempt_roles: Sequence[:class:`abc.Snowflake`]
             A list of roles that will be exempt from the automod rule.
         exempt_channels: Sequence[:class:`abc.Snowflake`]


### PR DESCRIPTION
## Summary

This PR fixes an unexpected error which is caused by not passing `enabled` in `Guild.create_automod_rule`, even it's not required.

**Code**
```python
import discord

automod_rule_action = discord.AutoModRuleAction(custom_message="hello")

trigger_type = discord.AutoModRuleTriggerType.keyword_preset
presets = discord.AutoModPresets().all()
trigger = discord.AutoModTrigger(type=trigger_type, presets=presets)
event_type = discord.AutoModRuleEventType.message_send

# enabled not passed
await guild.create_automod_rule(name="testbot", actions=[automod_rule_action], event_type=event_type, trigger=trigger)
```
**Error**
```
Traceback (most recent call last):
  File "C:\Users\andri\Documents\GitHub\Testing-Py\Discord.py\fork\venv\lib\site-packages\jishaku\features\python.py", line 189, in jsk_python
    async for send, result in AsyncSender(executor):  # type: ignore
  File "C:\Users\andri\Documents\GitHub\Testing-Py\Discord.py\fork\venv\lib\site-packages\jishaku\functools.py", line 124, in _internal
    value = await base.asend(self.send_value)
  File "C:\Users\andri\Documents\GitHub\Testing-Py\Discord.py\fork\venv\lib\site-packages\jishaku\repl\compilation.py", line 210, in traverse
    async for send, result in AsyncSender(func_g(*self.args)):  # type: ignore
  File "C:\Users\andri\Documents\GitHub\Testing-Py\Discord.py\fork\venv\lib\site-packages\jishaku\functools.py", line 124, in _internal
    value = await base.asend(self.send_value)
  File "<repl>", line 9, in _repl_coroutine
    await guild.create_automod_rule(name="testbot", actions=[automod_rule_action], event_type=event_type, trigger=trigger)
  File "c:\users\andri\documents\github\discord.py-1\discord\guild.py", line 4018, in create_automod_rule
    data = await self._state.http.create_auto_moderation_rule(
  File "c:\users\andri\documents\github\discord.py-1\discord\http.py", line 586, in request
    kwargs['data'] = utils._to_json(kwargs.pop('json'))
  File "c:\users\andri\documents\github\discord.py-1\discord\utils.py", line 645, in _to_json
    return json.dumps(obj, separators=(',', ':'), ensure_ascii=True)
TypeError: Object of type _MissingSentinel is not JSON serializable
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
