### PR TITLE
Fix return types in sync.py docstring

### DIFF
--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -636,9 +636,9 @@ class SyncWebhook(BaseWebhook):
 
         Returns
         --------
-        :class:`Webhook`
-            A partial :class:`Webhook`.
-            A partial webhook is just a webhook object with an ID and a token.
+        :class:`SyncWebhook`
+            A partial :class:`SyncWebhook`.
+            A partial :class:`SyncWebhook` is just a :class:`SyncWebhook` object with an ID and a token.
         """
         data: WebhookPayload = {
             'id': id,
@@ -678,9 +678,9 @@ class SyncWebhook(BaseWebhook):
 
         Returns
         --------
-        :class:`Webhook`
-            A partial :class:`Webhook`.
-            A partial webhook is just a webhook object with an ID and a token.
+        :class:`SyncWebhook`
+            A partial :class:`SyncWebhook`.
+            A partial :class:`SyncWebhook` is just a :class:`SyncWebhook` object with an ID and a token.
         """
         m = re.search(r'discord(?:app)?\.com/api/webhooks/(?P<id>[0-9]{17,20})/(?P<token>[A-Za-z0-9\.\-\_]{60,68})', url)
         if m is None:


### PR DESCRIPTION
## Summary

This PR fixes the return types of `SyncWebhook.partial()` and `SyncWebhook.from_url()` method's docstring.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
