### PR TITLE
Add silence padding after transmission breaks

### DIFF
--- a/discord/opus.py
+++ b/discord/opus.py
@@ -72,6 +72,8 @@ __all__ = (
 
 _log = logging.getLogger(__name__)
 
+OPUS_SILENCE = b'\xF8\xFF\xFE'
+
 c_int_ptr = ctypes.POINTER(ctypes.c_int)
 c_int16_ptr = ctypes.POINTER(ctypes.c_int16)
 c_float_ptr = ctypes.POINTER(ctypes.c_float)


### PR DESCRIPTION
## Summary
If you listen closely, you might hear a small audio distortion after pausing a player.  This is because the lib doesn't add silence padding.  Now it does.

## Checklist

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
