### PR TITLE
Fix Intents.auto_moderation flag to alias_flag_value

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1211,7 +1211,7 @@ class Intents(BaseFlags):
         """
         return 1 << 16
 
-    @flag_value
+    @alias_flag_value
     def auto_moderation(self):
         """:class:`bool`: Whether auto moderation related events are enabled.
 


### PR DESCRIPTION
## Summary

Changed Intents.auto_moderation flag from @flag_value to @alias_flag_value since it is a alias for Intents.auto_moderation_configuration and Intents.auto_moderation_execution

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
