### PR TITLE
Add support for default_values field on selects

### DIFF
--- a/discord/components.py
+++ b/discord/components.py
@@ -519,6 +519,17 @@ class TextInput(Component):
         return self.value
     
 class SelectDefaultValue:
+    """Represents a select menu's default value.
+    
+    .. versionadded:: 2.5
+
+    Parameters
+    -----------
+    id: :class:`int`
+        The id of a role, user, or channel.
+    type: :class:`SelectDefaultValueType`
+        The type of value that ``id`` represents.
+    """
     def __init__(
         self,
         *,

--- a/discord/components.py
+++ b/discord/components.py
@@ -279,7 +279,9 @@ class SelectMenu(Component):
         self.options: List[SelectOption] = [SelectOption.from_dict(option) for option in data.get('options', [])]
         self.disabled: bool = data.get('disabled', False)
         self.channel_types: List[ChannelType] = [try_enum(ChannelType, t) for t in data.get('channel_types', [])]
-        self.default_values: List[SelectDefaultValue] = [SelectDefaultValue.from_dict(d) for d in data.get('default_values', [])]
+        self.default_values: List[SelectDefaultValue] = [
+            SelectDefaultValue.from_dict(d) for d in data.get('default_values', [])
+        ]
 
     def to_dict(self) -> SelectMenuPayload:
         payload: SelectMenuPayload = {
@@ -299,7 +301,6 @@ class SelectMenu(Component):
             payload["default_values"] = [v.to_dict() for v in self.default_values]
 
         return payload
-
 
 
 class SelectOption:
@@ -517,10 +518,11 @@ class TextInput(Component):
         This is an alias to :attr:`value`.
         """
         return self.value
-    
+
+
 class SelectDefaultValue:
     """Represents a select menu's default value.
-    
+
     .. versionadded:: 2.5
 
     Parameters
@@ -530,6 +532,7 @@ class SelectDefaultValue:
     type: :class:`SelectDefaultValueType`
         The type of value that ``id`` represents.
     """
+
     def __init__(
         self,
         *,
@@ -538,28 +541,28 @@ class SelectDefaultValue:
     ) -> None:
         self.id: int = id
         self._type: SelectDefaultValueType = type
-    
+
     @property
     def type(self) -> SelectDefaultValueType:
         return self._type
-    
+
     @type.setter
     def type(self, value: SelectDefaultValueType) -> None:
         if not isinstance(value, SelectDefaultValueType):
             raise TypeError(f'expected SelectDefaultValueType, received {value.__class__.__name__} instead')
-    
+
         self._type = value
 
     def __repr__(self) -> str:
         return f'<SelectDefaultValue id={self.id!r} type={self.type!r}>'
-    
+
     @classmethod
     def from_dict(cls, data: SelectDefaultValuesPayload) -> SelectDefaultValue:
         return cls(
             id=data['id'],
             type=try_enum(SelectDefaultValueType, data['type']),
         )
-    
+
     def to_dict(self) -> SelectDefaultValuesPayload:
         return {
             'id': self.id,

--- a/discord/components.py
+++ b/discord/components.py
@@ -571,28 +571,28 @@ class SelectDefaultValue:
             'id': self.id,
             'type': self._type.value,
         }
-    
+
     @classmethod
     def from_channel(cls, channel: Snowflake, /) -> Self:
         return cls(
             id=channel.id,
             type=SelectDefaultValueType.channel,
         )
-    
+
     @classmethod
     def from_role(cls, role: Snowflake, /) -> Self:
         return cls(
             id=role.id,
             type=SelectDefaultValueType.role,
         )
-    
+
     @classmethod
     def from_user(cls, user: Snowflake, /) -> Self:
         return cls(
             id=user.id,
             type=SelectDefaultValueType.user,
         )
-    
+
 
 @overload
 def _component_factory(data: ActionRowChildComponentPayload) -> Optional[ActionRowChildComponentType]:

--- a/discord/components.py
+++ b/discord/components.py
@@ -281,19 +281,25 @@ class SelectMenu(Component):
         self.options: List[SelectOption] = [SelectOption.from_dict(option) for option in data.get('options', [])]
         self.disabled: bool = data.get('disabled', False)
         self.channel_types: List[ChannelType] = [try_enum(ChannelType, t) for t in data.get('channel_types', [])]
-        self.default_values: List[Object] = []
-        for dv in data.get("default_values", []):
-            for value_id, value_type in dv.items():
-                if self.type is ComponentType.user_select:
-                    self.default_values.append(Object(id=int(value_id), type=User))
-                elif self.type is ComponentType.role_select:
-                    self.default_values.append(Object(id=int(value_id), type=Role))
-                elif self.type is ComponentType.channel_select:
-                    self.default_values.append(Object(id=int(value_id), type=GuildChannel))
-                elif self.type is ComponentType.mentionable_select:
-                    _type = User if value_type == "user" else Role
-                    self.default_values.append(Object(id=int(value_id), type=_type))
-
+        if "default_values" in data:
+            if self.type is ComponentType.user_select:
+                self.default_values: List[Object] = [
+                    Object(id=int(d["id"]), type=User) for d in data["default_values"]
+                ]
+            elif self.type is ComponentType.role_select:
+                self.default_values: List[Object] = [
+                    Object(id=int(d["id"]), type=Role) for d in data["default_values"]
+                ]
+            elif self.type is ComponentType.channel_select:
+                self.default_values: List[Object] = [
+                    Object(id=int(d["id"]), type=GuildChannel) for d in data["default_values"]
+                ]
+            elif self.type is ComponentType.mentionable_select:
+                self.default_values: List[Object] = [
+                    Object(id=int(d["id"]), type=User if d["type"] == "user" else Role) for d in data["default_values"]
+                ]
+        else:
+            self.default_values: List[Object] = []
 
 
     def to_dict(self) -> SelectMenuPayload:

--- a/discord/components.py
+++ b/discord/components.py
@@ -523,6 +523,8 @@ class TextInput(Component):
 class SelectDefaultValue:
     """Represents a select menu's default value.
 
+    These can be created by users.
+
     .. versionadded:: 2.5
 
     Parameters

--- a/discord/components.py
+++ b/discord/components.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
         SelectDefaultValues as SelectDefaultValuesPayload,
     )
     from .emoji import Emoji
+    from .abc import Snowflake
 
     ActionRowChildComponentType = Union['Button', 'SelectMenu', 'TextInput']
 
@@ -570,7 +571,28 @@ class SelectDefaultValue:
             'id': self.id,
             'type': self._type.value,
         }
-
+    
+    @classmethod
+    def from_channel(cls, channel: Snowflake, /) -> Self:
+        return cls(
+            id=channel.id,
+            type=SelectDefaultValueType.channel,
+        )
+    
+    @classmethod
+    def from_role(cls, role: Snowflake, /) -> Self:
+        return cls(
+            id=role.id,
+            type=SelectDefaultValueType.role,
+        )
+    
+    @classmethod
+    def from_user(cls, user: Snowflake, /) -> Self:
+        return cls(
+            id=user.id,
+            type=SelectDefaultValueType.user,
+        )
+    
 
 @overload
 def _component_factory(data: ActionRowChildComponentPayload) -> Optional[ActionRowChildComponentType]:

--- a/discord/components.py
+++ b/discord/components.py
@@ -525,7 +525,7 @@ class SelectDefaultValue:
 
     These can be created by users.
 
-    .. versionadded:: 2.5
+    .. versionadded:: 2.4
 
     Parameters
     -----------

--- a/discord/components.py
+++ b/discord/components.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import ClassVar, List, Literal, Optional, TYPE_CHECKING, Tuple, Union, overload, Any, Dict
+from typing import ClassVar, List, Literal, Optional, TYPE_CHECKING, Tuple, Union, overload
 from .enums import try_enum, ComponentType, ButtonStyle, TextStyle, ChannelType, SelectDefaultValueType
 from .utils import get_slots, MISSING
 from .partial_emoji import PartialEmoji, _EmojiTag

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -772,7 +772,8 @@ class ForumOrderType(Enum):
     latest_activity = 0
     creation_date = 1
 
-class SelectDefaultValueType(Enum):    
+
+class SelectDefaultValueType(Enum):
     user = "user"
     role = "role"
     channel = "channel"

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -771,6 +771,11 @@ class ForumOrderType(Enum):
     latest_activity = 0
     creation_date = 1
 
+class SelectDefaultValueType(Enum):    
+    user = "user"
+    role = "role"
+    channel = "channel"
+
 
 def create_unknown_value(cls: Type[E], val: Any) -> E:
     value_cls = cls._enum_value_cls_  # type: ignore # This is narrowed below

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -774,9 +774,9 @@ class ForumOrderType(Enum):
 
 
 class SelectDefaultValueType(Enum):
-    user = "user"
-    role = "role"
-    channel = "channel"
+    user = 'user'
+    role = 'role'
+    channel = 'channel'
 
 
 def create_unknown_value(cls: Type[E], val: Any) -> E:

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -69,6 +69,7 @@ __all__ = (
     'AutoModRuleActionType',
     'ForumLayoutType',
     'ForumOrderType',
+    'SelectDefaultValueType',
 )
 
 if TYPE_CHECKING:

--- a/discord/types/components.py
+++ b/discord/types/components.py
@@ -75,7 +75,6 @@ class SelectDefaultValues(TypedDict):
 class StringSelectComponent(SelectComponent):
     type: Literal[3]
     options: NotRequired[List[SelectOption]]
-    default_values: NotRequired[List[SelectDefaultValues]]
 
 
 class UserSelectComponent(SelectComponent):

--- a/discord/types/components.py
+++ b/discord/types/components.py
@@ -33,6 +33,7 @@ from .channel import ChannelType
 ComponentType = Literal[1, 2, 3, 4]
 ButtonStyle = Literal[1, 2, 3, 4, 5]
 TextStyle = Literal[1, 2]
+DefaultValueType = Literal["user", "role", "channel"]
 
 
 class ActionRow(TypedDict):
@@ -65,27 +66,35 @@ class SelectComponent(TypedDict):
     max_values: NotRequired[int]
     disabled: NotRequired[bool]
 
+class SelectDefaultValues(TypedDict):
+    id: int
+    type: DefaultValueType
 
 class StringSelectComponent(SelectComponent):
     type: Literal[3]
     options: NotRequired[List[SelectOption]]
+    default_values: NotRequired[List[SelectDefaultValues]]
 
 
 class UserSelectComponent(SelectComponent):
     type: Literal[5]
+    default_values: NotRequired[List[SelectDefaultValues]]
 
 
 class RoleSelectComponent(SelectComponent):
     type: Literal[6]
+    default_values: NotRequired[List[SelectDefaultValues]]
 
 
 class MentionableSelectComponent(SelectComponent):
     type: Literal[7]
+    default_values: NotRequired[List[SelectDefaultValues]]
 
 
 class ChannelSelectComponent(SelectComponent):
     type: Literal[8]
     channel_types: NotRequired[List[ChannelType]]
+    default_values: NotRequired[List[SelectDefaultValues]]
 
 
 class TextInput(TypedDict):
@@ -104,6 +113,7 @@ class SelectMenu(SelectComponent):
     type: Literal[3, 5, 6, 7, 8]
     options: NotRequired[List[SelectOption]]
     channel_types: NotRequired[List[ChannelType]]
+    default_values: NotRequired[List[SelectDefaultValues]]
 
 
 ActionRowChildComponent = Union[ButtonComponent, SelectMenu, TextInput]

--- a/discord/types/components.py
+++ b/discord/types/components.py
@@ -66,9 +66,11 @@ class SelectComponent(TypedDict):
     max_values: NotRequired[int]
     disabled: NotRequired[bool]
 
+
 class SelectDefaultValues(TypedDict):
     id: int
     type: DefaultValueType
+
 
 class StringSelectComponent(SelectComponent):
     type: Literal[3]

--- a/discord/types/components.py
+++ b/discord/types/components.py
@@ -33,7 +33,7 @@ from .channel import ChannelType
 ComponentType = Literal[1, 2, 3, 4]
 ButtonStyle = Literal[1, 2, 3, 4, 5]
 TextStyle = Literal[1, 2]
-DefaultValueType = Literal["user", "role", "channel"]
+DefaultValueType = Literal['user', 'role', 'channel']
 
 
 class ActionRow(TypedDict):

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -475,6 +475,8 @@ class UserSelect(BaseSelect[V]):
         Whether the select is disabled or not.
     default_values: List[Any]
         A list of objects representing the users that should be selected by default.
+
+        .. versionchanged:: 2.4
     row: Optional[:class:`int`]
         The relative row this select menu belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -529,7 +531,10 @@ class UserSelect(BaseSelect[V]):
 
     @property
     def default_values(self) -> List[SelectDefaultValue]:
-        """List[:class:`discord.SelectDefaultValue`]: A list of default values for the select menu."""
+        """List[:class:`discord.SelectDefaultValue`]: A list of default values for the select menu.
+
+        .. versionchanged:: 2.4
+        """
         return self._underlying.default_values
 
     @default_values.setter
@@ -561,6 +566,8 @@ class RoleSelect(BaseSelect[V]):
         Whether the select is disabled or not.
     default_values: List[Any]
         A list of objects representing the users that should be selected by default.
+
+        .. versionchanged:: 2.4
     row: Optional[:class:`int`]
         The relative row this select menu belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -607,7 +614,10 @@ class RoleSelect(BaseSelect[V]):
 
     @property
     def default_values(self) -> List[SelectDefaultValue]:
-        """List[:class:`discord.SelectDefaultValue`]: A list of default values for the select menu."""
+        """List[:class:`discord.SelectDefaultValue`]: A list of default values for the select menu.
+
+        .. versionchanged:: 2.4
+        """
         return self._underlying.default_values
 
     @default_values.setter
@@ -643,6 +653,8 @@ class MentionableSelect(BaseSelect[V]):
     default_values: List[Any]
         A list of objects representing the users/roles that should be selected by default.
         if :class:`.Object` is passed, then the type must be specified in the constructor.
+
+        .. versionchanged:: 2.4
     row: Optional[:class:`int`]
         The relative row this select menu belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -695,7 +707,10 @@ class MentionableSelect(BaseSelect[V]):
 
     @property
     def default_values(self) -> List[SelectDefaultValue]:
-        """List[:class:`discord.SelectDefaultValue`]: A list of default values for the select menu."""
+        """List[:class:`discord.SelectDefaultValue`]: A list of default values for the select menu.
+
+        .. versionchanged:: 2.4
+        """
         return self._underlying.default_values
 
     @default_values.setter
@@ -729,6 +744,8 @@ class ChannelSelect(BaseSelect[V]):
         Whether the select is disabled or not.
     default_values: List[Any]
         A list of objects representing the channels that should be selected by default.
+
+        .. versionchanged:: 2.4
     row: Optional[:class:`int`]
         The relative row this select menu belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -794,7 +811,10 @@ class ChannelSelect(BaseSelect[V]):
 
     @property
     def default_values(self) -> List[SelectDefaultValue]:
-        """List[:class:`discord.SelectDefaultValue`]: A list of default values for the select menu."""
+        """List[:class:`discord.SelectDefaultValue`]: A list of default values for the select menu.
+
+        .. versionchanged:: 2.4
+        """
         return self._underlying.default_values
 
     @default_values.setter
@@ -925,6 +945,9 @@ def select(
     .. versionchanged:: 2.1
         Added the following keyword-arguments: ``cls``, ``channel_types``
 
+    .. versionchanged:: 2.4
+        Added the following keyword-arguments: ``default_values``
+
     Example
     ---------
     .. code-block:: python3
@@ -972,6 +995,8 @@ def select(
         A list of objects representing the default values for the select menu. This can only be used with :class:`ChannelSelect`,
         :class:`RoleSelect`, :class:`UserSelect`, and :class:`MentionableSelect` instances.
         if `cls` is :class:`MentionableSelect` and :class:`.Object` is passed, then the type must be specified in the constructor.
+
+        .. versionchanged:: 2.4
     """
 
     def decorator(func: ItemCallbackType[V, BaseSelectT]) -> ItemCallbackType[V, BaseSelectT]:

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -262,7 +262,7 @@ class BaseSelect(Item[V]):
     ) -> List[SelectDefaultValue]:
         if not defaults:
             return []
-        
+
         if not isinstance(defaults, list):
             raise TypeError('default_values must be a list.')
 
@@ -1027,8 +1027,8 @@ def select(
                 ChannelSelect: SelectDefaultValueType.channel,
             }
             func.__discord_ui_model_kwargs__['default_values'] = BaseSelect._handle_select_defaults(
-                 [] if default_values is MISSING else default_values,
-                 cls_to_default_type.get(cls),
+                [] if default_values is MISSING else default_values,
+                cls_to_default_type.get(cls),
             )
 
         return func

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -73,14 +73,14 @@ if TYPE_CHECKING:
         str, User, Member, Role, AppCommandChannel, AppCommandThread, Union[Role, Member], Union[Role, User]
     ]
     ValidDefaultValues: TypeAlias = Union[
-        Type[SelectDefaultValue],
-        Type[Object],
-        Type[Role],
-        Type[Member],
-        Type[User],
-        Type[AppCommandChannel],
-        Type[AppCommandThread],
-        Type[GuildChannel],
+        SelectDefaultValue,
+        Object,
+        Role,
+        Member,
+        User,
+        AppCommandChannel,
+        AppCommandThread,
+        GuildChannel,
     ]
 
 V = TypeVar('V', bound='View', covariant=True)
@@ -258,7 +258,7 @@ class BaseSelect(Item[V]):
     def _handle_select_defaults(
         defaults: List[ValidDefaultValues], value_type: Optional[SelectDefaultValueType] = None
     ) -> List[SelectDefaultValue]:
-        default_type_to_enum: Dict[ValidDefaultValues, SelectDefaultValueType] = {
+        default_type_to_enum: Dict[Type[ValidDefaultValues], SelectDefaultValueType] = {
             User: SelectDefaultValueType.user,
             Member: SelectDefaultValueType.user,
             Role: SelectDefaultValueType.role,
@@ -282,7 +282,7 @@ class BaseSelect(Item[V]):
                 values.append(
                     SelectDefaultValue(
                         id=obj.id,
-                        type=value_type or default_type_to_enum[obj.__class__ if not isinstance(obj, Object) else obj.type],
+                        type=value_type or default_type_to_enum[obj.__class__ if not isinstance(obj, Object) else obj.type],  # type: ignore
                     )
                 )
 

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -120,7 +120,7 @@ def _handle_select_defaults(
         ComponentType.mentionable_select,
     ],
 ) -> List[SelectDefaultValue]:
-    if not defaults:
+    if not defaults or defaults is MISSING:
         return []
 
     if component_type not in (
@@ -550,7 +550,7 @@ class UserSelect(BaseSelect[V]):
             max_values=max_values,
             disabled=disabled,
             row=row,
-            default_values=MISSING if default_values is MISSING else _handle_select_defaults(default_values, self.type),
+            default_values=_handle_select_defaults(default_values, self.type),
         )
 
     @property
@@ -639,7 +639,7 @@ class RoleSelect(BaseSelect[V]):
             max_values=max_values,
             disabled=disabled,
             row=row,
-            default_values=MISSING if default_values is MISSING else _handle_select_defaults(default_values, self.type),
+            default_values=_handle_select_defaults(default_values, self.type),
         )
 
     @property
@@ -724,7 +724,7 @@ class MentionableSelect(BaseSelect[V]):
             max_values=max_values,
             disabled=disabled,
             row=row,
-            default_values=MISSING if default_values is MISSING else _handle_select_defaults(default_values, self.type),
+            default_values=_handle_select_defaults(default_values, self.type),
         )
 
     @property
@@ -820,7 +820,7 @@ class ChannelSelect(BaseSelect[V]):
             disabled=disabled,
             row=row,
             channel_types=channel_types,
-            default_values=MISSING if default_values is MISSING else _handle_select_defaults(default_values, self.type),
+            default_values=_handle_select_defaults(default_values, self.type),
         )
 
     @property

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -276,12 +276,13 @@ class BaseSelect(Item[V]):
                 continue
 
             if not value_type and isinstance(obj, Object) and obj.type == Object:
-                raise ValueError("Object must have a type specified for the chosen select type. Please pass one using the `type` kwarg.")
+                raise ValueError(
+                    "Object must have a type specified for the chosen select type. Please pass one using the `type` kwarg."
+                )
 
             if not isinstance(obj, (Object, Role, Member, User, GuildChannel, AppCommandChannel, AppCommandThread)):
                 supported_classes = ', '.join(str(v) for v in default_type_to_enum)
                 raise TypeError(f"Invalid type {obj.__class__!r} for default value. Must be one of {supported_classes}")
-
 
             values.append(
                 SelectDefaultValue(

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -37,6 +37,9 @@ from ..components import (
     SelectMenu,
 )
 from ..app_commands.namespace import Namespace
+from ..abc import GuildChannel
+from ..role import Role
+from ..user import User
 
 __all__ = (
     'Select',
@@ -55,9 +58,8 @@ if TYPE_CHECKING:
     from ..types.interactions import SelectMessageComponentInteractionData
     from ..app_commands import AppCommandChannel, AppCommandThread
     from ..member import Member
-    from ..role import Role
-    from ..user import User
     from ..interactions import Interaction
+    from ..object import Object
 
     ValidSelectType: TypeAlias = Literal[
         ComponentType.string_select,
@@ -128,6 +130,7 @@ class BaseSelect(Item[V]):
         disabled: bool = False,
         options: List[SelectOption] = MISSING,
         channel_types: List[ChannelType] = MISSING,
+        default_values: List[Object] = MISSING,
     ) -> None:
         super().__init__()
         self._provided_custom_id = custom_id is not MISSING
@@ -144,6 +147,7 @@ class BaseSelect(Item[V]):
             disabled=disabled,
             channel_types=[] if channel_types is MISSING else channel_types,
             options=[] if options is MISSING else options,
+            default_values=[] if default_values is MISSING else default_values,
         )
 
         self.row = row
@@ -410,6 +414,8 @@ class UserSelect(BaseSelect[V]):
         Defaults to 1 and must be between 1 and 25.
     disabled: :class:`bool`
         Whether the select is disabled or not.
+    default_values: List[:class:`discord.Object`]
+        A list of :class:`discord.Object` representing the users that should be selected by default.
     row: Optional[:class:`int`]
         The relative row this select menu belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -427,7 +433,12 @@ class UserSelect(BaseSelect[V]):
         max_values: int = 1,
         disabled: bool = False,
         row: Optional[int] = None,
+        default_values: List[Object] = MISSING,
     ) -> None:
+        if default_values is not MISSING:
+            for obj in default_values:
+                obj.type = User
+
         super().__init__(
             self.type,
             custom_id=custom_id,
@@ -436,6 +447,7 @@ class UserSelect(BaseSelect[V]):
             max_values=max_values,
             disabled=disabled,
             row=row,
+            default_values=default_values,
         )
 
     @property
@@ -479,6 +491,8 @@ class RoleSelect(BaseSelect[V]):
         Defaults to 1 and must be between 1 and 25.
     disabled: :class:`bool`
         Whether the select is disabled or not.
+    default_values: List[:class:`discord.Object`]
+        A list of :class:`discord.Object` representing the roles that should be selected by default.
     row: Optional[:class:`int`]
         The relative row this select menu belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -496,7 +510,12 @@ class RoleSelect(BaseSelect[V]):
         max_values: int = 1,
         disabled: bool = False,
         row: Optional[int] = None,
+        default_values: List[Object] = MISSING,
     ) -> None:
+        if default_values is not MISSING:
+            for obj in default_values:
+                obj.type = Role
+
         super().__init__(
             self.type,
             custom_id=custom_id,
@@ -543,6 +562,9 @@ class MentionableSelect(BaseSelect[V]):
         Defaults to 1 and must be between 1 and 25.
     disabled: :class:`bool`
         Whether the select is disabled or not.
+    default_values: List[:class:`discord.Object`]
+        A list of :class:`discord.Object` representing the users/roles that should be selected by default.
+        The `type` kwarg must be specified for each object.
     row: Optional[:class:`int`]
         The relative row this select menu belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -560,7 +582,13 @@ class MentionableSelect(BaseSelect[V]):
         max_values: int = 1,
         disabled: bool = False,
         row: Optional[int] = None,
+        default_values: List[Object] = MISSING,
     ) -> None:
+        if default_values is not MISSING:
+            for obj in default_values:
+                if obj.type == Object:
+                    raise ValueError("Please specify the type of object...")
+
         super().__init__(
             self.type,
             custom_id=custom_id,
@@ -614,6 +642,8 @@ class ChannelSelect(BaseSelect[V]):
         Defaults to 1 and must be between 1 and 25.
     disabled: :class:`bool`
         Whether the select is disabled or not.
+    default_values: List[:class:`discord.Object`]
+        A list of :class:`discord.Object` representing the channels that should be selected by default.
     row: Optional[:class:`int`]
         The relative row this select menu belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -634,7 +664,12 @@ class ChannelSelect(BaseSelect[V]):
         max_values: int = 1,
         disabled: bool = False,
         row: Optional[int] = None,
+        default_values: List[Object] = MISSING,
     ) -> None:
+        if default_values is not MISSING:
+            for obj in default_values:
+                obj.type = GuildChannel
+
         super().__init__(
             self.type,
             custom_id=custom_id,
@@ -698,6 +733,7 @@ def select(
     min_values: int = ...,
     max_values: int = ...,
     disabled: bool = ...,
+    default_values: List[Object] = ...,
     row: Optional[int] = ...,
 ) -> SelectCallbackDecorator[V, UserSelectT]:
     ...
@@ -714,6 +750,7 @@ def select(
     min_values: int = ...,
     max_values: int = ...,
     disabled: bool = ...,
+    default_values: List[Object] = ...,
     row: Optional[int] = ...,
 ) -> SelectCallbackDecorator[V, RoleSelectT]:
     ...
@@ -730,6 +767,7 @@ def select(
     min_values: int = ...,
     max_values: int = ...,
     disabled: bool = ...,
+    default_values: List[Object] = ...,
     row: Optional[int] = ...,
 ) -> SelectCallbackDecorator[V, ChannelSelectT]:
     ...
@@ -746,6 +784,7 @@ def select(
     min_values: int = ...,
     max_values: int = ...,
     disabled: bool = ...,
+    default_values: List[Object] = ...,
     row: Optional[int] = ...,
 ) -> SelectCallbackDecorator[V, MentionableSelectT]:
     ...
@@ -761,6 +800,7 @@ def select(
     min_values: int = 1,
     max_values: int = 1,
     disabled: bool = False,
+    default_values: List[Object] = MISSING,
     row: Optional[int] = None,
 ) -> SelectCallbackDecorator[V, BaseSelectT]:
     """A decorator that attaches a select menu to a component.
@@ -832,6 +872,10 @@ def select(
         with :class:`ChannelSelect` instances.
     disabled: :class:`bool`
         Whether the select is disabled or not. Defaults to ``False``.
+    default_values: List[:class:`discord.Object`]
+        A list of :class:`discord.Object` representing the channels that should be selected by default.
+        The `type` kwarg must be specified for each object. This can only be used with :class:`ChannelSelect`,
+        :class:`RoleSelect`, :class:`UserSelect`, and :class:`MentionableSelect` instances.
     """
 
     def decorator(func: ItemCallbackType[V, BaseSelectT]) -> ItemCallbackType[V, BaseSelectT]:
@@ -855,6 +899,8 @@ def select(
             func.__discord_ui_model_kwargs__['options'] = options
         if issubclass(callback_cls, ChannelSelect):
             func.__discord_ui_model_kwargs__['channel_types'] = channel_types
+        if not issubclass(callback_cls, Select):
+            func.__discord_ui_model_kwargs__['default_values'] = options
 
         return func
 

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -467,6 +467,8 @@ class UserSelect(BaseSelect[V]):
         ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     """
 
+    __item_repr_attributes__ = BaseSelect.__item_repr_attributes__ + ('default_values',)
+
     def __init__(
         self,
         *,
@@ -549,6 +551,8 @@ class RoleSelect(BaseSelect[V]):
         ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     """
 
+    __item_repr_attributes__ = BaseSelect.__item_repr_attributes__ + ('default_values',)
+
     def __init__(
         self,
         *,
@@ -625,6 +629,8 @@ class MentionableSelect(BaseSelect[V]):
         For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
         ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     """
+
+    __item_repr_attributes__ = BaseSelect.__item_repr_attributes__ + ('default_values',)
 
     def __init__(
         self,
@@ -709,7 +715,7 @@ class ChannelSelect(BaseSelect[V]):
         ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     """
 
-    __item_repr_attributes__ = BaseSelect.__item_repr_attributes__ + ('channel_types',)
+    __item_repr_attributes__ = BaseSelect.__item_repr_attributes__ + ('channel_types', 'default_values',)
 
     def __init__(
         self,

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -43,6 +43,7 @@ from ..object import Object
 from ..role import Role
 from ..user import User
 from ..abc import GuildChannel
+from ..threads import Thread
 
 __all__ = (
     'Select',
@@ -78,9 +79,10 @@ if TYPE_CHECKING:
         Role,
         Member,
         User,
+        GuildChannel,
         AppCommandChannel,
         AppCommandThread,
-        GuildChannel,
+        Thread,
     ]
 
 V = TypeVar('V', bound='View', covariant=True)
@@ -267,6 +269,7 @@ class BaseSelect(Item[V]):
             GuildChannel: SelectDefaultValueType.channel,
             AppCommandChannel: SelectDefaultValueType.channel,
             AppCommandThread: SelectDefaultValueType.channel,
+            Thread: SelectDefaultValueType.channel,
         }
 
         values: List[SelectDefaultValue] = []
@@ -280,7 +283,7 @@ class BaseSelect(Item[V]):
                     "Object must have a type specified for the chosen select type. Please pass one using the `type` kwarg."
                 )
 
-            if not isinstance(obj, (Object, Role, Member, User, GuildChannel, AppCommandChannel, AppCommandThread)):
+            if not isinstance(obj, (Object, Role, Member, User, GuildChannel, AppCommandChannel, AppCommandThread, Thread)):
                 supported_classes = ', '.join(str(v) for v in default_type_to_enum)
                 raise TypeError(f"Invalid type {obj.__class__!r} for default value. Must be one of {supported_classes}")
 

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -253,13 +253,15 @@ class BaseSelect(Item[V]):
             custom_id=component.custom_id,
             row=None,
         )
-    
+
     @staticmethod
-    def _handle_select_defaults(defaults: List[ValidDefaultValues], value_type: Optional[SelectDefaultValueType] = None) -> List[SelectDefaultValue]:
+    def _handle_select_defaults(
+        defaults: List[ValidDefaultValues], value_type: Optional[SelectDefaultValueType] = None
+    ) -> List[SelectDefaultValue]:
         default_type_to_enum: Dict[ValidDefaultValues, SelectDefaultValueType] = {
-            Role: SelectDefaultValueType.role,
-            Member: SelectDefaultValueType.user,
             User: SelectDefaultValueType.user,
+            Member: SelectDefaultValueType.user,
+            Role: SelectDefaultValueType.role,
             GuildChannel: SelectDefaultValueType.channel,
             AppCommandChannel: SelectDefaultValueType.channel,
             AppCommandThread: SelectDefaultValueType.channel,
@@ -269,11 +271,11 @@ class BaseSelect(Item[V]):
         for obj in defaults:
             if not value_type and isinstance(obj, Object) and obj.type == Object:
                 raise ValueError("Please specify the type for Object...")
-            
+
             if not isinstance(obj, (Object, Role, Member, User, GuildChannel, AppCommandChannel, AppCommandThread)):
                 supported_classes = ', '.join(str(v) for v in default_type_to_enum)
                 raise TypeError(f"Invalid type {obj.__class__!r} for default value. Must be one of {supported_classes}")
-            
+
             if isinstance(obj, SelectDefaultValue):
                 values.append(obj)
             else:
@@ -488,7 +490,9 @@ class UserSelect(BaseSelect[V]):
             max_values=max_values,
             disabled=disabled,
             row=row,
-            default_values=MISSING if default_values is MISSING else self._handle_select_defaults(default_values, SelectDefaultValueType.user),
+            default_values=MISSING
+            if default_values is MISSING
+            else self._handle_select_defaults(default_values, SelectDefaultValueType.user),
         )
 
     @property
@@ -508,12 +512,12 @@ class UserSelect(BaseSelect[V]):
         If invoked in a guild, the values will always resolve to :class:`discord.Member`.
         """
         return super().values  # type: ignore
-    
+
     @property
     def default_values(self) -> List[SelectDefaultValue]:
         """List[:class:`discord.SelectDefaultValue`]: A list of default values for the select menu."""
         return self._underlying.default_values
-    
+
     @default_values.setter
     def default_values(self, value: List[ValidDefaultValues]) -> None:
         self._underlying.default_values = self._handle_select_defaults(value, SelectDefaultValueType.user)
@@ -572,7 +576,9 @@ class RoleSelect(BaseSelect[V]):
             max_values=max_values,
             disabled=disabled,
             row=row,
-            default_values=MISSING if default_values is MISSING else self._handle_select_defaults(default_values, SelectDefaultValueType.role),
+            default_values=MISSING
+            if default_values is MISSING
+            else self._handle_select_defaults(default_values, SelectDefaultValueType.role),
         )
 
     @property
@@ -589,7 +595,7 @@ class RoleSelect(BaseSelect[V]):
     def default_values(self) -> List[SelectDefaultValue]:
         """List[:class:`discord.SelectDefaultValue`]: A list of default values for the select menu."""
         return self._underlying.default_values
-    
+
     @default_values.setter
     def default_values(self, value: List[ValidDefaultValues]) -> None:
         self._underlying.default_values = self._handle_select_defaults(value, SelectDefaultValueType.role)
@@ -672,12 +678,12 @@ class MentionableSelect(BaseSelect[V]):
         If invoked in a guild, the values will always resolve to :class:`discord.Member`.
         """
         return super().values  # type: ignore
-    
+
     @property
     def default_values(self) -> List[SelectDefaultValue]:
         """List[:class:`discord.SelectDefaultValue`]: A list of default values for the select menu."""
         return self._underlying.default_values
-    
+
     @default_values.setter
     def default_values(self, value: List[ValidDefaultValues]) -> None:
         self._underlying.default_values = self._handle_select_defaults(value)
@@ -717,7 +723,10 @@ class ChannelSelect(BaseSelect[V]):
         ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     """
 
-    __item_repr_attributes__ = BaseSelect.__item_repr_attributes__ + ('channel_types', 'default_values',)
+    __item_repr_attributes__ = BaseSelect.__item_repr_attributes__ + (
+        'channel_types',
+        'default_values',
+    )
 
     def __init__(
         self,
@@ -740,7 +749,9 @@ class ChannelSelect(BaseSelect[V]):
             disabled=disabled,
             row=row,
             channel_types=channel_types,
-            default_values=MISSING if default_values is MISSING else self._handle_select_defaults(default_values, SelectDefaultValueType.channel),
+            default_values=MISSING
+            if default_values is MISSING
+            else self._handle_select_defaults(default_values, SelectDefaultValueType.channel),
         )
 
     @property
@@ -771,7 +782,7 @@ class ChannelSelect(BaseSelect[V]):
     def default_values(self) -> List[SelectDefaultValue]:
         """List[:class:`discord.SelectDefaultValue`]: A list of default values for the select menu."""
         return self._underlying.default_values
-    
+
     @default_values.setter
     def default_values(self, value: List[ValidDefaultValues]) -> None:
         self._underlying.default_values = self._handle_select_defaults(value, SelectDefaultValueType.channel)
@@ -976,7 +987,9 @@ def select(
                 RoleSelect: SelectDefaultValueType.role,
                 ChannelSelect: SelectDefaultValueType.channel,
             }
-            func.__discord_ui_model_kwargs__['default_values'] = BaseSelect._handle_select_defaults(default_values,cls_to_default_type.get(cls))
+            func.__discord_ui_model_kwargs__['default_values'] = BaseSelect._handle_select_defaults(
+                default_values, cls_to_default_type.get(cls)
+            )
 
         return func
 

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -158,7 +158,7 @@ class BaseSelect(Item[V]):
             disabled=disabled,
             channel_types=[] if channel_types is MISSING else channel_types,
             options=[] if options is MISSING else options,
-            default_values=[] if default_values is MISSING else [],
+            default_values=[] if default_values is MISSING else default_values,
         )
 
         self.row = row

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -123,14 +123,6 @@ def _handle_select_defaults(
     if not defaults or defaults is MISSING:
         return []
 
-    if component_type not in (
-        ComponentType.user_select,
-        ComponentType.role_select,
-        ComponentType.channel_select,
-        ComponentType.mentionable_select,
-    ):
-        raise TypeError('component_type must be one of user_select, role_select, channel_select, or mentionable_select')
-
     from ..app_commands import AppCommandChannel, AppCommandThread
 
     cls_to_type: Dict[Type[ValidDefaultValues], SelectDefaultValueType] = {
@@ -157,9 +149,8 @@ def _handle_select_defaults(
 
         object_type = obj.__class__ if not isinstance(obj, Object) else obj.type
 
-        print(object_type, component_type, object_type == Object)
-
         if object_type not in type_to_supported_classes[component_type]:
+            # TODO: split this into a util function
             supported_classes = [c.__name__ for c in type_to_supported_classes[component_type]]
             if len(supported_classes) > 2:
                 supported_classes = ', '.join(supported_classes[:-1]) + f', or {supported_classes[-1]}'
@@ -170,7 +161,7 @@ def _handle_select_defaults(
 
             raise TypeError(f'Expected an instance of {supported_classes} not {object_type.__name__}')
 
-        if object_type == Object:
+        if object_type is Object:
             if component_type is ComponentType.mentionable_select:
                 raise ValueError(
                     'Object must have a type specified for the chosen select type. Please pass one using the `type`` kwarg.'

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -262,6 +262,9 @@ class BaseSelect(Item[V]):
     ) -> List[SelectDefaultValue]:
         if not defaults:
             return []
+        
+        if not isinstance(defaults, list):
+            raise TypeError('default_values must be a list.')
 
         from ..app_commands import AppCommandChannel, AppCommandThread
 

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -732,6 +732,7 @@ class ChannelSelect(BaseSelect[V]):
             disabled=disabled,
             row=row,
             channel_types=channel_types,
+            default_values=default_values,
         )
 
     @property

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -517,7 +517,7 @@ class UserSelect(BaseSelect[V]):
         Defaults to 1 and must be between 1 and 25.
     disabled: :class:`bool`
         Whether the select is disabled or not.
-    default_values: Sequence[:class:`~abc.Snowflake`]
+    default_values: Sequence[:class:`~discord.abc.Snowflake`]
         A list of objects representing the users that should be selected by default.
 
         .. versionadded:: 2.4
@@ -606,7 +606,7 @@ class RoleSelect(BaseSelect[V]):
         Defaults to 1 and must be between 1 and 25.
     disabled: :class:`bool`
         Whether the select is disabled or not.
-    default_values: Sequence[:class:`~abc.Snowflake`]
+    default_values: Sequence[:class:`~discord.abc.Snowflake`]
         A list of objects representing the users that should be selected by default.
 
         .. versionadded:: 2.4
@@ -690,7 +690,7 @@ class MentionableSelect(BaseSelect[V]):
         Defaults to 1 and must be between 1 and 25.
     disabled: :class:`bool`
         Whether the select is disabled or not.
-    default_values: Sequence[:class:`~abc.Snowflake`]
+    default_values: Sequence[:class:`~discord.abc.Snowflake`]
         A list of objects representing the users/roles that should be selected by default.
         if :class:`.Object` is passed, then the type must be specified in the constructor.
 
@@ -782,7 +782,7 @@ class ChannelSelect(BaseSelect[V]):
         Defaults to 1 and must be between 1 and 25.
     disabled: :class:`bool`
         Whether the select is disabled or not.
-    default_values: Sequence[:class:`~abc.Snowflake`]
+    default_values: Sequence[:class:`~discord.abc.Snowflake`]
         A list of objects representing the channels that should be selected by default.
 
         .. versionadded:: 2.4
@@ -1026,7 +1026,7 @@ def select(
         with :class:`ChannelSelect` instances.
     disabled: :class:`bool`
         Whether the select is disabled or not. Defaults to ``False``.
-    default_values: Sequence[:class:`~abc.Snowflake`]
+    default_values: Sequence[:class:`~discord.abc.Snowflake`]
         A list of objects representing the default values for the select menu. This cannot be used with regular :class:`Select` instances.
         If ``cls`` is :class:`MentionableSelect` and :class:`.Object` is passed, then the type must be specified in the constructor.
         if `cls` is :class:`MentionableSelect` and :class:`.Object` is passed, then the type must be specified in the constructor.

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -141,7 +141,7 @@ class BaseSelect(Item[V]):
         disabled: bool = False,
         options: List[SelectOption] = MISSING,
         channel_types: List[ChannelType] = MISSING,
-        default_values: List[ValidDefaultValues] = MISSING,
+        default_values: List[SelectDefaultValue] = MISSING,
     ) -> None:
         super().__init__()
         self._provided_custom_id = custom_id is not MISSING
@@ -158,7 +158,7 @@ class BaseSelect(Item[V]):
             disabled=disabled,
             channel_types=[] if channel_types is MISSING else channel_types,
             options=[] if options is MISSING else options,
-            default_values=[] if default_values is MISSING else self._handle_select_defaults(default_values),
+            default_values=[] if default_values is MISSING else [],
         )
 
         self.row = row
@@ -488,7 +488,7 @@ class UserSelect(BaseSelect[V]):
             max_values=max_values,
             disabled=disabled,
             row=row,
-            default_values=default_values,
+            default_values=MISSING if default_values is MISSING else self._handle_select_defaults(default_values, SelectDefaultValueType.user),
         )
 
     @property
@@ -572,6 +572,7 @@ class RoleSelect(BaseSelect[V]):
             max_values=max_values,
             disabled=disabled,
             row=row,
+            default_values=MISSING if default_values is MISSING else self._handle_select_defaults(default_values, SelectDefaultValueType.role),
         )
 
     @property
@@ -651,6 +652,7 @@ class MentionableSelect(BaseSelect[V]):
             max_values=max_values,
             disabled=disabled,
             row=row,
+            default_values=MISSING if default_values is MISSING else self._handle_select_defaults(default_values),
         )
 
     @property
@@ -738,7 +740,7 @@ class ChannelSelect(BaseSelect[V]):
             disabled=disabled,
             row=row,
             channel_types=channel_types,
-            default_values=default_values,
+            default_values=MISSING if default_values is MISSING else self._handle_select_defaults(default_values, SelectDefaultValueType.channel),
         )
 
     @property

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -661,7 +661,7 @@ class RoleSelect(BaseSelect[V]):
         return self._underlying.default_values
 
     @default_values.setter
-    def default_values(self, value: List[ValidDefaultValues]) -> None:
+    def default_values(self, value: Sequence[ValidDefaultValues]) -> None:
         self._underlying.default_values = _handle_select_defaults(value, self.type)
 
 
@@ -754,7 +754,7 @@ class MentionableSelect(BaseSelect[V]):
         return self._underlying.default_values
 
     @default_values.setter
-    def default_values(self, value: List[ValidDefaultValues]) -> None:
+    def default_values(self, value: Sequence[ValidDefaultValues]) -> None:
         self._underlying.default_values = _handle_select_defaults(value, self.type)
 
 
@@ -856,7 +856,7 @@ class ChannelSelect(BaseSelect[V]):
         return self._underlying.default_values
 
     @default_values.setter
-    def default_values(self, value: List[ValidDefaultValues]) -> None:
+    def default_values(self, value: Sequence[ValidDefaultValues]) -> None:
         self._underlying.default_values = _handle_select_defaults(value, self.type)
 
 

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -260,6 +260,9 @@ class BaseSelect(Item[V]):
     def _handle_select_defaults(
         defaults: List[ValidDefaultValues], value_type: Optional[SelectDefaultValueType] = None
     ) -> List[SelectDefaultValue]:
+        if not defaults:
+            return []
+
         from ..app_commands import AppCommandChannel, AppCommandThread
 
         default_type_to_enum: Dict[Type[ValidDefaultValues], SelectDefaultValueType] = {
@@ -962,7 +965,7 @@ def select(
         with :class:`ChannelSelect` instances.
     disabled: :class:`bool`
         Whether the select is disabled or not. Defaults to ``False``.
-    default_values: List[Object]
+    default_values: List[Any]
         A list of objects representing the default values for the select menu. This can only be used with :class:`ChannelSelect`,
         :class:`RoleSelect`, :class:`UserSelect`, and :class:`MentionableSelect` instances.
         if `cls` is :class:`MentionableSelect` and :class:`.Object` is passed, then the type must be specified in the constructor.
@@ -996,7 +999,8 @@ def select(
                 ChannelSelect: SelectDefaultValueType.channel,
             }
             func.__discord_ui_model_kwargs__['default_values'] = BaseSelect._handle_select_defaults(
-                default_values, cls_to_default_type.get(cls)
+                 [] if default_values is MISSING else default_values,
+                 cls_to_default_type.get(cls),
             )
 
         return func

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3400,15 +3400,15 @@ of :class:`enum.Enum`.
 
     .. attribute:: user
 
-        The ID is of a user.
+        The underlying type of the ID is a user.
 
     .. attribute:: role
 
-        The ID is of a role.
+        The underlying type of the ID is a role.
 
     .. attribute:: channel
 
-        The ID is of a channel.
+        The underlying type of the ID is a channel or thread.
 
 
 .. _discord-api-audit-logs:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3396,7 +3396,7 @@ of :class:`enum.Enum`.
 
     Represents the default value of a select menu.
 
-    .. versionadded:: 2.5
+    .. versionadded:: 2.4
 
     .. attribute:: user
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3392,6 +3392,24 @@ of :class:`enum.Enum`.
 
         Sort forum posts by creation time (from most recent to oldest).
 
+.. class:: SelectDefaultValueType
+
+    Represents the default value of a select menu.
+
+    .. versionadded:: 2.5
+
+    .. attribute:: user
+
+        The ID is of a user.
+
+    .. attribute:: role
+
+        The ID is of a role.
+
+    .. attribute:: channel
+
+        The ID is of a channel.
+
 
 .. _discord-api-audit-logs:
 

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -166,6 +166,14 @@ SelectOption
 .. autoclass:: SelectOption
     :members:
 
+SelectDefaultValue
+~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: SelectDefaultValue
+
+.. autoclass:: SelectDefaultValue
+    :members:
+
 Choice
 ~~~~~~~
 


### PR DESCRIPTION
## Summary

This PR adds support for the recently added `default_values` field on auto populated selects

Relevant bikeshedding post on the server: [[:speech_balloon:`Select default_values`]](<https://canary.discord.com/channels/336642139381301249/1154880349709533254>)

Relevant API Docs:
- https://discord.com/developers/docs/change-log#default-value-in-autopopulated-select-menus
- https://discord.com/developers/docs/interactions/message-components#select-menus
- https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure
- https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-default-value-structure

**Test code:** https://mystb.in/RearRememberInstead (IDs are from the discord.py server)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
