### PR TITLE
Fix `View.from_message` not creating other Selects

### DIFF
--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -235,6 +235,7 @@ class BaseSelect(Item[V]):
     def from_component(cls, component: SelectMenu) -> Self:
         return cls(
             **{k: getattr(component, k) for k in cls.__item_repr_attributes__},
+            custom_id=component.custom_id,
             row=None,
         )
 

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -34,6 +34,7 @@ import time
 import os
 from .item import Item, ItemCallbackType
 from .dynamic import DynamicItem
+from ..enums import ComponentType
 from ..components import (
     Component,
     ActionRow as ActionRowComponent,
@@ -78,9 +79,26 @@ def _component_to_item(component: Component) -> Item:
 
         return Button.from_component(component)
     if isinstance(component, SelectComponent):
-        from .select import Select
+        if component.type is ComponentType.select:
+            from .select import Select
 
-        return Select.from_component(component)
+            return Select.from_component(component)
+        elif component.type is ComponentType.user_select:
+            from .select import UserSelect
+
+            return UserSelect.from_component(component)
+        elif component.type is ComponentType.mentionable_select:
+            from .select import MentionableSelect
+
+            return MentionableSelect.from_component(component)
+        elif component.type is ComponentType.channel_select:
+            from .select import ChannelSelect
+
+            return ChannelSelect().from_component(component)
+        elif component.type is ComponentType.role_select:
+            from .select import RoleSelect
+
+            return RoleSelect.from_component(component)
     return Item.from_component(component)
 
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
`View.from_message` would ignore the component type and only create string Selects even if it was a Channel, Role, User, or Mentionable Select. 

`BaseSelect.from_component` did not copy the original custom id.

This broke [dynamic selects](https://github.com/Rapptz/discord.py/blob/3827671bf748c6f44f75f72fe1a84935c24c01b9/discord/ui/view.py#L619) since component type and custom id would not match.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
