### PR TITLE
KeyError 'available' for GuildSticker

### DIFF
--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -414,7 +414,7 @@ class GuildSticker(Sticker):
 
     def _from_data(self, data: GuildStickerPayload) -> None:
         super()._from_data(data)
-        self.available: Optional[bool] = data.get('available')
+        self.available: bool = data.get('available', True)
         self.guild_id: int = int(data['guild_id'])
         user = data.get('user')
         self.user: Optional[User] = self._state.store_user(user) if user else None

--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -414,7 +414,7 @@ class GuildSticker(Sticker):
 
     def _from_data(self, data: GuildStickerPayload) -> None:
         super()._from_data(data)
-        self.available: bool = data.get('available')
+        self.available: Optional[bool] = data.get('available')
         self.guild_id: int = int(data['guild_id'])
         user = data.get('user')
         self.user: Optional[User] = self._state.store_user(user) if user else None

--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -399,7 +399,7 @@ class GuildSticker(Sticker):
         The description of the sticker.
     format: :class:`StickerFormatType`
         The format for the sticker's image.
-    available: :class:`bool`
+    available: Optional[:class:`bool`]
         Whether this sticker is available for use.
     guild_id: :class:`int`
         The ID of the guild that this sticker is from.

--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -399,7 +399,7 @@ class GuildSticker(Sticker):
         The description of the sticker.
     format: :class:`StickerFormatType`
         The format for the sticker's image.
-    available: Optional[:class:`bool`]
+    available: :class:`bool`
         Whether this sticker is available for use.
     guild_id: :class:`int`
         The ID of the guild that this sticker is from.

--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -414,7 +414,7 @@ class GuildSticker(Sticker):
 
     def _from_data(self, data: GuildStickerPayload) -> None:
         super()._from_data(data)
-        self.available: bool = data['available']
+        self.available: bool = data.get('available')
         self.guild_id: int = int(data['guild_id'])
         user = data.get('user')
         self.user: Optional[User] = self._state.store_user(user) if user else None

--- a/discord/types/sticker.py
+++ b/discord/types/sticker.py
@@ -55,7 +55,7 @@ class StandardSticker(BaseSticker):
 
 class GuildSticker(BaseSticker):
     type: Literal[2]
-    available: bool
+    available: Optional[bool]
     guild_id: Snowflake
     user: NotRequired[User]
 

--- a/discord/types/sticker.py
+++ b/discord/types/sticker.py
@@ -55,7 +55,7 @@ class StandardSticker(BaseSticker):
 
 class GuildSticker(BaseSticker):
     type: Literal[2]
-    available: Optional[bool]
+    available: NotRequired[bool]
     guild_id: Snowflake
     user: NotRequired[User]
 


### PR DESCRIPTION
## Summary

![image](https://user-images.githubusercontent.com/62267480/229199344-643e9765-3c05-4951-b08e-7aee9979ea75.png)

A KeyError is raised for `GuildSticker`s. The documentation states its an optional boolean 
![image](https://user-images.githubusercontent.com/62267480/229199492-7d7e6827-af1e-4fe7-b86f-6102dcb29c06.png)

however discord.py currently doesn't treat it as such. This PR fixes that.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
