### PR TITLE
Fix error when `app_commands.Group` misses a name

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -1548,6 +1548,9 @@ class Group:
         if not self.description:
             raise TypeError('groups must have a description')
 
+        if not self.name:
+            raise TypeError('groups must have a name')
+
         self.parent: Optional[Group] = parent
         self.module: Optional[str]
         if cls.__discord_app_commands_has_module__:


### PR DESCRIPTION
## Summary

When creating a slash group through this syntax:
```python
group = app_commands.Group(name="group")
```
`TypeError` will be raised, indicating that the group misses a `description`.
<details>
<summary>Traceback</summary>
<br><code>Traceback (most recent call last):<br>
&nbsp;&nbsp;File "C:\Users\User\Desktop\testty\main.py", line 26, in <module><br>
&nbsp;&nbsp;&nbsp;&nbsp;class Cog(commands.Cog):<br>
&nbsp;&nbsp;File "C:\Users\User\Desktop\testty\main.py", line 27, in Cog<br>
&nbsp;&nbsp;&nbsp;&nbsp;group = app_commands.Group(name="a")<br>
&nbsp;&nbsp;File "C:\Users\User\Desktop\testty\.venv\lib\site-packages\discord\app_commands\commands.py", line 1549, in __init__<br> &nbsp;&nbsp;&nbsp;&nbsp;raise TypeError('groups must have a description')<br>
TypeError: groups must have a description</code><br>
</details><br>

```python
group = app_commands.Group(description="description")
```
This instead raises an error when trying to encode the name while syncing, which is `MISSING`:
```python
Traceback (most recent call last):
  File "C:\Users\User\Desktop\testty\.venv\lib\site-packages\discord\client.py", line 441, in _run_event
    await coro(*args, **kwargs)
  File "C:\Users\User\Desktop\testty\main.py", line 22, in on_message
    synced = await bot.tree.sync()
  File "C:\Users\User\Desktop\testty\.venv\lib\site-packages\discord\app_commands\tree.py", line 1067, in sync
    data = await self._http.bulk_upsert_global_commands(self.client.application_id, payload=payload)
  File "C:\Users\User\Desktop\testty\.venv\lib\site-packages\discord\http.py", line 587, in request
    kwargs['data'] = utils._to_json(kwargs.pop('json'))
  File "C:\Users\User\Desktop\testty\.venv\lib\site-packages\discord\utils.py", line 650, in _to_json
    return json.dumps(obj, separators=(',', ':'), ensure_ascii=True)
  File "c:\users\User\appdata\local\programs\python\python310\lib\json\__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "c:\users\User\appdata\local\programs\python\python310\lib\json\encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "c:\users\User\appdata\local\programs\python\python310\lib\json\encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "c:\users\User\appdata\local\programs\python\python310\lib\json\encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type _MissingSentinel is not JSON serializable
```
The intended behaviour is for the name to be the class name when subclassing `app_commands.Group`, but since this isn't a subclass, it doesn't work.

This PR proposes to raise an error similar to the "missing description" one. This should not impact the creation of slash groups in any way while creating them through subclassing since the name is already set to the class name.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
