### PR TITLE
Add encoder params to VoiceClient.play

### DIFF
--- a/discord/opus.py
+++ b/discord/opus.py
@@ -39,8 +39,15 @@ from .errors import DiscordException
 
 if TYPE_CHECKING:
     T = TypeVar('T')
+    APPLICATION_CTL = Literal['audio', 'voip', 'lowdelay']
     BAND_CTL = Literal['narrow', 'medium', 'wide', 'superwide', 'full']
     SIGNAL_CTL = Literal['auto', 'voice', 'music']
+
+
+class ApplicationCtl(TypedDict):
+    audio: int
+    voip: int
+    lowdelay: int
 
 
 class BandCtl(TypedDict):
@@ -90,9 +97,10 @@ OK      = 0
 BAD_ARG = -1
 
 # Encoder CTLs
-APPLICATION_AUDIO    = 2049
-APPLICATION_VOIP     = 2048
-APPLICATION_LOWDELAY = 2051
+APPLICATION_AUDIO    = 'audio'
+APPLICATION_VOIP     = 'voip'
+APPLICATION_LOWDELAY = 'lowdelay'
+# These remain as strings for backwards compat
 
 CTL_SET_BITRATE      = 4002
 CTL_SET_BANDWIDTH    = 4008
@@ -104,6 +112,12 @@ CTL_SET_SIGNAL       = 4024
 CTL_SET_GAIN             = 4034
 CTL_LAST_PACKET_DURATION = 4039
 # fmt: on
+
+application_ctl: ApplicationCtl = {
+    'audio': 2049,
+    'voip': 2048,
+    'lowdelay': 2051,
+}
 
 band_ctl: BandCtl = {
     'narrow': 1101,
@@ -319,16 +333,36 @@ class _OpusStruct:
 
 
 class Encoder(_OpusStruct):
-    def __init__(self, application: int = APPLICATION_AUDIO):
-        _OpusStruct.get_opus_version()
+    def __init__(
+        self,
+        *,
+        application: APPLICATION_CTL = 'audio',
+        bitrate: int = 128,
+        fec: bool = True,
+        packet_loss_pct: float = 0.15,
+        bandwidth: BAND_CTL = 'full',
+        signal_type: SIGNAL_CTL = 'auto',
+    ):
+        if application not in application_ctl:
+            raise KeyError(f'{application} is not a valid application setting. Try one of: {"".join(application_ctl)}')
 
-        self.application: int = application
+        if not 16 <= bitrate <= 512:
+            raise ValueError(f'bitrate must be between 16 and 512, not {bitrate}')
+
+        if not 0 < packet_loss_pct <= 1.0:
+            raise ValueError(f'packet_loss_pct must be a positive number less than or equal to 1, not {packet_loss_pct}')
+
+        _OpusStruct.get_opus_version()  # lazy loads the opus library
+
+        self.application: int = application_ctl[application]
         self._state: EncoderStruct = self._create_state()
-        self.set_bitrate(128)
-        self.set_fec(True)
-        self.set_expected_packet_loss_percent(0.15)
-        self.set_bandwidth('full')
-        self.set_signal_type('auto')
+
+        self.set_bitrate(bitrate)
+        self.set_fec(fec)
+        if fec:
+            self.set_expected_packet_loss_percent(packet_loss_pct)
+        self.set_bandwidth(bandwidth)
+        self.set_signal_type(signal_type)
 
     def __del__(self) -> None:
         if hasattr(self, '_state'):
@@ -355,7 +389,7 @@ class Encoder(_OpusStruct):
 
     def set_signal_type(self, req: SIGNAL_CTL) -> None:
         if req not in signal_ctl:
-            raise KeyError(f'{req!r} is not a valid bandwidth setting. Try one of: {",".join(signal_ctl)}')
+            raise KeyError(f'{req!r} is not a valid signal type setting. Try one of: {",".join(signal_ctl)}')
 
         k = signal_ctl[req]
         _lib.opus_encoder_ctl(self._state, CTL_SET_SIGNAL, k)

--- a/discord/opus.py
+++ b/discord/opus.py
@@ -64,6 +64,15 @@ class SignalCtl(TypedDict):
     music: int
 
 
+class EncoderKwargs(TypedDict, total=False):
+    application: APPLICATION_CTL
+    bitrate: int
+    fec: bool
+    packet_loss_pct: float
+    bandwidth: BAND_CTL
+    signal_type: SIGNAL_CTL
+
+
 __all__ = (
     'Encoder',
     'OpusError',

--- a/discord/opus.py
+++ b/discord/opus.py
@@ -68,7 +68,7 @@ class EncoderKwargs(TypedDict, total=False):
     application: APPLICATION_CTL
     bitrate: int
     fec: bool
-    packet_loss_pct: float
+    expected_packet_loss: float
     bandwidth: BAND_CTL
     signal_type: SIGNAL_CTL
 
@@ -348,18 +348,20 @@ class Encoder(_OpusStruct):
         application: APPLICATION_CTL = 'audio',
         bitrate: int = 128,
         fec: bool = True,
-        packet_loss_pct: float = 0.15,
+        expected_packet_loss: float = 0.15,
         bandwidth: BAND_CTL = 'full',
         signal_type: SIGNAL_CTL = 'auto',
     ):
         if application not in application_ctl:
-            raise KeyError(f'{application} is not a valid application setting. Try one of: {"".join(application_ctl)}')
+            raise ValueError(f'{application} is not a valid application setting. Try one of: {"".join(application_ctl)}')
 
         if not 16 <= bitrate <= 512:
             raise ValueError(f'bitrate must be between 16 and 512, not {bitrate}')
 
-        if not 0 < packet_loss_pct <= 1.0:
-            raise ValueError(f'packet_loss_pct must be a positive number less than or equal to 1, not {packet_loss_pct}')
+        if not 0 < expected_packet_loss <= 1.0:
+            raise ValueError(
+                f'expected_packet_loss must be a positive number less than or equal to 1, not {expected_packet_loss}'
+            )
 
         _OpusStruct.get_opus_version()  # lazy loads the opus library
 
@@ -369,7 +371,7 @@ class Encoder(_OpusStruct):
         self.set_bitrate(bitrate)
         self.set_fec(fec)
         if fec:
-            self.set_expected_packet_loss_percent(packet_loss_pct)
+            self.set_expected_packet_loss_percent(expected_packet_loss)
         self.set_bandwidth(bandwidth)
         self.set_signal_type(signal_type)
 

--- a/discord/opus.py
+++ b/discord/opus.py
@@ -64,15 +64,6 @@ class SignalCtl(TypedDict):
     music: int
 
 
-class EncoderKwargs(TypedDict, total=False):
-    application: APPLICATION_CTL
-    bitrate: int
-    fec: bool
-    expected_packet_loss: float
-    bandwidth: BAND_CTL
-    signal_type: SIGNAL_CTL
-
-
 __all__ = (
     'Encoder',
     'OpusError',

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -586,14 +586,14 @@ class VoiceClient(VoiceProtocol):
         caught and the audio player is then stopped.  If no after callback is
         passed, any caught exception will be logged using the library logger.
 
-        Extra parameters may be passed to the :class:`Encoder` if a PCM based sink
-        is used.  Otherwise, they are ignored.
+        Extra parameters may be passed to the internal opus encoder if a PCM based
+        source is used.  Otherwise, they are ignored.
 
         .. versionchanged:: 2.0
             Instead of writing to ``sys.stderr``, the library's logger is used.
 
         .. versionchanged:: 2.4
-            Added :class:`Encoder` parameters as keyword arguments in ``encoder_kwargs``.
+            Added encoder parameters as keyword arguments in ``encoder_kwargs``.
 
         Parameters
         -----------
@@ -634,9 +634,9 @@ class VoiceClient(VoiceProtocol):
         OpusNotLoaded
             Source is not opus encoded and opus is not loaded.
         ValueError
-            An improper value was passed as an :class:`Encoder` parameter.
+            An improper value was passed as an encoder parameter.
         KeyError
-            An improper value was passed as an :class:`Encoder` parameter.
+            An improper value was passed as an encoder parameter.
         """
 
         if not self.is_connected():

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -594,7 +594,6 @@ class VoiceClient(VoiceProtocol):
 
         .. versionchanged:: 2.4
             Added :class:`Encoder` parameters as keyword arguments in ``encoder_kwargs``.
-            Constants can be accessed in the ``discord.opus`` module.
 
         Parameters
         -----------

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -45,7 +45,6 @@ import logging
 import struct
 import threading
 from typing import Any, Callable, List, Optional, TYPE_CHECKING, Tuple, Union
-from typing_extensions import Unpack
 
 from . import opus, utils
 from .backoff import ExponentialBackoff
@@ -55,6 +54,8 @@ from .player import AudioPlayer, AudioSource
 from .utils import MISSING
 
 if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
     from .client import Client
     from .guild import Guild
     from .state import ConnectionState
@@ -613,7 +614,7 @@ class VoiceClient(VoiceProtocol):
         fec: :class:`bool`
             Configures the encoder's use of inband forward error correction.
             Defaults to ``True``.
-        packet_loss_pct: :class:`float`
+        expected_packet_loss: :class:`float`
             Configures the encoder's expected packet loss percentage.  Requires FEC.
             Defaults to ``0.15``.
         bandwidth: :class:`str`
@@ -634,8 +635,6 @@ class VoiceClient(VoiceProtocol):
         OpusNotLoaded
             Source is not opus encoded and opus is not loaded.
         ValueError
-            An improper value was passed as an encoder parameter.
-        KeyError
             An improper value was passed as an encoder parameter.
         """
 

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -45,6 +45,7 @@ import logging
 import struct
 import threading
 from typing import Any, Callable, List, Optional, TYPE_CHECKING, Tuple, Union
+from typing_extensions import Unpack
 
 from . import opus, utils
 from .backoff import ExponentialBackoff
@@ -58,7 +59,7 @@ if TYPE_CHECKING:
     from .guild import Guild
     from .state import ConnectionState
     from .user import ClientUser
-    from .opus import Encoder
+    from .opus import Encoder, EncoderKwargs
     from .channel import StageChannel, VoiceChannel
     from . import abc
 
@@ -570,7 +571,11 @@ class VoiceClient(VoiceProtocol):
         return header + box.encrypt(bytes(data), bytes(nonce)).ciphertext + nonce[:4]
 
     def play(
-        self, source: AudioSource, *, after: Optional[Callable[[Optional[Exception]], Any]] = None, **encoder_kwargs
+        self,
+        source: AudioSource,
+        *,
+        after: Optional[Callable[[Optional[Exception]], Any]] = None,
+        **encoder_kwargs: Unpack[EncoderKwargs],
     ) -> None:
         """Plays an :class:`AudioSource`.
 

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -644,7 +644,7 @@ class VoiceClient(VoiceProtocol):
         if not isinstance(source, AudioSource):
             raise TypeError(f'source must be an AudioSource not {source.__class__.__name__}')
 
-        if not self.encoder and not source.is_opus():
+        if (not self.encoder or encoder_kwargs) and not source.is_opus():
             self.encoder = opus.Encoder(**encoder_kwargs)
 
         self._player = AudioPlayer(source, self, after=after)


### PR DESCRIPTION
## Summary
Adds kwarg parameters to allow access to setting `VoiceClient`'s underlying `Encoder` initial parameters.  In addition, this also changes the APPLICATION_ constants to be like the other CTL TypedDicts.  Also fixes an error message typo.  I'm not really sure about using stringly typed constants but its what the `Encoder` constructor uses. 

Closes #7130 

## Checklist

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
