### PR TITLE
Use get_bot_mapping to generate bot help (Resolves issue #9329)

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -1241,18 +1241,17 @@ class DefaultHelpCommand(HelpCommand):
 
         no_category = f'\u200b{self.no_category}:'
 
-        def get_category(command, *, no_category=no_category):
-            cog = command.cog
+        def get_cog_name(cog, *, no_category=no_category):
             return cog.qualified_name + ':' if cog is not None else no_category
+        
+        cogs = sorted(mapping.keys(), key=get_cog_name)
+        max_size = max([self.get_max_size(mapping[cog]) for cog in mapping], default=0)
 
-        filtered = await self.filter_commands(bot.commands, sort=True, key=get_category)
-        max_size = self.get_max_size(filtered)
-        to_iterate = itertools.groupby(filtered, key=get_category)
-
-        # Now we can add the commands to the page.
-        for category, commands in to_iterate:
-            commands = sorted(commands, key=lambda c: c.name) if self.sort_commands else list(commands)
-            self.add_indented_commands(commands, heading=category, max_size=max_size)
+        for cog in cogs:
+            commands = await self.filter_commands(mapping[cog])
+            if self.sort_commands:
+                commands = sorted(commands, key=lambda c: c.name)
+            self.add_indented_commands(commands, heading=get_cog_name(cog), max_size=max_size)
 
         note = self.get_ending_note()
         if note:


### PR DESCRIPTION
##Summary 

Resolves issue: https://github.com/Rapptz/discord.py/issues/9329

This change makes it so that `DefaultHelpCommand` uses it's `mapping` argument (generated by `get_bot_mapping()`), to generate it's help output. This change does not directly change DefaultHelpCommand behavior and will continue to generate the same output, but allows subclasses to override get_bot_mapping to make alterations to the return value of get_bot_mapping to, for example, add or remove elements.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (Not applicable, actually behavior now matches documentation)
- [x] This PR fixes an issue (https://github.com/Rapptz/discord.py/issues/9329)
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
