### PR TITLE
Add channel attribute in Interaction

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -3061,11 +3061,7 @@ class GroupChannel(discord.abc.Messageable, discord.abc.PrivateChannel, Hashable
         self.owner_id: Optional[int] = utils._get_as_snowflake(data, 'owner_id')
         self._icon: Optional[str] = data.get('icon')
         self.name: Optional[str] = data.get('name')
-        self.recipients: List[User] = []
-
-        recipients = data.get('recipients')
-        if recipients is not None:
-            self.recipients = [self._state.store_user(u) for u in recipients]
+        self.recipients: List[User] = [self._state.store_user(u) for u in data.get('recipients', [])]
 
         self.owner: Optional[BaseUser]
         if self.owner_id == self.me.id:

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2887,7 +2887,12 @@ class DMChannel(discord.abc.Messageable, discord.abc.PrivateChannel, Hashable):
 
     def __init__(self, *, me: ClientUser, state: ConnectionState, data: DMChannelPayload):
         self._state: ConnectionState = state
-        self.recipient: Optional[User] = state.store_user(data['recipients'][0])
+        self.recipient: Optional[User] = None
+
+        recipients = data.get('recipients')
+        if recipients is not None:
+            self.recipient = state.store_user(recipients[0])
+
         self.me: ClientUser = me
         self.id: int = int(data['id'])
 
@@ -3056,7 +3061,11 @@ class GroupChannel(discord.abc.Messageable, discord.abc.PrivateChannel, Hashable
         self.owner_id: Optional[int] = utils._get_as_snowflake(data, 'owner_id')
         self._icon: Optional[str] = data.get('icon')
         self.name: Optional[str] = data.get('name')
-        self.recipients: List[User] = [self._state.store_user(u) for u in data.get('recipients', [])]
+        self.recipients: List[User] = []
+
+        recipients = data.get('recipients')
+        if recipients is not None:
+            self.recipients = [self._state.store_user(u) for u in recipients]
 
         self.owner: Optional[BaseUser]
         if self.owner_id == self.me.id:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -194,13 +194,7 @@ class Interaction(Generic[ClientT]):
 
             channel = data['channel']
             if ch_type in (ChannelType.group, ChannelType.private):
-                try:
-                    channel = factory(me=self._client.user, data=channel, state=self._state)  # type: ignore
-                except KeyError:
-                    # Discord limitation
-                    channel = PartialMessageable(
-                        state=self._state, guild_id=self.guild_id, id=int(channel['id']), type=ch_type
-                    )
+                channel = factory(me=self._client.user, data=channel, state=self._state)  # type: ignore
             else:
                 guild = self._state._get_guild(self.guild_id)
                 channel = factory(guild=guild, state=self._state, data=channel)  # type: ignore

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -186,7 +186,7 @@ class Interaction(Generic[ClientT]):
         self.channel: Optional[InteractionChannel] = None
 
         raw_channel = data.get('channel', {})
-        factory, ch_type = _threaded_channel_factory(raw_channel['type'])
+        factory, ch_type = _threaded_channel_factory(raw_channel.get('type'))  # type is never None
         if factory is None:
             logging.info('Unknown channel type {type} for channel ID {id}.'.format_map(raw_channel))
         else:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -177,23 +177,6 @@ class Interaction(Generic[ClientT]):
         self.data: Optional[InteractionData] = data.get('data')
         self.token: str = data['token']
         self.version: int = data['version']
-        self._channel: Optional[InteractionChannel] = None
-
-        _channel = data.get('channel', {})
-        _channel_type = _channel.get('type')
-        if _channel_type is not None:
-            factory, channel_type = _threaded_channel_factory(_channel_type)
-            if factory is None:
-                raise InvalidData('Unknown channel type {type} for channel ID {id}.'.format_map(_channel))
-
-            if channel_type in (ChannelType.group, ChannelType.private):
-                channel = factory(me=self._client.user, data=_channel, state=self._state)  # type: ignore
-            else:
-                guild = self._state._get_guild(self.guild_id)
-                channel = factory(guild=guild, state=self._state, data=_channel)  # type: ignore
-
-            self._channel = channel
-
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, 'guild_id')
         self.application_id: int = int(data['application_id'])
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -156,7 +156,6 @@ class Interaction(Generic[ClientT]):
         '_cs_channel',
         '_cs_namespace',
         '_cs_command',
-        '_channel',
     )
 
     def __init__(self, *, data: InteractionPayload, state: ConnectionState[ClientT]):

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -183,7 +183,7 @@ class Interaction(Generic[ClientT]):
         self.token: str = data['token']
         self.version: int = data['version']
         self.channel_id: Optional[int] = utils._get_as_snowflake(data, 'channel_id')
-        self._channel = data.get('channel')
+        self._channel = data.get('channel', {})
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, 'guild_id')
         self.application_id: int = int(data['application_id'])
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -107,7 +107,7 @@ class Interaction(Generic[ClientT]):
         The guild ID the interaction was sent from.
     channel_id: Optional[:class:`int`]
         The channel ID the interaction was sent from.
-    channel: Optional[Union[:class:`abc.GuildChannel`, :class:`abc.PrivateChannel`, :class:`Thread`, :class:`PartialMessageable`]]
+    channel: Optional[Union[:class:`abc.GuildChannel`, :class:`abc.PrivateChannel`, :class:`Thread`]]
         The channel the interaction was sent from.
     application_id: :class:`int`
         The application ID that the interaction was for.

--- a/discord/types/channel.py
+++ b/discord/types/channel.py
@@ -153,13 +153,14 @@ GuildChannel = Union[TextChannel, NewsChannel, VoiceChannel, CategoryChannel, St
 class DMChannel(_BaseChannel):
     type: Literal[1]
     last_message_id: Optional[Snowflake]
-    recipients: List[PartialUser]
+    recipients: NotRequired[List[PartialUser]]
 
 
 class GroupDMChannel(_BaseChannel):
     type: Literal[3]
     icon: Optional[str]
     owner_id: Snowflake
+    recipients: NotRequired[List[PartialUser]]
 
 
 Channel = Union[GuildChannel, DMChannel, GroupDMChannel]

--- a/discord/types/channel.py
+++ b/discord/types/channel.py
@@ -150,9 +150,16 @@ class ForumChannel(_BaseTextChannel):
 GuildChannel = Union[TextChannel, NewsChannel, VoiceChannel, CategoryChannel, StageChannel, ThreadChannel, ForumChannel]
 
 
-class DMChannel(_BaseChannel):
+class _BaseDMChannel(_BaseChannel):
     type: Literal[1]
     last_message_id: Optional[Snowflake]
+
+
+class DMChannel(_BaseDMChannel):
+    recipients: List[PartialUser]
+
+
+class InteractionDMChannel(_BaseDMChannel):
     recipients: NotRequired[List[PartialUser]]
 
 
@@ -160,7 +167,7 @@ class GroupDMChannel(_BaseChannel):
     type: Literal[3]
     icon: Optional[str]
     owner_id: Snowflake
-    recipients: NotRequired[List[PartialUser]]
+    recipients: List[PartialUser]
 
 
 Channel = Union[GuildChannel, DMChannel, GroupDMChannel]

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Dict, List, Literal, TypedDict, Union
 from typing_extensions import NotRequired
 
-from .channel import ChannelTypeWithoutThread, ThreadMetadata, GuildChannel, DMChannel, GroupDMChannel
+from .channel import ChannelTypeWithoutThread, ThreadMetadata, GuildChannel, InteractionDMChannel, GroupDMChannel
 from .threads import ThreadType
 from .member import Member
 from .message import Attachment
@@ -204,7 +204,7 @@ class _BaseInteraction(TypedDict):
     version: Literal[1]
     guild_id: NotRequired[Snowflake]
     channel_id: NotRequired[Snowflake]
-    channel: Union[GuildChannel, DMChannel, GroupDMChannel]
+    channel: Union[GuildChannel, InteractionDMChannel, GroupDMChannel]
     app_permissions: NotRequired[str]
     locale: NotRequired[str]
     guild_locale: NotRequired[str]

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Dict, List, Literal, TypedDict, Union
 from typing_extensions import NotRequired
 
-from .channel import ChannelTypeWithoutThread, ThreadMetadata
+from .channel import ChannelTypeWithoutThread, ThreadMetadata, GuildChannel, DMChannel, GroupDMChannel
 from .threads import ThreadType
 from .member import Member
 from .message import Attachment
@@ -204,6 +204,7 @@ class _BaseInteraction(TypedDict):
     version: Literal[1]
     guild_id: NotRequired[Snowflake]
     channel_id: NotRequired[Snowflake]
+    channel: Union[GuildChannel, DMChannel, GroupDMChannel]
     app_permissions: NotRequired[str]
     locale: NotRequired[str]
     guild_locale: NotRequired[str]


### PR DESCRIPTION
## Summary

This PR adds a new attribute `channel` in Interaction.
Related PR: https://github.com/discord/discord-api-docs/pull/6051

### Discord Limitation
Because Discord doesn't send `recipients` in the payload when an interaction was sent from a DM channel, a new type `InteractionDMChannel` is added in which `recipients` is a `NotRequired` field.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
