### PR TITLE
Fix exception raised by history iterator when using the around stragety with a limit of 100+

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1722,12 +1722,12 @@ class Messageable:
 
         async def _around_strategy(retrieve: int, around: Optional[Snowflake], limit: Optional[int]):
             if not around:
-                return []
+                return [], None, 0
 
             around_id = around.id if around else None
             data = await self._state.http.logs_from(channel.id, retrieve, around=around_id)
 
-            return data, None, limit
+            return data, None, 0
 
         async def _after_strategy(retrieve: int, after: Optional[Snowflake], limit: Optional[int]):
             after_id = after.id if after else None
@@ -1799,7 +1799,7 @@ class Messageable:
         while True:
             retrieve = 100 if limit is None else min(limit, 100)
             if retrieve < 1:
-                return
+                break
 
             data, state, limit = await strategy(retrieve, state, limit)
 

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1799,7 +1799,7 @@ class Messageable:
         while True:
             retrieve = 100 if limit is None else min(limit, 100)
             if retrieve < 1:
-                break
+                return
 
             data, state, limit = await strategy(retrieve, state, limit)
 


### PR DESCRIPTION
## Summary

When using the around strategy, the limit should always be set to 0 afterwards to ensure no additional requests are made.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
