### PR TITLE
Support for AutoMod Members

### DIFF
--- a/discord/automod.py
+++ b/discord/automod.py
@@ -67,6 +67,7 @@ class AutoModRuleAction:
     -----------
     type: :class:`AutoModRuleActionType`
         The type of action to take.
+        Defaults to :attr:`~AutoModRuleActionType.block_message`.
 
         .. versionchanged:: 2.3
             This is an optional parameter.
@@ -139,16 +140,13 @@ class AutoModRuleAction:
         if sum(v is None for v in (channel_id, duration, custom_message)) < 2:
             raise ValueError('Only one of channel_id, duration, or custom_message can be passed.')
 
+        self.type: AutoModRuleActionType = AutoModRuleActionType.block_message
         if type is not None:
             self.type = type
         elif channel_id is not None:
             self.type = AutoModRuleActionType.send_alert_message
         elif duration is not None:
             self.type = AutoModRuleActionType.timeout
-        elif custom_message is not None:
-            self.type = AutoModRuleActionType.block_message
-        else:
-            raise ValueError('Please pass the action type explicitly if not using channel_id, custom_message, or duration.')
 
     def __repr__(self) -> str:
         return f'<AutoModRuleAction type={self.type} channel={self.channel_id} duration={self.duration}>'

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -112,9 +112,7 @@ class AutoModRuleAction:
         ...
 
     @overload
-    def __init__(
-        self, *, type: Literal[AutoModRuleActionType.block_message], custom_message: Optional[str] = ...
-    ) -> None:
+    def __init__(self, *, type: Literal[AutoModRuleActionType.block_message], custom_message: Optional[str] = ...) -> None:
         ...
 
     @overload
@@ -154,7 +152,7 @@ class AutoModRuleAction:
             self.type = AutoModRuleActionType.block_message
 
     def __repr__(self) -> str:
-        return f'<AutoModRuleAction type={self.type} channel={self.channel_id} duration={self.duration}>'
+        return f'<AutoModRuleAction type={self.type.value} channel={self.channel_id} duration={self.duration}>'
 
     @classmethod
     def from_data(cls, data: AutoModerationActionPayload) -> Self:

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -68,9 +68,6 @@ class AutoModRuleAction:
     type: :class:`AutoModRuleActionType`
         The type of action to take.
         Defaults to :attr:`~AutoModRuleActionType.block_message`.
-
-        .. versionchanged:: 2.3
-            This is an optional parameter.
     channel_id: Optional[:class:`int`]
         The ID of the channel or thread to send the alert message to, if any.
         Passing this sets :attr:`type` to :attr:`~AutoModRuleActionType.send_alert_message`.

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -92,7 +92,7 @@ class AutoModRuleAction:
         ...
 
     @overload
-    def __init__(self, *, type: Literal[AutoModRuleActionType.send_alert_message] = ..., channel_id: int = ...) -> None:
+    def __init__(self, *, type: Literal[AutoModRuleActionType.send_alert_message], channel_id: int = ...) -> None:
         ...
 
     @overload
@@ -100,7 +100,7 @@ class AutoModRuleAction:
         ...
 
     @overload
-    def __init__(self, *, type: Literal[AutoModRuleActionType.timeout] = ..., duration: datetime.timedelta = ...) -> None:
+    def __init__(self, *, type: Literal[AutoModRuleActionType.timeout], duration: datetime.timedelta = ...) -> None:
         ...
 
     @overload
@@ -108,17 +108,24 @@ class AutoModRuleAction:
         ...
 
     @overload
-    def __init__(self, *, type: Literal[AutoModRuleActionType.block_message] = ...) -> None:
+    def __init__(self, *, type: Literal[AutoModRuleActionType.block_message]) -> None:
         ...
 
     @overload
     def __init__(
-        self, *, type: Literal[AutoModRuleActionType.block_message] = ..., custom_message: Optional[str] = ...
+        self, *, type: Literal[AutoModRuleActionType.block_message], custom_message: Optional[str] = ...
     ) -> None:
         ...
 
     @overload
-    def __init__(self, *, type: Literal[AutoModRuleActionType.block_member_interactions] = ...) -> None:
+    def __init__(
+        self,
+        *,
+        type: Optional[AutoModRuleActionType] = ...,
+        channel_id: Optional[int] = ...,
+        duration: Optional[datetime.timedelta] = ...,
+        custom_message: Optional[str] = ...,
+    ) -> None:
         ...
 
     def __init__(

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -67,6 +67,9 @@ class AutoModRuleAction:
     -----------
     type: :class:`AutoModRuleActionType`
         The type of action to take.
+
+        .. versionchanged:: 2.3
+            This is an optional parameter.
     channel_id: Optional[:class:`int`]
         The ID of the channel or thread to send the alert message to, if any.
         Passing this sets :attr:`type` to :attr:`~AutoModRuleActionType.send_alert_message`.
@@ -194,7 +197,7 @@ class AutoModTrigger:
     |                                               | :attr:`mention_raid_protection`                |
     +-----------------------------------------------+------------------------------------------------+
     | :attr:`AutoModRuleTriggerType.member_profile` | :attr:`keyword_filter`, :attr:`regex_patterns`,|
-    |                                               | :attr:`allow_list                              |
+    |                                               | :attr:`allow_list`                             |
     +-----------------------------------------------+------------------------------------------------+
 
     .. versionadded:: 2.0

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -136,20 +136,15 @@ class AutoModRuleAction:
         if sum(v is None for v in (channel_id, duration, custom_message)) < 2:
             raise ValueError('Only one of channel_id, duration, or custom_message can be passed.')
 
-        for action_type, attribute, required in (
-            (AutoModRuleActionType.send_alert_message, 'channel_id', True),
-            (AutoModRuleActionType.timeout, 'duration', True),
-            (AutoModRuleActionType.block_message, 'custom_message', False),
-        ):
-            if getattr(self, attribute) is not None:
-                if type is None:
-                    type = action_type
-                elif type != action_type:
-                    raise ValueError(f'{attribute} can only be passed if type is {action_type.name} or None.')
-            elif required and type == action_type:
-                raise ValueError(f'{attribute} is required if type is {action_type.name}.')
-
-        self.type: AutoModRuleActionType = type or AutoModRuleActionType.block_message
+        self.type: AutoModRuleActionType
+        if type is not None:
+            self.type = type
+        elif channel_id is not None:
+            self.type = AutoModRuleActionType.send_alert_message
+        elif duration is not None:
+            self.type = AutoModRuleActionType.timeout
+        else:
+            self.type = AutoModRuleActionType.block_message
 
     def __repr__(self) -> str:
         return f'<AutoModRuleAction type={self.type} channel={self.channel_id} duration={self.duration}>'

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -140,13 +140,20 @@ class AutoModRuleAction:
         if sum(v is None for v in (channel_id, duration, custom_message)) < 2:
             raise ValueError('Only one of channel_id, duration, or custom_message can be passed.')
 
-        self.type: AutoModRuleActionType = AutoModRuleActionType.block_message
-        if type is not None:
-            self.type = type
-        elif channel_id is not None:
-            self.type = AutoModRuleActionType.send_alert_message
-        elif duration is not None:
-            self.type = AutoModRuleActionType.timeout
+        for action_type, attribute, required in (
+            (AutoModRuleActionType.send_alert_message, 'channel_id', True),
+            (AutoModRuleActionType.timeout, 'duration', True),
+            (AutoModRuleActionType.block_message, 'custom_message', False),
+        ):
+            if getattr(self, attribute) is not None:
+                if type is None:
+                    type = action_type
+                elif type != action_type:
+                    raise ValueError(f'{attribute} can only be passed if type is {action_type.name} or None.')
+            elif required and type == action_type:
+                raise ValueError(f'{attribute} is required if type is {action_type.name}.')
+
+        self.type: AutoModRuleActionType = type or AutoModRuleActionType.block_message
 
     def __repr__(self) -> str:
         return f'<AutoModRuleAction type={self.type} channel={self.channel_id} duration={self.duration}>'

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -137,18 +137,6 @@ class AutoModRuleAction:
         if sum(v is None for v in (channel_id, duration, custom_message)) < 2:
             raise ValueError('Only one of channel_id, duration, or custom_message can be passed.')
 
-        self.custom_message: Optional[str] = custom_message
-
-        if self.type is AutoModRuleActionType.send_alert_message and channel_id is None:
-            raise ValueError('channel_id must be set if AutoModRuleActionType is send_alert_message')
-        else:
-            self.channel_id: Optional[int] = channel_id
-
-        if self.type is AutoModRuleActionType.timeout and duration is None:
-            raise ValueError('duration must be set if AutoModRuleActionType is timeout')
-        else:
-            self.duration: Optional[datetime.timedelta] = duration
-
         self.type: AutoModRuleActionType
         if type is not None:
             self.type = type
@@ -158,6 +146,18 @@ class AutoModRuleAction:
             self.type = AutoModRuleActionType.timeout
         else:
             self.type = AutoModRuleActionType.block_message
+
+        if self.type is AutoModRuleActionType.send_alert_message:
+            if channel_id is None:
+                raise ValueError('channel_id cannot be None if type is send_alert_message')
+            self.channel_id: Optional[int] = channel_id
+
+        if self.type is AutoModRuleActionType.timeout:
+            if duration is None:
+                raise ValueError('duration cannot be None set if type is timeout')
+            self.duration: Optional[datetime.timedelta] = duration
+
+        self.custom_message: Optional[str] = custom_message
 
     def __repr__(self) -> str:
         return f'<AutoModRuleAction type={self.type.value} channel={self.channel_id} duration={self.duration}>'

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -236,7 +236,7 @@ class AutoModTrigger:
     mention_raid_protection: :class:`bool`
         Whether mention raid protection is enabled or not.
 
-        .. versionadded:: 2.3
+        .. versionadded:: 2.4
     """
 
     __slots__ = (

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -88,12 +88,12 @@ class AutoModRuleAction:
     __slots__ = ('type', 'channel_id', 'duration', 'custom_message')
 
     @overload
-    def __init__(self, *, channel_id: Optional[int] = ...) -> None:
+    def __init__(self, *, channel_id: int = ...) -> None:
         ...
 
     @overload
     def __init__(
-        self, *, type: Literal[AutoModRuleActionType.send_alert_message] = ..., channel_id: Optional[int] = ...
+        self, *, type: Literal[AutoModRuleActionType.send_alert_message] = ..., channel_id: int = ...
     ) -> None:
         ...
 
@@ -103,12 +103,12 @@ class AutoModRuleAction:
 
     @overload
     def __init__(
-        self, *, type: Literal[AutoModRuleActionType.timeout] = ..., duration: Optional[datetime.timedelta] = ...
+        self, *, type: Literal[AutoModRuleActionType.timeout] = ..., duration: datetime.timedelta = ...
     ) -> None:
         ...
 
     @overload
-    def __init__(self, *, custom_message: Optional[str] = ...) -> None:
+    def __init__(self, *, custom_message: str = ...) -> None:
         ...
 
     @overload
@@ -117,7 +117,7 @@ class AutoModRuleAction:
 
     @overload
     def __init__(
-        self, *, type: Literal[AutoModRuleActionType.block_message] = ..., custom_message: Optional[str] = ...
+        self, *, type: Literal[AutoModRuleActionType.block_message] = ..., custom_message: str = ...
     ) -> None:
         ...
 

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -134,12 +134,20 @@ class AutoModRuleAction:
         duration: Optional[datetime.timedelta] = None,
         custom_message: Optional[str] = None,
     ) -> None:
-        self.channel_id: Optional[int] = channel_id
-        self.duration: Optional[datetime.timedelta] = duration
-        self.custom_message: Optional[str] = custom_message
-
         if sum(v is None for v in (channel_id, duration, custom_message)) < 2:
             raise ValueError('Only one of channel_id, duration, or custom_message can be passed.')
+
+        self.custom_message: Optional[str] = custom_message
+
+        if self.type is AutoModRuleActionType.send_alert_message and channel_id is None:
+            raise ValueError('channel_id must be set if AutoModRuleActionType is send_alert_message')
+        else:
+            self.channel_id: Optional[int] = channel_id
+
+        if self.type is AutoModRuleActionType.timeout and duration is None:
+            raise ValueError('duration must be set if AutoModRuleActionType is timeout')
+        else:
+            self.duration: Optional[datetime.timedelta] = duration
 
         self.type: AutoModRuleActionType
         if type is not None:

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -92,9 +92,7 @@ class AutoModRuleAction:
         ...
 
     @overload
-    def __init__(
-        self, *, type: Literal[AutoModRuleActionType.send_alert_message] = ..., channel_id: int = ...
-    ) -> None:
+    def __init__(self, *, type: Literal[AutoModRuleActionType.send_alert_message] = ..., channel_id: int = ...) -> None:
         ...
 
     @overload
@@ -102,9 +100,7 @@ class AutoModRuleAction:
         ...
 
     @overload
-    def __init__(
-        self, *, type: Literal[AutoModRuleActionType.timeout] = ..., duration: datetime.timedelta = ...
-    ) -> None:
+    def __init__(self, *, type: Literal[AutoModRuleActionType.timeout] = ..., duration: datetime.timedelta = ...) -> None:
         ...
 
     @overload
@@ -117,7 +113,7 @@ class AutoModRuleAction:
 
     @overload
     def __init__(
-        self, *, type: Literal[AutoModRuleActionType.block_message] = ..., custom_message: str = ...
+        self, *, type: Literal[AutoModRuleActionType.block_message] = ..., custom_message: Optional[str] = ...
     ) -> None:
         ...
 

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -734,16 +734,19 @@ class AutoModRuleTriggerType(Enum):
     spam = 3
     keyword_preset = 4
     mention_spam = 5
+    member_profile = 6
 
 
 class AutoModRuleEventType(Enum):
     message_send = 1
+    member_update = 2
 
 
 class AutoModRuleActionType(Enum):
     block_message = 1
     send_alert_message = 2
     timeout = 3
+    block_member_interactions = 4
 
 
 class ForumLayoutType(Enum):

--- a/discord/types/automod.py
+++ b/discord/types/automod.py
@@ -79,6 +79,7 @@ class _AutoModerationTriggerMetadataKeywordPreset(TypedDict):
 
 class _AutoModerationTriggerMetadataMentionLimit(TypedDict):
     mention_total_limit: int
+    mention_raid_protection_enabled: bool
 
 
 AutoModerationTriggerMetadata = Union[

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3262,6 +3262,12 @@ of :class:`enum.Enum`.
         The rule will trigger when combined number of role and user mentions
         is greater than the set limit.
 
+    .. attribute:: member_profile
+
+        The rule will trigger when a user's profile contains a keyword.
+
+        .. versionadded:: 2.3
+
 .. class:: AutoModRuleEventType
 
     Represents the event type of an automod rule.
@@ -3271,6 +3277,11 @@ of :class:`enum.Enum`.
     .. attribute:: message_send
 
         The rule will trigger when a message is sent.
+
+    .. attribute:: member_update
+        The rule will trigger when a member's profile is updated.
+
+        .. versionadded:: 2.3
 
 .. class:: AutoModRuleActionType
 
@@ -3290,6 +3301,12 @@ of :class:`enum.Enum`.
 
         The rule will timeout a user.
 
+    .. attribute:: block_member_interactions
+
+        Similar to :attr:`timeout` the rule will timeout a user except of having a duration.
+        This will request the user to edit it's profile.
+
+        .. versionadded:: 2.3
 
 .. class:: ForumLayoutType
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3304,7 +3304,7 @@ of :class:`enum.Enum`.
 
     .. attribute:: block_member_interactions
 
-        Similar to :attr:`timeout` the rule will timeout a user except of having a duration.
+        Similar to :attr:`timeout`, except the user will be timed out indefinitely.
         This will request the user to edit it's profile.
 
         .. versionadded:: 2.3

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3266,7 +3266,7 @@ of :class:`enum.Enum`.
 
         The rule will trigger when a user's profile contains a keyword.
 
-        .. versionadded:: 2.3
+        .. versionadded:: 2.4
 
 .. class:: AutoModRuleEventType
 
@@ -3282,7 +3282,7 @@ of :class:`enum.Enum`.
 
         The rule will trigger when a member's profile is updated.
 
-        .. versionadded:: 2.3
+        .. versionadded:: 2.4
 
 .. class:: AutoModRuleActionType
 
@@ -3307,7 +3307,7 @@ of :class:`enum.Enum`.
         Similar to :attr:`timeout`, except the user will be timed out indefinitely.
         This will request the user to edit it's profile.
 
-        .. versionadded:: 2.3
+        .. versionadded:: 2.4
 
 .. class:: ForumLayoutType
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3279,6 +3279,7 @@ of :class:`enum.Enum`.
         The rule will trigger when a message is sent.
 
     .. attribute:: member_update
+
         The rule will trigger when a member's profile is updated.
 
         .. versionadded:: 2.3


### PR DESCRIPTION
## Summary

This PR adds support for AutoMod Members. This also adds the new param `mention_raid_protection` in `AutoModTrigger`.
Related PR: https://github.com/discord/discord-api-docs/pull/6040


<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
