### PR TITLE
Fix certain select types not appearing in Message.components

### DIFF
--- a/discord/components.py
+++ b/discord/components.py
@@ -527,7 +527,7 @@ def _component_factory(data: ComponentPayload) -> Optional[Union[ActionRow, Acti
         return ActionRow(data)
     elif data['type'] == 2:
         return Button(data)
-    elif data['type'] == 3:
-        return SelectMenu(data)
     elif data['type'] == 4:
         return TextInput(data)
+    elif data['type'] in (3, 5, 6, 7, 8):
+        return SelectMenu(data)


### PR DESCRIPTION
## Summary

This PR fixes an issue where select types 5,6,7 and 8 were not being parsed for `Message.components`.

The statement was moved below type 4 because of the following:
![image](https://i.imgur.com/SyiV2Pg.png)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
