### PR TITLE
[docs] document exceptions being ignored in teardown and cog_unload

### DIFF
--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -553,6 +553,10 @@ class Cog(metaclass=CogMeta):
         .. versionchanged:: 2.0
 
             This method can now be a :term:`coroutine`.
+
+        .. warning::
+
+            Exceptions raised in this method are ignored during extension unloading.
         """
         pass
 

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -550,13 +550,11 @@ class Cog(metaclass=CogMeta):
 
         Subclasses must replace this if they want special unloading behaviour.
 
+        Exceptions raised in this method are ignored during extension unloading.
+
         .. versionchanged:: 2.0
 
             This method can now be a :term:`coroutine`.
-
-        .. warning::
-
-            Exceptions raised in this method are ignored during extension unloading.
         """
         pass
 

--- a/docs/ext/commands/extensions.rst
+++ b/docs/ext/commands/extensions.rst
@@ -54,6 +54,10 @@ Cleaning Up
 
 Although rare, sometimes an extension needs to clean-up or know when it's being unloaded. For cases like these, there is another entry point named ``teardown`` which is similar to ``setup`` except called when the extension is unloaded.
 
+.. warning::
+
+    Exceptions raised in the ``tearDown`` function are ignored, and the extension is still unloaded.
+
 .. code-block:: python3
     :caption: basic_ext.py
 

--- a/docs/ext/commands/extensions.rst
+++ b/docs/ext/commands/extensions.rst
@@ -54,9 +54,7 @@ Cleaning Up
 
 Although rare, sometimes an extension needs to clean-up or know when it's being unloaded. For cases like these, there is another entry point named ``teardown`` which is similar to ``setup`` except called when the extension is unloaded.
 
-.. warning::
-
-    Exceptions raised in the ``teardown`` function are ignored, and the extension is still unloaded.
+Exceptions raised in the ``teardown`` function are ignored, and the extension is still unloaded.
 
 .. code-block:: python3
     :caption: basic_ext.py

--- a/docs/ext/commands/extensions.rst
+++ b/docs/ext/commands/extensions.rst
@@ -56,7 +56,7 @@ Although rare, sometimes an extension needs to clean-up or know when it's being 
 
 .. warning::
 
-    Exceptions raised in the ``tearDown`` function are ignored, and the extension is still unloaded.
+    Exceptions raised in the ``teardown`` function are ignored, and the extension is still unloaded.
 
 .. code-block:: python3
     :caption: basic_ext.py


### PR DESCRIPTION
## Summary

Documents the exception ignoring behavior of ``teardown`` and ``cog_unload``, to alleviate confusion EG https://github.com/Rapptz/discord.py/discussions/9421

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
