### PR TITLE
Fix localization support for hybrid group fallback

### DIFF
--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -593,11 +593,13 @@ class HybridGroup(Group[CogT, P, T]):
 
     Attributes
     -----------
-    fallback: Optional[Union[:class:`str`, :class:`~discord.app_commands.locale_str`]]
+    fallback: Optional[:class:`str`]
         The command name to use as a fallback for the application command. Since
         application command groups cannot be invoked, this creates a subcommand within
         the group that can be invoked with the given group callback. If ``None``
         then no fallback command is given. Defaults to ``None``.
+    fallback_locale: Optional[:class:`~discord.app_commands.locale_str`]
+        The fallback command name's locale string, if available.
     """
 
     __commands_is_hybrid__: ClassVar[bool] = True
@@ -635,7 +637,14 @@ class HybridGroup(Group[CogT, P, T]):
         # However, Python does not have conditional typing so it's very hard to
         # make this type depend on the with_app_command bool without a lot of needless repetition
         self.app_command: app_commands.Group = MISSING
-        self.fallback: Optional[Union[str, app_commands.locale_str]] = fallback
+
+        fallback, fallback_locale = (
+            (fallback.message, fallback)
+            if isinstance(fallback, app_commands.locale_str)
+            else (fallback, None)
+        )
+        self.fallback: Optional[str] = fallback
+        self.fallback_locale: Optional[app_commands.locale_str] = fallback_locale
 
         if self.with_app_command:
             guild_ids = attrs.pop('guild_ids', None) or getattr(

--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -665,7 +665,7 @@ class HybridGroup(Group[CogT, P, T]):
             self.app_command.module = self.module
 
             if fallback is not None:
-                command = HybridAppCommand(self, name=fallback)
+                command = HybridAppCommand(self, name=fallback_locale or fallback)
                 self.app_command.add_command(command)
 
     @property

--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -639,9 +639,7 @@ class HybridGroup(Group[CogT, P, T]):
         self.app_command: app_commands.Group = MISSING
 
         fallback, fallback_locale = (
-            (fallback.message, fallback)
-            if isinstance(fallback, app_commands.locale_str)
-            else (fallback, None)
+            (fallback.message, fallback) if isinstance(fallback, app_commands.locale_str) else (fallback, None)
         )
         self.fallback: Optional[str] = fallback
         self.fallback_locale: Optional[app_commands.locale_str] = fallback_locale


### PR DESCRIPTION
## Summary

This PR fixes localization support for the `HybridGroup`'s fallback command and allows the `fallback=` parameter to accept a `locale_str` instance.

### Cause

It appears the original implementation did not change the `HybridAppCommand._name_locale` attribute, causing the fallback command to mistakenly use the parent group's name localizations. It also bypassed the `app_commands.Command` constructor which would have prevented `auto_locale_strings=True` from localizing the fallback name had the previous bug been fixed.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
