### PR TITLE
Fix template.source_guild attempting to get from cache

### DIFF
--- a/discord/template.py
+++ b/discord/template.py
@@ -72,7 +72,7 @@ class _PartialTemplateState:
     @property
     def cache_guild_expressions(self):
         return False
-    
+
     def store_emoji(self, guild, packet) -> None:
         return None
 

--- a/discord/template.py
+++ b/discord/template.py
@@ -69,6 +69,10 @@ class _PartialTemplateState:
     def member_cache_flags(self):
         return self.__state.member_cache_flags
 
+    @property
+    def cache_guild_expressions(self):
+        return False
+    
     def store_emoji(self, guild, packet) -> None:
         return None
 

--- a/discord/template.py
+++ b/discord/template.py
@@ -146,18 +146,11 @@ class Template:
         self.created_at: Optional[datetime.datetime] = parse_time(data.get('created_at'))
         self.updated_at: Optional[datetime.datetime] = parse_time(data.get('updated_at'))
 
-        guild_id = int(data['source_guild_id'])
-        guild: Optional[Guild] = self._state._get_guild(guild_id)
-
-        self.source_guild: Guild
-        if guild is None:
-            source_serialised = data['serialized_source_guild']
-            source_serialised['id'] = guild_id
-            state = _PartialTemplateState(state=self._state)
-            # Guild expects a ConnectionState, we're passing a _PartialTemplateState
-            self.source_guild = Guild(data=source_serialised, state=state)  # type: ignore
-        else:
-            self.source_guild = guild
+        source_serialised = data['serialized_source_guild']
+        source_serialised['id'] = int(data['source_guild_id'])
+        state = _PartialTemplateState(state=self._state)
+        # Guild expects a ConnectionState, we're passing a _PartialTemplateState
+        self.source_guild = Guild(data=source_serialised, state=state)  # type: ignore
 
         self.is_dirty: Optional[bool] = data.get('is_dirty', None)
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR fixes `Template.source_guild` attempting to get from state, while it is supposed to be a serialized snapshot of the guild from when it was last synced.

I also ran into an AttributeError while testing that came from [Line 477 due to `_PartialTemplateState`](https://github.com/Rapptz/discord.py/blob/master/discord/guild.py#L477) so I added `_PartialTemplateState.cache_guild_expressions` to fix the error. It returns false as templates do not contain expressions.

This was brought up in [a bikeshedding post](https://canary.discord.com/channels/336642139381301249/1141837591784726580), but nothing futher has happened so I made a pr for it.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
