### PR TITLE
[docs] Change auto_mod_badge docs

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1432,7 +1432,7 @@ class ApplicationFlags(BaseFlags):
 
     @flag_value
     def auto_mod_badge(self):
-        """:class:`bool`: Returns ``True`` if the application uses auto moderation.
+        """:class:`bool`: Returns ``True`` if the application uses at least 100 automod rules across all guilds.
         This shows up as a badge in the official client.
 
         .. versionadded:: 2.3


### PR DESCRIPTION
## Summary

This PR changes the documentation of the `auto_mod_badge` application flag. The change is derived from [this Discord help article](https://support-dev.discord.com/hc/en-us/articles/13847462843543) which was announced yesterday. Otherwise I would have included the change in the PR #9313.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
