### PR TITLE
Normalize thread names

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -132,11 +132,12 @@ class KeepAliveHandler(threading.Thread):
         shard_id: Optional[int] = None,
         **kwargs: Any,
     ) -> None:
-        super().__init__(*args, **kwargs)
+        daemon: bool = kwargs.pop('daemon', True)
+        name: str = kwargs.pop('name', f'keep-alive-handler:shard-{shard_id}')
+        super().__init__(*args, daemon=daemon, name=name, **kwargs)
         self.ws: DiscordWebSocket = ws
         self._main_thread_id: int = ws.thread_id
         self.interval: Optional[float] = interval
-        self.daemon: bool = True
         self.shard_id: Optional[int] = shard_id
         self.msg: str = 'Keeping shard ID %s websocket alive with sequence %s.'
         self.block_msg: str = 'Shard ID %s heartbeat blocked for more than %s seconds.'
@@ -212,7 +213,8 @@ class KeepAliveHandler(threading.Thread):
 
 class VoiceKeepAliveHandler(KeepAliveHandler):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+        name: str = kwargs.pop('name', f'voice-keep-alive-handler:{id(self):#x}')
+        super().__init__(*args, name=name, **kwargs)
         self.recent_ack_latencies: Deque[float] = deque(maxlen=20)
         self.msg: str = 'Keeping shard ID %s voice websocket alive with timestamp %s.'
         self.block_msg: str = 'Shard ID %s voice heartbeat blocked for more than %s seconds'

--- a/discord/player.py
+++ b/discord/player.py
@@ -187,13 +187,13 @@ class FFmpegAudio(AudioSource):
         self._pipe_reader_thread: Optional[threading.Thread] = None
 
         if piping_stdin:
-            n = f'popen-stdin-writer:{id(self):#x}'
+            n = f'popen-stdin-writer:pid-{self._process.pid}'
             self._stdin = self._process.stdin
             self._pipe_writer_thread = threading.Thread(target=self._pipe_writer, args=(source,), daemon=True, name=n)
             self._pipe_writer_thread.start()
 
         if piping_stderr:
-            n = f'popen-stderr-reader:{id(self):#x}'
+            n = f'popen-stderr-reader:pid-{self._process.pid}'
             self._stderr = self._process.stderr
             self._pipe_reader_thread = threading.Thread(target=self._pipe_reader, args=(stderr,), daemon=True, name=n)
             self._pipe_reader_thread.start()
@@ -693,8 +693,7 @@ class AudioPlayer(threading.Thread):
         *,
         after: Optional[Callable[[Optional[Exception]], Any]] = None,
     ) -> None:
-        threading.Thread.__init__(self)
-        self.daemon: bool = True
+        super().__init__(daemon=True, name=f'audio-player:{id(self):#x}')
         self.source: AudioSource = source
         self.client: VoiceClient = client
         self.after: Optional[Callable[[Optional[Exception]], Any]] = after


### PR DESCRIPTION
## Summary

Every thread now has a name and either a contextually relevant identifier or their id in hex to disambiguate multiple threads of the same type.  While this is essentially a cosmetic change, I consider it nice to have for the purposes of debugging, introspection, and displaying nicely in htop.  Also finally gets rid of that old python 2 style `__init__` call.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
