### PR TITLE
Pass exceptions from coro to on_error

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -443,9 +443,9 @@ class Client:
             await coro(*args, **kwargs)
         except asyncio.CancelledError:
             pass
-        except Exception:
+        except Exception as e:
             try:
-                await self.on_error(event_name, *args, **kwargs)
+                await self.on_error(event_name, exception=e, *args, **kwargs)
             except asyncio.CancelledError:
                 pass
 
@@ -500,7 +500,7 @@ class Client:
         else:
             self._schedule_event(coro, method, *args, **kwargs)
 
-    async def on_error(self, event_method: str, /, *args: Any, **kwargs: Any) -> None:
+    async def on_error(self, event_method: str, /, exception=None, *args: Any, **kwargs: Any) -> None:
         """|coro|
 
         The default error handler provided by the client.


### PR DESCRIPTION
## Summary

This PR tries to resolve issue when `on_ready` event processing throws exception and it doesn't appear in any logs making it seem like bot is stuck at loading. I think this also affects other events, but at least this PR seems to fix for `on_ready` on my machine.

_Spent about an hour looking at logging and debugging after insignificant changes only to find out I'm try to access field which doesn't exist._

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. - if changes are OK, I can take a look to update them.
- [x] This PR fixes an issue. - _at least for me_
- [ ] ~~This PR adds something new (e.g. new method or parameters).~~
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed) - **please verify, but it seems to be non-breaking**
- [ ] ~~This PR is **not** a code change (e.g. documentation, README, ...)~~
