### PR TITLE
Add with_localizations to CommandTree.fetch_commands

### DIFF
--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -180,7 +180,9 @@ class CommandTree(Generic[ClientT]):
 
         return AppCommand(data=command, state=self._state)
 
-    async def fetch_commands(self, *, guild: Optional[Snowflake] = None) -> List[AppCommand]:
+    async def fetch_commands(
+        self, *, guild: Optional[Snowflake] = None, with_localizations: bool = False
+    ) -> List[AppCommand]:
         """|coro|
 
         Fetches the application's current commands.
@@ -197,6 +199,8 @@ class CommandTree(Generic[ClientT]):
         guild: Optional[:class:`~discord.abc.Snowflake`]
             The guild to fetch the commands from. If not passed then global commands
             are fetched instead.
+        with_localizations: :class:`bool`
+            Whether to fetch the localizations for the commands. Defaults to ``False``.
 
         Raises
         -------
@@ -214,9 +218,13 @@ class CommandTree(Generic[ClientT]):
             raise MissingApplicationID
 
         if guild is None:
-            commands = await self._http.get_global_commands(self.client.application_id)
+            commands = await self._http.get_global_commands(
+                self.client.application_id, with_localizations=with_localizations
+            )
         else:
-            commands = await self._http.get_guild_commands(self.client.application_id, guild.id)
+            commands = await self._http.get_guild_commands(
+                self.client.application_id, guild.id, with_localizations=with_localizations
+            )
 
         return [AppCommand(data=data, state=self._state) for data in commands]
 

--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -202,6 +202,8 @@ class CommandTree(Generic[ClientT]):
         with_localizations: :class:`bool`
             Whether to fetch the localizations for the commands. Defaults to ``False``.
 
+            .. versionadded:: 2.4
+
         Raises
         -------
         HTTPException

--- a/discord/http.py
+++ b/discord/http.py
@@ -2128,8 +2128,13 @@ class HTTPClient:
 
     # Application commands (global)
 
-    def get_global_commands(self, application_id: Snowflake) -> Response[List[command.ApplicationCommand]]:
-        return self.request(Route('GET', '/applications/{application_id}/commands', application_id=application_id))
+    def get_global_commands(
+        self, application_id: Snowflake, with_localizations: bool = False
+    ) -> Response[List[command.ApplicationCommand]]:
+        params = {'with_localizations': with_localizations}
+        return self.request(
+            Route('GET', '/applications/{application_id}/commands', application_id=application_id, params=params)
+        )
 
     def get_global_command(self, application_id: Snowflake, command_id: Snowflake) -> Response[command.ApplicationCommand]:
         r = Route(
@@ -2184,13 +2189,18 @@ class HTTPClient:
     # Application commands (guild)
 
     def get_guild_commands(
-        self, application_id: Snowflake, guild_id: Snowflake
+        self,
+        application_id: Snowflake,
+        guild_id: Snowflake,
+        with_localizations: bool = False,
     ) -> Response[List[command.ApplicationCommand]]:
+        params = {'with_localizations': with_localizations}
         r = Route(
             'GET',
             '/applications/{application_id}/guilds/{guild_id}/commands',
             application_id=application_id,
             guild_id=guild_id,
+            params=params,
         )
         return self.request(r)
 


### PR DESCRIPTION
## Summary

This PR adds a kwarg called `with_localizations` to CommandTree.fetch_commands and relevant HTTP methods.

This allows for fetching app commands localization strings.

Relevant API Docs:
- https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
- https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands

Post in server: https://discord.com/channels/336642139381301249/1118119655719043072
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
