### PR TITLE
Include `ssrc` parameter when sending a SPEAKING payload

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -991,7 +991,11 @@ class DiscordVoiceWebSocket:
     async def load_secret_key(self, data: Dict[str, Any]) -> None:
         _log.debug('received secret key for voice connection')
         self.secret_key = self._connection.secret_key = data['secret_key']
-        await self.speak()
+
+        # Send a speak command with the "not speaking" state.
+        # This also tells Discord our SSRC value, which Discord requires
+        # before sending any voice data (and is the real reason why we
+        # call this here).
         await self.speak(SpeakingState.none)
 
     async def poll_event(self) -> None:

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -915,6 +915,7 @@ class DiscordVoiceWebSocket:
             'd': {
                 'speaking': int(state),
                 'delay': 0,
+                'ssrc': self._connection.ssrc,
             },
         }
 


### PR DESCRIPTION
## Summary

As it is a required in [a SPEAKING payload](https://discord.com/developers/docs/topics/voice-connections#speaking). This is an equivalent PR to https://github.com/nextcord/nextcord/pull/1009 on nextcord, a fork of discord.py. Further details are in that PR's description, but they equally apply to discord.py.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
