### PR TITLE
Add support for attachment flags

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1824,3 +1824,76 @@ class MemberFlags(BaseFlags):
     def started_onboarding(self):
         """:class:`bool`: Returns ``True`` if the member has started onboarding."""
         return 1 << 3
+
+
+@fill_with_flags()
+class AttachmentFlags(BaseFlags):
+    r"""Wraps up the Discord Attachment flags
+
+    .. versionadded:: 2.4
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two AttachmentFlags are equal.
+
+        .. describe:: x != y
+
+            Checks if two AttachmentFlags are not equal.
+
+        .. describe:: x | y, x |= y
+
+            Returns a AttachmentFlags instance with all enabled flags from
+            both x and y.
+
+        .. describe:: x & y, x &= y
+
+            Returns a AttachmentFlags instance with only flags enabled on
+            both x and y.
+
+        .. describe:: x ^ y, x ^= y
+
+            Returns a AttachmentFlags instance with only flags enabled on
+            only one of x or y, not on both.
+
+        .. describe:: ~x
+
+            Returns a AttachmentFlags instance with all flags inverted from x.
+
+        .. describe:: hash(x)
+
+            Return the flag's hash.
+
+        .. describe:: iter(x)
+
+            Returns an iterator of ``(name, value)`` pairs. This allows it
+            to be, for example, constructed as a dict or a list of pairs.
+            Note that aliases are not shown.
+
+        .. describe:: bool(b)
+
+            Returns whether any flag is set to ``True``.
+
+
+    Attributes
+    -----------
+    value: :class:`int`
+        The raw value. You should query flags via the properties
+        rather than using this raw value.
+    """
+
+    @flag_value
+    def is_clip(self):
+        """:class:`bool`: Returns ``True`` if the attachment is a clip."""
+        return 1 << 0
+
+    @flag_value
+    def is_thumbnail(self):
+        """:class:`bool`: Returns ``True`` if the attachment is a thumbnail."""
+        return 1 << 1
+
+    @flag_value
+    def is_remix(self):
+        """:class:`bool`: Returns ``True`` if the attachment has been edited using the remix feature."""
+        return 1 << 2

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1885,16 +1885,16 @@ class AttachmentFlags(BaseFlags):
     """
 
     @flag_value
-    def is_clip(self):
+    def clip(self):
         """:class:`bool`: Returns ``True`` if the attachment is a clip."""
         return 1 << 0
 
     @flag_value
-    def is_thumbnail(self):
+    def thumbnail(self):
         """:class:`bool`: Returns ``True`` if the attachment is a thumbnail."""
         return 1 << 1
 
     @flag_value
-    def is_remix(self):
+    def remix(self):
         """:class:`bool`: Returns ``True`` if the attachment has been edited using the remix feature."""
         return 1 << 2

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -58,6 +58,7 @@ __all__ = (
     'ChannelFlags',
     'AutoModPresets',
     'MemberFlags',
+    'AttachmentFlags',
 )
 
 BF = TypeVar('BF', bound='BaseFlags')

--- a/discord/message.py
+++ b/discord/message.py
@@ -54,7 +54,7 @@ from .errors import HTTPException
 from .components import _component_factory
 from .embeds import Embed
 from .member import Member
-from .flags import MessageFlags
+from .flags import MessageFlags, AttachmentFlags
 from .file import File
 from .utils import escape_mentions, MISSING
 from .http import handle_message_parameters
@@ -207,6 +207,7 @@ class Attachment(Hashable):
         'ephemeral',
         'duration',
         'waveform',
+        '_flags',
     )
 
     def __init__(self, *, data: AttachmentPayload, state: ConnectionState):
@@ -225,6 +226,13 @@ class Attachment(Hashable):
 
         waveform = data.get('waveform')
         self.waveform: Optional[bytes] = utils._base64_to_bytes(waveform) if waveform is not None else None
+
+        self._flags: int = data.get('flags', 0)
+
+    @property
+    def flags(self) -> AttachmentFlags:
+        """:class:`AttachmentFlags`: The attachment's flags."""
+        return AttachmentFlags._from_value(self._flags)
 
     def is_spoiler(self) -> bool:
         """:class:`bool`: Whether this attachment contains a spoiler."""

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -70,6 +70,7 @@ class Attachment(TypedDict):
     ephemeral: NotRequired[bool]
     duration_secs: NotRequired[float]
     waveform: NotRequired[str]
+    flags: NotRequired[int]
 
 
 MessageActivityType = Literal[1, 2, 3, 5]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4970,6 +4970,14 @@ MemberFlags
 .. autoclass:: MemberFlags
     :members:
 
+AttachmentFlags
+~~~~~~~~~~~~~~~~
+
+.. attributetable:: AttachmentFlags
+
+.. autoclass:: AttachmentFlags
+    :members:
+
 ForumTag
 ~~~~~~~~~
 


### PR DESCRIPTION
## Summary

This PR adds support for attachment flags.

Depends on https://github.com/discord/discord-api-docs/pull/6272

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
