### PR TITLE
Fix misleading documentation for `Client.fetch_guild`

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -2243,8 +2243,8 @@ class Client:
 
         Raises
         ------
-        Forbidden
-            You do not have access to the guild.
+        NotFound
+            The guild doesn't exist or you got no access to it.
         HTTPException
             Getting the guild failed.
 


### PR DESCRIPTION
## Summary

The docs for `Client.fetch_guild` doesn't include `NotFound`, which is raised when passing a snowflake that isn't an existing guild. Also When passing an ID of a guild that actually exists, it's also `NotFound`, instead of `Forbidden`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)

## Background
I tried to fetch a inva
