### PR TITLE
Add support for asyncio debug mode.

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -786,6 +786,7 @@ class Client:
         log_formatter: logging.Formatter = MISSING,
         log_level: int = MISSING,
         root_logger: bool = False,
+        asyncio_debug: Optional[bool] = None,
     ) -> None:
         """A blocking call that abstracts away the event loop
         initialisation from you.
@@ -842,6 +843,14 @@ class Client:
             Defaults to ``False``.
 
             .. versionadded:: 2.0
+        asyncio_debug: Optional[:class:`bool`]
+            Whether to enable debug mode for asyncio.
+            This paramter is passed directly to the ``debug`` parameter of ``asyncio.run``.
+            See the documentation on asyncio's debug mode.
+
+            Defaults ``None`` as in ``asyncio.run``.
+
+            .. versionadded:: 2.4
         """
 
         async def runner():
@@ -857,7 +866,7 @@ class Client:
             )
 
         try:
-            asyncio.run(runner())
+            asyncio.run(runner(), debug=asyncio_debug)
         except KeyboardInterrupt:
             # nothing to do here
             # `asyncio.run` handles the loop cleanup


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
<!--
私は日本語話者なので、日本語でもPRの内容を記しておきます。
(I am Japanease. I will write down the content in my native language as well.)

asyncioのdebug modeを設定する簡単な方法を追加したい。

特に初心者にとって、awaitable objectをawaitしていないことに気づいてもらうためには、
asyncioのdebug modeは有効だと考えている。
しかし、今までは、client.runと同じ機能を自分で書いてasyncio.runに渡すか、
setup_hookなどで設定するしかなかったと思う。
-->

Add an easy way to enable asyncio debug mode.
[asyncio debug mode](https://docs.python.org/3/library/asyncio-dev.html#asyncio-debug-mode)

Now
```py
import asyncio, discord

class MyClient(discord.Client):
    async def setup_hooks(self):
        asyncio.get_running_loop().set_debug(True)

client = MyClient(...)
client.run(token)
```

After
```py
client = discord.Client(...)
client.run(token, asyncio_debug=True)
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
