### PR TITLE
Convert input for UserConverter and MemberConverter to lower case during last lookup step

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -217,7 +217,7 @@ class MemberConverter(IDConverter[discord.Member]):
             predicate = lambda m: m.name == username and m.discriminator == discriminator
         else:
             lookup = argument
-            predicate = lambda m: m.nick == argument or m.global_name == argument or m.name == argument
+            predicate = lambda m: m.nick == argument or m.global_name == argument or m.name == argument.lower()
 
         members = await guild.query_members(lookup, limit=100, cache=cache)
         return discord.utils.find(predicate, members)
@@ -329,7 +329,7 @@ class UserConverter(IDConverter[discord.User]):
         if discriminator == '0' or (len(discriminator) == 4 and discriminator.isdigit()):
             predicate = lambda u: u.name == username and u.discriminator == discriminator
         else:
-            predicate = lambda u: u.global_name == argument or u.name == argument
+            predicate = lambda u: u.global_name == argument or u.name == argument.lower()
 
         result = discord.utils.find(predicate, state._users.values())
         if result is None:

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -190,7 +190,7 @@ class MemberConverter(IDConverter[discord.Member]):
     4. Lookup by username#0 (deprecated, only gets users that migrated from their discriminator).
     5. Lookup by guild nickname.
     6. Lookup by global name.
-    7. Lookup by user name.
+    7. Lookup by user name (case insensitive).
 
     .. versionchanged:: 1.5
          Raise :exc:`.MemberNotFound` instead of generic :exc:`.BadArgument`
@@ -290,7 +290,7 @@ class UserConverter(IDConverter[discord.User]):
     3. Lookup by username#discriminator (deprecated).
     4. Lookup by username#0 (deprecated, only gets users that migrated from their discriminator).
     5. Lookup by global name.
-    6. Lookup by user name.
+    6. Lookup by user name (case insensitive).
 
     .. versionchanged:: 1.5
          Raise :exc:`.UserNotFound` instead of generic :exc:`.BadArgument`


### PR DESCRIPTION
## Summary

This PR converts the input for `UserConverter` and `MemberConverter` classes to lower case during last lookup step, for the new discord username system. The new username system does not allow for uppercase characters in your username and thus I think it would be a good idea to lower case the input automatically for that scenario.  
If the user still has a discriminator it will function as before.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
