### PR TITLE
Fix `Intents.emoji`, `emojis_and_stickers` having swapped alias/non-alias decors

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -850,7 +850,7 @@ class Intents(BaseFlags):
         """
         return 1 << 2
 
-    @flag_value
+    @alias_flag_value
     def emojis(self):
         """:class:`bool`: Alias of :attr:`.emojis_and_stickers`.
 
@@ -859,7 +859,7 @@ class Intents(BaseFlags):
         """
         return 1 << 3
 
-    @alias_flag_value
+    @flag_value
     def emojis_and_stickers(self):
         """:class:`bool`: Whether guild emoji and sticker related events are enabled.
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Extremely minor detail, but I noticed that `Intents.emojis` flag docs say "Changed to an alias in 2.0." however it still has `@flag_value` decorator, while vice-versa for `Intents.emojis_and_stickers`, when looks like, it's supposed to be a new main flag. Therefore, two lines PR. 😮 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (docs are fine)
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
