### PR TITLE
[commands] Add guild(s) kwarg to BotBase.add_command and correct BotBase.add_cog doc

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -790,6 +790,8 @@ class BotBase(GroupMixin[None]):
             the guild the app commands will be added to.
             If not given, all app commands will be global.
 
+            .. versionchanged:: 2.3
+                This kwarg is now also used by hybrid app commands.
             .. versionadded:: 2.0
         guilds: List[:class:`~discord.abc.Snowflake`]
             If the cog has application commands, then these
@@ -797,6 +799,8 @@ class BotBase(GroupMixin[None]):
             If not given, all app commands will be global. Cannot be mixed with
             ``guild``.
 
+            .. versionchanged:: 2.3
+                This kwarg is now also used by hybrid app commands.
             .. versionadded:: 2.0
 
         Raises

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -241,8 +241,51 @@ class BotBase(GroupMixin[None]):
 
     # GroupMixin overrides
 
-    @discord.utils.copy_doc(GroupMixin.add_command)
-    def add_command(self, command: Command[Any, ..., Any], /) -> None:
+    def add_command(
+        self,
+        command: Command[Any, ..., Any],
+        /,
+        *,
+        guild: Optional[Snowflake] = MISSING,
+        guilds: Sequence[Snowflake] = MISSING,
+    ) -> None:
+        """Adds a :class:`.Command` into the internal list of commands.
+
+        This is usually not called, instead the :meth:`~.GroupMixin.command` or
+        :meth:`~.GroupMixin.group` shortcut decorators are used instead.
+
+        .. versionchanged:: 1.4
+             Raise :exc:`.CommandRegistrationError` instead of generic :exc:`.ClientException`
+
+        .. versionchanged:: 2.0
+
+            ``command`` parameter is now positional-only.
+
+        Parameters
+        -----------
+        command: :class:`Command`
+            The command to add.
+        guild: Optional[:class:`~discord.abc.Snowflake`]
+            If the command is a hybrid command with an application command attached, then this
+            will be the guild the app command will be added to.
+            If not given, the app command will be global.
+
+            .. versionadded:: 2.3
+        guilds: List[:class:`~discord.abc.Snowflake`]
+            If the command is a hybrid command with an application command attached, then these
+            would be the guilds the app command will be added to.
+            If not given, the app command will be global. Cannot be mixed with
+            ``guild``.
+
+            .. versionadded:: 2.3
+
+        Raises
+        -------
+        CommandRegistrationError
+            If the command or its alias is already registered by different command.
+        TypeError
+            If the command passed is not a subclass of :class:`.Command`. Or, guild and guilds were both given.
+        """
         super().add_command(command)
         if isinstance(command, (HybridCommand, HybridGroup)) and command.app_command:
             # If a cog is also inheriting from app_commands.Group then it'll also
@@ -250,7 +293,7 @@ class BotBase(GroupMixin[None]):
             # hybrid commands as slash commands. This check just terminates that recursion
             # from happening
             if command.cog is None or not command.cog.__cog_is_app_commands_group__:
-                self.tree.add_command(command.app_command)
+                self.tree.add_command(command.app_command, guild=guild, guilds=guilds)
 
     @discord.utils.copy_doc(GroupMixin.remove_command)
     def remove_command(self, name: str, /) -> Optional[Command[Any, ..., Any]]:
@@ -743,15 +786,15 @@ class BotBase(GroupMixin[None]):
 
             .. versionadded:: 2.0
         guild: Optional[:class:`~discord.abc.Snowflake`]
-            If the cog is an application command group, then this would be the
-            guild where the cog group would be added to. If not given then
-            it becomes a global command instead.
+            If the cog has application commands, then this would
+            the guild the app commands will be added to.
+            If not given, all app commands will be global.
 
             .. versionadded:: 2.0
         guilds: List[:class:`~discord.abc.Snowflake`]
-            If the cog is an application command group, then this would be the
-            guilds where the cog group would be added to. If not given then
-            it becomes a global command instead. Cannot be mixed with
+            If the cog has application commands, then these
+            would the guilds the app commands will be added to.
+            If not given, all app commands will be global. Cannot be mixed with
             ``guild``.
 
             .. versionadded:: 2.0
@@ -759,7 +802,7 @@ class BotBase(GroupMixin[None]):
         Raises
         -------
         TypeError
-            The cog does not inherit from :class:`.Cog`.
+            The cog does not inherit from :class:`.Cog`. Or, guild and guilds were both given.
         CommandError
             An error happened during loading.
         ClientException

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -691,7 +691,7 @@ class Cog(metaclass=CogMeta):
             command.cog = self
             if command.parent is None:
                 try:
-                    bot.add_command(command)
+                    bot.add_command(command, guild=guild, guilds=guilds)
                 except Exception as e:
                     # undo our additions
                     for to_undo in self.__cog_commands__[:index]:


### PR DESCRIPTION
## Summary

Fixes #9366

This PR adds the following kwargs to `Bot.add_cog`: `guild` and `guilds` for hybrid app commands. This allows defining guilds for a hybrid app command while adding it to the bot, these are also used by the lib in `BotBase.add_cog` if any guild(s) were passed to that.

This PR also corrects the doc of the `guild(s)` kwargs in `BotBase.add_cog` which previously led users to believe that the kwargs are only valid for GroupCog/app_commands.Group which is not the case.

This can be a breaking change since previously hybrid app commands in cogs were not added as guild commands when the kwarg was used. This could lead to unexpected behaviour.

I have not tested all possibilities/edge cases(if any) with the new kwargs for add_command.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
