### PR TITLE
fix(docs): replace dot with space

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3607,7 +3607,7 @@ class Guild(Hashable):
 
         The guild must have ``COMMUNITY`` in :attr:`~Guild.features`.
 
-        You must have :attr:`~Permissions.manage_guild` to do this.as well.
+        You must have :attr:`~Permissions.manage_guild` to do this as well.
 
         .. versionadded:: 2.0
 


### PR DESCRIPTION
## Summary

Replace dot with space in docs for [`discord.Guild.vanity_invite`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Guild.vanity_invite)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
