### PR TITLE
[docs] Fix on_socket_raw_send and on_raw_thread_member_remove param types

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -491,8 +491,9 @@ Debug
         WebSocket. The voice WebSocket will not trigger this event.
 
     :param payload: The message that is about to be passed on to the
-                    WebSocket library.
-    :type payload: :class:`str`
+                    WebSocket library. It can be :class:`bytes` to denote a binary
+                    message or :class:`str` to denote a regular text message.
+    :type payload: Union[:class:`bytes`, :class:`str`]
 
 
 Gateway

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -491,8 +491,8 @@ Debug
         WebSocket. The voice WebSocket will not trigger this event.
 
     :param payload: The message that is about to be passed on to the
-                    WebSocket library. It can be :class:`bytes` to denote a binary
-                    message or :class:`str` to denote a regular text message.
+                    WebSocket library.
+    :type payload: :class:`str`
 
 
 Gateway
@@ -1363,7 +1363,7 @@ Threads
     .. versionadded:: 2.0
 
     :param payload: The raw event payload data.
-    :type member: :class:`RawThreadMembersUpdate`
+    :type payload: :class:`RawThreadMembersUpdate`
 
 Voice
 ~~~~~~


### PR DESCRIPTION
## Summary

This PR adds missing param type for `on_socket_raw_send` and fixes wrong param type for `on_raw_thread_member_remove`. 

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
