### PR TITLE
Multiple small CSS changes to fix mobile/tablet issues.

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -16,6 +16,10 @@ Historically however, thanks to:
   box-sizing: border-box;
 }
 
+section {
+  word-break: break-all;
+}
+
 /* CSS variables would go here */
 :root {
   --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
@@ -216,6 +220,7 @@ body {
   display: grid;
   min-height: 100%;
   grid-auto-rows: min-content auto min-content;
+  grid-template-columns: minmax(0, 1fr);
   grid-template-areas:
     "s"
     "h"
@@ -1046,6 +1051,7 @@ code.xref, a code {
 
 span.pre {
   padding: 0 2px;
+  white-space: pre-wrap!important;
 }
 
 dl.class {
@@ -1211,12 +1217,13 @@ div.code-block-caption {
 
 /* desktop stuff */
 
-@media screen and (min-width: 600px) {
+@media screen and (min-width: 768px) {
   .grid-item {
     max-width: unset;
   }
 
   .main-grid {
+    grid-template-columns: repeat(6, 1fr);
     grid-template-areas:
       "h h h h h h"
       "n n n n n n"
@@ -1273,6 +1280,7 @@ div.code-block-caption {
     position: sticky;
     top: 1em;
     max-height: calc(100vh - 2em);
+    max-width: 100%;
     overflow-y: auto;
     margin: 1em;
   }
@@ -1320,6 +1328,10 @@ div.code-block-caption {
       "n n n n n n n n n n n n n n n n"
       "s s s . . c c c c c c c c c . ."
       "s s s f f f f f f f f f f f f f"
+  }
+
+  #sidebar {
+    max-width: unset;
   }
 
   header > nav {

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -1051,7 +1051,7 @@ code.xref, a code {
 
 span.pre {
   padding: 0 2px;
-  white-space: pre-wrap!important;
+  white-space: pre-wrap !important;
 }
 
 dl.class {

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -17,7 +17,7 @@ Historically however, thanks to:
 }
 
 section {
-  word-break: break-all;
+  word-break: break-word;
 }
 
 /* CSS variables would go here */


### PR DESCRIPTION
## Summary
Fixes some CSS mainly targeting mobile and tablet devices on the docs.

Previously responsiveness on mobile was not working as expected, resulting in large gaps on some devices or forced horizontal scrolling. This hopefully remedies most of those issues.

This also fixes a minor bug where, depending on the size of your window, the main content would overlap into the sidebar.

You can view a hosted version of the docs:
https://discordpy-css.readthedocs.io/en/latest/

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)

I have attached some images for reference.
![image](https://github.com/Rapptz/discord.py/assets/29671945/82fdda60-82e2-44ec-b910-2e34c3a160f3)
![image](https://github.com/Rapptz/discord.py/assets/29671945/c7676aba-d6f5-4995-a22c-f5a40deac518)
![image](https://github.com/Rapptz/discord.py/assets/29671945/4c33f6b8-a269-4870-a721-cd3c9a656a53)
![image](https://github.com/Rapptz/discord.py/assets/29671945/8cab4da3-0f51-440d-a951-79828070dad4)


