### PR TITLE
Document the change in behavior of bool(flag_obj) in d.py 2.0

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -239,6 +239,12 @@ class SystemChannelFlags(BaseFlags):
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
 
+        .. describe:: bool(b)
+
+            Returns whether any flag is set to ``True``.
+
+            .. versionadded:: 2.0
+
     Attributes
     -----------
     value: :class:`int`
@@ -360,6 +366,12 @@ class MessageFlags(BaseFlags):
 
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
+
+        .. describe:: bool(b)
+
+            Returns whether any flag is set to ``True``.
+
+            .. versionadded:: 2.0
 
     .. versionadded:: 1.3
 
@@ -508,6 +520,12 @@ class PublicUserFlags(BaseFlags):
             Returns an iterator of ``(name, value)`` pairs. This allows it
             to be, for example, constructed as a dict or a list of pairs.
             Note that aliases are not shown.
+
+        .. describe:: bool(b)
+
+            Returns whether any flag is set to ``True``.
+
+            .. versionadded:: 2.0
 
     .. versionadded:: 1.4
 
@@ -692,6 +710,12 @@ class Intents(BaseFlags):
 
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
+
+        .. describe:: bool(b)
+
+            Returns whether any intent is enabled.
+
+            .. versionadded:: 2.0
 
     Attributes
     -----------
@@ -1278,6 +1302,12 @@ class MemberCacheFlags(BaseFlags):
                Returns an iterator of ``(name, value)`` pairs. This allows it
                to be, for example, constructed as a dict or a list of pairs.
 
+        .. describe:: bool(b)
+
+            Returns whether any flag is set to ``True``.
+
+            .. versionadded:: 2.0
+
     Attributes
     -----------
     value: :class:`int`
@@ -1421,6 +1451,10 @@ class ApplicationFlags(BaseFlags):
             to be, for example, constructed as a dict or a list of pairs.
             Note that aliases are not shown.
 
+        .. describe:: bool(b)
+
+            Returns whether any flag is set to ``True``.
+
     .. versionadded:: 2.0
 
     Attributes
@@ -1556,6 +1590,10 @@ class ChannelFlags(BaseFlags):
             to be, for example, constructed as a dict or a list of pairs.
             Note that aliases are not shown.
 
+        .. describe:: bool(b)
+
+            Returns whether any flag is set to ``True``.
+
     .. versionadded:: 2.0
 
     Attributes
@@ -1652,6 +1690,10 @@ class AutoModPresets(ArrayFlags):
             to be, for example, constructed as a dict or a list of pairs.
             Note that aliases are not shown.
 
+        .. describe:: bool(b)
+
+            Returns whether any flag is set to ``True``.
+
     Attributes
     -----------
     value: :class:`int`
@@ -1735,6 +1777,10 @@ class MemberFlags(BaseFlags):
             Returns an iterator of ``(name, value)`` pairs. This allows it
             to be, for example, constructed as a dict or a list of pairs.
             Note that aliases are not shown.
+
+        .. describe:: bool(b)
+
+            Returns whether any flag is set to ``True``.
 
 
     Attributes

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -119,6 +119,12 @@ class Permissions(BaseFlags):
                to be, for example, constructed as a dict or a list of pairs.
                Note that aliases are not shown.
 
+        .. describe:: bool(b)
+
+            Returns whether the permissions object has any permissions set to ``True``.
+
+            .. versionadded:: 2.0
+
     Attributes
     -----------
     value: :class:`int`

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -1006,6 +1006,20 @@ Due to a breaking API change by Discord, :meth:`Guild.bans` no longer returns a 
     async for ban in guild.bans(limit=1000):
         ...
 
+Flag classes now have a custom ``bool()`` implementation
+--------------------------------------------------------
+
+To allow library users to easily check whether an instance of a flag class has any flags enabled,
+using `bool` on them will now only return ``True`` if at least one flag is enabled.
+
+This means that evaluating instances of the following classes in a bool context (such as ``if obj:``) may no longer return ``True``:
+
+- :class:`Intents`
+- :class:`MemberCacheFlags`
+- :class:`MessageFlags`
+- :class:`Permissions`
+- :class:`PublicUserFlags`
+- :class:`SystemChannelFlags`
 
 Function Signature Changes
 ----------------------------


### PR DESCRIPTION
## Summary

We've encountered a bug today that was caused by the change in the behavior of `bool()` on the `Permissions` object so I figured that it would be good to document this. I also added it to the supported operations table on all flag classes as I'm guessing it wasn't intentionally omitted there.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
