### PR TITLE
Rewrite voice connection internals

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1858,7 +1858,7 @@ class Connectable(Protocol):
         Parameters
         -----------
         timeout: :class:`float`
-            The timeout in seconds to wait for the voice endpoint.
+            The timeout in seconds to wait the connection to complete.
         reconnect: :class:`bool`
             Whether the bot should automatically attempt
             a reconnect if a part of the handshake fails

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1842,7 +1842,7 @@ class Connectable(Protocol):
     async def connect(
         self,
         *,
-        timeout: float = 60.0,
+        timeout: float = 30.0,
         reconnect: bool = True,
         cls: Callable[[Client, Connectable], T] = VoiceClient,
         self_deaf: bool = False,

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -983,10 +983,13 @@ class DiscordVoiceWebSocket:
         def get_ip_packet(data: bytes):
             if data[1] == 0x02 and len(data) == 74:
                 self.loop.call_soon_threadsafe(fut.set_result, data)
+            # TODO: add a second escape hatch condition if the connection gets killed or something, just in case
 
         fut.add_done_callback(lambda f: state.remove_socket_listener(get_ip_packet))
         state.add_socket_listener(get_ip_packet)
         recv = await fut
+
+        # TODO: is there any way that this future and listener can avoid being removed, i.e. being cancelled?
 
         _log.debug('Received ip discovery packet: %s', recv)
 

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -960,10 +960,11 @@ class DiscordVoiceWebSocket:
         await self.loop.sock_connect(state.socket, (state.endpoint_ip, state.voice_port))
 
         # Only do ip discovery if the ip/port aren't cached from a previous call.
-        # I'm not entirely sure this is sound since I can imagine that there is probably a
-        # scenario where doing this breaks on some network issue out of the lib's control
-        # where it didn't break previously since it would do this step every time.
-        # That said, the ip/port are cleared on disconnect() calls so its probably be fine?
+        # TODO: Finalize comment:
+        #   I'm not entirely sure this is sound since I can imagine that there is probably a
+        #   scenario where doing this breaks on some network issue out of the lib's control
+        #   where it didn't break previously since it would do this step every time.
+        #   That said, the ip/port are cleared on disconnect() calls so it's probably fine?
         if not (state.ip and state.port):
             state.ip, state.port = await self.discover_ip()
         else:
@@ -1029,9 +1030,8 @@ class DiscordVoiceWebSocket:
         self.secret_key = self._connection.secret_key = data['secret_key']
 
         # Send a speak command with the "not speaking" state.
-        # This also tells Discord our SSRC value, which Discord requires
-        # before sending any voice data (and is the real reason why we
-        # call this here).
+        # This also tells Discord our SSRC value, which Discord requires before
+        # sending any voice data (and is the real reason why we call this here).
         await self.speak(SpeakingState.none)
 
     async def poll_event(self) -> None:

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -867,7 +867,11 @@ class DiscordVoiceWebSocket:
 
     @classmethod
     async def from_connection_state(
-        cls, state: VoiceConnectionState, *, resume: bool = False, hook: Optional[Callable[..., Coroutine[Any, Any, Any]]] = None
+        cls,
+        state: VoiceConnectionState,
+        *,
+        resume: bool = False,
+        hook: Optional[Callable[..., Coroutine[Any, Any, Any]]] = None,
     ) -> Self:
         """Creates a voice websocket for the :class:`VoiceClient`."""
         gateway = 'wss://' + state.endpoint + '/?v=4'

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -874,7 +874,9 @@ class DiscordVoiceWebSocket:
         hook: Optional[Callable[..., Coroutine[Any, Any, Any]]] = None,
     ) -> Self:
         """Creates a voice websocket for the :class:`VoiceClient`."""
-        gateway = 'wss://' + state.endpoint + '/?v=4'
+        # TODO: Do I add a `if state.endpoint is None: raise Something` check here?
+        #       Putting None in there would be awkward, if that's even possible
+        gateway = f'wss://{state.endpoint}/?v=4'
         client = state.voice_client
         http = client._state.http
         socket = await http.ws_connect(gateway, compress=15)

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
 
     from .client import Client
     from .state import ConnectionState
-    from .voice_client import VoiceClient
+    # from .voice_client import VoiceClient
     from .voice_state import VoiceConnectionState
 
 
@@ -867,26 +867,26 @@ class DiscordVoiceWebSocket:
         }
         await self.send_as_json(payload)
 
-    @classmethod
-    async def from_client(
-        cls, client: VoiceClient, *, resume: bool = False, hook: Optional[Callable[..., Coroutine[Any, Any, Any]]] = None
-    ) -> Self:
-        """Creates a voice websocket for the :class:`VoiceClient`."""
-        gateway = 'wss://' + client.endpoint + '/?v=4'
-        http = client._state.http
-        socket = await http.ws_connect(gateway, compress=15)
-        ws = cls(socket, loop=client.loop, hook=hook)
-        ws.gateway = gateway
-        ws._connection = client # type: ignore
-        ws._max_heartbeat_timeout = 60.0
-        ws.thread_id = threading.get_ident()
+    # @classmethod
+    # async def from_client(
+    #     cls, client: VoiceClient, *, resume: bool = False, hook: Optional[Callable[..., Coroutine[Any, Any, Any]]] = None
+    # ) -> Self:
+    #     """Creates a voice websocket for the :class:`VoiceClient`."""
+    #     gateway = 'wss://' + client.endpoint + '/?v=4'
+    #     http = client._state.http
+    #     socket = await http.ws_connect(gateway, compress=15)
+    #     ws = cls(socket, loop=client.loop, hook=hook)
+    #     ws.gateway = gateway
+    #     ws._connection = client # type: ignore
+    #     ws._max_heartbeat_timeout = 60.0
+    #     ws.thread_id = threading.get_ident()
 
-        if resume:
-            await ws.resume()
-        else:
-            await ws.identify()
+    #     if resume:
+    #         await ws.resume()
+    #     else:
+    #         await ws.identify()
 
-        return ws
+    #     return ws
 
     @classmethod
     async def from_connection_state(

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -983,13 +983,10 @@ class DiscordVoiceWebSocket:
         def get_ip_packet(data: bytes):
             if data[1] == 0x02 and len(data) == 74:
                 self.loop.call_soon_threadsafe(fut.set_result, data)
-            # TODO: add a second escape hatch condition if the connection gets killed or something, just in case
 
         fut.add_done_callback(lambda f: state.remove_socket_listener(get_ip_packet))
         state.add_socket_listener(get_ip_packet)
         recv = await fut
-
-        # TODO: is there any way that this future and listener can avoid being removed, i.e. being cancelled?
 
         _log.debug('Received ip discovery packet: %s', recv)
 

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -867,27 +867,6 @@ class DiscordVoiceWebSocket:
         }
         await self.send_as_json(payload)
 
-    # @classmethod
-    # async def from_client(
-    #     cls, client: VoiceClient, *, resume: bool = False, hook: Optional[Callable[..., Coroutine[Any, Any, Any]]] = None
-    # ) -> Self:
-    #     """Creates a voice websocket for the :class:`VoiceClient`."""
-    #     gateway = 'wss://' + client.endpoint + '/?v=4'
-    #     http = client._state.http
-    #     socket = await http.ws_connect(gateway, compress=15)
-    #     ws = cls(socket, loop=client.loop, hook=hook)
-    #     ws.gateway = gateway
-    #     ws._connection = client # type: ignore
-    #     ws._max_heartbeat_timeout = 60.0
-    #     ws.thread_id = threading.get_ident()
-
-    #     if resume:
-    #         await ws.resume()
-    #     else:
-    #         await ws.identify()
-
-    #     return ws
-
     @classmethod
     async def from_connection_state(
         cls, state: VoiceConnectionState, *, resume: bool = False, hook: Optional[Callable[..., Coroutine[Any, Any, Any]]] = None

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -59,7 +59,6 @@ if TYPE_CHECKING:
 
     from .client import Client
     from .state import ConnectionState
-    # from .voice_client import VoiceClient
     from .voice_state import VoiceConnectionState
 
 
@@ -798,7 +797,6 @@ class DiscordVoiceWebSocket:
 
     if TYPE_CHECKING:
         thread_id: int
-        # _connection: VoiceClient
         _connection: VoiceConnectionState
         gateway: str
         _max_heartbeat_timeout: float
@@ -961,12 +959,13 @@ class DiscordVoiceWebSocket:
         state.socket.sendto(packet, (state.endpoint_ip, state.voice_port))
 
         while True:
+            # Read packets until we find the ip discovery packet.
+            # On a fresh connection this will always be the first packet, but
+            # otherwise the socket will be full of RTP and RTCP packets.
+            # TODO: add a hook for these packets
             recv = await self.loop.sock_recv(state.socket, 2048)
             if recv[1] == 0x02:
                 break
-            # else:
-                # _log.debug("Ignoring rtp packet")
-        # recv = await self.loop.sock_recv(state.socket, 74)
         _log.debug('received packet in initial_connection: %s', recv)
 
         # the ip is ascii starting at the 8th byte and ending at the first null

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -964,11 +964,11 @@ class DiscordVoiceWebSocket:
         if not (state.ip and state.port):
             state.ip, state.port = await self.discover_ip()
         else:
-            _log.debug("Reusing previously found ip and port: %s:%s", state.ip, state.port)
+            _log.debug('Reusing previously found ip and port: %s:%s', state.ip, state.port)
 
         # there *should* always be at least one supported mode (xsalsa20_poly1305)
         modes = [mode for mode in data['modes'] if mode in self._connection.supported_modes]
-        _log.debug('received supported encryption modes: %s', ", ".join(modes))
+        _log.debug('received supported encryption modes: %s', ', '.join(modes))
 
         mode = modes[0]
         await self.select_protocol(state.ip, state.port, mode)

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -874,8 +874,6 @@ class DiscordVoiceWebSocket:
         hook: Optional[Callable[..., Coroutine[Any, Any, Any]]] = None,
     ) -> Self:
         """Creates a voice websocket for the :class:`VoiceClient`."""
-        # TODO: Do I add a `if state.endpoint is None: raise Something` check here?
-        #       Putting None in there would be awkward, if that's even possible
         gateway = f'wss://{state.endpoint}/?v=4'
         client = state.voice_client
         http = client._state.http

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -1040,10 +1040,10 @@ class DiscordVoiceWebSocket:
         if msg.type is aiohttp.WSMsgType.TEXT:
             await self.received_message(utils._from_json(msg.data))
         elif msg.type is aiohttp.WSMsgType.ERROR:
-            _log.debug('Received %s', msg)
+            _log.debug('Received voice %s', msg)
             raise ConnectionClosed(self.ws, shard_id=None) from msg.data
         elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING):
-            _log.debug('Received %s', msg)
+            _log.debug('Received voice %s', msg)
             raise ConnectionClosed(self.ws, shard_id=None, code=self._close_code)
 
     async def close(self, code: int = 1000) -> None:

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -959,17 +959,7 @@ class DiscordVoiceWebSocket:
         _log.debug('Connecting to voice socket')
         await self.loop.sock_connect(state.socket, (state.endpoint_ip, state.voice_port))
 
-        # Only do ip discovery if the ip/port aren't cached from a previous call.
-        # TODO: Finalize comment:
-        #   I'm not entirely sure this is sound since I can imagine that there is probably a
-        #   scenario where doing this breaks on some network issue out of the lib's control
-        #   where it didn't break previously since it would do this step every time.
-        #   That said, the ip/port are cleared on disconnect() calls so it's probably fine?
-        if not (state.ip and state.port):
-            state.ip, state.port = await self.discover_ip()
-        else:
-            _log.debug('Reusing previously found ip and port: %s:%s', state.ip, state.port)
-
+        state.ip, state.port = await self.discover_ip()
         # there *should* always be at least one supported mode (xsalsa20_poly1305)
         modes = [mode for mode in data['modes'] if mode in self._connection.supported_modes]
         _log.debug('received supported encryption modes: %s', ', '.join(modes))

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -980,7 +980,14 @@ class DiscordVoiceWebSocket:
         struct.pack_into('>H', packet, 2, 70)  # 70 = Length
         struct.pack_into('>I', packet, 4, state.ssrc)
         state.socket.sendto(packet, (state.endpoint_ip, state.voice_port))
-        recv = await self.loop.sock_recv(state.socket, 74)
+
+        while True:
+            recv = await self.loop.sock_recv(state.socket, 2048)
+            if recv[1] == 0x02:
+                break
+            # else:
+                # _log.debug("Ignoring rtp packet")
+        # recv = await self.loop.sock_recv(state.socket, 74)
         _log.debug('received packet in initial_connection: %s', recv)
 
         # the ip is ascii starting at the 8th byte and ending at the first null

--- a/discord/player.py
+++ b/discord/player.py
@@ -732,12 +732,12 @@ class AudioPlayer(threading.Thread):
 
             # are we disconnected from voice?
             if not self.client.is_connected():
-                _log.info("Not connected, waiting...")
+                _log.info('Not connected, waiting...')
                 # wait until we are connected
                 self.client.wait_until_connected()
                 if self._end.is_set():
                     return
-                _log.info("Reconnected, resuming playback")
+                _log.info('Reconnected, resuming playback')
                 self._speak(SpeakingState.voice)
                 # reset our internal data
                 self.loops = 0

--- a/discord/player.py
+++ b/discord/player.py
@@ -735,6 +735,8 @@ class AudioPlayer(threading.Thread):
                 _log.info("Not connected, waiting...")
                 # wait until we are connected
                 self.client.wait_until_connected()
+                if self._end.is_set():
+                    return
                 _log.info("Reconnected, resuming playback")
                 self._speak(SpeakingState.voice)
                 # reset our internal data

--- a/discord/player.py
+++ b/discord/player.py
@@ -713,7 +713,8 @@ class AudioPlayer(threading.Thread):
         self._start = time.perf_counter()
 
         # getattr lookup speed ups
-        play_audio = self.client.send_audio_packet
+        client = self.client
+        play_audio = client.send_audio_packet
         self._speak(SpeakingState.voice)
 
         while not self._end.is_set():
@@ -731,10 +732,10 @@ class AudioPlayer(threading.Thread):
                 break
 
             # are we disconnected from voice?
-            if not self.client.is_connected():
+            if not client.is_connected():
                 _log.info('Not connected, waiting...')
                 # wait until we are connected
-                self.client.wait_until_connected()
+                client.wait_until_connected()
                 if self._end.is_set():
                     return
                 _log.info('Reconnected, resuming playback')

--- a/discord/player.py
+++ b/discord/player.py
@@ -733,7 +733,7 @@ class AudioPlayer(threading.Thread):
 
             # are we disconnected from voice?
             if not self.client.is_connected():
-                _log.warning("Not connected, waiting...")
+                _log.info("Not connected, waiting...")
                 # wait until we are connected
                 self.client.wait_until_connected()
                 _log.info("Reconnected, resuming playback")

--- a/discord/player.py
+++ b/discord/player.py
@@ -737,6 +737,7 @@ class AudioPlayer(threading.Thread):
                 # wait until we are connected
                 self.client.wait_until_connected()
                 _log.info("Reconnected, resuming playback")
+                self._speak(SpeakingState.voice)
                 # reset our internal data
                 self.loops = 0
                 self._start = time.perf_counter()

--- a/discord/player.py
+++ b/discord/player.py
@@ -798,7 +798,7 @@ class AudioPlayer(threading.Thread):
     def is_paused(self) -> bool:
         return not self._end.is_set() and not self._resumed.is_set()
 
-    def _set_source(self, source: AudioSource) -> None:
+    def set_source(self, source: AudioSource) -> None:
         with self._lock:
             self.pause(update_speaking=False)
             self.source = source

--- a/discord/player.py
+++ b/discord/player.py
@@ -703,7 +703,6 @@ class AudioPlayer(threading.Thread):
         self._resumed: threading.Event = threading.Event()
         self._resumed.set()  # we are not paused
         self._current_error: Optional[Exception] = None
-        # self._connected: threading.Event = client._connected
         self._lock: threading.Lock = threading.Lock()
 
         if after is not None and not callable(after):
@@ -803,7 +802,6 @@ class AudioPlayer(threading.Thread):
 
     def _speak(self, speaking: SpeakingState) -> None:
         try:
-            # TODO: expose this ------------------------------------------vvvvvvvv
             asyncio.run_coroutine_threadsafe(self.client.connection_state.ws.speak(speaking), self.client.client.loop)
         except Exception:
             _log.exception("Speaking call in player failed")

--- a/discord/player.py
+++ b/discord/player.py
@@ -733,9 +733,9 @@ class AudioPlayer(threading.Thread):
 
             # are we disconnected from voice?
             if not client.is_connected():
-                _log.debug('Not connected, waiting...')
-                # wait until we are connected
-                connected = client.wait_until_connected()
+                _log.debug('Not connected, waiting for %ss...', client.timeout)
+                # wait until we are connected, but not forever
+                connected = client.wait_until_connected(client.timeout)
                 if self._end.is_set() or not connected:
                     _log.debug('Aborting playback')
                     return

--- a/discord/player.py
+++ b/discord/player.py
@@ -733,12 +733,13 @@ class AudioPlayer(threading.Thread):
 
             # are we disconnected from voice?
             if not client.is_connected():
-                _log.info('Not connected, waiting...')
+                _log.debug('Not connected, waiting...')
                 # wait until we are connected
-                client.wait_until_connected()
-                if self._end.is_set():
+                connected = client.wait_until_connected()
+                if self._end.is_set() or not connected:
+                    _log.debug('Aborting playback')
                     return
-                _log.info('Reconnected, resuming playback')
+                _log.debug('Reconnected, resuming playback')
                 self._speak(SpeakingState.voice)
                 # reset our internal data
                 self.loops = 0

--- a/discord/player.py
+++ b/discord/player.py
@@ -802,7 +802,7 @@ class AudioPlayer(threading.Thread):
 
     def _speak(self, speaking: SpeakingState) -> None:
         try:
-            asyncio.run_coroutine_threadsafe(self.client.connection_state.ws.speak(speaking), self.client.client.loop)
+            asyncio.run_coroutine_threadsafe(self.client.ws.speak(speaking), self.client.client.loop)
         except Exception:
             _log.exception("Speaking call in player failed")
 

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -224,7 +224,6 @@ class VoiceClient(VoiceProtocol):
 
         self.sequence: int = 0
         self.timestamp: int = 0
-        self.timeout: float = 0
         self._player: Optional[AudioPlayer] = None
         self.encoder: Encoder = MISSING
         self._lite_nonce: int = 0
@@ -264,6 +263,10 @@ class VoiceClient(VoiceProtocol):
     def ws(self) -> DiscordVoiceWebSocket:
         return self._connection.ws
 
+    @property
+    def timeout(self) -> float:
+        return self._connection.timeout
+
     def checked_add(self, attr: str, value: int, limit: int) -> None:
         val = getattr(self, attr)
         if val + value > limit:
@@ -283,6 +286,10 @@ class VoiceClient(VoiceProtocol):
         await self._connection.connect(
             reconnect=reconnect, timeout=timeout, self_deaf=self_deaf, self_mute=self_mute, resume=False
         )
+
+    def wait_until_connected(self, timeout: Optional[float] = 30.0) -> bool:
+        self._connection.wait(timeout)
+        return self._connection.is_connected()
 
     @property
     def latency(self) -> float:
@@ -314,7 +321,7 @@ class VoiceClient(VoiceProtocol):
         await self._connection.disconnect(force=force)
         self.cleanup()
 
-    async def move_to(self, channel: Optional[abc.Snowflake], *, timeout: Optional[float] = None) -> None:
+    async def move_to(self, channel: Optional[abc.Snowflake], *, timeout: Optional[float] = 30.0) -> None:
         """|coro|
 
         Moves you to a different voice channel.
@@ -331,22 +338,6 @@ class VoiceClient(VoiceProtocol):
 
     def is_connected(self) -> bool:
         """Indicates if the voice client is connected to voice."""
-        return self._connection.is_connected()
-
-    def wait_until_connected(self, *, timeout: Optional[float] = None) -> bool:
-        """Waits until the voice client is connected.
-
-        Parameters
-        -----------
-        timeout: Optional[:class:`float`]
-            How long to wait to be connected.
-
-        Returns
-        ---------
-        :class:`bool`
-            If the client is connected (from ``is_connected()``).
-        """
-        self._connection.wait(timeout)
         return self._connection.is_connected()
 
     # audio related

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -248,6 +248,18 @@ class VoiceClient(VoiceProtocol):
         return self._state.user  # type: ignore
 
     @property
+    def session_id(self) -> Optional[str]:
+        return self._connection.session_id
+
+    @property
+    def token(self) -> Optional[str]:
+        return self._connection.token
+
+    @property
+    def endpoint(self) -> Optional[str]:
+        return self._connection.endpoint
+
+    @property
     def ssrc(self) -> int:
         return self._connection.ssrc
 

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -247,8 +247,6 @@ class VoiceClient(VoiceProtocol):
         """:class:`ClientUser`: The user connected to voice (i.e. ourselves)."""
         return self._state.user  # type: ignore
 
-    # TODO: Do I really need five (5) properties for these...?
-
     @property
     def ssrc(self) -> int:
         return self._connection.ssrc

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -511,7 +511,7 @@ class VoiceClient(VoiceProtocol):
         if self._player is None:
             raise ValueError('Not playing anything.')
 
-        self._player._set_source(value)
+        self._player.set_source(value)
 
     def send_audio_packet(self, data: bytes, *, encode: bool = True) -> None:
         """Sends an audio packet composed of the data.

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -228,7 +228,7 @@ class VoiceClient(VoiceProtocol):
         self.encoder: Encoder = MISSING
         self._lite_nonce: int = 0
 
-        self._connection: VoiceConnectionState = VoiceConnectionState(self)
+        self._connection: VoiceConnectionState = self.create_connection_state()
 
     warn_nacl: bool = not has_nacl
     supported_modes: Tuple[SupportedModes, ...] = (
@@ -275,6 +275,9 @@ class VoiceClient(VoiceProtocol):
             setattr(self, attr, val + value)
 
     # connection related
+
+    def create_connection_state(self) -> VoiceConnectionState:
+        return VoiceConnectionState(self)
 
     async def on_voice_state_update(self, data: GuildVoiceStatePayload) -> None:
         await self._connection.voice_state_update(data)

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -326,6 +326,7 @@ class VoiceClient(VoiceProtocol):
         """
         self.stop()
         await self._connection.disconnect(force=force)
+        self.cleanup()
 
     async def move_to(self, channel: Optional[abc.Snowflake]) -> None:
         """|coro|

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -247,6 +247,8 @@ class VoiceClient(VoiceProtocol):
         """:class:`ClientUser`: The user connected to voice (i.e. ourselves)."""
         return self._state.user  # type: ignore
 
+    # TODO: Do I really need five (5) properties for these...?
+
     @property
     def ssrc(self) -> int:
         return self._connection.ssrc

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -348,7 +348,7 @@ class VoiceClient(VoiceProtocol):
         timeout: Optional[:class:`float`]
             How long to wait for the move to complete.
 
-            .. versionchanged:: 2.4
+            .. versionadded:: 2.4
 
         Raises
         -------

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -348,8 +348,7 @@ class VoiceClient(VoiceProtocol):
         timeout: Optional[:class:`float`]
             How long to wait for the move to complete.
 
-        .. versionchanged:: 2.4
-            Added timeout parameter.
+            .. versionchanged:: 2.4
 
         Raises
         -------

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -340,7 +340,7 @@ class VoiceClient(VoiceProtocol):
             The channel to move to. Must be a voice channel.
         """
         await self._connection.move_to(channel)
-        # TODO: temporary static timeout
+        # TODO: static timeout or a timeout parameter?
         await self._connection.wait_async(30)
 
     def is_connected(self) -> bool:

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -340,6 +340,8 @@ class VoiceClient(VoiceProtocol):
             The channel to move to. Must be a voice channel.
         """
         await self._connection.move_to(channel)
+        # TODO: temporary static timeout
+        await self._connection.wait_async(30)
 
     def is_connected(self) -> bool:
         """Indicates if the voice client is connected to voice."""
@@ -355,9 +357,10 @@ class VoiceClient(VoiceProtocol):
         Returns
         ---------
         :class:`bool`
-            The same as what :meth:`threading.Event.wait()` returns (The state of the internal :class:`threading.Event` flag).
+            If the client is connected (from ``is_connected()``).
         """
-        return self._connection.wait(timeout)
+        self._connection.wait(timeout)
+        return self._connection.is_connected()
 
     # audio related
 

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -295,11 +295,7 @@ class VoiceClient(VoiceProtocol):
 
     async def connect(self, *, reconnect: bool, timeout: float, self_deaf: bool = False, self_mute: bool = False) -> None:
         await self._voice_state.connect(
-            reconnect=reconnect,
-            timeout=timeout,
-            self_deaf=self_deaf,
-            self_mute=self_mute,
-            resume=False
+            reconnect=reconnect, timeout=timeout, self_deaf=self_deaf, self_mute=self_mute, resume=False
         )
 
     @property
@@ -347,7 +343,7 @@ class VoiceClient(VoiceProtocol):
         """Indicates if the voice client is connected to voice."""
         return self._voice_state.is_connected()
 
-    def wait_until_connected(self, *, timeout: Optional[float]=None) -> None:
+    def wait_until_connected(self, *, timeout: Optional[float] = None) -> None:
         """TODO: Do i actually need this function on VoiceClient?"""
         self._voice_state.wait(timeout)
 

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -40,18 +40,19 @@ Some documentation to refer to:
 from __future__ import annotations
 
 import asyncio
-import socket
+# import socket
 import logging
 import struct
-import threading
+# import threading
 from typing import Any, Callable, List, Optional, TYPE_CHECKING, Tuple, Union
 
-from . import opus, utils
-from .backoff import ExponentialBackoff
+from . import opus#, utils
+# from .backoff import ExponentialBackoff
 from .gateway import *
-from .errors import ClientException, ConnectionClosed
+from .errors import ClientException#, ConnectionClosed
 from .player import AudioPlayer, AudioSource
 from .utils import MISSING
+from .voice_state import VoiceConnectionState
 
 if TYPE_CHECKING:
     from .client import Client
@@ -226,12 +227,12 @@ class VoiceClient(VoiceProtocol):
     """
 
     channel: VocalGuildChannel
-    endpoint_ip: str
-    voice_port: int
-    ip: str
-    port: int
-    secret_key: List[int]
-    ssrc: int
+    # endpoint_ip: str
+    # voice_port: int
+    # ip: str
+    # port: int
+    # secret_key: List[int]
+    # ssrc: int
 
     def __init__(self, client: Client, channel: abc.Connectable) -> None:
         if not has_nacl:
@@ -239,29 +240,31 @@ class VoiceClient(VoiceProtocol):
 
         super().__init__(client, channel)
         state = client._connection
-        self.token: str = MISSING
+        # self.token: str = MISSING
         self.server_id: int = MISSING
         self.socket = MISSING
         self.loop: asyncio.AbstractEventLoop = state.loop
         self._state: ConnectionState = state
         # this will be used in the AudioPlayer thread
-        self._connected: threading.Event = threading.Event()
+        # self._connected: threading.Event = threading.Event()
 
-        self._handshaking: bool = False
-        self._potentially_reconnecting: bool = False
-        self._voice_state_complete: asyncio.Event = asyncio.Event()
-        self._voice_server_complete: asyncio.Event = asyncio.Event()
+        # self._handshaking: bool = False
+        # self._potentially_reconnecting: bool = False
+        # self._voice_state_complete: asyncio.Event = asyncio.Event()
+        # self._voice_server_complete: asyncio.Event = asyncio.Event()
 
-        self.mode: str = MISSING
-        self._connections: int = 0
+        # self.mode: str = MISSING
+        # self._connections: int = 0
         self.sequence: int = 0
         self.timestamp: int = 0
         self.timeout: float = 0
-        self._runner: asyncio.Task = MISSING
+        # self._runner: asyncio.Task = MISSING
         self._player: Optional[AudioPlayer] = None
         self.encoder: Encoder = MISSING
         self._lite_nonce: int = 0
-        self.ws: DiscordVoiceWebSocket = MISSING
+        # self.ws: DiscordVoiceWebSocket = MISSING
+
+        self.connection_state: VoiceConnectionState = VoiceConnectionState(self)
 
     warn_nacl: bool = not has_nacl
     supported_modes: Tuple[SupportedModes, ...] = (
@@ -280,6 +283,18 @@ class VoiceClient(VoiceProtocol):
         """:class:`ClientUser`: The user connected to voice (i.e. ourselves)."""
         return self._state.user  # type: ignore
 
+    @property
+    def ssrc(self) -> int:
+        return self.connection_state.ssrc
+
+    @property
+    def mode(self) -> str:
+        return self.connection_state.mode
+
+    @property
+    def secret_key(self) -> List[int]:
+        return self.connection_state.secret_key
+
     def checked_add(self, attr: str, value: int, limit: int) -> None:
         val = getattr(self, attr)
         if val + value > limit:
@@ -290,148 +305,157 @@ class VoiceClient(VoiceProtocol):
     # connection related
 
     async def on_voice_state_update(self, data: GuildVoiceStatePayload) -> None:
-        self.session_id: str = data['session_id']
-        channel_id = data['channel_id']
+        await self.connection_state.voice_state_update(data)
+        # self.session_id: str = data['session_id']
+        # channel_id = data['channel_id']
 
-        if not self._handshaking or self._potentially_reconnecting:
-            # If we're done handshaking then we just need to update ourselves
-            # If we're potentially reconnecting due to a 4014, then we need to differentiate
-            # a channel move and an actual force disconnect
-            if channel_id is None:
-                # We're being disconnected so cleanup
-                await self.disconnect()
-            else:
-                self.channel = channel_id and self.guild.get_channel(int(channel_id))  # type: ignore
-        else:
-            self._voice_state_complete.set()
+        # if not self._handshaking or self._potentially_reconnecting:
+        #     # If we're done handshaking then we just need to update ourselves
+        #     # If we're potentially reconnecting due to a 4014, then we need to differentiate
+        #     # a channel move and an actual force disconnect
+        #     if channel_id is None:
+        #         # We're being disconnected so cleanup
+        #         await self.disconnect()
+        #     else:
+        #         self.channel = channel_id and self.guild.get_channel(int(channel_id))  # type: ignore
+        # else:
+        #     self._voice_state_complete.set()
 
     async def on_voice_server_update(self, data: VoiceServerUpdatePayload) -> None:
-        if self._voice_server_complete.is_set():
-            _log.warning('Ignoring extraneous voice server update.')
-            return
+        await self.connection_state.voice_server_update(data)
+        # if self._voice_server_complete.is_set():
+        #     _log.warning('Ignoring extraneous voice server update.')
+        #     return
 
-        self.token = data['token']
-        self.server_id = int(data['guild_id'])
-        endpoint = data.get('endpoint')
+        # self.token = data['token']
+        # self.server_id = int(data['guild_id'])
+        # endpoint = data.get('endpoint')
 
-        if endpoint is None or self.token is None:
-            _log.warning(
-                'Awaiting endpoint... This requires waiting. '
-                'If timeout occurred considering raising the timeout and reconnecting.'
-            )
-            return
+        # if endpoint is None or self.token is None:
+        #     _log.warning(
+        #         'Awaiting endpoint... This requires waiting. '
+        #         'If timeout occurred considering raising the timeout and reconnecting.'
+        #     )
+        #     return
 
-        self.endpoint, _, _ = endpoint.rpartition(':')
-        if self.endpoint.startswith('wss://'):
-            # Just in case, strip it off since we're going to add it later
-            self.endpoint: str = self.endpoint[6:]
+        # self.endpoint, _, _ = endpoint.rpartition(':')
+        # if self.endpoint.startswith('wss://'):
+        #     # Just in case, strip it off since we're going to add it later
+        #     self.endpoint: str = self.endpoint[6:]
 
-        # This gets set later
-        self.endpoint_ip = MISSING
+        # # This gets set later
+        # self.endpoint_ip = MISSING
 
-        self.socket: socket.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self.socket.setblocking(False)
+        # self.socket: socket.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        # self.socket.setblocking(False)
 
-        if not self._handshaking:
-            # If we're not handshaking then we need to terminate our previous connection in the websocket
-            await self.ws.close(4000)
-            return
+        # if not self._handshaking:
+        #     # If we're not handshaking then we need to terminate our previous connection in the websocket
+        #     await self.ws.close(4000)
+        #     return
 
-        self._voice_server_complete.set()
+        # self._voice_server_complete.set()
 
-    async def voice_connect(self, self_deaf: bool = False, self_mute: bool = False) -> None:
-        await self.channel.guild.change_voice_state(channel=self.channel, self_deaf=self_deaf, self_mute=self_mute)
+    # async def voice_connect(self, self_deaf: bool = False, self_mute: bool = False) -> None:
+    #     await self.channel.guild.change_voice_state(channel=self.channel, self_deaf=self_deaf, self_mute=self_mute)
 
-    async def voice_disconnect(self) -> None:
-        _log.info('The voice handshake is being terminated for Channel ID %s (Guild ID %s)', self.channel.id, self.guild.id)
-        await self.channel.guild.change_voice_state(channel=None)
+    # async def voice_disconnect(self) -> None:
+    #     _log.info('The voice handshake is being terminated for Channel ID %s (Guild ID %s)', self.channel.id, self.guild.id)
+    #     await self.channel.guild.change_voice_state(channel=None)
 
-    def prepare_handshake(self) -> None:
-        self._voice_state_complete.clear()
-        self._voice_server_complete.clear()
-        self._handshaking = True
-        _log.info('Starting voice handshake... (connection attempt %d)', self._connections + 1)
-        self._connections += 1
+    # def prepare_handshake(self) -> None:
+    #     self._voice_state_complete.clear()
+    #     self._voice_server_complete.clear()
+    #     self._handshaking = True
+    #     _log.info('Starting voice handshake... (connection attempt %d)', self._connections + 1)
+    #     self._connections += 1
 
-    def finish_handshake(self) -> None:
-        _log.info('Voice handshake complete. Endpoint found %s', self.endpoint)
-        self._handshaking = False
-        self._voice_server_complete.clear()
-        self._voice_state_complete.clear()
+    # def finish_handshake(self) -> None:
+    #     _log.info('Voice handshake complete. Endpoint found %s', self.endpoint)
+    #     self._handshaking = False
+    #     self._voice_server_complete.clear()
+    #     self._voice_state_complete.clear()
 
-    async def connect_websocket(self) -> DiscordVoiceWebSocket:
-        ws = await DiscordVoiceWebSocket.from_client(self)
-        self._connected.clear()
-        while ws.secret_key is None:
-            await ws.poll_event()
-        self._connected.set()
-        return ws
+    # async def connect_websocket(self) -> DiscordVoiceWebSocket:
+    #     ws = await DiscordVoiceWebSocket.from_client(self)
+    #     self._connected.clear()
+    #     while ws.secret_key is None:
+    #         await ws.poll_event()
+    #     self._connected.set()
+    #     return ws
 
     async def connect(self, *, reconnect: bool, timeout: float, self_deaf: bool = False, self_mute: bool = False) -> None:
-        _log.info('Connecting to voice...')
-        self.timeout = timeout
+        await self.connection_state.connect(
+            reconnect=reconnect,
+            timeout=timeout,
+            self_deaf=self_deaf,
+            self_mute=self_mute,
+            resume=False
+        )
+        # _log.info('Connecting to voice...')
+        # self.timeout = timeout
 
-        for i in range(5):
-            self.prepare_handshake()
+        # for i in range(5):
+        #     self.prepare_handshake()
 
-            # This has to be created before we start the flow.
-            futures = [
-                self._voice_state_complete.wait(),
-                self._voice_server_complete.wait(),
-            ]
+        #     # This has to be created before we start the flow.
+        #     futures = [
+        #         self._voice_state_complete.wait(),
+        #         self._voice_server_complete.wait(),
+        #     ]
 
-            # Start the connection flow
-            await self.voice_connect(self_deaf=self_deaf, self_mute=self_mute)
+        #     # Start the connection flow
+        #     await self.voice_connect(self_deaf=self_deaf, self_mute=self_mute)
 
-            try:
-                await utils.sane_wait_for(futures, timeout=timeout)
-            except asyncio.TimeoutError:
-                await self.disconnect(force=True)
-                raise
+        #     try:
+        #         await utils.sane_wait_for(futures, timeout=timeout)
+        #     except asyncio.TimeoutError:
+        #         await self.disconnect(force=True)
+        #         raise
 
-            self.finish_handshake()
+        #     self.finish_handshake()
 
-            try:
-                self.ws = await self.connect_websocket()
-                break
-            except (ConnectionClosed, asyncio.TimeoutError):
-                if reconnect:
-                    _log.exception('Failed to connect to voice... Retrying...')
-                    await asyncio.sleep(1 + i * 2.0)
-                    await self.voice_disconnect()
-                    continue
-                else:
-                    raise
+        #     try:
+        #         self.ws = await self.connect_websocket()
+        #         break
+        #     except (ConnectionClosed, asyncio.TimeoutError):
+        #         if reconnect:
+        #             _log.exception('Failed to connect to voice... Retrying...')
+        #             await asyncio.sleep(1 + i * 2.0)
+        #             await self.voice_disconnect()
+        #             continue
+        #         else:
+        #             raise
 
-        if self._runner is MISSING:
-            self._runner = self.client.loop.create_task(self.poll_voice_ws(reconnect))
+        # if self._runner is MISSING:
+        #     self._runner = self.client.loop.create_task(self.poll_voice_ws(reconnect))
 
-    async def potential_reconnect(self) -> bool:
-        # Attempt to stop the player thread from playing early
-        self._connected.clear()
-        self.prepare_handshake()
-        self._potentially_reconnecting = True
-        try:
-            # We only care about VOICE_SERVER_UPDATE since VOICE_STATE_UPDATE can come before we get disconnected
-            await asyncio.wait_for(self._voice_server_complete.wait(), timeout=self.timeout)
-        except asyncio.TimeoutError:
-            self._potentially_reconnecting = False
-            await self.disconnect(force=True)
-            return False
+    # async def potential_reconnect(self) -> bool:
+    #     # Attempt to stop the player thread from playing early
+    #     self._connected.clear()
+    #     self.prepare_handshake()
+    #     self._potentially_reconnecting = True
+    #     try:
+    #         # We only care about VOICE_SERVER_UPDATE since VOICE_STATE_UPDATE can come before we get disconnected
+    #         await asyncio.wait_for(self._voice_server_complete.wait(), timeout=self.timeout)
+    #     except asyncio.TimeoutError:
+    #         self._potentially_reconnecting = False
+    #         await self.disconnect(force=True)
+    #         return False
 
-        self.finish_handshake()
-        self._potentially_reconnecting = False
+    #     self.finish_handshake()
+    #     self._potentially_reconnecting = False
 
-        if self.ws:
-            _log.debug("Closing existing voice websocket")
-            await self.ws.close()
+    #     if self.ws:
+    #         _log.debug("Closing existing voice websocket")
+    #         await self.ws.close()
 
-        try:
-            self.ws = await self.connect_websocket()
-        except (ConnectionClosed, asyncio.TimeoutError):
-            return False
-        else:
-            return True
+    #     try:
+    #         self.ws = await self.connect_websocket()
+    #     except (ConnectionClosed, asyncio.TimeoutError):
+    #         return False
+    #     else:
+    #         return True
 
     @property
     def latency(self) -> float:
@@ -442,7 +466,7 @@ class VoiceClient(VoiceProtocol):
 
         .. versionadded:: 1.4
         """
-        ws = self.ws
+        ws = self.connection_state.ws
         return float("inf") if not ws else ws.latency
 
     @property
@@ -451,70 +475,72 @@ class VoiceClient(VoiceProtocol):
 
         .. versionadded:: 1.4
         """
-        ws = self.ws
+        ws = self.connection_state.ws
         return float("inf") if not ws else ws.average_latency
 
-    async def poll_voice_ws(self, reconnect: bool) -> None:
-        backoff = ExponentialBackoff()
-        while True:
-            try:
-                await self.ws.poll_event()
-            except (ConnectionClosed, asyncio.TimeoutError) as exc:
-                if isinstance(exc, ConnectionClosed):
-                    # The following close codes are undocumented so I will document them here.
-                    # 1000 - normal closure (obviously)
-                    # 4014 - voice channel has been deleted.
-                    # 4015 - voice server has crashed
-                    if exc.code in (1000, 4015):
-                        _log.info('Disconnecting from voice normally, close code %d.', exc.code)
-                        await self.disconnect()
-                        break
-                    if exc.code == 4014:
-                        _log.info('Disconnected from voice by force... potentially reconnecting.')
-                        successful = await self.potential_reconnect()
-                        if not successful:
-                            _log.info('Reconnect was unsuccessful, disconnecting from voice normally...')
-                            await self.disconnect()
-                            break
-                        else:
-                            continue
+    # async def poll_voice_ws(self, reconnect: bool) -> None:
+    #     backoff = ExponentialBackoff()
+    #     while True:
+    #         try:
+    #             await self.ws.poll_event()
+    #         except (ConnectionClosed, asyncio.TimeoutError) as exc:
+    #             if isinstance(exc, ConnectionClosed):
+    #                 # The following close codes are undocumented so I will document them here.
+    #                 # 1000 - normal closure (obviously)
+    #                 # 4014 - voice channel has been deleted.
+    #                 # 4015 - voice server has crashed
+    #                 if exc.code in (1000, 4015):
+    #                     _log.info('Disconnecting from voice normally, close code %d.', exc.code)
+    #                     await self.disconnect()
+    #                     break
+    #                 if exc.code == 4014:
+    #                     _log.info('Disconnected from voice by force... potentially reconnecting.')
+    #                     successful = await self.potential_reconnect()
+    #                     if not successful:
+    #                         _log.info('Reconnect was unsuccessful, disconnecting from voice normally...')
+    #                         await self.disconnect()
+    #                         break
+    #                     else:
+    #                         continue
 
-                if not reconnect:
-                    await self.disconnect()
-                    raise
+    #             if not reconnect:
+    #                 await self.disconnect()
+    #                 raise
 
-                retry = backoff.delay()
-                _log.exception('Disconnected from voice... Reconnecting in %.2fs.', retry)
-                self._connected.clear()
-                await asyncio.sleep(retry)
-                await self.voice_disconnect()
-                try:
-                    await self.connect(reconnect=True, timeout=self.timeout)
-                except asyncio.TimeoutError:
-                    # at this point we've retried 5 times... let's continue the loop.
-                    _log.warning('Could not connect to voice... Retrying...')
-                    continue
+    #             retry = backoff.delay()
+    #             _log.exception('Disconnected from voice... Reconnecting in %.2fs.', retry)
+    #             self._connected.clear()
+    #             await asyncio.sleep(retry)
+    #             await self.voice_disconnect()
+    #             try:
+    #                 await self.connect(reconnect=True, timeout=self.timeout)
+    #             except asyncio.TimeoutError:
+    #                 # at this point we've retried 5 times... let's continue the loop.
+    #                 _log.warning('Could not connect to voice... Retrying...')
+    #                 continue
 
     async def disconnect(self, *, force: bool = False) -> None:
         """|coro|
 
         Disconnects this voice client from voice.
         """
-        if not force and not self.is_connected():
-            return
-
         self.stop()
-        self._connected.clear()
+        await self.connection_state.disconnect(force=force)
+        # if not force and not self.is_connected():
+        #     return
 
-        try:
-            if self.ws:
-                await self.ws.close()
+        # self.stop()
+        # self._connected.clear()
 
-            await self.voice_disconnect()
-        finally:
-            self.cleanup()
-            if self.socket:
-                self.socket.close()
+        # try:
+        #     if self.ws:
+        #         await self.ws.close()
+
+        #     await self.voice_disconnect()
+        # finally:
+        #     self.cleanup()
+        #     if self.socket:
+        #         self.socket.close()
 
     async def move_to(self, channel: Optional[abc.Snowflake]) -> None:
         """|coro|
@@ -526,11 +552,16 @@ class VoiceClient(VoiceProtocol):
         channel: Optional[:class:`abc.Snowflake`]
             The channel to move to. Must be a voice channel.
         """
-        await self.channel.guild.change_voice_state(channel=channel)
+        await self.connection_state.move_to(channel)
+        # await self.channel.guild.change_voice_state(channel=channel)
 
     def is_connected(self) -> bool:
         """Indicates if the voice client is connected to voice."""
-        return self._connected.is_set()
+        return self.connection_state.is_connected()
+        # return self._connected.is_set()
+
+    def wait_until_connected(self) -> None:
+        self.connection_state.wait()
 
     # audio related
 
@@ -732,7 +763,7 @@ class VoiceClient(VoiceProtocol):
             encoded_data = data
         packet = self._get_voice_packet(encoded_data)
         try:
-            self.socket.sendto(packet, (self.endpoint_ip, self.voice_port))
+            self.connection_state.send_packet(packet)
         except BlockingIOError:
             _log.warning('A packet has been dropped (seq: %s, timestamp: %s)', self.sequence, self.timestamp)
 

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -347,6 +347,14 @@ class VoiceClient(VoiceProtocol):
             The channel to move to. Must be a voice channel.
         timeout: Optional[:class:`float`]
             How long to wait for the move to complete.
+
+        .. versionchanged:: 2.4
+            Added timeout parameter.
+
+        Raises
+        -------
+        asyncio.TimeoutError
+            The move did not complete in time, but may still be ongoing.
         """
         await self._connection.move_to(channel)
         await self._connection.wait_async(timeout)

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -40,16 +40,13 @@ Some documentation to refer to:
 from __future__ import annotations
 
 import asyncio
-# import socket
 import logging
 import struct
-# import threading
 from typing import Any, Callable, List, Optional, TYPE_CHECKING, Tuple, Union
 
-from . import opus#, utils
-# from .backoff import ExponentialBackoff
+from . import opus
 from .gateway import *
-from .errors import ClientException#, ConnectionClosed
+from .errors import ClientException
 from .player import AudioPlayer, AudioSource
 from .utils import MISSING
 from .voice_state import VoiceConnectionState
@@ -350,8 +347,9 @@ class VoiceClient(VoiceProtocol):
         """Indicates if the voice client is connected to voice."""
         return self._voice_state.is_connected()
 
-    def wait_until_connected(self) -> None:
-        self._voice_state.wait()
+    def wait_until_connected(self, *, timeout: Optional[float]=None) -> None:
+        """TODO: Do i actually need this function on VoiceClient?"""
+        self._voice_state.wait(timeout)
 
     # audio related
 

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -52,6 +52,7 @@ from .utils import MISSING
 from .voice_state import VoiceConnectionState
 
 if TYPE_CHECKING:
+    from .gateway import DiscordVoiceWebSocket
     from .client import Client
     from .guild import Guild
     from .state import ConnectionState
@@ -267,7 +268,7 @@ class VoiceClient(VoiceProtocol):
         return self._connection.ssrc
 
     @property
-    def mode(self) -> str:
+    def mode(self) -> SupportedModes:
         return self._connection.mode
 
     @property
@@ -275,7 +276,7 @@ class VoiceClient(VoiceProtocol):
         return self._connection.secret_key
 
     @property
-    def ws(self):
+    def ws(self) -> DiscordVoiceWebSocket:
         return self._connection.ws
 
     def checked_add(self, attr: str, value: int, limit: int) -> None:
@@ -344,14 +345,19 @@ class VoiceClient(VoiceProtocol):
         """Indicates if the voice client is connected to voice."""
         return self._connection.is_connected()
 
-    def wait_until_connected(self, *, timeout: Optional[float] = None) -> None:
+    def wait_until_connected(self, *, timeout: Optional[float] = None) -> bool:
         """Waits until the voice client is connected.
 
         Parameters
         -----------
         timeout: Optional[:class:`float`]
+
+        Returns
+        ---------
+        :class:`bool`
+            The same as what :meth:`threading.Event.wait()` returns (The state of the internal :class:`threading.Event` flag).
         """
-        self._connection.wait(timeout)
+        return self._connection.wait(timeout)
 
     # audio related
 

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -159,11 +159,11 @@ class VoiceConnectionState:
             if self._expecting_disconnect:
                 self._expecting_disconnect = False
             else:
-                _log.debug("We were probably disconnected from voice by someone else.")
+                _log.debug('We were probably disconnected from voice by someone else.')
                 await self.disconnect()
 
             if self.state != ConnectionFlowState.connected:
-                _log.warning("Ignoring voice_state_update event while in state %s", self.state)
+                _log.warning('Ignoring voice_state_update event while in state %s', self.state)
 
             return
 
@@ -184,8 +184,8 @@ class VoiceConnectionState:
                 # For some unfortunate reason we were moved during the connection flow
                 # We *could* try to wrangle whatever state we're in back in order...
                 # ...or we just reconnect fully and spare ourselves the effort of figuring that mess out
-                _log.info("Handling channel move during connection flow...")
-                _log.debug("Current state is %s", self.state)
+                _log.info('Handling channel move during connection flow...')
+                _log.debug('Current state is %s', self.state)
 
                 self.voice_client.channel = channel_id and self.guild.get_channel(int(channel_id))  # type: ignore
                 await self.ws.close(4014)
@@ -278,6 +278,8 @@ class VoiceConnectionState:
             if self.ws:
                 await self.ws.close()
             await self._voice_disconnect()
+        except Exception:
+            _log.debug('Ignoring exception disconnecting from voice', exc_info=True)
         finally:
             self.ip = MISSING
             self.port = MISSING

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -212,13 +212,13 @@ class VoiceConnectionState:
 
     @state.setter
     def state(self, state: ConnectionFlowState) -> None:
-        if state != self._state:
+        if state is not self._state:
             _log.debug('Connection state changed to %s', state.name)
         self._state = state
         self._state_event.set()
         self._state_event.clear()
 
-        if state == ConnectionFlowState.connected:
+        if state is ConnectionFlowState.connected:
             self._connected.set()
         else:
             self._connected.clear()
@@ -247,7 +247,7 @@ class VoiceConnectionState:
                 _log.debug('We were probably disconnected from voice by someone else.')
                 await self.disconnect()
 
-            if self.state != ConnectionFlowState.connected:
+            if self.state is not ConnectionFlowState.connected:
                 _log.warning('Ignoring voice_state_update event while in state %s', self.state)
 
             return
@@ -256,15 +256,15 @@ class VoiceConnectionState:
 
         # if we get the event while connecting
         if self.state in (ConnectionFlowState.set_guild_voice_state, ConnectionFlowState.got_voice_server_update):
-            if self.state == ConnectionFlowState.set_guild_voice_state:
+            if self.state is ConnectionFlowState.set_guild_voice_state:
                 self.state = ConnectionFlowState.got_voice_state_update
             else:
                 self.state = ConnectionFlowState.got_both_voice_updates
             return
 
-        if self.state == ConnectionFlowState.connected:
+        if self.state is ConnectionFlowState.connected:
             self.voice_client.channel = channel_id and self.guild.get_channel(int(channel_id))  # type: ignore
-        elif self.state != ConnectionFlowState.disconnected:
+        elif self.state is not ConnectionFlowState.disconnected:
             if channel_id != self.voice_client.channel.id:
                 # For some unfortunate reason we were moved during the connection flow
                 # We *could* try to wrangle whatever state we're in back in order...
@@ -306,15 +306,15 @@ class VoiceConnectionState:
             self._socket_reader.resume()
 
             # sets our connection state to either voice_server_update or both, if we already had the other one
-            if self.state == ConnectionFlowState.set_guild_voice_state:
+            if self.state is ConnectionFlowState.set_guild_voice_state:
                 self.state = ConnectionFlowState.got_voice_server_update
             else:
                 self.state = ConnectionFlowState.got_both_voice_updates
-        elif self.state == ConnectionFlowState.connected:
+        elif self.state is ConnectionFlowState.connected:
             _log.debug('Voice server update, closing old voice websocket')
             await self.ws.close(4014)
             self.state = ConnectionFlowState.got_both_voice_updates
-        elif self.state != ConnectionFlowState.disconnected:
+        elif self.state is not ConnectionFlowState.disconnected:
             _log.warning('Ignoring unexpected voice_server_update event')
             # Something might need to be done here but I don't know what
 
@@ -397,10 +397,10 @@ class VoiceConnectionState:
         await self._wait_for_state(ConnectionFlowState.connected, timeout=timeout)
 
     def is_connected(self) -> bool:
-        return self.state == ConnectionFlowState.connected
+        return self.state is ConnectionFlowState.connected
 
     def send_packet(self, packet: bytes) -> None:
-        if self.state != ConnectionFlowState.connected:
+        if self.state is not ConnectionFlowState.connected:
             # TODO: do I drop the packet or let it go through and maybe raise?
             _log.debug('Not connected but sending packet anyway...')
             # _log.debug('Not connected to voice, dropping packet')

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -276,6 +276,9 @@ class VoiceConnectionState:
             await self._voice_disconnect()
         finally:
             self.stage = ConnectionStage.disconnected
+            # Flip the connected event just to unlock any waiters
+            self._connected.set()
+            self._connected.clear()
             if self.socket:
                 self.socket.close()
 

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -208,7 +208,7 @@ class VoiceConnectionState:
             _log.debug('Closing old voice websocket')
             await self.ws.close(4014)
             self.state = ConnectionFlowState.got_both_voice_updates
-        else:
+        elif self.state != ConnectionFlowState.disconnected:
             _log.warning('Got unexpected voice_server_update')
             # TODO: wat do?
 

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -187,7 +187,7 @@ class VoiceConnectionState:
         self.voice_client = voice_client
         self.hook = hook
 
-        self.timeout: float = 30
+        self.timeout: float = 30.0
         self.reconnect: bool = True
         self.self_deaf: bool = False
         self.self_mute: bool = False
@@ -366,12 +366,15 @@ class VoiceConnectionState:
         except asyncio.CancelledError:
             _log.debug('Cancelling voice connection')
             await self.soft_disconnect()
+            raise
         except asyncio.TimeoutError:
             _log.info('Timed out connecting to voice')
             await self.disconnect()
+            raise
         except Exception:
             _log.exception('Error connecting to voice... disconnecting')
             await self.disconnect()
+            raise
 
     async def _connect(self, reconnect: bool, timeout: float, self_deaf: bool, self_mute: bool, resume: bool) -> None:
         _log.info('Connecting to voice...')
@@ -403,6 +406,8 @@ class VoiceConnectionState:
                     else:
                         await self.disconnect()
                         raise
+
+        _log.info('Voice connection complete.')
 
         if not self._runner:
             self._runner = self.voice_client.loop.create_task(self._poll_voice_ws(reconnect), name='Voice websocket poller')

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -246,7 +246,7 @@ class VoiceConnectionState:
                     raise
 
         if self._runner is MISSING:
-            self._runner = self.voice_client.loop.create_task(self._poll_voice_ws(reconnect), name="Voice websocket poller")
+            self._runner = self.voice_client.loop.create_task(self._poll_voice_ws(reconnect), name='Voice websocket poller')
 
     async def disconnect(self, *, force: bool = False) -> None:
         if not force and not self.is_connected():
@@ -284,7 +284,7 @@ class VoiceConnectionState:
     def send_packet(self, packet: bytes) -> int:
         if not self.state == ConnectionFlowState.connected:
             # temporary, handling this needs a bit thought
-            _log.info("Not connected but sending packet anyway...")
+            _log.info('Not connected but sending packet anyway...')
             # raise RuntimeError('Not connected')
 
         return self.socket.sendto(packet, (self.endpoint_ip, self.voice_port))

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -85,7 +85,7 @@ class ConnectionFlowState(Enum, comparable=True):
     websocket_connected     = 5
     got_websocket_ready     = 6
     # we send udp discovery packet and read from the socket
-    got_udp_discovery       = 7
+    got_ip_discovery        = 7
     # we send SELECT_PROTOCOL then SPEAKING
     connected               = 8
     # fmt: on
@@ -290,10 +290,10 @@ class VoiceConnectionState:
 
         return self.socket.sendto(packet, (self.endpoint_ip, self.voice_port))
 
-    def read_packet(self, length: int = 2048) -> bytes:
+    def read_packet(self, *, length: int = 2048) -> bytes:
         return self._handle_packet(self.socket.recv(length))
 
-    async def read_packet_async(self, length: int = 2048) -> bytes:
+    async def read_packet_async(self, *, length: int = 2048) -> bytes:
         return self._handle_packet(await self.voice_client.loop.sock_recv(self.socket, length))
 
     def _handle_packet(self, data: bytes) -> bytes:
@@ -326,7 +326,7 @@ class VoiceConnectionState:
         self.state = ConnectionFlowState.websocket_connected
         while not self.ip:
             await ws.poll_event()
-        self.state = ConnectionFlowState.got_udp_discovery
+        self.state = ConnectionFlowState.got_ip_discovery
         while ws.secret_key is None:
             await ws.poll_event()
         self.state = ConnectionFlowState.connected

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -1,0 +1,87 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-present Rapptz
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+from typing_extensions import Self
+
+from .utils import MISSING
+
+if TYPE_CHECKING:
+    from . import abc
+    from .voice_client import VoiceProtocol
+    from .gateway import DiscordVoiceWebSocket
+
+    from .types.voice import (
+        GuildVoiceState as GuildVoiceStatePayload,
+        VoiceServerUpdate as VoiceServerUpdatePayload,
+        # SupportedModes,
+    )
+
+
+class VoiceConnectionState:
+    """Represents the internal state of a voice connection."""
+
+    def __init__(self, voice_client: VoiceProtocol):
+        self.voice_client = voice_client
+        self.token: str = MISSING
+        self.socket = MISSING
+        self.ws: DiscordVoiceWebSocket = MISSING
+
+    async def voice_state_update(self, data: GuildVoiceStatePayload) -> None:
+        ...
+
+    async def voice_server_update(self, data: VoiceServerUpdatePayload) -> None:
+        ...
+
+    async def connect(
+        self,
+        *,
+        reconnect: bool,
+        timeout: float,
+        self_deaf: bool,
+        self_mute: bool,
+        resume: bool
+    ) -> Self:
+        ...
+
+    async def disconnect(self, *, force: bool=False) -> None:
+        ...
+
+    async def move_to(self, channel: Optional[abc.Snowflake]) -> None:
+        ...
+
+    def wait(self, timeout: float=0) -> bool:
+        ...
+
+    async def wait_async(self, timeout: float=0) -> bool:
+        ...
+
+    def is_connected(self) -> bool:
+        ...
+
+    def send_packet(self, data: bytes) -> None:
+        ...

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -202,9 +202,6 @@ class VoiceConnectionState:
         self.secret_key: List[int] = MISSING
         self.ssrc: int = MISSING
         self.mode: SupportedModes = MISSING
-
-        # TODO: These two cause a lot of issues if they're Optional
-        #       Even if they really are optional, access should be already restricted based on state
         self.socket: socket.socket = MISSING
         self.ws: DiscordVoiceWebSocket = MISSING
 

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -25,15 +25,24 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
-from typing_extensions import Self
+import socket
+import asyncio
+import logging
+import threading
 
-from .utils import MISSING
+from typing import TYPE_CHECKING, Optional, Dict, List, Callable, Coroutine, Any, Union
+
+from .enums import Enum
+from .utils import MISSING, sane_wait_for
+from .errors import ConnectionClosed
+from .backoff import ExponentialBackoff
+from .gateway import DiscordVoiceWebSocket
 
 if TYPE_CHECKING:
     from . import abc
-    from .voice_client import VoiceProtocol
-    from .gateway import DiscordVoiceWebSocket
+    from .guild import Guild
+    from .user import ClientUser
+    from .voice_client import VoiceClient
 
     from .types.voice import (
         GuildVoiceState as GuildVoiceStatePayload,
@@ -41,21 +50,174 @@ if TYPE_CHECKING:
         # SupportedModes,
     )
 
+    WebsocketHook = Optional[Callable[['VoiceConnectionState', Dict[str, Any]], Coroutine[Any, Any, Any]]]
+
+    from enum import IntEnum as Enum # heck
+
+__all__ = (
+    'VoiceConnectionState',
+)
+
+_log = logging.getLogger(__name__)
+
+"""
+Some documentation to refer to:
+
+- Our main web socket (mWS) sends opcode 4 with a guild ID and channel ID.
+- The mWS receives VOICE_STATE_UPDATE and VOICE_SERVER_UPDATE.
+- We pull the session_id from VOICE_STATE_UPDATE.
+- We pull the token, endpoint and server_id from VOICE_SERVER_UPDATE.
+- Then we initiate the voice web socket (vWS) pointing to the endpoint.
+- We send opcode 0 with the user_id, server_id, session_id and token using the vWS.
+- The vWS sends back opcode 2 with an ssrc, port, modes(array) and heartbeat_interval.
+- We send a UDP discovery packet to endpoint:port and receive our IP and our port in LE.
+- Then we send our IP and port via vWS with opcode 1.
+- When that's all done, we receive opcode 4 from the vWS.
+- Finally we can transmit data to endpoint:port.
+"""
+
+class ConnectionStage(Enum, comparable=True):
+    """Enum representing voice connection flow state as 'what just happened'."""
+
+    disconnected            = 0b0
+    set_guild_voice_state   = 0b00_00000001
+    got_voice_state_update  = 0b00_00000010
+    got_voice_server_update = 0b00_00000100
+    got_both_voice_updates  = 0b00_00000110
+    websocket_connected     = 0b00_00001000
+    got_websocket_ready     = 0b00_00010000
+    # we send udp discovery packet and read from the socket
+    got_udp_discovery       = 0b00_00100000
+    # we send SELECT_PROTOCOL then SPEAKING
+    connected               = 0b00_01000000
+    resumed                 = 0b00_11000000
+    reconnecting            = 0b01_00000000
+
+    if TYPE_CHECKING:
+        @classmethod
+        def try_value(cls, value: Union[ConnectionStage, int]) -> Union[ConnectionStage, int]:
+            ...
+
 
 class VoiceConnectionState:
     """Represents the internal state of a voice connection."""
 
-    def __init__(self, voice_client: VoiceProtocol):
+    def __init__(self, voice_client: VoiceClient, *, hook: Optional[WebsocketHook]=None) -> None:
         self.voice_client = voice_client
+        self.hook = hook
+
         self.token: str = MISSING
+        self.session_id: str = MISSING
+        self.endpoint: str = MISSING
+        self.endpoint_ip: str = MISSING
+        self.server_id: int = MISSING
+        self.ip: str = MISSING
+        self.port: int = MISSING
+        self.voice_port: int = MISSING
+        self.secret_key: List[int] = MISSING
+        self.ssrc: int = MISSING
+        self.mode: str = MISSING
+
         self.socket = MISSING
         self.ws: DiscordVoiceWebSocket = MISSING
 
-    async def voice_state_update(self, data: GuildVoiceStatePayload) -> None:
-        ...
+        self._stage: ConnectionStage = ConnectionStage.disconnected
 
+        self._connected = threading.Event()
+        self._stage_event = asyncio.Event()
+        self._runner: asyncio.Task = MISSING
+
+    @property
+    def stage(self) -> ConnectionStage:
+        return self._stage
+
+    @stage.setter
+    def stage(self, stage: ConnectionStage) -> None:
+        self._stage = stage
+        _log.debug('Current stage is now: %s', stage)
+        self._stage_event.set()
+        self._stage_event.clear()
+
+        if stage.value & ConnectionStage.connected.value:
+            self._connected.set()
+        else:
+            self._connected.clear()
+
+    @property
+    def guild(self) -> Guild:
+        return self.voice_client.guild
+
+    @property
+    def user(self) -> ClientUser:
+        return self.voice_client.user
+
+    @property
+    def supported_modes(self):
+        return self.voice_client.supported_modes
+
+    async def voice_state_update(self, data: GuildVoiceStatePayload) -> None:
+        session_id = data['session_id']
+        channel_id = data['channel_id']
+
+        if channel_id is None:
+            await self.disconnect()
+
+        # if we get the event while connecting
+        if self.stage in (
+            ConnectionStage.set_guild_voice_state,
+            ConnectionStage.got_voice_server_update
+        ):
+            self.session_id = session_id
+            self.stage = ConnectionStage(self.stage.value | ConnectionStage.got_voice_state_update.value)
+            return
+
+        if session_id != self.session_id:
+            _log.debug('New session id, old: %r, new: %r', self.session_id, session_id)
+            self.session_id = session_id
+
+        if self.stage.value & ConnectionStage.reconnecting.value or self.stage.value & ConnectionStage.connected.value:
+            self.voice_client.channel = channel_id and self.guild.get_channel(int(channel_id)) # type: ignore
+
+        elif self.stage < ConnectionStage.connected:
+            _log.warning('Got unexpected voice_state_update before complete connection')
+            # TODO: kill it and start over?
+
+    # this whole function gives me the heebie jeebies
     async def voice_server_update(self, data: VoiceServerUpdatePayload) -> None:
-        ...
+        self.token = data['token']
+        self.server_id = int(data['guild_id'])
+        endpoint = data.get('endpoint')
+
+        if self.token is None or endpoint is None:
+            _log.warning(
+                'Awaiting endpoint... This requires waiting. '
+                'If timeout occurred considering raising the timeout and reconnecting.'
+            )
+            return
+
+        self.endpoint, _, _ = endpoint.rpartition(':')
+        if self.endpoint.startswith('wss://'):
+            # Just in case, strip it off since we're going to add it later
+            self.endpoint: str = self.endpoint[6:]
+
+        # if we get the event while connecting
+        if self.stage in (
+            ConnectionStage.set_guild_voice_state,
+            ConnectionStage.got_voice_state_update
+        ):
+            # This gets set after READY
+            self.endpoint_ip = MISSING
+
+            self.socket: socket.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            self.socket.setblocking(False)
+
+            self.stage = ConnectionStage(self.stage.value | ConnectionStage.got_voice_server_update.value)
+        elif self.stage.value & ConnectionStage.connected.value:
+            _log.debug('Closing old websocket')
+            await self.ws.close(4000)
+        else:
+            _log.warning('Got unexpected voice_server_update')
+            # TODO: wat do?
 
     async def connect(
         self,
@@ -65,23 +227,113 @@ class VoiceConnectionState:
         self_deaf: bool,
         self_mute: bool,
         resume: bool
-    ) -> Self:
-        ...
+    ) -> None:
+
+        _log.info('Connecting to voice...')
+        self.timeout = timeout
+
+        for i in range(5):
+            await self._voice_connect(self_deaf=self_deaf, self_mute=self_mute)
+            self.stage = ConnectionStage.set_guild_voice_state
+
+            try:
+                await self._wait_for_stage(ConnectionStage.got_both_voice_updates, timeout=timeout)
+            except asyncio.TimeoutError:
+                _log.debug('Timed out waiting for voice update events')
+                await self.disconnect(force=True)
+                raise
+
+            try:
+                self.ws = await self._connect_websocket(resume)
+            except (ConnectionClosed, asyncio.TimeoutError):
+                if reconnect:
+                    wait = 1 + i * 2.0
+                    _log.exception('Failed to connect to voice... Retrying in %ss...', wait)
+                    await asyncio.sleep(wait)
+                    await self._voice_disconnect()
+                    continue
+                else:
+                    try:
+                        await self._voice_disconnect()
+                    except Exception:
+                        _log.exception('Error setting voice state after connection failure')
+                    raise
+
+        if self._runner is MISSING:
+            self._runner = self.voice_client.loop.create_task(self._poll_voice_ws(reconnect))
+
 
     async def disconnect(self, *, force: bool=False) -> None:
-        ...
+        if not force and not self.is_connected():
+            return
+
+        try:
+            if self.ws:
+                await self.ws.close()
+
+            await self._voice_disconnect()
+        finally:
+            self.stage = ConnectionStage.disconnected
+            if self.socket:
+                self.socket.close()
 
     async def move_to(self, channel: Optional[abc.Snowflake]) -> None:
-        ...
+        if channel is None:
+            await self.disconnect()
+            return
 
-    def wait(self, timeout: float=0) -> bool:
-        ...
+        await self.voice_client.channel.guild.change_voice_state(channel=channel)
 
-    async def wait_async(self, timeout: float=0) -> bool:
-        ...
+    def wait(self, timeout: Optional[float]=None) -> bool:
+        return self._connected.wait(timeout)
+
+    async def wait_async(self, *, timeout: Optional[float]=None) -> bool:
+        return await self._wait_for_stage(ConnectionStage.connected, timeout=timeout, exact=False)
 
     def is_connected(self) -> bool:
-        ...
+        return bool(self.stage.value & ConnectionStage.connected.value)
 
     def send_packet(self, data: bytes) -> None:
         ...
+
+    async def _wait_for_stage(self, stage: ConnectionStage, *, timeout: Optional[float]=None, exact: bool=True):
+        while True:
+            if exact:
+                if self.stage == stage:
+                    return True
+            else:
+                if self.stage.value & stage.value == stage.value:
+                    return True
+            await sane_wait_for([self._stage_event.wait()], timeout=timeout)
+
+    async def _voice_connect(self, *, self_deaf: bool = False, self_mute: bool = False) -> None:
+        channel = self.voice_client.channel
+        await channel.guild.change_voice_state(channel=channel, self_deaf=self_deaf, self_mute=self_mute)
+
+    async def _voice_disconnect(self) -> None:
+        _log.info('The voice handshake is being terminated for Channel ID %s (Guild ID %s)',
+            self.voice_client.channel.id, self.voice_client.guild.id
+        )
+        self.stage = ConnectionStage.disconnected
+        await self.voice_client.channel.guild.change_voice_state(channel=None)
+
+    async def _connect_websocket(self, resume: bool) -> DiscordVoiceWebSocket:
+        ws = await DiscordVoiceWebSocket.from_connection_state(self, resume=resume, hook=self.hook)
+        self.stage = ConnectionStage.websocket_connected
+        while not self.ip:
+            await ws.poll_event()
+        self.stage = ConnectionStage.got_udp_discovery
+        while ws.secret_key is None:
+            await ws.poll_event()
+        if resume:
+            self.stage = ConnectionStage.resumed
+        self.stage = ConnectionStage.connected
+        return ws
+
+    async def _poll_voice_ws(self, reconnect: bool) -> None:
+        backoff = ExponentialBackoff()
+        while True:
+            try:
+                await self.ws.poll_event()
+            except (ConnectionClosed, asyncio.TimeoutError) as exc:
+                ...

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -172,7 +172,7 @@ class VoiceConnectionState:
             return
 
         if session_id != self.session_id:
-            _log.debug('New session id, old: %r, new: %r', self.session_id, session_id)
+            # _log.debug('New session id, old: %r, new: %r', self.session_id, session_id)
             self.session_id = session_id
 
         if self.stage.value & ConnectionStage.reconnecting.value or self.stage.value & ConnectionStage.connected.value:
@@ -241,7 +241,7 @@ class VoiceConnectionState:
             try:
                 await self._wait_for_stage(ConnectionStage.got_both_voice_updates, timeout=timeout)
             except asyncio.TimeoutError:
-                _log.debug('Timed out waiting for voice update events')
+                _log.info('Timed out waiting for voice update events')
                 await self.disconnect(force=True)
                 raise
 
@@ -297,7 +297,7 @@ class VoiceConnectionState:
 
     def send_packet(self, packet: bytes) -> int:
         if not self.stage.value & ConnectionStage.connected.value:
-            _log.warning("Not connected but sending packet anyway...")
+            _log.info("Not connected but sending packet anyway...")
             # raise RuntimeError('Not connected')
 
         return self.socket.sendto(packet, (self.endpoint_ip, self.voice_port))

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -259,6 +259,8 @@ class VoiceConnectionState:
             await self._voice_disconnect()
         finally:
             self.state = ConnectionFlowState.disconnected
+            self.ip = MISSING
+            self.port = MISSING
             # Flip the connected event just to unlock any waiters
             self._connected.set()
             self._connected.clear()
@@ -288,6 +290,15 @@ class VoiceConnectionState:
             # raise RuntimeError('Not connected')
 
         return self.socket.sendto(packet, (self.endpoint_ip, self.voice_port))
+
+    def read_packet(self, length: int = 2048) -> bytes:
+        return self._handle_packet(self.socket.recv(length))
+
+    async def read_packet_async(self, length: int = 2048) -> bytes:
+        return self._handle_packet(await self.voice_client.loop.sock_recv(self.socket, length))
+
+    def _handle_packet(self, data: bytes) -> bytes:
+        return data
 
     async def _wait_for_state(
         self, state: ConnectionFlowState, *other_states: ConnectionFlowState, timeout: Optional[float] = None

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -191,18 +191,22 @@ class VoiceConnectionState:
         self.reconnect: bool = True
         self.self_deaf: bool = False
         self.self_mute: bool = False
-        self.token: str = MISSING
-        self.session_id: str = MISSING
-        self.endpoint: str = MISSING
-        self.endpoint_ip: str = MISSING
-        self.server_id: int = MISSING
-        self.ip: str = MISSING
-        self.port: int = MISSING
-        self.voice_port: int = MISSING
+        self.token: Optional[str] = None
+        self.session_id: Optional[str] = None
+        self.endpoint: Optional[str] = None
+        self.endpoint_ip: Optional[str] = None
+        self.server_id: Optional[int] = None
+        self.ip: Optional[str] = None
+        self.port: Optional[int] = None
+        self.voice_port: Optional[int] = None
+        # TODO: These three MISSINGs are exposed as VoiceClient properties
+        #       I could type ignore them or just leave them as MISSING
         self.secret_key: List[int] = MISSING
         self.ssrc: int = MISSING
         self.mode: SupportedModes = MISSING
 
+        # TODO: These two cause a lot of issues if they're Optional
+        #       Even if they really are optional, access should be already restricted based on state
         self.socket: socket.socket = MISSING
         self.ws: DiscordVoiceWebSocket = MISSING
 
@@ -309,7 +313,7 @@ class VoiceConnectionState:
         self.endpoint, _, _ = endpoint.rpartition(':')
         if self.endpoint.startswith('wss://'):
             # Just in case, strip it off since we're going to add it later
-            self.endpoint: str = self.endpoint[6:]
+            self.endpoint = self.endpoint[6:]
 
         # we got the event while connecting
         if self.state in (ConnectionFlowState.set_guild_voice_state, ConnectionFlowState.got_voice_state_update):
@@ -525,7 +529,7 @@ class VoiceConnectionState:
         self.state = ConnectionFlowState.connected
 
     def _create_socket(self) -> None:
-        self.socket: socket.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.socket.setblocking(False)
         self._socket_reader.resume()
 

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -236,6 +236,7 @@ class VoiceConnectionState:
                 await self._wait_for_stage(ConnectionStage.got_both_voice_updates, timeout=timeout)
             except asyncio.TimeoutError:
                 _log.info('Timed out waiting for voice update events')
+                # I probably dont actually need this disconnect here
                 await self.disconnect(force=True)
                 raise
 
@@ -294,12 +295,14 @@ class VoiceConnectionState:
 
     def send_packet(self, packet: bytes) -> int:
         if not self.stage.value & ConnectionStage.connected.value:
+            # temporary, handling this needs a bit thought
             _log.info("Not connected but sending packet anyway...")
             # raise RuntimeError('Not connected')
 
         return self.socket.sendto(packet, (self.endpoint_ip, self.voice_port))
 
     async def _wait_for_stage(self, stage: ConnectionStage, *, timeout: Optional[float]=None, exact: bool=True):
+        # TODO: switch to asyncio.Condition
         while True:
             if exact:
                 if self.stage == stage:

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -199,8 +199,6 @@ class VoiceConnectionState:
         self.ip: Optional[str] = None
         self.port: Optional[int] = None
         self.voice_port: Optional[int] = None
-        # TODO: These three MISSINGs are exposed as VoiceClient properties
-        #       I could type ignore them or just leave them as MISSING
         self.secret_key: List[int] = MISSING
         self.ssrc: int = MISSING
         self.mode: SupportedModes = MISSING

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -90,12 +90,6 @@ class ConnectionStage(Enum, comparable=True):
     got_udp_discovery       = 0b00_00100000
     # we send SELECT_PROTOCOL then SPEAKING
     connected               = 0b00_01000000
-    resumed                 = 0b00_11000000
-
-    # if TYPE_CHECKING:
-    #     @classmethod
-    #     def try_value(cls, value: Union[ConnectionStage, int]) -> Union[ConnectionStage, int]:
-    #         ...
 
 
 class VoiceConnectionState:
@@ -334,8 +328,6 @@ class VoiceConnectionState:
         self.stage = ConnectionStage.got_udp_discovery
         while ws.secret_key is None:
             await ws.poll_event()
-        if resume:
-            self.stage = ConnectionStage.resumed
         self.stage = ConnectionStage.connected
         return ws
 

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -261,6 +261,7 @@ class VoiceConnectionState:
             self.state = ConnectionFlowState.disconnected
             self.ip = MISSING
             self.port = MISSING
+            self.voice_client.cleanup()
             # Flip the connected event just to unlock any waiters
             self._connected.set()
             self._connected.clear()


### PR DESCRIPTION
## Summary
I have taken the liberty of rewriting the voice connection code to deal with various issues caused by the current one.  Essentially, I have moved all of the connection related code out of `voice_client.py` into the new `voice_state.py`.  In the process, while the code remains largely the same overall, I have converted it to a state machine instead of relying entirely on Events for state.  This *should* be all internal changes not breaking anything outwards facing, but I'm not 100% sure I didn't accidentally break something.  

This code is in a done enough state to be reviewed but I still have a couple things left to finalize.
- [x] Sort out reading from the socket as a shared resource (so I don't break potential voice recv)
- [x] Logging pass to normalize message wording, levels, placements
- [x] Comments pass
- [x] Finish TODOs (needs input)

Fixes #2284
Fixes #4091
Fixes #8483
Fixes #9039
Fixes #9137
Fixes #9364
Fixes #9575

There may be other issues fixed by this incidentally.  I will bump several issues after the merge.

## Checklist
- [X] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
