### PR TITLE
Fix NameError in GuildChannel.create_invite

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -48,7 +48,7 @@ from typing import (
 
 from .object import OLDEST_OBJECT, Object
 from .context_managers import Typing
-from .enums import ChannelType
+from .enums import ChannelType, InviteTarget
 from .errors import ClientException
 from .mentions import AllowedMentions
 from .permissions import PermissionOverwrite, Permissions
@@ -93,7 +93,6 @@ if TYPE_CHECKING:
         StageChannel,
     )
     from .threads import Thread
-    from .enums import InviteTarget
     from .ui.view import View
     from .types.channel import (
         PermissionOverwrite as PermissionOverwritePayload,


### PR DESCRIPTION
## Summary

Fixes a NameError discovered in a [discord help thread](https://discord.com/channels/336642139381301249/1132096421659680869) 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
