### PR TITLE
fix `StageChannel.last_message_id`

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -615,7 +615,7 @@ class ConnectionState(Generic[ClientT]):
         if self._messages is not None:
             self._messages.append(message)
         # we ensure that the channel is either a TextChannel, VoiceChannel, or Thread
-        if channel and channel.__class__ in (TextChannel, VoiceChannel, Thread):
+        if channel and channel.__class__ in (TextChannel, VoiceChannel, Thread, StageChannel):
             channel.last_message_id = message.id  # type: ignore
 
     def parse_message_delete(self, data: gw.MessageDeleteEvent) -> None:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR fixes `last_message_id` attribute being always `None` for StageChannel instances.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
