### PR TITLE
Support for interactions-only bots

### DIFF
--- a/discord/app_commands/__init__.py
+++ b/discord/app_commands/__init__.py
@@ -18,3 +18,4 @@ from .transformers import *
 from .translator import *
 from . import checks as checks
 from .checks import Cooldown as Cooldown
+from .app import *

--- a/discord/app_commands/app.py
+++ b/discord/app_commands/app.py
@@ -1,0 +1,74 @@
+import aiohttp
+from fastapi import FastAPI
+from fastapi.requests import Request
+from fastapi.responses import Response, JSONResponse, PlainTextResponse
+from nacl.signing import VerifyKey
+from nacl.exceptions import BadSignatureError
+from .. import utils
+from ..interactions import Interaction
+from .tree import CommandTree
+from ..http import HTTPClient
+import asyncio
+from .errors import AppCommandError
+from ..interactions import Interaction
+import json
+
+
+class App(FastAPI):
+    def __init__(self, application_id, public_key, token, **kwargs):
+        super().__init__(**kwargs)
+        self.application_id = application_id
+        self.verify_key = VerifyKey(bytes.fromhex(public_key))
+        self.token = token
+        self.tree = CommandTree(app=self)
+        self.add_route('/interactions', self.interactions, ['POST'], include_in_schema=False)
+        self.add_api_route('/sync', self.sync, methods=['GET'], include_in_schema=False)
+        self.router.add_event_handler('startup', self.startup)
+        self.router.add_event_handler('shutdown', self.shutdown)
+
+    async def startup(self):
+        loop = asyncio.get_running_loop()
+        self.http = HTTPClient(loop)
+        self.tree._http = self.http
+        await self.http.static_login(self.token, get=False)
+
+    async def shutdown(self):
+        await self.http._HTTPClient__session.close()
+
+    async def sync(self):
+        return PlainTextResponse('\n'.join(repr(i) for i in await self.tree.sync()))
+
+    async def interactions(self, request: Request):
+        signature = request.headers.get('X-Signature-Ed25519')
+        timestamp = request.headers.get('X-Signature-Timestamp')
+        body = await request.body()
+        try:
+            self.verify_key.verify(str(timestamp).encode() + body, bytes.fromhex(signature))
+        except BadSignatureError:
+            return Response('invalid request signature', 401)
+        data = await request.json()
+        interaction = Interaction(data=data, app=self)
+
+        try:
+            if data['type'] in (2, 4) and self.tree: # application command and auto complete
+                try:
+                    await self.tree._call(interaction)
+                except AppCommandError as e:
+                    await self.tree._dispatch_error(interaction, e)
+            elif data['type'] == 3:  # interaction component
+                # These keys are always there for this interaction type
+                # inner_data = data['data']
+                # custom_id = inner_data['custom_id']
+                # component_type = inner_data['component_type']
+                # self._view_store.dispatch_view(component_type, custom_id, interaction)
+                pass
+            elif data['type'] == 5:  # modal submit
+                # These keys are always there for this interaction type
+                # inner_data = data['data']
+                # custom_id = inner_data['custom_id']
+                # components = inner_data['components']
+                pass
+        except Exception as e:
+            raise e
+        else:
+            return JSONResponse({'type': 1})

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -183,7 +183,7 @@ class AppCommand(Hashable):
         '_state',
     )
 
-    def __init__(self, *, data: ApplicationCommandPayload, state: ConnectionState) -> None:
+    def __init__(self, *, data: ApplicationCommandPayload, state: ConnectionState = None) -> None:
         self._state: ConnectionState = state
         self._from_data(data)
 

--- a/discord/app_commands/namespace.py
+++ b/discord/app_commands/namespace.py
@@ -177,6 +177,8 @@ class Namespace:
     def _get_resolved_items(cls, interaction: Interaction, resolved: ResolvedData) -> Dict[ResolveKey, Any]:
         completed: Dict[ResolveKey, Any] = {}
         state = interaction._state
+        if not state:
+          return
         members = resolved.get('members', {})
         guild_id = interaction.guild_id
         guild = state._get_or_create_unavailable_guild(guild_id) if guild_id is not None else None

--- a/discord/http.py
+++ b/discord/http.py
@@ -781,7 +781,7 @@ class HTTPClient:
 
     # login management
 
-    async def static_login(self, token: str) -> user.User:
+    async def static_login(self, token: str, get = True) -> user.User:
         # Necessary to get aiohttp to stop complaining about session creation
         if self.connector is MISSING:
             self.connector = aiohttp.TCPConnector(limit=0)
@@ -797,15 +797,16 @@ class HTTPClient:
         old_token = self.token
         self.token = token
 
-        try:
-            data = await self.request(Route('GET', '/users/@me'))
-        except HTTPException as exc:
-            self.token = old_token
-            if exc.status == 401:
-                raise LoginFailure('Improper token has been passed.') from exc
-            raise
+        if get:
+          try:
+              data = await self.request(Route('GET', '/users/@me'))
+          except HTTPException as exc:
+              self.token = old_token
+              if exc.status == 401:
+                  raise LoginFailure('Improper token has been passed.') from exc
+              raise
 
-        return data
+          return data
 
     def logout(self) -> Response[None]:
         return self.request(Route('POST', '/auth/logout'))

--- a/examples/app_commands/app.py
+++ b/examples/app_commands/app.py
@@ -1,0 +1,17 @@
+from discord.app_commands import App
+
+app = App(
+    application_id = 1000000000000,
+    public_key = 'PUBLIC_KEY',
+    token = 'TOKEN'
+)
+
+@app.tree.command()
+async def hello(interaction):
+    await interaction.response.send_message('hello')  
+
+# 1. Copy this code to your "main.py" file
+# 2. Run "uvicorn main:app" to start the webserver
+# 3. Update Interactions Endpoint URL in discord dev page to "<URL>/interactions"
+# 4. Go to "<URL>/sync" to sync commands
+# 5. F5 Discord and run /hello to make the bot say hello

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,10 @@ extras_require = {
         'pytest-mock',
         'typing-extensions>=4.3,<5',
     ],
+    'web' : [
+        'fastapi',
+        'PyNaCl'
+    ]
 }
 
 packages = [


### PR DESCRIPTION
## Summary
This creates the `App` class to run a webserver so you can receive interactions by the [other of the two ways](https://discord.com/developers/docs/interactions/receiving-and-responding#receiving-an-interaction), via HTTP `INTERACTIONS_ENDPOINT_URL` instead of gateway (websocket). It uses `discord.py` models like `discord.Interaction` so responding to interactions is the same, just receiving is different.

The `FastAPI` dependency is optional from `discord[web]`. The file `examples/app_commands/app.py` is a working example. Only `Interaction.response.send_message` has been tested.

Some bots have no reason to be stateful, so it saves resources for heartbeats, sharding and stateful things.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
