### PR TITLE
[Context] New function: maybe_reply

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -745,7 +745,7 @@ class Context(discord.abc.Messageable, Generic[BotT]):
     async def maybe_reply(self, content: Optional[str] = None, **kwargs: Any):
         """|coro|
         
-        A shortcut method to both :meth:`reply` and :meht:`send` to either reply to a
+        A shortcut method to both :meth:`reply` and :meth:`send` to either reply to a
         message or send a message in the context's channel.
 
         For interaction based contexts, this is the same as :meth:`send`.

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -741,6 +741,42 @@ class Context(discord.abc.Messageable, Generic[BotT]):
             return await self.send(content, reference=self.message, **kwargs)
         else:
             return await self.send(content, **kwargs)
+        
+    async def maybe_reply(self, content: Optional[str] = None, **kwargs: Any):
+        """|coro|
+        
+        A shortcut method to both :meth:`reply` and :meht:`send` to either reply to a
+        message or send a message in the context's channel.
+
+        For interaction based contexts, this is the same as :meth:`send`.
+
+        .. versionadded:: 2.2.3
+
+        Raises
+        --------
+        ~discord.HTTPException
+            Sending the message failed
+        ~discord.Forbidden
+            You do not have the proper permissions to send the message.
+        ValueError
+            The ``files`` list is not of the appropriate size.
+        TypeError
+            You specified both ``file`` and ``files``.
+            You specified both ``embed`` and ``embeds``.
+        """
+
+        if self.interaction is None:
+            try:
+                m = await self.send(content, reference = self.message, **kwargs)
+
+                return m
+            except:
+
+                m = await self.send(content, **kwargs)
+                return m
+            
+        else:
+            return await self.send(content, **kwargs)
 
     def typing(self, *, ephemeral: bool = False) -> Union[Typing, DeferTyping]:
         """Returns an asynchronous context manager that allows you to send a typing indicator to


### PR DESCRIPTION
## Summary

Added new feature to `discord.ext.commands.Context`.
This function is called `maybe_reply`.
Basically this function tries to reply to the `Context.message` but if cannot it just sends a message in context's channel.

In a command it would be used like this:
```py
client = commands.Bot(...)

from discord.ext import commands

@client.command()
async def ping(ctx: commands.Context, delete_message: bool = False) -> None:

    if delete_message == True:
        await ctx.message.delete()
    await ctx.maybe_reply('Test executed!')
```
That code would be an example of this new function for Context class. Photo:
![dpy new func](https://github.com/Rapptz/discord.py/assets/108473820/2025f574-3bb6-4928-bea7-0ee5c80b7eef)
## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
