### PR TITLE
Undeprecate discriminator usage

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -219,7 +219,7 @@ class User(Snowflake, Protocol):
     name: :class:`str`
         The user's username.
     discriminator: :class:`str`
-        The user's discriminator. This is a legacy concept that is no longer used.
+        The user's discriminator. This is only used by bot users and users who have not migrated to the new username system.
     global_name: Optional[:class:`str`]
         The user's global nickname.
     bot: :class:`bool`

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -186,8 +186,8 @@ class MemberConverter(IDConverter[discord.Member]):
 
     1. Lookup by ID.
     2. Lookup by mention.
-    3. Lookup by username#discriminator (deprecated).
-    4. Lookup by username#0 (deprecated, only gets users that migrated from their discriminator).
+    3. Lookup by username#discriminator.
+    4. Lookup by username#0 (only gets users who migrated from their discriminators).
     5. Lookup by guild nickname.
     6. Lookup by global name.
     7. Lookup by user name.
@@ -198,10 +198,6 @@ class MemberConverter(IDConverter[discord.Member]):
     .. versionchanged:: 1.5.1
         This converter now lazily fetches members from the gateway and HTTP APIs,
         optionally caching the result if :attr:`.MemberCacheFlags.joined` is enabled.
-
-    .. deprecated:: 2.3
-        Looking up users by discriminator will be removed in a future version due to
-        the removal of discriminators in an API change.
     """
 
     async def query_member_named(self, guild: discord.Guild, argument: str) -> Optional[discord.Member]:
@@ -282,8 +278,8 @@ class UserConverter(IDConverter[discord.User]):
 
     1. Lookup by ID.
     2. Lookup by mention.
-    3. Lookup by username#discriminator (deprecated).
-    4. Lookup by username#0 (deprecated, only gets users that migrated from their discriminator).
+    3. Lookup by username#discriminator.
+    4. Lookup by username#0 (only gets users who migrated from their discriminators).
     5. Lookup by global name.
     6. Lookup by user name.
 
@@ -293,10 +289,6 @@ class UserConverter(IDConverter[discord.User]):
     .. versionchanged:: 1.6
         This converter now lazily fetches users from the HTTP APIs if an ID is passed
         and it's not available in cache.
-
-    .. deprecated:: 2.3
-        Looking up users by discriminator will be removed in a future version due to
-        the removal of discriminators in an API change.
     """
 
     async def convert(self, ctx: Context[BotT], argument: str) -> discord.User:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1077,8 +1077,8 @@ class Guild(Hashable):
 
         The name is looked up in the following order:
 
-        - Username#Discriminator (deprecated)
-        - Username#0 (deprecated, only gets users that migrated from their discriminator)
+        - Username#Discriminator
+        - Username#0 (only gets users who migrated from their discriminators)
         - Nickname
         - Global name
         - Username
@@ -1089,14 +1089,10 @@ class Guild(Hashable):
 
             ``name`` parameter is now positional-only.
 
-        .. deprecated:: 2.3
-
-            Looking up users via discriminator due to Discord API change.
-
         Parameters
         -----------
         name: :class:`str`
-            The name of the member to lookup.
+            The name of the member to lookup with an optional discriminator.
 
         Returns
         --------

--- a/discord/team.py
+++ b/discord/team.py
@@ -119,7 +119,7 @@ class TeamMember(BaseUser):
     id: :class:`int`
         The team member's unique ID.
     discriminator: :class:`str`
-        The team member's discriminator. This is a legacy concept that is no longer used.
+        The team member's discriminator. This is no longer used for normal users.
     global_name: Optional[:class:`str`]
         The team member's global nickname, taking precedence over the username in display.
 

--- a/discord/team.py
+++ b/discord/team.py
@@ -119,7 +119,7 @@ class TeamMember(BaseUser):
     id: :class:`int`
         The team member's unique ID.
     discriminator: :class:`str`
-        The team member's discriminator. This is no longer used for normal users.
+        The team member's discriminator. This is only used by bot users and users who have not migrated to the new username system.
     global_name: Optional[:class:`str`]
         The team member's global nickname, taking precedence over the username in display.
 

--- a/discord/user.py
+++ b/discord/user.py
@@ -328,7 +328,7 @@ class ClientUser(BaseUser):
     id: :class:`int`
         The user's unique ID.
     discriminator: :class:`str`
-        The user's discriminator. This is a legacy concept that is no longer used.
+        The user's discriminator. This is only used by bot users and users who have not migrated to the new username system.
     global_name: Optional[:class:`str`]
         The user's global nickname, taking precedence over the username in display.
 
@@ -468,7 +468,7 @@ class User(BaseUser, discord.abc.Messageable):
     id: :class:`int`
         The user's unique ID.
     discriminator: :class:`str`
-        The user's discriminator. This is a legacy concept that is no longer used.
+        The user's discriminator. This is only used by bot users and users who have not migrated to the new username system.
     global_name: Optional[:class:`str`]
         The user's global nickname, taking precedence over the username in display.
 

--- a/discord/widget.py
+++ b/discord/widget.py
@@ -130,7 +130,7 @@ class WidgetMember(BaseUser):
     name: :class:`str`
         The member's username.
     discriminator: :class:`str`
-        The member's discriminator. This is a legacy concept that is no longer used.
+        The member's discriminator. This is only used by bot users and users who have not migrated to the new username system.
     global_name: Optional[:class:`str`]
         The member's global nickname, taking precedence over the username in display.
 


### PR DESCRIPTION
## Summary
Discord is [no longer making bots migrate to the new username system (Discord Developers #api-announcements)](https://canary.discord.com/channels/613425648685547541/697138785317814292/1115340475939967076), which also means the API will retain the discriminator field, meaning discriminator use doesn't need to be deprecated (for now at least).
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
