### PR TITLE
Begin `discord.app_commands` documentation

### DIFF
--- a/docs/app_commands/index.rst
+++ b/docs/app_commands/index.rst
@@ -1,0 +1,15 @@
+.. currentmodule:: discord
+
+``discord.app_commands`` -- Slash commands framework
+=====================================================
+
+.. versionadded:: 2.0
+
+Appliation commands provide a robust framework for developing interactive slash commands. Unlike :ref:`discord.ext.commands <ext_commands_commands>`, aka prefix commands, ``discord.app_commands`` utilizes :ref:`Discord's Interactions API <discord_interactions_api>`.
+
+This implementation makes extensive use of webhooks to offer advanced features and interaction mechanisms. App commands provide advanced features such as:
+
+- Auto-completetion of command arguments
+- Argument desciptors while the user is typing the command
+- Messages that are only visible to the user invoking the interaction
+    - Created using ``ephemeral=True`` and only if the type of webhook is :attr:`WebhookType.application`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,16 @@ If you're having trouble with something, these resources might help.
 - Report bugs in the :resource:`issue tracker <issues>`.
 - Ask in our :resource:`GitHub discussions page <discussions>`.
 
+Interactions
+--------------
+
+These pages explain how to handle user actions via various interaction types.
+
+.. toctree::
+  :maxdepth: 1
+
+  app_commands/index.rst
+
 Extensions
 ------------
 

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -1,5 +1,7 @@
 .. currentmodule:: discord
 
+.. _discord_interactions_api:
+
 Interactions API Reference
 ============================
 


### PR DESCRIPTION
## Summary

Got inspired to step forward and start this much needed (imo) addition to the docs. I also did this to become more familiar with app_commands myself as someone still on a very old version of Discord.py, so I'm in no position to flesh this out with examples, etc. However I'm hoping that this base will inspire others to hop onboard.

Notable things:
- I referenced the page on the root index.rst under a newly created "Interactions" section, further setting the docs up for pages about other interactions
- I left the Applications Commands API Reference where it was in interactions/api.rst since I'm unsure how to split it up, or if it should be split up

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
