### PR TITLE
change DynamicItem to error with custom id

### DIFF
--- a/discord/ui/dynamic.py
+++ b/discord/ui/dynamic.py
@@ -110,7 +110,7 @@ class DynamicItem(Generic[BaseT], Item['View']):
             raise TypeError('item must be dispatchable, e.g. not a URL button')
 
         if not self.template.match(self.custom_id):
-            raise ValueError(f'item custom_id must match the template {self.template.pattern!r}')
+            raise ValueError(f'item custom_id {self.custom_id} must match the template {self.template.pattern!r}')
 
     @property
     def template(self) -> re.Pattern[str]:

--- a/discord/ui/dynamic.py
+++ b/discord/ui/dynamic.py
@@ -110,7 +110,7 @@ class DynamicItem(Generic[BaseT], Item['View']):
             raise TypeError('item must be dispatchable, e.g. not a URL button')
 
         if not self.template.match(self.custom_id):
-            raise ValueError(f'item custom_id {self.custom_id} must match the template {self.template.pattern!r}')
+            raise ValueError(f'item custom_id {self.custom_id!r} must match the template {self.template.pattern!r}')
 
     @property
     def template(self) -> re.Pattern[str]:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Changes ``DynamicItem.__init__`` to error with the given custom id alongside the template for easier debugging if the custom id does not match the template.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
