### PR TITLE
Add create_expressions permission

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -213,6 +213,7 @@ class Permissions(BaseFlags):
         - :attr:`kick_members`
         - :attr:`ban_members`
         - :attr:`administrator`
+        - :attr:`create_expressions`
 
         .. versionchanged:: 1.7
            Added :attr:`stream`, :attr:`priority_speaker` and :attr:`use_application_commands` permissions.
@@ -223,9 +224,9 @@ class Permissions(BaseFlags):
            :attr:`request_to_speak` permissions.
 
         .. versionchanged:: 2.3
-           Added :attr:`use_soundboard`
+           Added :attr:`use_soundboard`, :attr:`create_expressions` permissions.
         """
-        return cls(0b1000111110110110011111101111111111101010001)
+        return cls(0b01000111110110110011111101111111111101010001)
 
     @classmethod
     def general(cls) -> Self:
@@ -237,8 +238,11 @@ class Permissions(BaseFlags):
            permissions :attr:`administrator`, :attr:`create_instant_invite`, :attr:`kick_members`,
            :attr:`ban_members`, :attr:`change_nickname` and :attr:`manage_nicknames` are
            no longer part of the general permissions.
+
+        .. versionchanged:: 2.3
+            Added :attr:`create_expressions` permission.
         """
-        return cls(0b01110000000010000000010010110000)
+        return cls(0b10000000000001110000000010000000010010110000)
 
     @classmethod
     def membership(cls) -> Self:
@@ -551,7 +555,7 @@ class Permissions(BaseFlags):
 
     @flag_value
     def manage_guild_expressions(self) -> int:
-        """:class:`bool`: Returns ``True`` if a user can create, edit, or delete emojis, stickers, and soundboard sounds.
+        """:class:`bool`: Returns ``True`` if a user can edit or delete emojis, stickers, and soundboard sounds.
 
         .. versionadded:: 2.3
         """
@@ -665,6 +669,14 @@ class Permissions(BaseFlags):
         .. versionadded:: 2.3
         """
         return 1 << 42
+
+    @flag_value
+    def create_expressions(self) -> int:
+        """:class:`bool`: Returns ``True`` if a user can create emojis, stickers, and soundboard sounds.
+
+        .. versionadded:: 2.3
+        """
+        return 1 << 43
 
     @flag_value
     def use_external_sounds(self) -> int:
@@ -800,6 +812,7 @@ class PermissionOverwrite:
         use_soundboard: Optional[bool]
         use_external_sounds: Optional[bool]
         send_voice_messages: Optional[bool]
+        create_expressions: Optional[bool]
 
     def __init__(self, **kwargs: Optional[bool]):
         self._values: Dict[str, Optional[bool]] = {}


### PR DESCRIPTION
## Summary

This PR adds the permission `create_expressions` and changes the documentation of `manage_guild_expressions` accordingly.
In the `all_channel` method I added a leading zero, which is technically not needed, but I thought it was clearer regarding the number of bits.


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
