### PR TITLE
add logging to examples

### DIFF
--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -62,6 +62,7 @@ def core(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
 
 _bot_template = """#!/usr/bin/env python3
 
+import logging
 from discord.ext import commands
 import discord
 import config
@@ -75,7 +76,7 @@ class Bot(commands.{base}):
             try:
                 await self.load_extension(cog)
             except Exception as exc:
-                print(f'Could not load extension {{cog}} due to {{exc.__class__.__name__}}: {{exc}}')
+                logging.error(f'Could not load extension {{cog}} due to {{exc.__class__.__name__}}: {{exc}}')
 
     async def on_ready(self):
         print(f'Logged on as {{self.user}} (ID: {{self.user.id}})')
@@ -87,7 +88,7 @@ bot = Bot(intents=intents)
 
 # write general commands here
 
-bot.run(config.token)
+bot.run(config.token, root_logger=True)
 """
 
 _gitignore_template = """# Byte-compiled / optimized / DLL files
@@ -157,7 +158,7 @@ _cog_extras = '''
     async def cog_command_error(self, ctx, error):
         # error handling to every command in here
         pass
-        
+
     async def cog_app_command_error(self, interaction, error):
         # error handling to every application command in here
         pass

--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -79,7 +79,7 @@ class Bot(commands.{base}):
                 logging.error(f'Could not load extension {{cog}} due to {{exc.__class__.__name__}}: {{exc}}')
 
     async def on_ready(self):
-        print(f'Logged on as {{self.user}} (ID: {{self.user.id}})')
+        logging.info(f'Logged on as {{self.user}} (ID: {{self.user.id}})')
 
 
 intents = discord.Intents.default()

--- a/examples/advanced_startup.py
+++ b/examples/advanced_startup.py
@@ -30,7 +30,6 @@ class CustomBot(commands.Bot):
         self.initial_extensions = initial_extensions
 
     async def setup_hook(self) -> None:
-
         # here, we are loading extensions prior to sync to ensure we are syncing interactions defined in those extensions.
 
         for extension in self.initial_extensions:
@@ -52,7 +51,6 @@ class CustomBot(commands.Bot):
 
 
 async def main():
-
     # When taking over how the bot process is run, you become responsible for a few additional things.
 
     # 1. logging
@@ -89,7 +87,6 @@ async def main():
 
         exts = ['general', 'mod', 'dice']
         async with CustomBot(commands.when_mentioned, db_pool=pool, web_client=our_client, initial_extensions=exts) as bot:
-
             await bot.start(os.getenv('TOKEN', ''))
 
 

--- a/examples/app_commands/basic.py
+++ b/examples/app_commands/basic.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 
 import discord
@@ -34,8 +35,8 @@ client = MyClient(intents=intents)
 
 @client.event
 async def on_ready():
-    print(f'Logged in as {client.user} (ID: {client.user.id})')
-    print('------')
+    logging.info(f'Logged in as {client.user} (ID: {client.user.id})')
+    logging.info('------')
 
 
 @client.tree.command()
@@ -82,6 +83,7 @@ async def joined(interaction: discord.Interaction, member: Optional[discord.Memb
 # accessing a menu within the client, usually via right clicking.
 # It always takes an interaction as its first parameter and a Member or Message as its second parameter.
 
+
 # This context menu command only works on members
 @client.tree.context_menu(name='Show Join Date')
 async def show_join_date(interaction: discord.Interaction, member: discord.Member):
@@ -113,4 +115,4 @@ async def report_message(interaction: discord.Interaction, message: discord.Mess
     await log_channel.send(embed=embed, view=url_view)
 
 
-client.run('token')
+client.run('token', root_logger=True)

--- a/examples/app_commands/transformers.py
+++ b/examples/app_commands/transformers.py
@@ -28,7 +28,7 @@ client = MyClient()
 @client.event
 async def on_ready():
     logging.info(f'Logged in as {client.user} (ID: {client.user.id})')
-    logging.infot('------')
+    logging.info('------')
 
 
 # A transformer is a class that specifies how a parameter in your code

--- a/examples/app_commands/transformers.py
+++ b/examples/app_commands/transformers.py
@@ -1,6 +1,7 @@
 # This example builds on the concepts of the app_commands/basic.py example
 # It's suggested to look at that one to understand certain concepts first.
 
+import logging
 from typing import Literal, Union, NamedTuple
 from enum import Enum
 
@@ -26,8 +27,8 @@ client = MyClient()
 
 @client.event
 async def on_ready():
-    print(f'Logged in as {client.user} (ID: {client.user.id})')
-    print('------')
+    logging.info(f'Logged in as {client.user} (ID: {client.user.id})')
+    logging.infot('------')
 
 
 # A transformer is a class that specifies how a parameter in your code
@@ -57,6 +58,7 @@ async def add(
 # Examples of these include int, str, float, bool, User, Member, Role, and any channel type.
 # Since there are a lot of these, for brevity only a channel example will be included.
 
+
 # This command shows how to only show text and voice channels to a user using the Union type hint
 # combined with the VoiceChannel and TextChannel types.
 @client.tree.command(name='channel-info')
@@ -79,6 +81,7 @@ async def channel_info(interaction: discord.Interaction, channel: Union[discord.
 
 # In order to support choices, the library has a few ways of doing this.
 # The first one is using a typing.Literal for basic choices.
+
 
 # On Discord, this will show up as two choices, Buy and Sell.
 # In the code, you will receive either 'Buy' or 'Sell' as a string.
@@ -160,4 +163,4 @@ async def graph3d(interaction: discord.Interaction, point: Point3D):
     await interaction.response.send_message(str(point))
 
 
-client.run('token')
+client.run('token', root_logger=True)

--- a/examples/background_task.py
+++ b/examples/background_task.py
@@ -1,3 +1,4 @@
+import logging
 from discord.ext import tasks
 
 import discord
@@ -15,8 +16,8 @@ class MyClient(discord.Client):
         self.my_background_task.start()
 
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logging.info(f'Logged in as {self.user} (ID: {self.user.id})')
+        logging.info('------')
 
     @tasks.loop(seconds=60)  # task runs every 60 seconds
     async def my_background_task(self):
@@ -30,4 +31,4 @@ class MyClient(discord.Client):
 
 
 client = MyClient(intents=discord.Intents.default())
-client.run('token')
+client.run('token', root_logger=True)

--- a/examples/background_task_asyncio.py
+++ b/examples/background_task_asyncio.py
@@ -1,3 +1,4 @@
+import logging
 import discord
 import asyncio
 
@@ -11,8 +12,8 @@ class MyClient(discord.Client):
         self.bg_task = self.loop.create_task(self.my_background_task())
 
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logging.info(f'Logged in as {self.user} (ID: {self.user.id})')
+        logging.info('------')
 
     async def my_background_task(self):
         await self.wait_until_ready()
@@ -25,4 +26,4 @@ class MyClient(discord.Client):
 
 
 client = MyClient(intents=discord.Intents.default())
-client.run('token')
+client.run('token', root_logger=True)

--- a/examples/basic_bot.py
+++ b/examples/basic_bot.py
@@ -1,5 +1,6 @@
 # This example requires the 'members' and 'message_content' privileged intents to function.
 
+import logging
 import discord
 from discord.ext import commands
 import random
@@ -18,8 +19,8 @@ bot = commands.Bot(command_prefix='?', description=description, intents=intents)
 
 @bot.event
 async def on_ready():
-    print(f'Logged in as {bot.user} (ID: {bot.user.id})')
-    print('------')
+    logging.info(f'Logged in as {bot.user} (ID: {bot.user.id})')
+    logging.info('------')
 
 
 @bot.command()
@@ -76,4 +77,4 @@ async def _bot(ctx):
     await ctx.send('Yes, the bot is cool.')
 
 
-bot.run('token')
+bot.run('token', root_logger=True)

--- a/examples/converters.py
+++ b/examples/converters.py
@@ -1,7 +1,7 @@
 # This example requires the 'members' privileged intent to use the Member converter.
 # This example also requires the 'message_content' privileged intent to function.
 
-import traceback
+import logging
 import typing
 
 import discord
@@ -45,7 +45,7 @@ async def userinfo_error(ctx: commands.Context, error: commands.CommandError):
     # because we made our own command-specific error handler,
     # so we need to log tracebacks ourselves.
     else:
-        traceback.print_exception(type(error), error, error.__traceback__)
+        logging.error('', exc_info=(type(error), error, error.__traceback__))
 
 
 # Custom Converter here
@@ -122,4 +122,4 @@ async def multiply(ctx: commands.Context, number: int, maybe: bool):
     await ctx.send(number * 5)
 
 
-bot.run('token')
+bot.run('token', root_logger=True)

--- a/examples/deleted.py
+++ b/examples/deleted.py
@@ -1,12 +1,13 @@
 # This example requires the 'message_content' privileged intent to function.
 
+import logging
 import discord
 
 
 class MyClient(discord.Client):
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logging.info(f'Logged in as {self.user} (ID: {self.user.id})')
+        logging.info('------')
 
     async def on_message(self, message):
         if message.content.startswith('!deleteme'):
@@ -25,4 +26,4 @@ intents = discord.Intents.default()
 intents.message_content = True
 
 client = MyClient(intents=intents)
-client.run('token')
+client.run('token', root_logger=True)

--- a/examples/edits.py
+++ b/examples/edits.py
@@ -1,13 +1,14 @@
 # This example requires the 'message_content' privileged intent to function.
 
+import logging
 import discord
 import asyncio
 
 
 class MyClient(discord.Client):
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logging.info(f'Logged in as {self.user} (ID: {self.user.id})')
+        logging.info('------')
 
     async def on_message(self, message):
         if message.content.startswith('!editme'):
@@ -24,4 +25,4 @@ intents = discord.Intents.default()
 intents.message_content = True
 
 client = MyClient(intents=intents)
-client.run('token')
+client.run('token', root_logger=True)

--- a/examples/guessing_game.py
+++ b/examples/guessing_game.py
@@ -1,5 +1,6 @@
 # This example requires the 'message_content' privileged intent to function.
 
+import logging
 import discord
 import random
 import asyncio
@@ -7,8 +8,8 @@ import asyncio
 
 class MyClient(discord.Client):
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logging.info(f'Logged in as {self.user} (ID: {self.user.id})')
+        logging.info('------')
 
     async def on_message(self, message):
         # we do not want the bot to reply to itself
@@ -38,4 +39,4 @@ intents = discord.Intents.default()
 intents.message_content = True
 
 client = MyClient(intents=intents)
-client.run('token')
+client.run('token', root_logger=True)

--- a/examples/modals/basic.py
+++ b/examples/modals/basic.py
@@ -60,7 +60,7 @@ class Feedback(discord.ui.Modal, title='Feedback'):
         await interaction.response.send_message('Oops! Something went wrong.', ephemeral=True)
 
         # Make sure we know what the error actually is
-        logging.error('', exc_info=(type(error), error, error.__traceback__))
+        logging.error('', exc_info=error)
 
 
 client = MyClient()

--- a/examples/modals/basic.py
+++ b/examples/modals/basic.py
@@ -1,7 +1,6 @@
+import logging
 import discord
 from discord import app_commands
-
-import traceback
 
 # The guild in which this slash command will be registered.
 # It is recommended to have a test guild to separate from your "production" bot
@@ -21,8 +20,8 @@ class MyClient(discord.Client):
         self.tree = app_commands.CommandTree(self)
 
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logging.info(f'Logged in as {self.user} (ID: {self.user.id})')
+        logging.info('------')
 
     async def setup_hook(self) -> None:
         # Sync the application command with Discord.
@@ -61,7 +60,7 @@ class Feedback(discord.ui.Modal, title='Feedback'):
         await interaction.response.send_message('Oops! Something went wrong.', ephemeral=True)
 
         # Make sure we know what the error actually is
-        traceback.print_exception(type(error), error, error.__traceback__)
+        logging.error('', exc_info=(type(error), error, error.__traceback__))
 
 
 client = MyClient()
@@ -75,4 +74,4 @@ async def feedback(interaction: discord.Interaction):
     await interaction.response.send_modal(Feedback())
 
 
-client.run('token')
+client.run('token', root_logger=True)

--- a/examples/new_member.py
+++ b/examples/new_member.py
@@ -1,12 +1,13 @@
 # This example requires the 'members' privileged intent to function.
 
+import logging
 import discord
 
 
 class MyClient(discord.Client):
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logging.info(f'Logged in as {self.user} (ID: {self.user.id})')
+        logging.info('------')
 
     async def on_member_join(self, member):
         guild = member.guild
@@ -19,4 +20,4 @@ intents = discord.Intents.default()
 intents.members = True
 
 client = MyClient(intents=intents)
-client.run('token')
+client.run('token', root_logger=True)

--- a/examples/reply.py
+++ b/examples/reply.py
@@ -1,12 +1,13 @@
 # This example requires the 'message_content' privileged intent to function.
 
+import logging
 import discord
 
 
 class MyClient(discord.Client):
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logging.info(f'Logged in as {self.user} (ID: {self.user.id})')
+        logging.info('------')
 
     async def on_message(self, message):
         # we do not want the bot to reply to itself
@@ -21,4 +22,4 @@ intents = discord.Intents.default()
 intents.message_content = True
 
 client = MyClient(intents=intents)
-client.run('token')
+client.run('token', root_logger=True)

--- a/examples/secret.py
+++ b/examples/secret.py
@@ -7,6 +7,7 @@ intents = discord.Intents.default()
 
 bot = commands.Bot(command_prefix=commands.when_mentioned, description="Nothing to see here!", intents=intents)
 
+
 # the `hidden` keyword argument hides it from the help command.
 @bot.group(hidden=True)
 async def secret(ctx: commands.Context):

--- a/examples/views/confirm.py
+++ b/examples/views/confirm.py
@@ -1,5 +1,6 @@
 # This example requires the 'message_content' privileged intent to function.
 
+import logging
 from discord.ext import commands
 
 import discord
@@ -13,8 +14,8 @@ class Bot(commands.Bot):
         super().__init__(command_prefix=commands.when_mentioned_or('$'), intents=intents)
 
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logging.info(f'Logged in as {self.user} (ID: {self.user.id})')
+        logging.info('------')
 
 
 # Define a simple View that gives us a confirmation menu
@@ -52,11 +53,11 @@ async def ask(ctx: commands.Context):
     # Wait for the View to stop listening for input...
     await view.wait()
     if view.value is None:
-        print('Timed out...')
+        logging.info('Timed out...')
     elif view.value:
-        print('Confirmed...')
+        logging.info('Confirmed...')
     else:
-        print('Cancelled...')
+        logging.info('Cancelled...')
 
 
-bot.run('token')
+bot.run('token', root_logger=True)

--- a/examples/views/counter.py
+++ b/examples/views/counter.py
@@ -1,5 +1,6 @@
 # This example requires the 'message_content' privileged intent to function.
 
+import logging
 from discord.ext import commands
 
 import discord
@@ -13,13 +14,12 @@ class CounterBot(commands.Bot):
         super().__init__(command_prefix=commands.when_mentioned_or('$'), intents=intents)
 
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logging.info(f'Logged in as {self.user} (ID: {self.user.id})')
+        logging.info('------')
 
 
 # Define a simple View that gives us a counter button
 class Counter(discord.ui.View):
-
     # Define the actual button
     # When pressed, this increments the number displayed until it hits 5.
     # When it hits 5, the counter button is disabled and it turns green.
@@ -45,4 +45,4 @@ async def counter(ctx: commands.Context):
     await ctx.send('Press!', view=Counter())
 
 
-bot.run('token')
+bot.run('token', root_logger=True)

--- a/examples/views/dropdown.py
+++ b/examples/views/dropdown.py
@@ -1,14 +1,15 @@
 # This example requires the 'message_content' privileged intent to function.
 
+import logging
 import discord
 from discord.ext import commands
+
 
 # Defines a custom Select containing colour options
 # that the user can choose. The callback function
 # of this class is called when the user changes their choice
 class Dropdown(discord.ui.Select):
     def __init__(self):
-
         # Set the options that will be presented inside the dropdown
         options = [
             discord.SelectOption(label='Red', description='Your favourite colour is red', emoji='🟥'),
@@ -45,8 +46,8 @@ class Bot(commands.Bot):
         super().__init__(command_prefix=commands.when_mentioned_or('$'), intents=intents)
 
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logging.info(f'Logged in as {self.user} (ID: {self.user.id})')
+        logging.info('------')
 
 
 bot = Bot()
@@ -63,4 +64,4 @@ async def colour(ctx):
     await ctx.send('Pick your favourite colour:', view=view)
 
 
-bot.run('token')
+bot.run('token', root_logger=True)

--- a/examples/views/ephemeral.py
+++ b/examples/views/ephemeral.py
@@ -1,5 +1,6 @@
 # This example requires the 'message_content' privileged intent to function.
 
+import logging
 from discord.ext import commands
 
 import discord
@@ -13,13 +14,12 @@ class EphemeralCounterBot(commands.Bot):
         super().__init__(command_prefix=commands.when_mentioned_or('$'), intents=intents)
 
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logging.info(f'Logged in as {self.user} (ID: {self.user.id})')
+        logging.info('------')
 
 
 # Define a simple View that gives us a counter button
 class Counter(discord.ui.View):
-
     # Define the actual button
     # When pressed, this increments the number displayed until it hits 5.
     # When it hits 5, the counter button is disabled and it turns green.
@@ -55,4 +55,4 @@ async def counter(ctx: commands.Context):
     await ctx.send('Press!', view=EphemeralCounter())
 
 
-bot.run('token')
+bot.run('token', root_logger=True)

--- a/examples/views/link.py
+++ b/examples/views/link.py
@@ -1,5 +1,6 @@
 # This example requires the 'message_content' privileged intent to function.
 
+import logging
 from discord.ext import commands
 
 import discord
@@ -14,8 +15,8 @@ class GoogleBot(commands.Bot):
         super().__init__(command_prefix=commands.when_mentioned_or('$'), intents=intents)
 
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logging.info(f'Logged in as {self.user} (ID: {self.user.id})')
+        logging.info('------')
 
 
 # Define a simple View that gives us a google link button.
@@ -42,4 +43,4 @@ async def google(ctx: commands.Context, *, query: str):
     await ctx.send(f'Google Result for: `{query}`', view=Google(query))
 
 
-bot.run('token')
+bot.run('token', root_logger=True)

--- a/examples/views/persistent.py
+++ b/examples/views/persistent.py
@@ -1,5 +1,6 @@
 # This example requires the 'message_content' privileged intent to function.
 
+import logging
 from discord.ext import commands
 import discord
 
@@ -45,8 +46,8 @@ class PersistentViewBot(commands.Bot):
         self.add_view(PersistentView())
 
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logging.info(f'Logged in as {self.user} (ID: {self.user.id})')
+        logging.info('------')
 
 
 bot = PersistentViewBot()
@@ -63,4 +64,4 @@ async def prepare(ctx: commands.Context):
     await ctx.send("What's your favourite colour?", view=PersistentView())
 
 
-bot.run('token')
+bot.run('token', root_logger=True)

--- a/examples/views/tic_tac_toe.py
+++ b/examples/views/tic_tac_toe.py
@@ -1,8 +1,10 @@
 # This example requires the 'message_content' privileged intent to function.
 
+import logging
 from typing import List
 from discord.ext import commands
 import discord
+
 
 # Defines a custom button that contains the logic of the game.
 # The ['TicTacToe'] bit is for type hinting purposes to tell your IDE or linter
@@ -128,8 +130,8 @@ class TicTacToeBot(commands.Bot):
         super().__init__(command_prefix=commands.when_mentioned_or('$'), intents=intents)
 
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logging.info(f'Logged in as {self.user} (ID: {self.user.id})')
+        logging.info('------')
 
 
 bot = TicTacToeBot()
@@ -141,4 +143,4 @@ async def tic(ctx: commands.Context):
     await ctx.send('Tic Tac Toe: X goes first', view=TicTacToe())
 
 
-bot.run('token')
+bot.run('token', root_logger=True)


### PR DESCRIPTION
## Summary

With the changes to logging (i.e having the library create a logger for you by default), I thought it would be a good idea to migrate all the examples (and newbot) to use logging rather than printing to be more in-line with the rest of the library.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
