### PR TITLE
Fix TextInput's is_persistent() flow

### DIFF
--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -162,10 +162,10 @@ class BaseSelect(Item[V]):
     @custom_id.setter
     def custom_id(self, value: str) -> None:
         if not isinstance(value, str):
-            raise TypeError('custom_id must be None or str')
+            raise TypeError('custom_id must be a str')
 
         self._underlying.custom_id = value
-        self._provided_custom_id = value is not None
+        self._provided_custom_id = True
 
     @property
     def placeholder(self) -> Optional[str]:

--- a/discord/ui/text_input.py
+++ b/discord/ui/text_input.py
@@ -137,10 +137,11 @@ class TextInput(Item[V]):
     @custom_id.setter
     def custom_id(self, value: str) -> None:
         if not isinstance(value, str):
-            raise TypeError('custom_id must be None or str')
+            raise TypeError('custom_id must be a str')
 
         self._underlying.custom_id = value
-
+        self._provided_custom_id = True
+        
     @property
     def width(self) -> int:
         return 5


### PR DESCRIPTION
## Summary

I updated the **BaseSelect** and **TextInput** `@custom_id.setter`

Both TypeError messages were wrong, they said that None is a valid custom_id value.
Also, `TextInput(label="...").is_persistent()` remained False after setting a custom_id after initialization.

**Currently**
```pycon
>>> from discord.ui import TextInput
>>>
>>> text_input = TextInput(label="beautiful label")
>>> text_input.is_persistent()
False
>>> text_input.custom_id = "beautiful:textinput"
>>> text_input.is_persistent()
False
```

**Now**
```pycon
>>> from discord.ui import TextInput
>>>
>>> text_input = TextInput(label="beautiful label")
>>> text_input.is_persistent()
False
>>> text_input.custom_id = "beautiful:textinput"
>>> text_input.is_persistent()
True
```
*(this is my first pull request ever, please be kind)*

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
