### PR TITLE
Fixes/improvements to FFmpegAudio and subclasses

### DIFF
--- a/discord/oggparse.py
+++ b/discord/oggparse.py
@@ -99,7 +99,7 @@ class OggStream:
         elif not head:
             return None
         else:
-            raise OggError('invalid header magic')
+            raise OggError(f'invalid header magic {head}')
 
     def _iter_pages(self) -> Generator[OggPage, None, None]:
         page = self._next_page()

--- a/discord/player.py
+++ b/discord/player.py
@@ -175,6 +175,7 @@ class FFmpegAudio(AudioSource):
             self._pipe_thread.start()
 
     def _spawn_process(self, args: Any, **subprocess_kwargs: Any) -> subprocess.Popen:
+        _log.debug('Spawning ffmpeg process with command: %s', args)
         process = None
         try:
             process = subprocess.Popen(args, creationflags=CREATE_NO_WINDOW, **subprocess_kwargs)

--- a/discord/player.py
+++ b/discord/player.py
@@ -391,7 +391,9 @@ class FFmpegOpusAudio(FFmpegAudio):
                      '-ar', '48000',
                      '-ac', '2',
                      '-b:a', f'{bitrate}k',
-                     '-loglevel', 'warning'))
+                     '-loglevel', 'warning',
+                     '-fec true',
+                     '-packet_loss 15'))
         # fmt: on
 
         if isinstance(options, str):

--- a/discord/player.py
+++ b/discord/player.py
@@ -382,7 +382,7 @@ class FFmpegOpusAudio(FFmpegAudio):
         args.append('-i')
         args.append('-' if pipe else source)
 
-        codec = 'copy' if codec in ('opus', 'libopus') else 'libopus'
+        codec = 'copy' if codec in ('opus', 'libopus', 'copy') else 'libopus'
         bitrate = bitrate if bitrate is not None else 128
 
         # fmt: off

--- a/discord/player.py
+++ b/discord/player.py
@@ -257,10 +257,12 @@ class FFmpegAudio(AudioSource):
                 return
             if data is None:
                 return
-            # TODO: Do I need to check if this explodes?  catch OSError or something?
-            #       What happens if dest can no longer be written to?  Keep reading without writing or exit?
-            #       Does it pose an issue if the stderr pipe doesn't get read from?
-            dest.write(data)
+            try:
+                dest.write(data)
+            except Exception:
+                _log.exception('Write error for %s', self)
+                self._stderr.close()
+                return
 
     def cleanup(self) -> None:
         self._kill_process()

--- a/discord/player.py
+++ b/discord/player.py
@@ -182,6 +182,7 @@ class FFmpegAudio(AudioSource):
         self._process = self._spawn_process(args, **kwargs)
         self._stdout: IO[bytes] = self._process.stdout  # type: ignore # process stdout is explicitly set
         self._stdin: Optional[IO[bytes]] = None
+        self._stderr: Optional[IO[bytes]] = None
         self._pipe_writer_thread: Optional[threading.Thread] = None
         self._pipe_reader_thread: Optional[threading.Thread] = None
 
@@ -256,6 +257,9 @@ class FFmpegAudio(AudioSource):
                 return
             if data is None:
                 return
+            # TODO: Do I need to check if this explodes?  catch OSError or something?
+            #       What happens if dest can no longer be written to?  Keep reading without writing or exit?
+            #       Does it pose an issue if the stderr pipe doesn't get read from?
             dest.write(data)
 
     def cleanup(self) -> None:


### PR DESCRIPTION
## Summary
- Enables FEC on `FFmpegOpusAudio`
- Adds [-blocksize](https://ffmpeg.org/ffmpeg-all.html#pipe "ffmpeg docs: pipe") to the ffmpeg cli arguments
- Fixes 'copy' codec not working when passed directly to `FFmpegOpusAudio`
- Improves error message for Ogg parsing failure
- Adds a debug logging message for when an ffmpeg process is spawned
- Fixes the `stderr` parameter
  - Deprecates support for passing `subprocess.PIPE`, as it did nothing.  Now emits a `DeprecationWarning`.
  - Corrects the type hint
  - Properly support non-fs backed file objects (like `BytesIO`) by adding a reader thread

## Checklist

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
