### PR TITLE
Support app command contexts

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -623,7 +623,7 @@ class Command(Generic[GroupT, P, T]):
 
         Due to a Discord limitation, this does not work on subcommands.
     allowed_contexts: Optional[:class:`~discord.flags.AppCommandContext`]
-        A list of contexts that the command is allowed to be used in.
+        The contexts that the command is allowed to be used in.
         Overrides ``guild_only`` if this is set.
     nsfw: :class:`bool`
         Whether the command is NSFW and should only work in NSFW channels.

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -622,7 +622,7 @@ class Command(Generic[GroupT, P, T]):
         Whether the command should only be usable in guild contexts.
 
         Due to a Discord limitation, this does not work on subcommands.
-    allowed_contexts: Optional[:class:`~discord.AppCommandContext`]
+    allowed_contexts: Optional[:class:`~discord.flags.AppCommandContext`]
         A list of contexts that the command is allowed to be used in.
         Overrides ``guild_only`` if this is set.
     nsfw: :class:`bool`
@@ -1179,7 +1179,7 @@ class ContextMenu:
     guild_only: :class:`bool`
         Whether the command should only be usable in guild contexts.
         Defaults to ``False``.
-    allowed_contexts: Optional[:class:`.AppCommandContext`]
+    allowed_contexts: Optional[:class:`~discord.flags.AppCommandContext`]
         The contexts that this context menu is allowed to be used in.
         Overrides ``guild_only`` if set.
     nsfw: :class:`bool`
@@ -1425,7 +1425,7 @@ class Group:
         Whether the group should only be usable in guild contexts.
 
         Due to a Discord limitation, this does not work on subcommands.
-    allowed_contexts: Optional[:class:`.AppCommandContext`]
+    allowed_contexts: Optional[:class:`~discord.flags.AppCommandContext`]
         The contexts that this group is allowed to be used in. Overrides
         guild_only if set.
     nsfw: :class:`bool`

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -48,9 +48,9 @@ from typing import (
 import re
 from copy import copy as shallow_copy
 
-from discord.flags import AppCommandContext
 
 from ..enums import AppCommandOptionType, AppCommandType, ChannelType, Locale
+from ..flags import AppCommandContext
 from .models import Choice
 from .transformers import annotation_to_parameter, CommandParameter, NoneType
 from .errors import AppCommandError, CheckFailure, CommandInvokeError, CommandSignatureMismatch, CommandAlreadyRegistered
@@ -622,7 +622,7 @@ class Command(Generic[GroupT, P, T]):
         Whether the command should only be usable in guild contexts.
 
         Due to a Discord limitation, this does not work on subcommands.
-    restrict_contexts: Optional[List[:class:`~discord.AppCommandContext`]]
+    restrict_contexts: Optional[:class:`~discord.AppCommandContext`]
         A list of contexts that the command is allowed to be used in.
         Overrides ``guild_only`` if this is set.
     nsfw: :class:`bool`

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -622,7 +622,7 @@ class Command(Generic[GroupT, P, T]):
         Due to a Discord limitation, this does not work on subcommands.
     allowed_contexts: Optional[List[:class:`~discord.AppCommandContext`]]
         A list of contexts that the command is allowed to be used in.
-        Overrides guild_only if tihs is set.
+        Overrides ``guild_only`` if this is set.
     nsfw: :class:`bool`
         Whether the command is NSFW and should only work in NSFW channels.
 
@@ -1179,7 +1179,7 @@ class ContextMenu:
         Defaults to ``False``.
     allowed_contexts: Optional[List[:class:`.AppCommandContext`]]
         The contexts that this context menu is allowed to be used in.
-        Overrides `guild_only` if set.
+        Overrides ``guild_only`` if set.
     nsfw: :class:`bool`
         Whether the command is NSFW and should only work in NSFW channels.
         Defaults to ``False``.
@@ -2458,8 +2458,8 @@ def guild_only(func: Optional[T] = None) -> Union[T, Callable[[T], T]]:
             allowed_contexts = getattr(f, '__discord_app_commands_contexts__', None) or []
             f.__discord_app_commands_contexts__ = allowed_contexts  # type: ignore # Runtime attribute assignment
 
-        if AppCommandContext.GUILD not in allowed_contexts:
-            allowed_contexts.append(AppCommandContext.GUILD)
+        if AppCommandContext.guild not in allowed_contexts:
+            allowed_contexts.append(AppCommandContext.guild)
 
         return f
 
@@ -2501,8 +2501,8 @@ def private_only(func: Optional[T] = None) -> Union[T, Callable[[T], T]]:
             allowed_contexts = getattr(f, '__discord_app_commands_contexts__', None) or []
             f.__discord_app_commands_contexts__ = allowed_contexts  # type: ignore # Runtime attribute assignment
 
-        if AppCommandContext.PRIVATE_CHANNEL not in allowed_contexts:
-            allowed_contexts.append(AppCommandContext.PRIVATE_CHANNEL)
+        if AppCommandContext.private_channel not in allowed_contexts:
+            allowed_contexts.append(AppCommandContext.private_channel)
 
         return f
 
@@ -2544,8 +2544,9 @@ def dm_only(func: Optional[T] = None) -> Union[T, Callable[[T], T]]:
             allowed_contexts = getattr(f, '__discord_app_commands_contexts__', None) or []
             f.__discord_app_commands_contexts__ = allowed_contexts  # type: ignore # Runtime attribute assignment
 
-        if AppCommandContext.BOT_DM not in allowed_contexts:
-            allowed_contexts.append(AppCommandContext.BOT_DM)
+        if AppCommandContext.bot_dm not in allowed_contexts:
+            allowed_contexts.append(AppCommandContext.bot_dm)
+            
         return f
 
     # Check if called with parentheses or not

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -90,7 +90,7 @@ __all__ = (
     'guilds',
     'guild_only',
     'dm_only',
-    'private_only',
+    'private_channel_only',
     'default_permissions',
 )
 
@@ -2472,7 +2472,7 @@ def guild_only(func: Optional[T] = None) -> Union[T, Callable[[T], T]]:
         return inner(func)
 
 
-def private_only(func: Optional[T] = None) -> Union[T, Callable[[T], T]]:
+def private_channel_only(func: Optional[T] = None) -> Union[T, Callable[[T], T]]:
     """A decorator that indicates this command can only be used in the context of DMs and group DMs.
 
     This is **not** implemented as a :func:`check`, and is instead verified by Discord server side.
@@ -2488,8 +2488,8 @@ def private_only(func: Optional[T] = None) -> Union[T, Callable[[T], T]]:
     .. code-block:: python3
 
         @app_commands.command()
-        @app_commands.private_only()
-        async def my_private_only_command(interaction: discord.Interaction) -> None:
+        @app_commands.private_channel_only()
+        async def my_private_channel_only_command(interaction: discord.Interaction) -> None:
             await interaction.response.send_message('I am only available in DMs and GDMs!')
     """
 

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -622,7 +622,7 @@ class Command(Generic[GroupT, P, T]):
         Whether the command should only be usable in guild contexts.
 
         Due to a Discord limitation, this does not work on subcommands.
-    allowed_contexts: Optional[List[:class:`~discord.AppCommandContext`]]
+    restrict_contexts: Optional[List[:class:`~discord.AppCommandContext`]]
         A list of contexts that the command is allowed to be used in.
         Overrides ``guild_only`` if this is set.
     nsfw: :class:`bool`
@@ -645,7 +645,7 @@ class Command(Generic[GroupT, P, T]):
         nsfw: bool = False,
         parent: Optional[Group] = None,
         guild_ids: Optional[List[int]] = None,
-        allowed_contexts: Optional[AppCommandContext] = None,
+        restrict_contexts: Optional[AppCommandContext] = None,
         auto_locale_strings: bool = True,
         extras: Dict[Any, Any] = MISSING,
     ):
@@ -680,7 +680,7 @@ class Command(Generic[GroupT, P, T]):
             callback, '__discord_app_commands_default_permissions__', None
         )
         self.guild_only: bool = getattr(callback, '__discord_app_commands_guild_only__', False)
-        self.allowed_contexts: Optional[AppCommandContext] = allowed_contexts or getattr(
+        self.restrict_contexts: Optional[AppCommandContext] = restrict_contexts or getattr(
             callback, '__discord_app_commands_contexts__', None
         )
         self.nsfw: bool = nsfw
@@ -771,7 +771,7 @@ class Command(Generic[GroupT, P, T]):
             base['nsfw'] = self.nsfw
             base['dm_permission'] = not self.guild_only
             base['default_member_permissions'] = None if self.default_permissions is None else self.default_permissions.value
-            base['contexts'] = self.allowed_contexts.to_array() if self.allowed_contexts is not None else None
+            base['contexts'] = self.restrict_contexts.to_array() if self.restrict_contexts is not None else None
 
         return base
 
@@ -1179,7 +1179,7 @@ class ContextMenu:
     guild_only: :class:`bool`
         Whether the command should only be usable in guild contexts.
         Defaults to ``False``.
-    allowed_contexts: Optional[:class:`.AppCommandContext`]
+    restrict_contexts: Optional[:class:`.AppCommandContext`]
         The contexts that this context menu is allowed to be used in.
         Overrides ``guild_only`` if set.
     nsfw: :class:`bool`
@@ -1204,7 +1204,7 @@ class ContextMenu:
         type: AppCommandType = MISSING,
         nsfw: bool = False,
         guild_ids: Optional[List[int]] = None,
-        allowed_contexts: Optional[AppCommandContext] = MISSING,
+        restrict_contexts: Optional[AppCommandContext] = MISSING,
         auto_locale_strings: bool = True,
         extras: Dict[Any, Any] = MISSING,
     ):
@@ -1230,7 +1230,7 @@ class ContextMenu:
         )
         self.nsfw: bool = nsfw
         self.guild_only: bool = getattr(callback, '__discord_app_commands_guild_only__', False)
-        self.allowed_contexts: Optional[AppCommandContext] = allowed_contexts or getattr(
+        self.restrict_contexts: Optional[AppCommandContext] = restrict_contexts or getattr(
             callback, '__discord_app_commands_contexts__', None
         )
         self.checks: List[Check] = getattr(callback, '__discord_app_commands_checks__', [])
@@ -1268,7 +1268,7 @@ class ContextMenu:
             'name': self.name,
             'type': self.type.value,
             'dm_permission': not self.guild_only,
-            'contexts': self.allowed_contexts.to_array() if self.allowed_contexts is not None else None,
+            'contexts': self.restrict_contexts.to_array() if self.restrict_contexts is not None else None,
             'default_member_permissions': None if self.default_permissions is None else self.default_permissions.value,
             'nsfw': self.nsfw,
         }
@@ -1425,7 +1425,7 @@ class Group:
         Whether the group should only be usable in guild contexts.
 
         Due to a Discord limitation, this does not work on subcommands.
-    allowed_contexts: Optional[:class:`.AppCommandContext`]
+    restrict_contexts: Optional[:class:`.AppCommandContext`]
         The contexts that this group is allowed to be used in. Overrides
         guild_only if set.
     nsfw: :class:`bool`
@@ -1516,7 +1516,7 @@ class Group:
         parent: Optional[Group] = None,
         guild_ids: Optional[List[int]] = None,
         guild_only: bool = MISSING,
-        allowed_contexts: Optional[AppCommandContext] = MISSING,
+        restrict_contexts: Optional[AppCommandContext] = MISSING,
         nsfw: bool = MISSING,
         auto_locale_strings: bool = True,
         default_permissions: Optional[Permissions] = MISSING,
@@ -1565,13 +1565,13 @@ class Group:
 
         self.guild_only: bool = guild_only
 
-        if allowed_contexts is MISSING:
+        if restrict_contexts is MISSING:
             if cls.__discord_app_commands_contexts__ is MISSING:
-                allowed_contexts = None
+                restrict_contexts = None
             else:
-                allowed_contexts = cls.__discord_app_commands_contexts__
+                restrict_contexts = cls.__discord_app_commands_contexts__
 
-        self.allowed_contexts: Optional[AppCommandContext] = allowed_contexts
+        self.restrict_contexts: Optional[AppCommandContext] = restrict_contexts
 
         if nsfw is MISSING:
             nsfw = cls.__discord_app_commands_group_nsfw__
@@ -1702,7 +1702,7 @@ class Group:
             base['nsfw'] = self.nsfw
             base['dm_permission'] = not self.guild_only
             base['default_member_permissions'] = None if self.default_permissions is None else self.default_permissions.value
-            base['contexts'] = self.allowed_contexts.to_array() if self.allowed_contexts is not None else None
+            base['contexts'] = self.restrict_contexts.to_array() if self.restrict_contexts is not None else None
 
         return base
 
@@ -2452,15 +2452,15 @@ def guild_only(func: Optional[T] = None) -> Union[T, Callable[[T], T]]:
     def inner(f: T) -> T:
         if isinstance(f, (Command, Group, ContextMenu)):
             f.guild_only = True
-            allowed_contexts = f.allowed_contexts or AppCommandContext.none()
-            f.allowed_contexts = allowed_contexts
+            restrict_contexts = f.restrict_contexts or AppCommandContext.none()
+            f.restrict_contexts = restrict_contexts
         else:
             f.__discord_app_commands_guild_only__ = True  # type: ignore # Runtime attribute assignment
 
-            allowed_contexts = getattr(f, '__discord_app_commands_contexts__', None) or AppCommandContext.none()
-            f.__discord_app_commands_contexts__ = allowed_contexts  # type: ignore # Runtime attribute assignment
+            restrict_contexts = getattr(f, '__discord_app_commands_contexts__', None) or AppCommandContext.none()
+            f.__discord_app_commands_contexts__ = restrict_contexts  # type: ignore # Runtime attribute assignment
 
-        allowed_contexts.guild = True
+        restrict_contexts.guild = True
 
         return f
 
@@ -2496,13 +2496,13 @@ def private_only(func: Optional[T] = None) -> Union[T, Callable[[T], T]]:
     def inner(f: T) -> T:
         if isinstance(f, (Command, Group, ContextMenu)):
             f.guild_only = False
-            allowed_contexts = f.allowed_contexts or AppCommandContext.none()
-            f.allowed_contexts = allowed_contexts
+            restrict_contexts = f.restrict_contexts or AppCommandContext.none()
+            f.restrict_contexts = restrict_contexts
         else:
-            allowed_contexts = getattr(f, '__discord_app_commands_contexts__', None) or AppCommandContext.none()
-            f.__discord_app_commands_contexts__ = allowed_contexts  # type: ignore # Runtime attribute assignment
+            restrict_contexts = getattr(f, '__discord_app_commands_contexts__', None) or AppCommandContext.none()
+            f.__discord_app_commands_contexts__ = restrict_contexts  # type: ignore # Runtime attribute assignment
 
-        allowed_contexts.private_channel = True
+        restrict_contexts.private_channel = True
 
         return f
 
@@ -2538,13 +2538,13 @@ def dm_only(func: Optional[T] = None) -> Union[T, Callable[[T], T]]:
     def inner(f: T) -> T:
         if isinstance(f, (Command, Group, ContextMenu)):
             f.guild_only = False
-            allowed_contexts = f.allowed_contexts or AppCommandContext.none()
-            f.allowed_contexts = allowed_contexts
+            restrict_contexts = f.restrict_contexts or AppCommandContext.none()
+            f.restrict_contexts = restrict_contexts
         else:
-            allowed_contexts = getattr(f, '__discord_app_commands_contexts__', None) or AppCommandContext.none()
-            f.__discord_app_commands_contexts__ = allowed_contexts  # type: ignore # Runtime attribute assignment
+            restrict_contexts = getattr(f, '__discord_app_commands_contexts__', None) or AppCommandContext.none()
+            f.__discord_app_commands_contexts__ = restrict_contexts  # type: ignore # Runtime attribute assignment
 
-        allowed_contexts.dm_channel = True
+        restrict_contexts.dm_channel = True
 
         return f
 

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -169,7 +169,7 @@ class AppCommand(Hashable):
     dm_permission: :class:`bool`
         A boolean that indicates whether this command can be run in direct messages.
     allowed_contexts: Optional[List[:class:`AppCommandContext`]]
-        A list of contexts that this command can be run in. Overrides the `dm_permission` attribute.
+        A list of contexts that this command can be run in. Overrides the ``dm_permission`` attribute.
     guild_id: Optional[:class:`int`]
         The ID of the guild this command is registered in. A value of ``None``
         denotes that it is a global command.

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -26,10 +26,10 @@ from __future__ import annotations
 from datetime import datetime
 
 from .errors import MissingApplicationID
+from ..flags import AppCommandContext
 from .translator import TranslationContextLocation, TranslationContext, locale_str, Translator
 from ..permissions import Permissions
 from ..enums import (
-    AppCommandContext,
     AppCommandOptionType,
     AppCommandType,
     AppCommandPermissionType,
@@ -168,7 +168,7 @@ class AppCommand(Hashable):
         The default member permissions that can run this command.
     dm_permission: :class:`bool`
         A boolean that indicates whether this command can be run in direct messages.
-    allowed_contexts: Optional[List[:class:`AppCommandContext`]]
+    allowed_contexts: Optional[:class:`AppCommandContext`]
         A list of contexts that this command can be run in. Overrides the ``dm_permission`` attribute.
     guild_id: Optional[:class:`int`]
         The ID of the guild this command is registered in. A value of ``None``
@@ -224,9 +224,9 @@ class AppCommand(Hashable):
 
         allowed_contexts = data.get('contexts')
         if allowed_contexts is None:
-            self.allowed_contexts: Optional[List[AppCommandContext]] = None
+            self.allowed_contexts: Optional[AppCommandContext] = None
         else:
-            self.allowed_contexts = [try_enum(AppCommandContext, ctx) for ctx in allowed_contexts]
+            self.allowed_contexts = AppCommandContext._from_value(allowed_contexts)
 
         self.nsfw: bool = data.get('nsfw', False)
         self.name_localizations: Dict[Locale, str] = _to_locale_dict(data.get('name_localizations') or {})
@@ -241,7 +241,7 @@ class AppCommand(Hashable):
             'description': self.description,
             'name_localizations': {str(k): v for k, v in self.name_localizations.items()},
             'description_localizations': {str(k): v for k, v in self.description_localizations.items()},
-            'contexts': [ctx.value for ctx in self.allowed_contexts] if self.allowed_contexts else None,
+            'contexts': self.allowed_contexts.to_array() if self.allowed_contexts is not None else None,
             'options': [opt.to_dict() for opt in self.options],
         }  # type: ignore # Type checker does not understand this literal.
 

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -168,7 +168,7 @@ class AppCommand(Hashable):
         The default member permissions that can run this command.
     dm_permission: :class:`bool`
         A boolean that indicates whether this command can be run in direct messages.
-    restrict_contexts: Optional[:class:`AppCommandContext`]
+    allowed_contexts: Optional[:class:`AppCommandContext`]
         A list of contexts that this command can be run in. Overrides the ``dm_permission`` attribute.
     guild_id: Optional[:class:`int`]
         The ID of the guild this command is registered in. A value of ``None``
@@ -189,7 +189,7 @@ class AppCommand(Hashable):
         'options',
         'default_member_permissions',
         'dm_permission',
-        'restrict_contexts',
+        'allowed_contexts',
         'nsfw',
         '_state',
     )
@@ -222,11 +222,11 @@ class AppCommand(Hashable):
 
         self.dm_permission: bool = dm_permission
 
-        restrict_contexts = data.get('contexts')
-        if restrict_contexts is None:
-            self.restrict_contexts: Optional[AppCommandContext] = None
+        allowed_contexts = data.get('contexts')
+        if allowed_contexts is None:
+            self.allowed_contexts: Optional[AppCommandContext] = None
         else:
-            self.restrict_contexts = AppCommandContext._from_value(restrict_contexts)
+            self.allowed_contexts = AppCommandContext._from_value(allowed_contexts)
 
         self.nsfw: bool = data.get('nsfw', False)
         self.name_localizations: Dict[Locale, str] = _to_locale_dict(data.get('name_localizations') or {})
@@ -241,7 +241,7 @@ class AppCommand(Hashable):
             'description': self.description,
             'name_localizations': {str(k): v for k, v in self.name_localizations.items()},
             'description_localizations': {str(k): v for k, v in self.description_localizations.items()},
-            'contexts': self.restrict_contexts.to_array() if self.restrict_contexts is not None else None,
+            'contexts': self.allowed_contexts.to_array() if self.allowed_contexts is not None else None,
             'options': [opt.to_dict() for opt in self.options],
         }  # type: ignore # Type checker does not understand this literal.
 

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -168,7 +168,7 @@ class AppCommand(Hashable):
         The default member permissions that can run this command.
     dm_permission: :class:`bool`
         A boolean that indicates whether this command can be run in direct messages.
-    allowed_contexts: Optional[:class:`AppCommandContext`]
+    restrict_contexts: Optional[:class:`AppCommandContext`]
         A list of contexts that this command can be run in. Overrides the ``dm_permission`` attribute.
     guild_id: Optional[:class:`int`]
         The ID of the guild this command is registered in. A value of ``None``
@@ -189,7 +189,7 @@ class AppCommand(Hashable):
         'options',
         'default_member_permissions',
         'dm_permission',
-        'allowed_contexts',
+        'restrict_contexts',
         'nsfw',
         '_state',
     )
@@ -222,11 +222,11 @@ class AppCommand(Hashable):
 
         self.dm_permission: bool = dm_permission
 
-        allowed_contexts = data.get('contexts')
-        if allowed_contexts is None:
-            self.allowed_contexts: Optional[AppCommandContext] = None
+        restrict_contexts = data.get('contexts')
+        if restrict_contexts is None:
+            self.restrict_contexts: Optional[AppCommandContext] = None
         else:
-            self.allowed_contexts = AppCommandContext._from_value(allowed_contexts)
+            self.restrict_contexts = AppCommandContext._from_value(restrict_contexts)
 
         self.nsfw: bool = data.get('nsfw', False)
         self.name_localizations: Dict[Locale, str] = _to_locale_dict(data.get('name_localizations') or {})
@@ -241,7 +241,7 @@ class AppCommand(Hashable):
             'description': self.description,
             'name_localizations': {str(k): v for k, v in self.name_localizations.items()},
             'description_localizations': {str(k): v for k, v in self.description_localizations.items()},
-            'contexts': self.allowed_contexts.to_array() if self.allowed_contexts is not None else None,
+            'contexts': self.restrict_contexts.to_array() if self.restrict_contexts is not None else None,
             'options': [opt.to_dict() for opt in self.options],
         }  # type: ignore # Type checker does not understand this literal.
 

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -168,7 +168,7 @@ class AppCommand(Hashable):
         The default member permissions that can run this command.
     dm_permission: :class:`bool`
         A boolean that indicates whether this command can be run in direct messages.
-    allowed_contexts: Optional[:class:`AppCommandContext`]
+    allowed_contexts: Optional[:class:`~discord.flags.AppCommandContext`]
         A list of contexts that this command can be run in. Overrides the ``dm_permission`` attribute.
     guild_id: Optional[:class:`int`]
         The ID of the guild this command is registered in. A value of ``None``

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -169,7 +169,7 @@ class AppCommand(Hashable):
     dm_permission: :class:`bool`
         A boolean that indicates whether this command can be run in direct messages.
     allowed_contexts: Optional[:class:`~discord.flags.AppCommandContext`]
-        A list of contexts that this command can be run in. Overrides the ``dm_permission`` attribute.
+        The contexts that this command is allowed to be used in. Overrides the ``dm_permission`` attribute.
     guild_id: Optional[:class:`int`]
         The ID of the guild this command is registered in. A value of ``None``
         denotes that it is a global command.

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -28,7 +28,15 @@ from datetime import datetime
 from .errors import MissingApplicationID
 from .translator import TranslationContextLocation, TranslationContext, locale_str, Translator
 from ..permissions import Permissions
-from ..enums import AppCommandOptionType, AppCommandType, AppCommandPermissionType, ChannelType, Locale, try_enum
+from ..enums import (
+    AppCommandContext,
+    AppCommandOptionType,
+    AppCommandType,
+    AppCommandPermissionType,
+    ChannelType,
+    Locale,
+    try_enum,
+)
 from ..mixins import Hashable
 from ..utils import _get_as_snowflake, parse_time, snowflake_time, MISSING
 from ..object import Object
@@ -160,6 +168,8 @@ class AppCommand(Hashable):
         The default member permissions that can run this command.
     dm_permission: :class:`bool`
         A boolean that indicates whether this command can be run in direct messages.
+    allowed_contexts: Optional[List[:class:`AppCommandContext`]]
+        A list of contexts that this command can be run in. Overrides the `dm_permission` attribute.
     guild_id: Optional[:class:`int`]
         The ID of the guild this command is registered in. A value of ``None``
         denotes that it is a global command.
@@ -179,6 +189,7 @@ class AppCommand(Hashable):
         'options',
         'default_member_permissions',
         'dm_permission',
+        'allowed_contexts',
         'nsfw',
         '_state',
     )
@@ -210,6 +221,13 @@ class AppCommand(Hashable):
             dm_permission = True
 
         self.dm_permission: bool = dm_permission
+
+        allowed_contexts = data.get('contexts')
+        if allowed_contexts is None:
+            self.allowed_contexts: Optional[List[AppCommandContext]] = None
+        else:
+            self.allowed_contexts = [try_enum(AppCommandContext, ctx) for ctx in allowed_contexts]
+
         self.nsfw: bool = data.get('nsfw', False)
         self.name_localizations: Dict[Locale, str] = _to_locale_dict(data.get('name_localizations') or {})
         self.description_localizations: Dict[Locale, str] = _to_locale_dict(data.get('description_localizations') or {})
@@ -223,6 +241,7 @@ class AppCommand(Hashable):
             'description': self.description,
             'name_localizations': {str(k): v for k, v in self.name_localizations.items()},
             'description_localizations': {str(k): v for k, v in self.description_localizations.items()},
+            'contexts': [ctx.value for ctx in self.allowed_contexts] if self.allowed_contexts else None,
             'options': [opt.to_dict() for opt in self.options],
         }  # type: ignore # Type checker does not understand this literal.
 

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -63,7 +63,6 @@ __all__ = (
     'AppCommandType',
     'AppCommandOptionType',
     'AppCommandPermissionType',
-    'AppCommandContext',
     'AutoModRuleTriggerType',
     'AutoModRuleEventType',
     'AutoModRuleActionType',
@@ -727,12 +726,6 @@ class AppCommandPermissionType(Enum):
     role = 1
     user = 2
     channel = 3
-
-
-class AppCommandContext(Enum):
-    guild = 0
-    bot_dm = 1  # this is DMs only
-    private_channel = 2  # this is DMs + GDMs
 
 
 class AutoModRuleTriggerType(Enum):

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -63,6 +63,7 @@ __all__ = (
     'AppCommandType',
     'AppCommandOptionType',
     'AppCommandPermissionType',
+    'AppCommandContext',
     'AutoModRuleTriggerType',
     'AutoModRuleEventType',
     'AutoModRuleActionType',
@@ -726,6 +727,12 @@ class AppCommandPermissionType(Enum):
     role = 1
     user = 2
     channel = 3
+
+
+class AppCommandContext(Enum):
+    GUILD = 0
+    BOT_DM = 1  # this is DMs only
+    PRIVATE_CHANNEL = 2  # this is DMs + GDMs
 
 
 class AutoModRuleTriggerType(Enum):

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -730,9 +730,9 @@ class AppCommandPermissionType(Enum):
 
 
 class AppCommandContext(Enum):
-    GUILD = 0
-    BOT_DM = 1  # this is DMs only
-    PRIVATE_CHANNEL = 2  # this is DMs + GDMs
+    guild = 0
+    bot_dm = 1  # this is DMs only
+    private_channel = 2  # this is DMs + GDMs
 
 
 class AutoModRuleTriggerType(Enum):

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1636,6 +1636,22 @@ class ArrayFlags(BaseFlags):
     def to_array(self) -> List[int]:
         return [i + 1 for i in range(self.value.bit_length()) if self.value & (1 << i)]
 
+    @classmethod
+    def all(cls: Type[Self]) -> Self:
+        """A factory method that creates an instance of ArrayFlags with everything enabled."""
+        bits = max(cls.VALID_FLAGS.values()).bit_length()
+        value = (1 << bits) - 1
+        self = cls.__new__(cls)
+        self.value = value
+        return self
+
+    @classmethod
+    def none(cls: Type[Self]) -> Self:
+        """A factory method that creates an instance of ArrayFlags with everything disabled."""
+        self = cls.__new__(cls)
+        self.value = self.DEFAULT_VALUE
+        return self
+
 
 @fill_with_flags()
 class AutoModPresets(ArrayFlags):
@@ -1716,21 +1732,86 @@ class AutoModPresets(ArrayFlags):
         """:class:`bool`: Whether to use the preset slurs filter."""
         return 1 << 2
 
-    @classmethod
-    def all(cls: Type[Self]) -> Self:
-        """A factory method that creates a :class:`AutoModPresets` with everything enabled."""
-        bits = max(cls.VALID_FLAGS.values()).bit_length()
-        value = (1 << bits) - 1
-        self = cls.__new__(cls)
-        self.value = value
-        return self
 
-    @classmethod
-    def none(cls: Type[Self]) -> Self:
-        """A factory method that creates a :class:`AutoModPresets` with everything disabled."""
-        self = cls.__new__(cls)
-        self.value = self.DEFAULT_VALUE
-        return self
+@fill_with_flags()
+class AppCommandContext(ArrayFlags):
+    DEFAULT_VALUE = 3
+    r"""Wraps up the Discord :class:`AppCommand` context.
+
+    .. versionadded:: 2.3
+
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two AppCommand context flags are equal.
+
+        .. describe:: x != y
+
+            Checks if two AppCommand context flags are not equal.
+
+        .. describe:: x | y, x |= y
+
+            Returns an AppCommandContext instance with all enabled flags from
+            both x and y.
+
+            .. versionadded:: 2.3
+
+        .. describe:: x & y, x &= y
+
+            Returns an AppCommandContext instance with only flags enabled on
+            both x and y.
+
+            .. versionadded:: 2.3
+
+        .. describe:: x ^ y, x ^= y
+
+            Returns an AppCommandContext instance with only flags enabled on
+            only one of x or y, not on both.
+
+            .. versionadded:: 2.3
+
+        .. describe:: ~x
+
+            Returns an AppCommandContext instance with all flags inverted from x
+
+            .. versionadded:: 2.3
+
+        .. describe:: hash(x)
+
+            Return the flag's hash.
+        .. describe:: iter(x)
+
+            Returns an iterator of ``(name, value)`` pairs. This allows it
+            to be, for example, constructed as a dict or a list of pairs.
+            Note that aliases are not shown.
+
+        .. describe:: bool(b)
+
+            Returns whether any flag is set to ``True``.
+
+    Attributes
+    -----------
+    value: :class:`int`
+        The raw value. You should query flags via the properties
+        rather than using this raw value.
+    """
+
+    @flag_value
+    def guild(self):
+        """:class:`bool`: Whether the context allows usage in a guild."""
+        return 1 << 0
+
+    @flag_value
+    def dm_channel(self):
+        """:class:`bool`: Whether the context allows usage in a DM channel."""
+        return 1 << 1
+
+    @flag_value
+    def private_channel(self):
+        """:class:`bool`: Whether the context allows usage in a DM or a GDM channel."""
+        return 1 << 2
 
 
 @fill_with_flags()

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1801,9 +1801,6 @@ class AppCommandContext(ArrayFlags):
         rather than using this raw value.
     """
 
-    def to_array(self) -> List[int]:
-        return super().to_array()
-
     @flag_value
     def guild(self):
         """:class:`bool`: Whether the context allows usage in a guild."""

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1633,8 +1633,8 @@ class ArrayFlags(BaseFlags):
         self.value = reduce(or_, map((1).__lshift__, value), 0) >> 1
         return self
 
-    def to_array(self) -> List[int]:
-        return [i + 1 for i in range(self.value.bit_length()) if self.value & (1 << i)]
+    def to_array(self, *, offset: int = 0) -> List[int]:
+        return [i + offset for i in range(self.value.bit_length()) if self.value & (1 << i)]
 
     @classmethod
     def all(cls: Type[Self]) -> Self:
@@ -1717,6 +1717,9 @@ class AutoModPresets(ArrayFlags):
         rather than using this raw value.
     """
 
+    def to_array(self) -> List[int]:
+        return super().to_array(offset=1)
+
     @flag_value
     def profanity(self):
         """:class:`bool`: Whether to use the preset profanity filter."""
@@ -1797,6 +1800,9 @@ class AppCommandContext(ArrayFlags):
         The raw value. You should query flags via the properties
         rather than using this raw value.
     """
+
+    def to_array(self) -> List[int]:
+        return super().to_array()
 
     @flag_value
     def guild(self):

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1738,11 +1738,9 @@ class AutoModPresets(ArrayFlags):
 
 @fill_with_flags()
 class AppCommandContext(ArrayFlags):
-    DEFAULT_VALUE = 3
     r"""Wraps up the Discord :class:`AppCommand` context.
 
     .. versionadded:: 2.3
-
 
     .. container:: operations
 
@@ -1800,6 +1798,8 @@ class AppCommandContext(ArrayFlags):
         The raw value. You should query flags via the properties
         rather than using this raw value.
     """
+
+    DEFAULT_VALUE = 3
 
     @flag_value
     def guild(self):

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -44,6 +44,7 @@ __all__ = (
     'ChannelFlags',
     'AutoModPresets',
     'MemberFlags',
+    "AppCommandContext",
 )
 
 BF = TypeVar('BF', bound='BaseFlags')
@@ -1746,7 +1747,7 @@ class AppCommandContext(ArrayFlags):
 
         .. describe:: x == y
 
-            Checks if two AppCommand context flags are equal.
+            Checks if two app command context flags are equal.
 
         .. describe:: x != y
 

--- a/discord/types/command.py
+++ b/discord/types/command.py
@@ -141,6 +141,7 @@ class _BaseApplicationCommand(TypedDict):
     id: Snowflake
     application_id: Snowflake
     name: str
+    contexts: List[int]
     dm_permission: NotRequired[Optional[bool]]
     default_member_permissions: NotRequired[Optional[str]]
     nsfw: NotRequired[bool]

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -410,6 +410,22 @@ Enumerations
 
         The permission is for a user.
 
+.. class:: AppCommandContext
+
+    The application command's contexts type.
+
+    .. versionadded:: 2.3
+
+    .. attribute:: guild
+
+        The context is for guild.
+    .. attribute:: bot_dm
+
+        The context is for bot DMs.
+    .. attribute:: private_channel
+
+        The context is for bot DMs and group DMs.
+
 .. _discord_ui_kit:
 
 Bot UI Kit

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -129,6 +129,14 @@ AppCommandPermissions
 .. autoclass:: discord.app_commands.AppCommandPermissions()
     :members:
 
+AppCommandContext
+~~~~~~~~~~~~~~~~~
+
+.. attributetable:: AppCommandContext
+
+.. autoclass:: AppCommandContext
+    :members:
+
 GuildAppCommandPermissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -410,22 +418,6 @@ Enumerations
 
         The permission is for a user.
 
-.. class:: AppCommandContext
-
-    The application command's contexts type.
-
-    .. versionadded:: 2.3
-
-    .. attribute:: guild
-
-        The context is for guild.
-    .. attribute:: bot_dm
-
-        The context is for bot DMs.
-    .. attribute:: private_channel
-
-        The context is for bot DMs and group DMs.
-
 .. _discord_ui_kit:
 
 Bot UI Kit
@@ -639,6 +631,12 @@ Decorators
     :decorator:
 
 .. autofunction:: discord.app_commands.guild_only
+    :decorator:
+
+.. autofunction:: discord.app_commands.dm_only
+    :decorator:
+
+.. autofunction:: discord.app_commands.private_channel_only
     :decorator:
 
 .. autofunction:: discord.app_commands.default_permissions

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -639,6 +639,9 @@ Decorators
 .. autofunction:: discord.app_commands.private_channel_only
     :decorator:
 
+-- autofunction:: discord.app_commands.allow_contexts
+    :decorator:
+
 .. autofunction:: discord.app_commands.default_permissions
     :decorator:
 


### PR DESCRIPTION
## Summary

Adds `@dm_only` and `@private_only` decorators to allow specifying the new `contexts` field in app commands, as specified [here](https://gist.github.com/devsnek/a47893004bc0ee577eb8e9fb76b4d57f), as well as the relevant init args.

The docs mention that if this field is specified, the permission calculation ignores the `dm_permission` field. Not sure how this should be reflected in the library for backwards compatibility purposes.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested. (needs a bit more testing for groups and context commands)
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
