### PR TITLE
Change _get_as_snowflake to handle empty strings

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -605,6 +605,8 @@ def _get_as_snowflake(data: Any, key: str) -> Optional[int]:
     except KeyError:
         return None
     else:
+        if value == '':
+            return None
         return value and int(value)
 
 


### PR DESCRIPTION
## Summary

This PR changes the behavior of `utils._get_as_snowflake` to handle empty strings.

Normally, the value of a snowflake field shouldn't be an empty string, but due of a Discord bug this can still be the case which the following issue shows: https://github.com/discord/discord-api-docs/issues/6069

This change should prevent such a case which results in such an error:
```
Traceback (most recent call last):
  File "c:\users\andri\documents\github\discord.py-1\discord\ext\commands\core.py", line 229, in wrapped
    ret = await coro(*args, **kwargs)
  File "C:\Users\andri\Documents\GitHub\Punchax\cogs\!api.py", line 90, in audit_log
    async for entry in ctx.guild.audit_logs(limit=1):
  File "c:\users\andri\documents\github\discord.py-1\discord\guild.py", line 3896, in audit_logs
    yield AuditLogEntry(
  File "c:\users\andri\documents\github\discord.py-1\discord\audit_logs.py", line 592, in __init__
    self._from_data(data)
  File "c:\users\andri\documents\github\discord.py-1\discord\audit_logs.py", line 651, in _from_data
    channel = self.guild.get_channel_or_thread(channel_id) or Object(id=channel_id)
  File "c:\users\andri\documents\github\discord.py-1\discord\object.py", line 97, in __init__
    raise TypeError(f'id parameter must be convertible to int not {id.__class__.__name__}') from None
TypeError: id parameter must be convertible to int not str

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "c:\users\andri\documents\github\discord.py-1\discord\ext\commands\bot.py", line 1350, in invoke
    await ctx.command.invoke(ctx)
  File "c:\users\andri\documents\github\discord.py-1\discord\ext\commands\core.py", line 1023, in invoke
    await injected(*ctx.args, **ctx.kwargs)  # type: ignore
  File "c:\users\andri\documents\github\discord.py-1\discord\ext\commands\core.py", line 238, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: TypeError: id parameter must be convertible to int not str
```


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
