### PR TITLE
Document `user_channel` argument in `StageChannel.edit()`

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1687,6 +1687,7 @@ class StageChannel(VocalGuildChannel):
         *,
         name: str = ...,
         nsfw: bool = ...,
+        user_limit: int = ...,
         position: int = ...,
         sync_permissions: int = ...,
         category: Optional[CategoryChannel] = ...,
@@ -1726,6 +1727,8 @@ class StageChannel(VocalGuildChannel):
             The new channel's position.
         nsfw: :class:`bool`
             To mark the channel as NSFW or not.
+        user_limit: :class:`int`
+            The new channel's user limit.
         sync_permissions: :class:`bool`
             Whether to sync permissions with the channel's new or pre-existing
             category. Defaults to ``False``.


### PR DESCRIPTION
## Summary

The type checker yelled at me and I was very sad. This adds `user_limit` to `StageChannel.edit()`'s overload signature and its docstring. Since this was already supported, just not documented, I didn't add `.. versionadded:: 2.3` here.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
