### PR TITLE
Updated deprecated versioning in .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,9 @@ version: 2
 formats: []
 
 build:
-  image: latest
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
 
 sphinx:
   configuration: docs/conf.py
@@ -10,7 +12,6 @@ sphinx:
   builder: html
 
 python:
-  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
``python.version`` is deprectated (see https://docs.readthedocs.io/en/stable/config-file/v2.html#python-version)
this fix uses the new recommended way ``build.tools.python``

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
