### PR TITLE
Refactor ``from_components`` for select classes

### DIFF
--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -813,7 +813,10 @@ class ChannelSelect(BaseSelect[V]):
         ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     """
 
-    __component_attributes__ = BaseSelect.__component_attributes__ + ('channel_types', 'default_values',)
+    __component_attributes__ = BaseSelect.__component_attributes__ + (
+        'channel_types',
+        'default_values',
+    )
 
     def __init__(
         self,

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -351,7 +351,7 @@ class BaseSelect(Item[V]):
 
     @classmethod
     def from_component(cls, component: SelectMenu) -> Self:
-        type_to_cls: Dict[ValidSelectType, Type[BaseSelect[Any]]] = {
+        type_to_cls: Dict[ComponentType, Type[BaseSelect[Any]]] = {
             ComponentType.string_select: Select,
             ComponentType.user_select: UserSelect,
             ComponentType.role_select: RoleSelect,

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -358,10 +358,7 @@ class BaseSelect(Item[V]):
             ComponentType.channel_select: ChannelSelect,
             ComponentType.mentionable_select: MentionableSelect,
         }
-        if component.type not in type_to_cls:
-            raise TypeError(f'Unknown component type {component.type}')
-
-        constructor = type_to_cls[component.type]
+        constructor = type_to_cls.get(component.type, Select)
         kwrgs = {key: getattr(component, key) for key in constructor.__component_attributes__}
         return constructor(**kwrgs)
 

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -34,7 +34,6 @@ import time
 import os
 from .item import Item, ItemCallbackType
 from .dynamic import DynamicItem
-from ..enums import ComponentType
 from ..components import (
     Component,
     ActionRow as ActionRowComponent,

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -79,26 +79,10 @@ def _component_to_item(component: Component) -> Item:
 
         return Button.from_component(component)
     if isinstance(component, SelectComponent):
-        if component.type is ComponentType.select:
-            from .select import Select
+        from .select import BaseSelect
 
-            return Select.from_component(component)
-        elif component.type is ComponentType.user_select:
-            from .select import UserSelect
+        return BaseSelect.from_component(component)
 
-            return UserSelect.from_component(component)
-        elif component.type is ComponentType.mentionable_select:
-            from .select import MentionableSelect
-
-            return MentionableSelect.from_component(component)
-        elif component.type is ComponentType.channel_select:
-            from .select import ChannelSelect
-
-            return ChannelSelect().from_component(component)
-        elif component.type is ComponentType.role_select:
-            from .select import RoleSelect
-
-            return RoleSelect.from_component(component)
     return Item.from_component(component)
 
 


### PR DESCRIPTION
## Summary

This PR "refactors" the `from_component` class method for selects to not be weird and use the `__item_repr_attributes__ ` class var.

Not sure if this is the best way to do this but it seems to work fine: https://mystb.in/MeasuresConspiracyDeaf

The classmethod is not considered private but also not documented, so I'm not sure if the `isinstance` and `else` is needed.


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
