### PR TITLE
Make _Overwrites.is_member and is_role use _Ovewrites.ROLE and MEMBER

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -323,10 +323,10 @@ class _Overwrites:
         }
 
     def is_role(self) -> bool:
-        return self.type == 0
+        return self.type == self.ROLE
 
     def is_member(self) -> bool:
-        return self.type == 1
+        return self.type == self.MEMBER
 
 
 class GuildChannel:


### PR DESCRIPTION
## Summary
It just makes the checks use the ROLE and MEMBER vars

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
