### PR TITLE
Voice message

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1727,6 +1727,10 @@ class Webhook(BaseWebhook):
             in the UI, but will not actually send a notification.
 
             .. versionadded:: 2.2
+        voice_message: :class:`bool`
+            Whether to send this message as a voice message. This will only work with audio files.
+
+            .. versionadded:: 2.3
 
         Raises
         --------

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1594,6 +1594,7 @@ class Webhook(BaseWebhook):
         wait: Literal[True],
         suppress_embeds: bool = MISSING,
         silent: bool = MISSING,
+        voice_message: bool = MISSING,
     ) -> WebhookMessage:
         ...
 
@@ -1617,6 +1618,7 @@ class Webhook(BaseWebhook):
         wait: Literal[False] = ...,
         suppress_embeds: bool = MISSING,
         silent: bool = MISSING,
+        voice_message: bool = MISSING,
     ) -> None:
         ...
 
@@ -1639,6 +1641,7 @@ class Webhook(BaseWebhook):
         wait: bool = False,
         suppress_embeds: bool = False,
         silent: bool = False,
+        voice_message: bool = False,
     ) -> Optional[WebhookMessage]:
         """|coro|
 
@@ -1754,11 +1757,12 @@ class Webhook(BaseWebhook):
         previous_mentions: Optional[AllowedMentions] = getattr(self._state, 'allowed_mentions', None)
         if content is None:
             content = MISSING
-        if ephemeral or suppress_embeds or silent:
+        if ephemeral or suppress_embeds or silent or voice_message:
             flags = MessageFlags._from_value(0)
             flags.ephemeral = ephemeral
             flags.suppress_embeds = suppress_embeds
             flags.suppress_notifications = silent
+            flags.voice = voice_message
         else:
             flags = MISSING
 

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -978,6 +978,10 @@ class SyncWebhook(BaseWebhook):
             in the UI, but will not actually send a notification.
 
             .. versionadded:: 2.2
+        voice_message: :class:`bool`
+            Whether to send this message as a voice message. This will only work with audio files.
+
+            .. versionadded:: 2.3
 
         Raises
         --------

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -870,6 +870,7 @@ class SyncWebhook(BaseWebhook):
         wait: Literal[True],
         suppress_embeds: bool = MISSING,
         silent: bool = MISSING,
+        voice_message: bool = MISSING,
     ) -> SyncWebhookMessage:
         ...
 
@@ -891,6 +892,7 @@ class SyncWebhook(BaseWebhook):
         wait: Literal[False] = ...,
         suppress_embeds: bool = MISSING,
         silent: bool = MISSING,
+        voice_message: bool = MISSING,
     ) -> None:
         ...
 
@@ -911,6 +913,7 @@ class SyncWebhook(BaseWebhook):
         wait: bool = False,
         suppress_embeds: bool = False,
         silent: bool = False,
+        voice_message: bool = False,
     ) -> Optional[SyncWebhookMessage]:
         """Sends a message using the webhook.
 
@@ -1004,10 +1007,11 @@ class SyncWebhook(BaseWebhook):
         if content is None:
             content = MISSING
 
-        if suppress_embeds or silent:
+        if suppress_embeds or silent or voice_message:
             flags = MessageFlags._from_value(0)
             flags.suppress_embeds = suppress_embeds
             flags.suppress_notifications = silent
+            flags.voice = voice_message
         else:
             flags = MISSING
 


### PR DESCRIPTION
## Summary

Implement a voice_message field in Webhook.send that passes the MessageFlags.voice flag and converts the file sent into a voice message.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)


## Additional Information

Although this same method is used for replying to Interactions, due to a known issue in the Discord API, message flags are dropped in webhooks that reply to command contexts. Nothing can be done about it, other than waiting for Discord to fix it.

## Media
![84Rm4](https://github.com/Rapptz/discord.py/assets/30734036/ca874128-0afd-4e0f-8788-e67e543bc840)
![gSm8h](https://github.com/Rapptz/discord.py/assets/30734036/55bae8bd-0211-40bb-9544-25ff14ffc350)

