### PR TITLE
Add missing ``scheduled_event`` field to StageChannel.create_instance

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1600,6 +1600,7 @@ class StageChannel(VocalGuildChannel):
         topic: str,
         privacy_level: PrivacyLevel = MISSING,
         send_start_notification: bool = False,
+        scheduled_event: Snowflake = MISSING,
         reason: Optional[str] = None,
     ) -> StageInstance:
         """|coro|
@@ -1621,6 +1622,10 @@ class StageChannel(VocalGuildChannel):
             You must have :attr:`~Permissions.mention_everyone` to do this.
 
             .. versionadded:: 2.3
+        scheduled_event: :class:`~discord.abc.Snowflake`
+            The guild scheduled event associated with the stage instance.
+
+            .. versionadded:: 2.4
         reason: :class:`str`
             The reason the stage instance was created. Shows up on the audit log.
 
@@ -1646,6 +1651,9 @@ class StageChannel(VocalGuildChannel):
                 raise TypeError('privacy_level field must be of type PrivacyLevel')
 
             payload['privacy_level'] = privacy_level.value
+
+        if scheduled_event is not MISSING:
+            payload['guild_scheduled_event_id'] = scheduled_event.id
 
         payload['send_start_notification'] = send_start_notification
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -1918,6 +1918,7 @@ class HTTPClient:
             'topic',
             'privacy_level',
             'send_start_notification',
+            'guild_scheduled_event_id',
         )
         payload = {k: v for k, v in payload.items() if k in valid_keys}
 


### PR DESCRIPTION
## Summary

This PR adds a parameter called `scheduled_event` to `StageChannel.create_instance` and `guild_scheduled_event_id` to valid_keys in `HTTPClient.create_stage_instance`

Relevant API Docs:
- https://github.com/discord/discord-api-docs/commit/67ce08b1e300c63e5a1e362838e21fb3fc7b1fcc

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
