### PR TITLE
Renamed some things of guilds, members and roles for the Guild Premiums Subscription system

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -882,7 +882,7 @@ class Guild(Hashable):
     @property
     def boosters(self) -> List[Member]:
         """List[:class:`Member`]: A list of members who have "boosted" this guild."""
-        return [member for member in self.members if member.nitro_subsciber_since is not None]
+        return [member for member in self.members if member.nitro_subscriber_since is not None]
 
     @property
     def roles(self) -> Sequence[Role]:
@@ -2134,7 +2134,7 @@ class Guild(Hashable):
             fields['features'] = list(features)
 
         if boost_progress_bar_enabled is not MISSING:
-            fields['boost_progress_bar_enabled'] = boost_progress_bar_enabled
+            fields['premium_progress_bar_enabled'] = boost_progress_bar_enabled
 
         widget_payload: EditWidgetSettings = {}
         if widget_channel is not MISSING:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -229,8 +229,16 @@ class Guild(Hashable):
     boost_tier: :class:`int`
         The boost tier for this guild. Corresponds to "Nitro Server" in the official UI.
         The number goes from 0 to 3 inclusive.
+
+    premium_tier: :class:`int`
+        An alias for ``boost_tier``.
+
     boost_count: :class:`int`
         The number of "boosts" this guild currently has.
+
+    premium_subscription_count: :class:`int`
+        An alias for ``boost_count``.
+
     preferred_locale: :class:`Locale`
         The preferred locale for the guild. Used when filtering Server Discovery
         results to a specific language.
@@ -262,6 +270,10 @@ class Guild(Hashable):
         Indicates if the guild has server boost level progress bar enabled.
 
         .. versionadded:: 2.0
+
+    premium_progress_bar_enabled: :class:`bool`
+        An alias for ``boost_progress_bar_enabled``.
+
     widget_enabled: :class:`bool`
         Indicates if the guild has widget enabled.
 
@@ -320,6 +332,12 @@ class Guild(Hashable):
         'boost_progress_bar_enabled',
         '_safety_alerts_channel_id',
         'max_stage_video_users',
+
+        # ALIASES
+
+        'premium_progress_bar_enabled',
+        'premium_tier',
+        'premium_subscription_count'
     )
 
     _BOOSTED_GUILD_LIMITS: ClassVar[Dict[Optional[int], _GuildLimit]] = {
@@ -543,6 +561,11 @@ class Guild(Hashable):
             for s in guild['guild_scheduled_events']:
                 scheduled_event = ScheduledEvent(data=s, state=self._state)
                 self._scheduled_events[scheduled_event.id] = scheduled_event
+
+        # ALIASES:
+        self.premium_tier = self.boost_tier
+        self.premium_progress_bar_enabled = self.boost_progress_bar_enabled
+        self.premium_subscription_count = self.boost_count
 
     @property
     def channels(self) -> Sequence[GuildChannel]:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -229,7 +229,7 @@ class Guild(Hashable):
     boost_tier: :class:`int`
         The boost tier for this guild. Corresponds to "Nitro Server" in the official UI.
         The number goes from 0 to 3 inclusive.
-    nitro_boost_count: :class:`int`
+    boost_count: :class:`int`
         The number of "boosts" this guild currently has.
     preferred_locale: :class:`Locale`
         The preferred locale for the guild. Used when filtering Server Discovery
@@ -258,7 +258,7 @@ class Guild(Hashable):
         :meth:`Client.fetch_guild` or :meth:`Client.fetch_guilds` with ``with_counts=True``.
 
         .. versionchanged:: 2.0
-    boost_progress_bar_enagle: :class:`bool`
+    boost_progress_bar_enabled: :class:`bool`
         Indicates if the guild has server boost level progress bar enabled.
 
         .. versionadded:: 2.0
@@ -289,7 +289,7 @@ class Guild(Hashable):
         'max_members',
         'max_video_channel_users',
         'boost_tier',
-        'nitro_boost_count',
+        'boost_count',
         'preferred_locale',
         'nsfw_level',
         'mfa_level',
@@ -317,7 +317,7 @@ class Guild(Hashable):
         '_threads',
         'approximate_member_count',
         'approximate_presence_count',
-        'boost_progress_bar_enagle',
+        'boost_progress_bar_enabled',
         '_safety_alerts_channel_id',
         'max_stage_video_users',
     )
@@ -485,7 +485,7 @@ class Guild(Hashable):
         self.max_video_channel_users: Optional[int] = guild.get('max_video_channel_users')
         self.max_stage_video_users: Optional[int] = guild.get('max_stage_video_channel_users')
         self.boost_tier: int = guild.get('premium_tier', 0)
-        self.nitro_boost_count: int = guild.get('premium_subscription_count') or 0
+        self.boost_count: int = guild.get('premium_subscription_count') or 0
         self.vanity_url_code: Optional[str] = guild.get('vanity_url_code')
         self.widget_enabled: bool = guild.get('widget_enabled', False)
         self._widget_channel_id: Optional[int] = utils._get_as_snowflake(guild, 'widget_channel_id')
@@ -499,7 +499,7 @@ class Guild(Hashable):
         self.mfa_level: MFALevel = try_enum(MFALevel, guild.get('mfa_level', 0))
         self.approximate_presence_count: Optional[int] = guild.get('approximate_presence_count')
         self.approximate_member_count: Optional[int] = guild.get('approximate_member_count')
-        self.boost_progress_bar_enagle: bool = guild.get('premium_progress_bar_enabled', False)
+        self.boost_progress_bar_enabled: bool = guild.get('premium_progress_bar_enabled', False)
         self.owner_id: Optional[int] = utils._get_as_snowflake(guild, 'owner_id')
         self._large: Optional[bool] = None if self._member_count is None else self._member_count >= 250
         self._afk_channel_id: Optional[int] = utils._get_as_snowflake(guild, 'afk_channel_id')
@@ -1829,7 +1829,7 @@ class Guild(Hashable):
         preferred_locale: Locale = MISSING,
         rules_channel: Optional[TextChannel] = MISSING,
         public_updates_channel: Optional[TextChannel] = MISSING,
-        boost_progress_bar_enagle: bool = MISSING,
+        boost_progress_bar_enabled: bool = MISSING,
         discoverable: bool = MISSING,
         invites_disabled: bool = MISSING,
         widget_enabled: bool = MISSING,
@@ -1923,7 +1923,7 @@ class Guild(Hashable):
             public updates channel.
 
             .. versionadded:: 1.4
-        boost_progress_bar_enagle: :class:`bool`
+        boost_progress_bar_enabled: :class:`bool`
             Whether the premium AKA server boost level progress bar should be enabled for the guild.
 
             .. versionadded:: 2.0
@@ -2133,8 +2133,8 @@ class Guild(Hashable):
 
             fields['features'] = list(features)
 
-        if boost_progress_bar_enagle is not MISSING:
-            fields['boost_progress_bar_enagle'] = boost_progress_bar_enagle
+        if boost_progress_bar_enabled is not MISSING:
+            fields['boost_progress_bar_enabled'] = boost_progress_bar_enabled
 
         widget_payload: EditWidgetSettings = {}
         if widget_channel is not MISSING:

--- a/discord/member.py
+++ b/discord/member.py
@@ -301,6 +301,8 @@ class Member(discord.abc.Messageable, _UserTag):
     nitro_subsriber_since: Optional[:class:`datetime.datetime`]
         An aware datetime object that specifies the date and time in UTC when the member used their
         "Nitro boost" on the guild, if available. This could be ``None``.
+    premium_since: Optional[:class:`datetime.datetime`]
+        An alias for `nitro_subscriber_since`.
     timed_out_until: Optional[:class:`datetime.datetime`]
         An aware datetime object that specifies the date and time in UTC that the member's time out will expire.
         This will be set to ``None`` if the user is not timed out.
@@ -312,6 +314,7 @@ class Member(discord.abc.Messageable, _UserTag):
         '_roles',
         'joined_at',
         'nitro_subscriber_since',
+        'premium_since',
         'activities',
         'guild',
         'pending',
@@ -363,6 +366,9 @@ class Member(discord.abc.Messageable, _UserTag):
             self._permissions = None
 
         self.timed_out_until: Optional[datetime.datetime] = utils.parse_time(data.get('communication_disabled_until'))
+
+        # ALIASES:
+        self.premium_since = self.nitro_subscriber_since
 
     def __str__(self) -> str:
         return str(self._user)

--- a/discord/member.py
+++ b/discord/member.py
@@ -298,7 +298,7 @@ class Member(discord.abc.Messageable, _UserTag):
         Whether the member is pending member verification.
 
         .. versionadded:: 1.6
-    premium_since: Optional[:class:`datetime.datetime`]
+    nitro_subsriber_since: Optional[:class:`datetime.datetime`]
         An aware datetime object that specifies the date and time in UTC when the member used their
         "Nitro boost" on the guild, if available. This could be ``None``.
     timed_out_until: Optional[:class:`datetime.datetime`]
@@ -311,7 +311,7 @@ class Member(discord.abc.Messageable, _UserTag):
     __slots__ = (
         '_roles',
         'joined_at',
-        'premium_since',
+        'nitro_subscriber_since',
         'activities',
         'guild',
         'pending',
@@ -348,7 +348,7 @@ class Member(discord.abc.Messageable, _UserTag):
         self._user: User = state.store_user(data['user'])
         self.guild: Guild = guild
         self.joined_at: Optional[datetime.datetime] = utils.parse_time(data.get('joined_at'))
-        self.premium_since: Optional[datetime.datetime] = utils.parse_time(data.get('premium_since'))
+        self.nitro_subscriber_since: Optional[datetime.datetime] = utils.parse_time(data.get('premium_since'))
         self._roles: utils.SnowflakeList = utils.SnowflakeList(map(int, data['roles']))
         self._client_status: _ClientStatus = _ClientStatus()
         self.activities: Tuple[ActivityTypes, ...] = ()
@@ -390,7 +390,7 @@ class Member(discord.abc.Messageable, _UserTag):
 
     def _update_from_message(self, data: MemberPayload) -> None:
         self.joined_at = utils.parse_time(data.get('joined_at'))
-        self.premium_since = utils.parse_time(data.get('premium_since'))
+        self.nitro_subscriber_since = utils.parse_time(data.get('premium_since'))
         self._roles = utils.SnowflakeList(map(int, data['roles']))
         self.nick = data.get('nick', None)
         self.pending = data.get('pending', False)
@@ -414,7 +414,7 @@ class Member(discord.abc.Messageable, _UserTag):
 
         self._roles = utils.SnowflakeList(member._roles, is_sorted=True)
         self.joined_at = member.joined_at
-        self.premium_since = member.premium_since
+        self.nitro_subscriber_since = member.premium_since
         self._client_status = _ClientStatus._copy(member._client_status)
         self.guild = member.guild
         self.nick = member.nick
@@ -448,7 +448,7 @@ class Member(discord.abc.Messageable, _UserTag):
         except KeyError:
             pass
 
-        self.premium_since = utils.parse_time(data.get('premium_since'))
+        self.nitro_subscriber_since = utils.parse_time(data.get('premium_since'))
         self.timed_out_until = utils.parse_time(data.get('communication_disabled_until'))
         self._roles = utils.SnowflakeList(map(int, data['roles']))
         self._avatar = data.get('avatar')

--- a/discord/role.py
+++ b/discord/role.py
@@ -74,7 +74,7 @@ class RoleTags:
     __slots__ = (
         'bot_id',
         'integration_id',
-        '_premium_subscriber',
+        '_nitro_subscriber',
         '_available_for_purchase',
         'subscription_listing_id',
         '_guild_connections',
@@ -89,7 +89,7 @@ class RoleTags:
         # This is different from other fields where "null" means "not there".
         # So in this case, a value of None is the same as True.
         # Which means we would need a different sentinel.
-        self._premium_subscriber: bool = data.get('premium_subscriber', MISSING) is None
+        self._nitro_subscriber: bool = data.get('premium_subscriber', MISSING) is None
         self._available_for_purchase: bool = data.get('available_for_purchase', MISSING) is None
         self._guild_connections: bool = data.get('guild_connections', MISSING) is None
 
@@ -98,8 +98,8 @@ class RoleTags:
         return self.bot_id is not None
 
     def is_booster(self) -> bool:
-        """:class:`bool`: Whether the role is the premium subscriber, AKA "boost", role for the guild."""
-        return self._premium_subscriber
+        """:class:`bool`: Whether the role is the "boost", role for the guild."""
+        return self._nitro_subscriber
 
     def is_integration(self) -> bool:
         """:class:`bool`: Whether the role is managed by an integration."""
@@ -122,7 +122,7 @@ class RoleTags:
     def __repr__(self) -> str:
         return (
             f'<RoleTags bot_id={self.bot_id} integration_id={self.integration_id} '
-            f'premium_subscriber={self.is_booster()}>'
+            f'nitro_subscriber={self.is_booster()}>'
         )
 
 

--- a/discord/role.py
+++ b/discord/role.py
@@ -97,7 +97,7 @@ class RoleTags:
         """:class:`bool`: Whether the role is associated with a bot."""
         return self.bot_id is not None
 
-    def is_premium_subscriber(self) -> bool:
+    def is_booster(self) -> bool:
         """:class:`bool`: Whether the role is the premium subscriber, AKA "boost", role for the guild."""
         return self._premium_subscriber
 
@@ -122,7 +122,7 @@ class RoleTags:
     def __repr__(self) -> str:
         return (
             f'<RoleTags bot_id={self.bot_id} integration_id={self.integration_id} '
-            f'premium_subscriber={self.is_premium_subscriber()}>'
+            f'premium_subscriber={self.is_booster()}>'
         )
 
 
@@ -303,7 +303,7 @@ class Role(Hashable):
 
         .. versionadded:: 1.6
         """
-        return self.tags is not None and self.tags.is_premium_subscriber()
+        return self.tags is not None and self.tags.is_booster()
 
     def is_integration(self) -> bool:
         """:class:`bool`: Whether the role is managed by an integration.

--- a/discord/role.py
+++ b/discord/role.py
@@ -298,8 +298,8 @@ class Role(Hashable):
         """
         return self.tags is not None and self.tags.is_bot_managed()
 
-    def is_premium_subscriber(self) -> bool:
-        """:class:`bool`: Whether the role is the premium subscriber, AKA "boost", role for the guild.
+    def is_booster(self) -> bool:
+        """:class:`bool`: Whether the role is the "booster" role for the guild.
 
         .. versionadded:: 1.6
         """

--- a/discord/role.py
+++ b/discord/role.py
@@ -65,9 +65,10 @@ class RoleTags:
         The bot's user ID that manages this role.
     integration_id: Optional[:class:`int`]
         The integration ID that manages the role.
-    subscription_listing_id: Optional[:class:`int`]
+    boost_listing_id: Optional[:class:`int`]
         The ID of this role's subscription SKU and listing.
-
+    subscription_listing_id: Optional[:class:`int`]
+        An alias for `boost_listing_id`
         .. versionadded:: 2.2
     """
 
@@ -76,6 +77,7 @@ class RoleTags:
         'integration_id',
         '_nitro_subscriber',
         '_available_for_purchase',
+        'boost_listing_id',
         'subscription_listing_id',
         '_guild_connections',
     )
@@ -83,7 +85,8 @@ class RoleTags:
     def __init__(self, data: RoleTagPayload):
         self.bot_id: Optional[int] = _get_as_snowflake(data, 'bot_id')
         self.integration_id: Optional[int] = _get_as_snowflake(data, 'integration_id')
-        self.subscription_listing_id: Optional[int] = _get_as_snowflake(data, 'subscription_listing_id')
+        self.boost_listing_id: Optional[int] = _get_as_snowflake(data, 'subscription_listing_id')
+        self.subscription_listing_id: Optional[int] = self.boost_listing_id
 
         # NOTE: The API returns "null" for this if it's valid, which corresponds to None.
         # This is different from other fields where "null" means "not there".
@@ -100,6 +103,10 @@ class RoleTags:
     def is_booster(self) -> bool:
         """:class:`bool`: Whether the role is the "boost", role for the guild."""
         return self._nitro_subscriber
+    
+    def is_premium_subscriber(self) -> bool:
+        """:class:`bool`: An alias for `is_booster`"""
+        return self.is_booster()
 
     def is_integration(self) -> bool:
         """:class:`bool`: Whether the role is managed by an integration."""
@@ -304,6 +311,10 @@ class Role(Hashable):
         .. versionadded:: 1.6
         """
         return self.tags is not None and self.tags.is_booster()
+    
+    def is_premium_subscriber(self) -> bool:
+        """:class:`bool`: An alias for `is_booster`"""
+        return self.is_booster()
 
     def is_integration(self) -> bool:
         """:class:`bool`: Whether the role is managed by an integration.


### PR DESCRIPTION
## Summary
This PR basically changes the name of some things in the next files:
>> Modified member.py: Changed the 'premium_since' to 'nitro_subsriber_since'
>> Modified guild.py: Changed 'premium_tier' to 'boost_tier', changed 'premium_subscription_count' to 'boost_count', changed 'premium_progress_bar_enabled' to 'boost_progress_bar_enabled, changed 'Guild._PREMIUM_GUILD_LIMITS' to 'Guild._BOOSTED_GUILD_LIMITS'
>> Modified role.py: Changed 'is_premium_subscriber' to 'is_booster'
I did this because as you may know Discord will launch a complete Guild Premium Subscription system, this change will affect to the Nitro and Boost things in discord.py, as they are referred as `premium`, so they are renamed as `nitro` or `boost` (depending of what it refers).
If this PR is merged I know the users that use discord.py will need to change everything related to nitro and boost that are referred as `premium` to the new names, but, as I said, it is for the best (ig).

Also as I kept the old names as aliases.

## Checklist
- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
