### PR TITLE
save a reference to created tasks

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -827,7 +827,7 @@ class InteractionResponse(Generic[ClientT]):
                 except HTTPException:
                     pass
 
-            asyncio.create_task(inner_call())
+            task = asyncio.create_task(inner_call())
 
     async def edit_message(
         self,
@@ -941,7 +941,7 @@ class InteractionResponse(Generic[ClientT]):
                 except HTTPException:
                     pass
 
-            asyncio.create_task(inner_call())
+            task = asyncio.create_task(inner_call())
 
     async def send_modal(self, modal: Modal, /) -> None:
         """|coro|
@@ -1227,6 +1227,6 @@ class InteractionMessage(Message):
                 except HTTPException:
                     pass
 
-            asyncio.create_task(inner_call())
+            task = asyncio.create_task(inner_call())
         else:
             await self._state._interaction.delete_original_response()

--- a/discord/message.py
+++ b/discord/message.py
@@ -854,7 +854,7 @@ class PartialMessage(Hashable):
                 except HTTPException:
                     pass
 
-            asyncio.create_task(delete(delay))
+            task = asyncio.create_task(delete(delay))
         else:
             await self._state.http.delete_message(self.channel.id, self.id)
 

--- a/discord/state.py
+++ b/discord/state.py
@@ -1232,7 +1232,7 @@ class ConnectionState(Generic[ClientT]):
 
         # check if it requires chunking
         if self._guild_needs_chunking(guild):
-            asyncio.create_task(self._chunk_and_dispatch(guild, unavailable))
+            task = asyncio.create_task(self._chunk_and_dispatch(guild, unavailable))
             return
 
         # Dispatch available if newly available
@@ -1524,7 +1524,7 @@ class ConnectionState(Generic[ClientT]):
                 voice = self._get_voice_client(guild.id)
                 if voice is not None:
                     coro = voice.on_voice_state_update(data)
-                    asyncio.create_task(logging_coroutine(coro, info='Voice Protocol voice state update handler'))
+                    task = asyncio.create_task(logging_coroutine(coro, info='Voice Protocol voice state update handler'))
 
             member, before, after = guild._update_voice_state(data, channel_id)  # type: ignore
             if member is not None:
@@ -1545,7 +1545,7 @@ class ConnectionState(Generic[ClientT]):
         vc = self._get_voice_client(key_id)
         if vc is not None:
             coro = vc.on_voice_server_update(data)
-            asyncio.create_task(logging_coroutine(coro, info='Voice Protocol voice server update handler'))
+            task = asyncio.create_task(logging_coroutine(coro, info='Voice Protocol voice server update handler'))
 
     def parse_typing_start(self, data: gw.TypingStartEvent) -> None:
         raw = RawTypingEvent(data)

--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -196,7 +196,7 @@ class Modal(View):
     def _dispatch_submit(
         self, interaction: Interaction, components: List[ModalSubmitComponentInteractionDataPayload]
     ) -> None:
-        asyncio.create_task(self._scheduled_task(interaction, components), name=f'discord-ui-modal-dispatch-{self.id}')
+        task = asyncio.create_task(self._scheduled_task(interaction, components), name=f'discord-ui-modal-dispatch-{self.id}')
 
     def to_dict(self) -> Dict[str, Any]:
         payload = {

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -446,13 +446,13 @@ class View:
             self.__cancel_callback = None
 
         self.__stopped.set_result(True)
-        asyncio.create_task(self.on_timeout(), name=f'discord-ui-view-timeout-{self.id}')
+        task = asyncio.create_task(self.on_timeout(), name=f'discord-ui-view-timeout-{self.id}')
 
     def _dispatch_item(self, item: Item, interaction: Interaction):
         if self.__stopped.done():
             return
 
-        asyncio.create_task(self._scheduled_task(item, interaction), name=f'discord-ui-view-dispatch-{self.id}')
+        task = asyncio.create_task(self._scheduled_task(item, interaction), name=f'discord-ui-view-dispatch-{self.id}')
 
     def _refresh(self, components: List[Component]) -> None:
         # fmt: off

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -931,7 +931,7 @@ class WebhookMessage(Message):
                 except HTTPException:
                     pass
 
-            asyncio.create_task(inner_call())
+            task = asyncio.create_task(inner_call())
         else:
             await self._state._webhook.delete_message(self.id, thread=self._state._thread)
 


### PR DESCRIPTION
> Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn’t referenced elsewhere may get garbage collected at any time, even before it’s done.
>
> [python docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task)

## Summary

Please review the link: https://textual.textualize.io/blog/2023/02/11/the-heisenbug-lurking-in-your-async-code/

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
