### PR TITLE
patching doc extensions to work with later sphinx versions

### DIFF
--- a/docs/extensions/builder.py
+++ b/docs/extensions/builder.py
@@ -1,5 +1,5 @@
 from sphinx.builders.html import StandaloneHTMLBuilder
-from sphinx.builders.gettext import MessageCatalogBuilder, I18nBuilder, timestamp, ltz, should_write, GettextRenderer
+from sphinx.builders.gettext import MessageCatalogBuilder, I18nBuilder, ctime,should_write, GettextRenderer
 from sphinx.locale import __
 from sphinx.util import status_iterator
 from sphinx.util.osutil import ensuredir
@@ -69,7 +69,7 @@ class DPYMessageCatalogBuilder(MessageCatalogBuilder):
             'project': self.config.project,
             'last_translator': self.config.gettext_last_translator,
             'language_team': self.config.gettext_language_team,
-            'ctime': datetime.datetime.fromtimestamp(timestamp, ltz).strftime('%Y-%m-%d %H:%M%z'),
+            'ctime': ctime,
             'display_location': self.config.gettext_location,
             'display_uuid': self.config.gettext_uuid,
         }


### PR DESCRIPTION
fix for  `doc/extensions/builder.py` to allow for compatibility with sphinx 7.2.5 and up.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X ] If code changes were made then they have been tested.
    - [X ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
