### PR TITLE
Overloads + smaller changes in `AutoModRuleAction`

### DIFF
--- a/discord/automod.py
+++ b/discord/automod.py
@@ -119,11 +119,11 @@ class AutoModRuleAction:
 
     @classmethod
     def from_data(cls, data: AutoModerationActionPayload) -> Self:
-        type_ = try_enum(AutoModRuleActionType, data['type'])
-        if data['type'] == AutoModRuleActionType.timeout.value:
+        _type = try_enum(AutoModRuleActionType, data['type'])
+        if _type == AutoModRuleActionType.timeout:
             duration_seconds = data['metadata']['duration_seconds']
             return cls(duration=datetime.timedelta(seconds=duration_seconds))
-        elif data['type'] == AutoModRuleActionType.send_alert_message.value:
+        elif _type == AutoModRuleActionType.send_alert_message:
             channel_id = int(data['metadata']['channel_id'])
             return cls(channel_id=channel_id)
         return cls(custom_message=data.get('metadata', {}).get('custom_message'))

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -58,6 +58,9 @@ __all__ = (
 class AutoModRuleAction:
     """Represents an auto moderation's rule action.
 
+    .. note::
+        Only one of ``channel_id``, ``duration``, or ``custom_message`` can be used.
+
     .. versionadded:: 2.0
 
     Attributes
@@ -100,19 +103,18 @@ class AutoModRuleAction:
         duration: Optional[datetime.timedelta] = None,
         custom_message: Optional[str] = None,
     ) -> None:
+        self.type: AutoModRuleActionType = AutoModRuleActionType.block_message
+        if channel_id:
+            self.type = AutoModRuleActionType.send_alert_message
+        elif duration:
+            self.type = AutoModRuleActionType.timeout
+
         self.channel_id: Optional[int] = channel_id
         self.duration: Optional[datetime.timedelta] = duration
         self.custom_message: Optional[str] = custom_message
 
         if sum(v is None for v in (channel_id, duration, custom_message)) < 2:
             raise ValueError('Only one of channel_id, duration, or custom_message can be passed.')
-
-        if channel_id:
-            self.type = AutoModRuleActionType.send_alert_message
-        elif duration:
-            self.type = AutoModRuleActionType.timeout
-        else:
-            self.type = AutoModRuleActionType.block_message
 
     def __repr__(self) -> str:
         return f'<AutoModRuleAction type={self.type.value} channel={self.channel_id} duration={self.duration}>'

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -103,18 +103,18 @@ class AutoModRuleAction:
         duration: Optional[datetime.timedelta] = None,
         custom_message: Optional[str] = None,
     ) -> None:
-        self.type: AutoModRuleActionType = AutoModRuleActionType.block_message
-        if channel_id:
-            self.type = AutoModRuleActionType.send_alert_message
-        elif duration:
-            self.type = AutoModRuleActionType.timeout
-
         self.channel_id: Optional[int] = channel_id
         self.duration: Optional[datetime.timedelta] = duration
         self.custom_message: Optional[str] = custom_message
 
         if sum(v is None for v in (channel_id, duration, custom_message)) < 2:
             raise ValueError('Only one of channel_id, duration, or custom_message can be passed.')
+
+        self.type: AutoModRuleActionType = AutoModRuleActionType.block_message
+        if channel_id:
+            self.type = AutoModRuleActionType.send_alert_message
+        elif duration:
+            self.type = AutoModRuleActionType.timeout
 
     def __repr__(self) -> str:
         return f'<AutoModRuleAction type={self.type.value} channel={self.channel_id} duration={self.duration}>'

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 import datetime
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, List, Sequence, Set, Union, Sequence
+from typing import TYPE_CHECKING, Any, Dict, Optional, List, Set, Union, Sequence, overload
 
 from .enums import AutoModRuleTriggerType, AutoModRuleActionType, AutoModRuleEventType, try_enum
 from .flags import AutoModPresets
@@ -80,6 +80,18 @@ class AutoModRuleAction:
     """
 
     __slots__ = ('type', 'channel_id', 'duration', 'custom_message')
+
+    @overload
+    def __init__(self, channel_id: int = None) -> None:
+        ...
+
+    @overload
+    def __init__(self, duration: datetime.timedelta = None) -> None:
+        ...
+
+    @overload
+    def __init__(self, custom_message: str = None) -> None:
+        ...
 
     def __init__(
         self,

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -85,15 +85,15 @@ class AutoModRuleAction:
     __slots__ = ('type', 'channel_id', 'duration', 'custom_message')
 
     @overload
-    def __init__(self, channel_id: int = None) -> None:
+    def __init__(self, *, channel_id: Optional[int] = ...) -> None:
         ...
 
     @overload
-    def __init__(self, duration: datetime.timedelta = None) -> None:
+    def __init__(self, *, duration: Optional[datetime.timedelta] = ...) -> None:
         ...
 
     @overload
-    def __init__(self, custom_message: str = None) -> None:
+    def __init__(self, *, custom_message: Optional[str] = ...) -> None:
         ...
 
     def __init__(
@@ -121,11 +121,10 @@ class AutoModRuleAction:
 
     @classmethod
     def from_data(cls, data: AutoModerationActionPayload) -> Self:
-        _type = try_enum(AutoModRuleActionType, data['type'])
-        if _type == AutoModRuleActionType.timeout:
+        if data['type'] == AutoModRuleActionType.timeout.value:
             duration_seconds = data['metadata']['duration_seconds']
             return cls(duration=datetime.timedelta(seconds=duration_seconds))
-        elif _type == AutoModRuleActionType.send_alert_message:
+        elif data['type'] == AutoModRuleActionType.send_alert_message.value:
             channel_id = int(data['metadata']['channel_id'])
             return cls(channel_id=channel_id)
         return cls(custom_message=data.get('metadata', {}).get('custom_message'))


### PR DESCRIPTION
## Summary

This PR has following changes:
* Add overloads to `AutoModRuleAction.__init__`
* Move `self.type` assignments and use type hint
* Removed unused variable in `from_data`
* Add note to documentation, that only one of `channel_id`, `duration`, or `custom_message` can be used

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
