### PR TITLE
Fix voice websocket not being closed before being replaced

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -622,10 +622,10 @@ class DiscordWebSocket:
             elif msg.type is aiohttp.WSMsgType.BINARY:
                 await self.received_message(msg.data)
             elif msg.type is aiohttp.WSMsgType.ERROR:
-                _log.debug('Received ws message %s', msg)
+                _log.debug('Received %s', msg)
                 raise msg.data
             elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSE):
-                _log.debug('Received ws message %s', msg)
+                _log.debug('Received %s', msg)
                 raise WebSocketClosure
         except (asyncio.TimeoutError, WebSocketClosure) as e:
             # Ensure the keep alive handler is closed
@@ -1004,10 +1004,10 @@ class DiscordVoiceWebSocket:
         if msg.type is aiohttp.WSMsgType.TEXT:
             await self.received_message(utils._from_json(msg.data))
         elif msg.type is aiohttp.WSMsgType.ERROR:
-            _log.debug('Received vws message %s', msg)
+            _log.debug('Received %s', msg)
             raise ConnectionClosed(self.ws, shard_id=None) from msg.data
         elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING):
-            _log.debug('Received vws message %s', msg)
+            _log.debug('Received %s', msg)
             raise ConnectionClosed(self.ws, shard_id=None, code=self._close_code)
 
     async def close(self, code: int = 1000) -> None:

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -622,10 +622,10 @@ class DiscordWebSocket:
             elif msg.type is aiohttp.WSMsgType.BINARY:
                 await self.received_message(msg.data)
             elif msg.type is aiohttp.WSMsgType.ERROR:
-                _log.debug('Received %s', msg)
+                _log.debug('Received ws message %s', msg)
                 raise msg.data
             elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSE):
-                _log.debug('Received %s', msg)
+                _log.debug('Received ws message %s', msg)
                 raise WebSocketClosure
         except (asyncio.TimeoutError, WebSocketClosure) as e:
             # Ensure the keep alive handler is closed
@@ -1004,10 +1004,10 @@ class DiscordVoiceWebSocket:
         if msg.type is aiohttp.WSMsgType.TEXT:
             await self.received_message(utils._from_json(msg.data))
         elif msg.type is aiohttp.WSMsgType.ERROR:
-            _log.debug('Received %s', msg)
+            _log.debug('Received vws message %s', msg)
             raise ConnectionClosed(self.ws, shard_id=None) from msg.data
         elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING):
-            _log.debug('Received %s', msg)
+            _log.debug('Received vws message %s', msg)
             raise ConnectionClosed(self.ws, shard_id=None, code=self._close_code)
 
     async def close(self, code: int = 1000) -> None:

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -477,7 +477,6 @@ class VoiceClient(VoiceProtocol):
                             await self.disconnect()
                             break
                         else:
-                            _log.info("Reconnect was successful")
                             continue
 
                 if not reconnect:

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -421,6 +421,11 @@ class VoiceClient(VoiceProtocol):
 
         self.finish_handshake()
         self._potentially_reconnecting = False
+
+        if self.ws:
+            _log.debug("Closing existing voice websocket")
+            await self.ws.close()
+
         try:
             self.ws = await self.connect_websocket()
         except (ConnectionClosed, asyncio.TimeoutError):
@@ -472,6 +477,7 @@ class VoiceClient(VoiceProtocol):
                             await self.disconnect()
                             break
                         else:
+                            _log.info("Reconnect was successful")
                             continue
 
                 if not reconnect:


### PR DESCRIPTION
## Summary

Looking into #9364, I found two issues.
1. Failure to drag move a bot to a channel is NOT a bug, but a discord client limitation.  You seemingly cannot drag move bots into voice channels marked as NSFW.
2. The voice websocket was not being closed before it was being replaced.

~~I haven't figured out the problem with the rtc region stuff yet, but i'm open to either leaving this pr open until then or just making a second one.~~
The voice region thing is a separate issue and will be another pr.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
