### PR TITLE
Raise ValueError if token is None in request

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -559,6 +559,9 @@ class HTTPClient:
         form: Optional[Iterable[Dict[str, Any]]] = None,
         **kwargs: Any,
     ) -> Any:
+        if self.token is None:
+            raise ValueError('token is missing.')
+
         method = route.method
         url = route.url
         route_key = route.key


### PR DESCRIPTION
## Summary

### Current Problem
If you neither user `client.start()` nor `client.run()` following exception is raised if `client.login()` is not called:
```
Traceback (most recent call last):
  File "C:\Users\andri\Documents\GitHub\Punchax\main.py", line 16, in <module>
    asyncio.run(main())
  File "C:\Users\andri\AppData\Local\Programs\Python\Python38\lib\asyncio\runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "C:\Users\andri\AppData\Local\Programs\Python\Python38\lib\asyncio\base_events.py", line 616, in run_until_complete
    return future.result()
  File "C:\Users\andri\Documents\GitHub\Punchax\main.py", line 13, in main
    guilds = await bot.fetch_user(305354423801217025)
  File "c:\users\andri\documents\github\discord.py\discord\client.py", line 2523, in fetch_user
    data = await self.http.get_user(user_id)
  File "c:\users\andri\documents\github\discord.py\discord\http.py", line 607, in request
    if not self._global_over.is_set():
AttributeError: '_MissingSentinel' object has no attribute 'is_set'
```

### Solution
To fix that the PR adds a check if `self.token` is `None` and raises a  `ValueError`. Maybe the error msg can be improved.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
