### PR TITLE
Fix bad voice state when failing to move to a voice channel without permissions

### DIFF
--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -355,8 +355,7 @@ class VoiceClient(VoiceProtocol):
         asyncio.TimeoutError
             The move did not complete in time, but may still be ongoing.
         """
-        await self._connection.move_to(channel)
-        await self._connection.wait_async(timeout)
+        await self._connection.move_to(channel, timeout)
 
     def is_connected(self) -> bool:
         """Indicates if the voice client is connected to voice."""

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -464,21 +464,19 @@ class VoiceConnectionState:
             await self.disconnect()
             return
 
-        # this is only an outgoing ws request; if it fails, nothing happens and nothing changes
+        previous_state = self.state
+        # this is only an outgoing ws request
+        # if it fails, nothing happens and nothing changes (besides self.state)
         await self._move_to(channel)
 
         last_state = self.state
         try:
             await self.wait_async(timeout)
         except asyncio.TimeoutError:
-            _log.warning(
-                'Timed out trying to move to channel %s in guild %s',
-                channel.id,
-                self.guild.id,
-            )
+            _log.warning('Timed out trying to move to channel %s in guild %s', channel.id, self.guild.id)
             if self.state is last_state:
                 _log.debug('Reverting to previous state %s', last_state.name)
-                self.state = last_state
+                self.state = previous_state
 
     def wait(self, timeout: Optional[float] = None) -> bool:
         return self._connected.wait(timeout)

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -475,7 +475,8 @@ class VoiceConnectionState:
         except asyncio.TimeoutError:
             _log.warning('Timed out trying to move to channel %s in guild %s', channel.id, self.guild.id)
             if self.state is last_state:
-                _log.debug('Reverting to previous state %s', last_state.name)
+                _log.debug('Reverting to previous state %s', previous_state.name)
+
                 self.state = previous_state
 
     def wait(self, timeout: Optional[float] = None) -> bool:


### PR DESCRIPTION
## Summary

Since discord's way of handling trying to connect to voice without permissions is to just completely ignoring the request, we have to have a timeout on moving channels and revert the voice state.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
