### PR TITLE
Rework login-flow to retrieve user object from appinfo

### DIFF
--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
         Team as TeamPayload,
         InstallParams as InstallParamsPayload,
     )
+    from .types.user import User as UserPayload
     from .user import User
     from .state import ConnectionState
 
@@ -131,6 +132,10 @@ class AppInfo:
         a verification method in the guild's role verification configuration.
 
         .. versionadded:: 2.2
+    bot: Optional[:class:`User`]
+        The bot user, if this application belongs to a bot.
+
+        .. versionadded:: 2.4
     """
 
     __slots__ = (
@@ -141,6 +146,7 @@ class AppInfo:
         'rpc_origins',
         'bot_public',
         'bot_require_code_grant',
+        'bot',
         'owner',
         '_icon',
         'verify_key',
@@ -173,6 +179,9 @@ class AppInfo:
 
         team: Optional[TeamPayload] = data.get('team')
         self.team: Optional[Team] = Team(state, team) if team else None
+
+        bot: Optional[UserPayload] = data.get('bot')
+        self.bot: Optional[User] = state.create_user(bot) if bot else None
 
         self.verify_key: str = data['verify_key']
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -610,8 +610,8 @@ class Client:
         token = token.strip()
 
         data = await self.http.static_login(token)
-        self._connection.user = ClientUser(state=self._connection, data=data)
-        self._application = await self.application_info()
+        self._connection.user = ClientUser(state=self._connection, data=data['bot'])  # type: ignore
+        self._application = AppInfo(self._connection, data)
         if self._connection.application_id is None:
             self._connection.application_id = self._application.id
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -781,7 +781,7 @@ class HTTPClient:
 
     # login management
 
-    async def static_login(self, token: str) -> user.User:
+    async def static_login(self, token: str) -> appinfo.AppInfo:
         # Necessary to get aiohttp to stop complaining about session creation
         if self.connector is MISSING:
             # discord does not support ipv6
@@ -799,7 +799,7 @@ class HTTPClient:
         self.token = token
 
         try:
-            data = await self.request(Route('GET', '/users/@me'))
+            data = await self.application_info()
         except HTTPException as exc:
             self.token = old_token
             if exc.status == 401:

--- a/discord/types/appinfo.py
+++ b/discord/types/appinfo.py
@@ -55,6 +55,7 @@ class AppInfo(BaseAppInfo):
     owner: User
     bot_public: bool
     bot_require_code_grant: bool
+    bot: NotRequired[User]
     team: NotRequired[Team]
     guild_id: NotRequired[Snowflake]
     primary_sku_id: NotRequired[Snowflake]


### PR DESCRIPTION
## Summary

This PR reworks login flow to use the new `bot` key in the application payload for the ClientUser object, rather than making a 2nd HTTP request.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
