### PR TITLE
Fix automod audit log entries raising typeerrors

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -652,6 +652,8 @@ class AuditLogEntry(Hashable):
             ):
                 channel_id = utils._get_as_snowflake(extra, 'channel_id')
                 channel = None
+
+                # May be an empty string instead of None due to a Discord issue
                 if channel_id:
                     channel = self.guild.get_channel_or_thread(channel_id) or Object(id=channel_id)
 

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -652,7 +652,7 @@ class AuditLogEntry(Hashable):
             ):
                 channel_id = utils._get_as_snowflake(extra, 'channel_id')
                 channel = None
-                if channel_id is not None:
+                if channel_id:
                     channel = self.guild.get_channel_or_thread(channel_id) or Object(id=channel_id)
 
                 self.extra = _AuditLogProxyAutoModAction(


### PR DESCRIPTION
## Summary

Alternative to #9350 without the performance penalty, since Discord doesn't seem to care to fix this in a timely manner.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
