### PR TITLE
Fix Piped Audio Input Ends Prematurely

### DIFF
--- a/discord/player.py
+++ b/discord/player.py
@@ -206,15 +206,15 @@ class FFmpegAudio(AudioSource):
             _log.info('ffmpeg process %s successfully terminated with return code of %s.', proc.pid, proc.returncode)
 
     def _pipe_writer(self, source: io.BufferedIOBase) -> None:
+        assert self._stdin is not None
         while self._process:
             # arbitrarily large read size
             data = source.read(8192)
             if not data:
-                self._process.terminate()
+                self._stdin.close()
                 return
             try:
-                if self._stdin is not None:
-                    self._stdin.write(data)
+                self._stdin.write(data)
             except Exception:
                 _log.debug('Write error for %s, this is probably not a problem', self, exc_info=True)
                 # at this point the source data is either exhausted or the process is fubar

--- a/discord/player.py
+++ b/discord/player.py
@@ -212,10 +212,6 @@ class FFmpegAudio(AudioSource):
             if not data:
                 if self._stdin is not None:
                     self._stdin.close()
-                try:
-                    self._process.wait(timeout=60.0)
-                except subprocess.TimeoutExpired:
-                    self._process.terminate()
                 return
             try:
                 if self._stdin is not None:

--- a/discord/player.py
+++ b/discord/player.py
@@ -212,8 +212,10 @@ class FFmpegAudio(AudioSource):
             if not data:
                 if self._stdin is not None:
                     self._stdin.close()
-                self._process.wait()
-                self._process.terminate()
+                try:
+                    self._process.wait(timeout=60.0)
+                except subprocess.TimeoutExpired:
+                    self._process.terminate()
                 return
             try:
                 if self._stdin is not None:


### PR DESCRIPTION
## Summary

This commit fix #9001 by ~~replacing `self._process.terminate()` with `self._stdin.close()` to fix the issue where the process was being interrupted after reading input.
I also add an `assert self._stdin is not None` statement to resolve the type of `self._stdin` and remove the redundant if statement.~~
adding `self._stdin.close()` ~~and `self._process.wait()`~~ only.

This PR is a duplicate of the PR #9188 closed for no reason.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
