### PR TITLE
[tasks] support defining tasks on a slotted class

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -278,23 +278,26 @@ class Loop(Generic[LF]):
         if obj is None:
             return self
 
-        copy: Loop[LF] = Loop(
-            self.coro,
-            seconds=self._seconds,
-            hours=self._hours,
-            minutes=self._minutes,
-            time=self._time,
-            count=self.count,
-            reconnect=self.reconnect,
-            name=self._name,
-            slot_name=self._slot_name,
-        )
-        copy._injected = obj
-        copy._before_loop = self._before_loop
-        copy._after_loop = self._after_loop
-        copy._error = self._error
-        setattr(obj, self._slot_name, copy)
-        return copy
+        try:
+            return getattr(obj, self._slot_name)
+        except AttributeError:
+            copy: Loop[LF] = Loop(
+                self.coro,
+                seconds=self._seconds,
+                hours=self._hours,
+                minutes=self._minutes,
+                time=self._time,
+                count=self.count,
+                reconnect=self.reconnect,
+                name=self._name,
+                slot_name=self._slot_name,
+            )
+            copy._injected = obj
+            copy._before_loop = self._before_loop
+            copy._after_loop = self._after_loop
+            copy._error = self._error
+            setattr(obj, self._slot_name, copy)
+            return copy
 
     @property
     def seconds(self) -> Optional[float]:

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -145,6 +145,7 @@ class Loop(Generic[LF]):
         count: Optional[int],
         reconnect: bool,
         name: Optional[str],
+        slot_name: Optional[str],
     ) -> None:
         self.coro: LF = coro
         self.reconnect: bool = reconnect
@@ -167,6 +168,7 @@ class Loop(Generic[LF]):
         self._has_failed = False
         self._stop_next_iteration = False
         self._name: str = f'discord-ext-tasks: {coro.__qualname__}' if name is None else name
+        self._slot_name: str = slot_name or coro.__name__
 
         if self.count is not None and self.count <= 0:
             raise ValueError('count must be greater than 0 or None.')
@@ -285,12 +287,13 @@ class Loop(Generic[LF]):
             count=self.count,
             reconnect=self.reconnect,
             name=self._name,
+            slot_name=self._slot_name,
         )
         copy._injected = obj
         copy._before_loop = self._before_loop
         copy._after_loop = self._after_loop
         copy._error = self._error
-        setattr(obj, self.coro.__name__, copy)
+        setattr(obj, self._slot_name, copy)
         return copy
 
     @property
@@ -774,6 +777,7 @@ def loop(
     count: Optional[int] = None,
     reconnect: bool = True,
     name: Optional[str] = None,
+    slot_name: Optional[str] = None,
 ) -> Callable[[LF], Loop[LF]]:
     """A decorator that schedules a task in the background for you with
     optional reconnect logic. The decorator returns a :class:`Loop`.
@@ -813,6 +817,12 @@ def loop(
 
         .. versionadded:: 2.4
 
+    slot_name: Optional[:class:`str`]
+        The name of the attribute to assign instances of this loop to when it is created in a class context.
+        By default it is assigned the name of the function being decorated.
+
+        .. versionadded:: 2.4
+
     Raises
     --------
     ValueError
@@ -832,6 +842,7 @@ def loop(
             time=time,
             reconnect=reconnect,
             name=name,
+            slot_name=slot_name,
         )
 
     return decorator

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -819,7 +819,7 @@ def loop(
 
     slot_name: Optional[:class:`str`]
         The name of the attribute to assign instances of this loop to when it is created in a class context.
-        By default it is assigned the name of the function being decorated.
+        By default it is assigned the name of the callable.
 
         .. versionadded:: 2.4
 


### PR DESCRIPTION
## Summary

support defining tasks on a slotted class.

Before:
```py
import asyncio
from discord.ext import tasks

class MyClass:
    __slots__ = ("foo", "bar")

    def __init__(self):
        self.foo = "Hello"
        self.bar = "World!"

    @tasks.loop(seconds=5.0)
    async def baz(self):
        print(self.foo, self.bar)

async def main():
    a = MyClass()
    a.baz.start()  # error

    await asyncio.sleep(float("inf"))

if __name__ == "__main__":
    asyncio.run(main())
```
```py
Traceback (most recent call last):
  File "/home/sebnlaw/discord.py/_test.py", line 25, in <module>
    asyncio.run(main())
  File "/home/sebnlaw/miniconda3/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/home/sebnlaw/miniconda3/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/home/sebnlaw/discord.py/_test.py", line 19, in main
    a.baz.start()
  File "/home/sebnlaw/discord.py/discord/ext/tasks/__init__.py", line 293, in __get__
    setattr(obj, self.coro.__name__, copy)
AttributeError: 'MyClass' object attribute 'baz' is read-only. Did you mean: 'bar'?
```
After:
```py
import asyncio
from discord.ext import tasks

class MyClass:
    __slots__ = ("foo", "bar", "_cs_baz")

    def __init__(self):
        self.foo = "Hello"
        self.bar = "World!"

    @tasks.loop(seconds=5.0, slot_name="_cs_baz")
    async def baz(self):
        print(self.foo, self.bar)

async def main():
    a = MyClass()
    a.baz.start()  # yippee

    await asyncio.sleep(float("inf"))

if __name__ == "__main__":
    asyncio.run(main())
```

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
