### PR TITLE
add Class in enums , utils files

### DIFF
--- a/enums.py
+++ b/enums.py
@@ -1,0 +1,1025 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-2021 Rapptz
+Copyright (c) 2021-present Pycord Development
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+from __future__ import annotations
+
+import types
+from collections import namedtuple
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, Union
+
+__all__ = (
+    "Enum",
+    "ChannelType",
+    "MessageType",
+    "VoiceRegion",
+    "SpeakingState",
+    "VerificationLevel",
+    "ContentFilter",
+    "Status",
+    "DefaultAvatar",
+    "AuditLogAction",
+    "AuditLogActionCategory",
+    "UserFlags",
+    "ActivityType",
+    "NotificationLevel",
+    "TeamMembershipState",
+    "WebhookType",
+    "ExpireBehaviour",
+    "ExpireBehavior",
+    "StickerType",
+    "StickerFormatType",
+    "InviteTarget",
+    "VideoQualityMode",
+    "ComponentType",
+    "ButtonStyle",
+    "StagePrivacyLevel",
+    "InteractionType",
+    "InteractionResponseType",
+    "NSFWLevel",
+    "EmbeddedActivity",
+    "ScheduledEventStatus",
+    "ScheduledEventPrivacyLevel",
+    "ScheduledEventLocationType",
+    "InputTextStyle",
+    "SlashCommandOptionType",
+    "AutoModTriggerType",
+    "AutoModEventType",
+    "AutoModActionType",
+    "AutoModKeywordPresetType",
+    "ApplicationRoleConnectionMetadataType",
+)
+
+
+def _create_value_cls(name, comparable):
+    cls = namedtuple(f"_EnumValue_{name}", "name value")
+    cls.__repr__ = lambda self: f"<{name}.{self.name}: {self.value!r}>"
+    cls.__str__ = lambda self: f"{name}.{self.name}"
+    if comparable:
+        cls.__le__ = (
+            lambda self, other: isinstance(other, self.__class__)
+            and self.value <= other.value
+        )
+        cls.__ge__ = (
+            lambda self, other: isinstance(other, self.__class__)
+            and self.value >= other.value
+        )
+        cls.__lt__ = (
+            lambda self, other: isinstance(other, self.__class__)
+            and self.value < other.value
+        )
+        cls.__gt__ = (
+            lambda self, other: isinstance(other, self.__class__)
+            and self.value > other.value
+        )
+    return cls
+
+
+def _is_descriptor(obj):
+    return (
+        hasattr(obj, "__get__") or hasattr(obj, "__set__") or hasattr(obj, "__delete__")
+    )
+
+
+class EnumMeta(type):
+    if TYPE_CHECKING:
+        __name__: ClassVar[str]
+        _enum_member_names_: ClassVar[list[str]]
+        _enum_member_map_: ClassVar[dict[str, Any]]
+        _enum_value_map_: ClassVar[dict[Any, Any]]
+
+    def __new__(cls, name, bases, attrs, *, comparable: bool = False):
+        value_mapping = {}
+        member_mapping = {}
+        member_names = []
+
+        value_cls = _create_value_cls(name, comparable)
+        for key, value in list(attrs.items()):
+            is_descriptor = _is_descriptor(value)
+            if key[0] == "_" and not is_descriptor:
+                continue
+
+            # Special case classmethod to just pass through
+            if isinstance(value, classmethod):
+                continue
+
+            if is_descriptor:
+                setattr(value_cls, key, value)
+                del attrs[key]
+                continue
+
+            try:
+                new_value = value_mapping[value]
+            except KeyError:
+                new_value = value_cls(name=key, value=value)
+                value_mapping[value] = new_value
+                member_names.append(key)
+
+            member_mapping[key] = new_value
+            attrs[key] = new_value
+
+        attrs["_enum_value_map_"] = value_mapping
+        attrs["_enum_member_map_"] = member_mapping
+        attrs["_enum_member_names_"] = member_names
+        attrs["_enum_value_cls_"] = value_cls
+        actual_cls = super().__new__(cls, name, bases, attrs)
+        value_cls._actual_enum_cls_ = actual_cls  # type: ignore
+        return actual_cls
+
+    def __iter__(cls):
+        return (cls._enum_member_map_[name] for name in cls._enum_member_names_)
+
+    def __reversed__(cls):
+        return (
+            cls._enum_member_map_[name] for name in reversed(cls._enum_member_names_)
+        )
+
+    def __len__(cls):
+        return len(cls._enum_member_names_)
+
+    def __repr__(cls):
+        return f"<enum {cls.__name__}>"
+
+    @property
+    def __members__(cls):
+        return types.MappingProxyType(cls._enum_member_map_)
+
+    def __call__(cls, value):
+        try:
+            return cls._enum_value_map_[value]
+        except (KeyError, TypeError):
+            raise ValueError(f"{value!r} is not a valid {cls.__name__}")
+
+    def __getitem__(cls, key):
+        return cls._enum_member_map_[key]
+
+    def __setattr__(cls, name, value):
+        raise TypeError("Enums are immutable.")
+
+    def __delattr__(cls, attr):
+        raise TypeError("Enums are immutable")
+
+    def __instancecheck__(self, instance):
+        # isinstance(x, Y)
+        # -> __instancecheck__(Y, x)
+        try:
+            return instance._actual_enum_cls_ is self
+        except AttributeError:
+            return False
+
+
+if TYPE_CHECKING:
+    from enum import Enum
+else:
+
+    class Enum(metaclass=EnumMeta):
+        @classmethod
+        def try_value(cls, value):
+            try:
+                return cls._enum_value_map_[value]
+            except (KeyError, TypeError):
+                return value
+
+
+class ChannelType(Enum):
+    """Channel type"""
+
+    text = 0
+    private = 1
+    voice = 2
+    group = 3
+    category = 4
+    news = 5
+    news_thread = 10
+    public_thread = 11
+    private_thread = 12
+    stage_voice = 13
+    directory = 14
+    forum = 15
+
+    def __str__(self):
+        return self.name
+
+
+class MessageType(Enum):
+    """Message type"""
+
+    default = 0
+    recipient_add = 1
+    recipient_remove = 2
+    call = 3
+    channel_name_change = 4
+    channel_icon_change = 5
+    pins_add = 6
+    new_member = 7
+    premium_guild_subscription = 8
+    premium_guild_tier_1 = 9
+    premium_guild_tier_2 = 10
+    premium_guild_tier_3 = 11
+    channel_follow_add = 12
+    guild_stream = 13
+    guild_discovery_disqualified = 14
+    guild_discovery_requalified = 15
+    guild_discovery_grace_period_initial_warning = 16
+    guild_discovery_grace_period_final_warning = 17
+    thread_created = 18
+    reply = 19
+    application_command = 20
+    thread_starter_message = 21
+    guild_invite_reminder = 22
+    context_menu_command = 23
+    auto_moderation_action = 24
+    role_subscription_purchase = 25
+    interaction_premium_upsell = 26
+    stage_start = 27
+    stage_end = 28
+    stage_speaker = 29
+    stage_raise_hand = 30
+    stage_topic = 31
+    guild_application_premium_subscription = 32
+
+
+class VoiceRegion(Enum):
+    """Voice region"""
+
+    us_west = "us-west"
+    us_east = "us-east"
+    us_south = "us-south"
+    us_central = "us-central"
+    eu_west = "eu-west"
+    eu_central = "eu-central"
+    singapore = "singapore"
+    london = "london"
+    sydney = "sydney"
+    amsterdam = "amsterdam"
+    frankfurt = "frankfurt"
+    brazil = "brazil"
+    hongkong = "hongkong"
+    russia = "russia"
+    japan = "japan"
+    southafrica = "southafrica"
+    south_korea = "south-korea"
+    india = "india"
+    europe = "europe"
+    dubai = "dubai"
+    vip_us_east = "vip-us-east"
+    vip_us_west = "vip-us-west"
+    vip_amsterdam = "vip-amsterdam"
+
+    def __str__(self):
+        return self.value
+
+
+class SpeakingState(Enum):
+    """Speaking state"""
+
+    none = 0
+    voice = 1
+    soundshare = 2
+    priority = 4
+
+    def __str__(self):
+        return self.name
+
+    def __int__(self):
+        return self.value
+
+
+class VerificationLevel(Enum, comparable=True):
+    """Verification level"""
+
+    none = 0
+    low = 1
+    medium = 2
+    high = 3
+    highest = 4
+
+    def __str__(self):
+        return self.name
+
+
+class SortOrder(Enum):
+    """Forum Channel Sort Order"""
+
+    latest_activity = 0
+    creation_date = 1
+
+    def __str__(self):
+        return self.name
+
+
+class ContentFilter(Enum, comparable=True):
+    """Content Filter"""
+
+    disabled = 0
+    no_role = 1
+    all_members = 2
+
+    def __str__(self):
+        return self.name
+
+
+class Status(Enum):
+    """Status"""
+
+    online = "online"
+    offline = "offline"
+    idle = "idle"
+    dnd = "dnd"
+    do_not_disturb = "dnd"
+    invisible = "invisible"
+    streaming = "streaming"
+
+    def __str__(self):
+        return self.value
+
+
+class DefaultAvatar(Enum):
+    """Default avatar"""
+
+    blurple = 0
+    grey = 1
+    gray = 1
+    green = 2
+    orange = 3
+    red = 4
+
+    def __str__(self):
+        return self.name
+
+
+class NotificationLevel(Enum, comparable=True):
+    """Notification level"""
+
+    all_messages = 0
+    only_mentions = 1
+
+
+class AuditLogActionCategory(Enum):
+    """Audit log action category"""
+
+    create = 1
+    delete = 2
+    update = 3
+
+
+class AuditLogAction(Enum):
+    """Audit log action"""
+
+    guild_update = 1
+    channel_create = 10
+    channel_update = 11
+    channel_delete = 12
+    overwrite_create = 13
+    overwrite_update = 14
+    overwrite_delete = 15
+    kick = 20
+    member_prune = 21
+    ban = 22
+    unban = 23
+    member_update = 24
+    member_role_update = 25
+    member_move = 26
+    member_disconnect = 27
+    bot_add = 28
+    role_create = 30
+    role_update = 31
+    role_delete = 32
+    invite_create = 40
+    invite_update = 41
+    invite_delete = 42
+    webhook_create = 50
+    webhook_update = 51
+    webhook_delete = 52
+    emoji_create = 60
+    emoji_update = 61
+    emoji_delete = 62
+    message_delete = 72
+    message_bulk_delete = 73
+    message_pin = 74
+    message_unpin = 75
+    integration_create = 80
+    integration_update = 81
+    integration_delete = 82
+    stage_instance_create = 83
+    stage_instance_update = 84
+    stage_instance_delete = 85
+    sticker_create = 90
+    sticker_update = 91
+    sticker_delete = 92
+    scheduled_event_create = 100
+    scheduled_event_update = 101
+    scheduled_event_delete = 102
+    thread_create = 110
+    thread_update = 111
+    thread_delete = 112
+    application_command_permission_update = 121
+    auto_moderation_rule_create = 140
+    auto_moderation_rule_update = 141
+    auto_moderation_rule_delete = 142
+    auto_moderation_block_message = 143
+
+    @property
+    def category(self) -> AuditLogActionCategory | None:
+        lookup: dict[AuditLogAction, AuditLogActionCategory | None] = {
+            AuditLogAction.guild_update: AuditLogActionCategory.update,
+            AuditLogAction.channel_create: AuditLogActionCategory.create,
+            AuditLogAction.channel_update: AuditLogActionCategory.update,
+            AuditLogAction.channel_delete: AuditLogActionCategory.delete,
+            AuditLogAction.overwrite_create: AuditLogActionCategory.create,
+            AuditLogAction.overwrite_update: AuditLogActionCategory.update,
+            AuditLogAction.overwrite_delete: AuditLogActionCategory.delete,
+            AuditLogAction.kick: None,
+            AuditLogAction.member_prune: None,
+            AuditLogAction.ban: None,
+            AuditLogAction.unban: None,
+            AuditLogAction.member_update: AuditLogActionCategory.update,
+            AuditLogAction.member_role_update: AuditLogActionCategory.update,
+            AuditLogAction.member_move: None,
+            AuditLogAction.member_disconnect: None,
+            AuditLogAction.bot_add: None,
+            AuditLogAction.role_create: AuditLogActionCategory.create,
+            AuditLogAction.role_update: AuditLogActionCategory.update,
+            AuditLogAction.role_delete: AuditLogActionCategory.delete,
+            AuditLogAction.invite_create: AuditLogActionCategory.create,
+            AuditLogAction.invite_update: AuditLogActionCategory.update,
+            AuditLogAction.invite_delete: AuditLogActionCategory.delete,
+            AuditLogAction.webhook_create: AuditLogActionCategory.create,
+            AuditLogAction.webhook_update: AuditLogActionCategory.update,
+            AuditLogAction.webhook_delete: AuditLogActionCategory.delete,
+            AuditLogAction.emoji_create: AuditLogActionCategory.create,
+            AuditLogAction.emoji_update: AuditLogActionCategory.update,
+            AuditLogAction.emoji_delete: AuditLogActionCategory.delete,
+            AuditLogAction.message_delete: AuditLogActionCategory.delete,
+            AuditLogAction.message_bulk_delete: AuditLogActionCategory.delete,
+            AuditLogAction.message_pin: None,
+            AuditLogAction.message_unpin: None,
+            AuditLogAction.integration_create: AuditLogActionCategory.create,
+            AuditLogAction.integration_update: AuditLogActionCategory.update,
+            AuditLogAction.integration_delete: AuditLogActionCategory.delete,
+            AuditLogAction.stage_instance_create: AuditLogActionCategory.create,
+            AuditLogAction.stage_instance_update: AuditLogActionCategory.update,
+            AuditLogAction.stage_instance_delete: AuditLogActionCategory.delete,
+            AuditLogAction.sticker_create: AuditLogActionCategory.create,
+            AuditLogAction.sticker_update: AuditLogActionCategory.update,
+            AuditLogAction.sticker_delete: AuditLogActionCategory.delete,
+            AuditLogAction.scheduled_event_create: AuditLogActionCategory.create,
+            AuditLogAction.scheduled_event_update: AuditLogActionCategory.update,
+            AuditLogAction.scheduled_event_delete: AuditLogActionCategory.delete,
+            AuditLogAction.thread_create: AuditLogActionCategory.create,
+            AuditLogAction.thread_update: AuditLogActionCategory.update,
+            AuditLogAction.thread_delete: AuditLogActionCategory.delete,
+            AuditLogAction.application_command_permission_update: (
+                AuditLogActionCategory.update
+            ),
+            AuditLogAction.auto_moderation_rule_create: AuditLogActionCategory.create,
+            AuditLogAction.auto_moderation_rule_update: AuditLogActionCategory.update,
+            AuditLogAction.auto_moderation_rule_delete: AuditLogActionCategory.delete,
+            AuditLogAction.auto_moderation_block_message: None,
+        }
+        return lookup[self]
+
+    @property
+    def target_type(self) -> str | None:
+        v = self.value
+        if v == -1:
+            return "all"
+        elif v < 10:
+            return "guild"
+        elif v < 20:
+            return "channel"
+        elif v < 30:
+            return "user"
+        elif v < 40:
+            return "role"
+        elif v < 50:
+            return "invite"
+        elif v < 60:
+            return "webhook"
+        elif v < 70:
+            return "emoji"
+        elif v == 73:
+            return "channel"
+        elif v < 80:
+            return "message"
+        elif v < 83:
+            return "integration"
+        elif v < 90:
+            return "stage_instance"
+        elif v < 93:
+            return "sticker"
+        elif v < 103:
+            return "scheduled_event"
+        elif v < 113:
+            return "thread"
+        elif v < 122:
+            return "application_command_permission"
+        elif v < 144:
+            return "auto_moderation_rule"
+
+
+class UserFlags(Enum):
+    """User flags"""
+
+    staff = 1
+    partner = 2
+    hypesquad = 4
+    bug_hunter = 8
+    mfa_sms = 16
+    premium_promo_dismissed = 32
+    hypesquad_bravery = 64
+    hypesquad_brilliance = 128
+    hypesquad_balance = 256
+    early_supporter = 512
+    team_user = 1024
+    partner_or_verification_application = 2048
+    system = 4096
+    has_unread_urgent_messages = 8192
+    bug_hunter_level_2 = 16384
+    underage_deleted = 32768
+    verified_bot = 65536
+    verified_bot_developer = 131072
+    discord_certified_moderator = 262144
+    bot_http_interactions = 524288
+    spammer = 1048576
+    active_developer = 4194304
+
+
+class ActivityType(Enum):
+    """Activity type"""
+
+    unknown = -1
+    playing = 0
+    streaming = 1
+    listening = 2
+    watching = 3
+    custom = 4
+    competing = 5
+
+    def __int__(self):
+        return self.value
+
+
+class TeamMembershipState(Enum):
+    """Team membership state"""
+
+    invited = 1
+    accepted = 2
+
+
+class WebhookType(Enum):
+    """Webhook Type"""
+
+    incoming = 1
+    channel_follower = 2
+    application = 3
+
+
+class ExpireBehaviour(Enum):
+    """Expire Behaviour"""
+
+    remove_role = 0
+    kick = 1
+
+
+ExpireBehavior = ExpireBehaviour
+
+
+class StickerType(Enum):
+    """Sticker type"""
+
+    standard = 1
+    guild = 2
+
+
+class StickerFormatType(Enum):
+    """Sticker format Type"""
+
+    png = 1
+    apng = 2
+    lottie = 3
+    gif = 4
+
+    @property
+    def file_extension(self) -> str:
+        lookup: dict[StickerFormatType, str] = {
+            StickerFormatType.png: "png",
+            StickerFormatType.apng: "png",
+            StickerFormatType.lottie: "json",
+            StickerFormatType.gif: "gif",
+        }
+        # TODO: Improve handling of unknown sticker format types if possible
+        return lookup.get(self, "png")
+
+
+class InviteTarget(Enum):
+    """Invite target"""
+
+    unknown = 0
+    stream = 1
+    embedded_application = 2
+
+
+class InteractionType(Enum):
+    """Interaction type"""
+
+    ping = 1
+    application_command = 2
+    component = 3
+    auto_complete = 4
+    modal_submit = 5
+
+
+class InteractionResponseType(Enum):
+    """Interaction response type"""
+
+    pong = 1
+    # ack = 2 (deprecated)
+    # channel_message = 3 (deprecated)
+    channel_message = 4  # (with source)
+    deferred_channel_message = 5  # (with source)
+    deferred_message_update = 6  # for components
+    message_update = 7  # for components
+    auto_complete_result = 8  # for autocomplete interactions
+    modal = 9  # for modal dialogs
+
+
+class VideoQualityMode(Enum):
+    """Video quality mode"""
+
+    auto = 1
+    full = 2
+
+    def __int__(self):
+        return self.value
+
+
+class ComponentType(Enum):
+    """Component type"""
+
+    action_row = 1
+    button = 2
+    string_select = 3
+    select = string_select  # (deprecated) alias for string_select
+    input_text = 4
+    user_select = 5
+    role_select = 6
+    mentionable_select = 7
+    channel_select = 8
+
+    def __int__(self):
+        return self.value
+
+
+class ButtonStyle(Enum):
+    """Button style"""
+
+    primary = 1
+    secondary = 2
+    success = 3
+    danger = 4
+    link = 5
+
+    # Aliases
+    blurple = 1
+    grey = 2
+    gray = 2
+    green = 3
+    red = 4
+    url = 5
+
+    def __int__(self):
+        return self.value
+class Locale(Enum):
+    american_english = 'en-US'
+    british_english = 'en-GB'
+    bulgarian = 'bg'
+    chinese = 'zh-CN'
+    taiwan_chinese = 'zh-TW'
+    croatian = 'hr'
+    czech = 'cs'
+    indonesian = 'id'
+    danish = 'da'
+    dutch = 'nl'
+    finnish = 'fi'
+    french = 'fr'
+    german = 'de'
+    greek = 'el'
+    hindi = 'hi'
+    hungarian = 'hu'
+    italian = 'it'
+    japanese = 'ja'
+    korean = 'ko'
+    lithuanian = 'lt'
+    norwegian = 'no'
+    polish = 'pl'
+    brazil_portuguese = 'pt-BR'
+    romanian = 'ro'
+    russian = 'ru'
+    spain_spanish = 'es-ES'
+    swedish = 'sv-SE'
+    thai = 'th'
+    turkish = 'tr'
+    ukrainian = 'uk'
+    vietnamese = 'vi'
+
+    def __str__(self) -> str:
+        return self.value
+
+class InputTextStyle(Enum):
+    """Input text style"""
+
+    short = 1
+    singleline = 1
+    paragraph = 2
+    multiline = 2
+    long = 2
+
+
+class ApplicationType(Enum):
+    """Application type"""
+
+    game = 1
+    music = 2
+    ticketed_events = 3
+    guild_role_subscriptions = 4
+
+class AppCommandOptionType(Enum):
+    subcommand = 1
+    subcommand_group = 2
+    string = 3
+    integer = 4
+    boolean = 5
+    user = 6
+    channel = 7
+    role = 8
+    mentionable = 9
+    number = 10
+    attachment = 11
+    
+class AppCommandPermissionType(Enum):
+    role = 1
+    user = 2
+    channel = 3
+    
+class StagePrivacyLevel(Enum):
+    """Stage privacy level"""
+
+    # public = 1 (deprecated)
+    closed = 2
+    guild_only = 2
+
+class AppCommandType(Enum):
+    chat_input = 1
+    user = 2
+    message = 3
+
+class NSFWLevel(Enum, comparable=True):
+    """NSFW level"""
+
+    default = 0
+    explicit = 1
+    safe = 2
+    age_restricted = 3
+
+
+class SlashCommandOptionType(Enum):
+    """Slash command option type"""
+
+    sub_command = 1
+    sub_command_group = 2
+    string = 3
+    integer = 4
+    boolean = 5
+    user = 6
+    channel = 7
+    role = 8
+    mentionable = 9
+    number = 10
+    attachment = 11
+
+    @classmethod
+    def from_datatype(cls, datatype):
+        if isinstance(datatype, tuple):  # typing.Union has been used
+            datatypes = [cls.from_datatype(op) for op in datatype]
+            if all(x == cls.channel for x in datatypes):
+                return cls.channel
+            elif set(datatypes) <= {cls.role, cls.user}:
+                return cls.mentionable
+            else:
+                raise TypeError("Invalid usage of typing.Union")
+
+        py_3_10_union_type = hasattr(types, "UnionType") and isinstance(
+            datatype, types.UnionType
+        )
+
+        if py_3_10_union_type or getattr(datatype, "__origin__", None) is Union:
+            # Python 3.10+ "|" operator or typing.Union has been used. The __args__ attribute is a tuple of the types.
+            # Type checking fails for this case, so ignore it.
+            return cls.from_datatype(datatype.__args__)  # type: ignore
+
+        if datatype.__name__ in ["Member", "User"]:
+            return cls.user
+        if datatype.__name__ in [
+            "GuildChannel",
+            "TextChannel",
+            "VoiceChannel",
+            "StageChannel",
+            "CategoryChannel",
+            "ThreadOption",
+            "Thread",
+            "ForumChannel",
+            "DMChannel",
+        ]:
+            return cls.channel
+        if datatype.__name__ == "Role":
+            return cls.role
+        if datatype.__name__ == "Attachment":
+            return cls.attachment
+        if datatype.__name__ == "Mentionable":
+            return cls.mentionable
+
+        if issubclass(datatype, str):
+            return cls.string
+        if issubclass(datatype, bool):
+            return cls.boolean
+        if issubclass(datatype, int):
+            return cls.integer
+        if issubclass(datatype, float):
+            return cls.number
+
+        from .commands.context import ApplicationContext
+
+        if not issubclass(
+            datatype, ApplicationContext
+        ):  # TODO: prevent ctx being passed here in cog commands
+            raise TypeError(
+                f"Invalid class {datatype} used as an input type for an Option"
+            )  # TODO: Improve the error message
+
+
+class EmbeddedActivity(Enum):
+    """Embedded activity"""
+
+    ask_away = 976052223358406656
+    awkword = 879863881349087252
+    awkword_dev = 879863923543785532
+    bash_out = 1006584476094177371
+    betrayal = 773336526917861400
+    blazing_8s = 832025144389533716
+    blazing_8s_dev = 832013108234289153
+    blazing_8s_qa = 832025114077298718
+    blazing_8s_staging = 832025061657280566
+    bobble_league = 947957217959759964
+    checkers_in_the_park = 832013003968348200
+    checkers_in_the_park_dev = 832012682520428625
+    checkers_in_the_park_qa = 832012894068801636
+    checkers_in_the_park_staging = 832012938398400562
+    chess_in_the_park = 832012774040141894
+    chess_in_the_park_dev = 832012586023256104
+    chess_in_the_park_qa = 832012815819604009
+    chess_in_the_park_staging = 832012730599735326
+    decoders_dev = 891001866073296967
+    doodle_crew = 878067389634314250
+    doodle_crew_dev = 878067427668275241
+    fishington = 814288819477020702
+    know_what_i_meme = 950505761862189096
+    land = 903769130790969345
+    letter_league = 879863686565621790
+    letter_league_dev = 879863753519292467
+    poker_night = 755827207812677713
+    poker_night_dev = 763133495793942528
+    poker_night_qa = 801133024841957428
+    poker_night_staging = 763116274876022855
+    putt_party = 945737671223947305
+    putt_party_dev = 910224161476083792
+    putt_party_qa = 945748195256979606
+    putt_party_staging = 945732077960188005
+    putts = 832012854282158180
+    sketch_heads = 902271654783242291
+    sketch_heads_dev = 902271746701414431
+    sketchy_artist = 879864070101172255
+    sketchy_artist_dev = 879864104980979792
+    spell_cast = 852509694341283871
+    spell_cast_staging = 893449443918086174
+    watch_together = 880218394199220334
+    watch_together_dev = 880218832743055411
+    word_snacks = 879863976006127627
+    word_snacks_dev = 879864010126786570
+    youtube_together = 755600276941176913
+
+
+class ScheduledEventStatus(Enum):
+    """Scheduled event status"""
+
+    scheduled = 1
+    active = 2
+    completed = 3
+    canceled = 4
+    cancelled = 4
+
+    def __int__(self):
+        return self.value
+
+
+class ScheduledEventPrivacyLevel(Enum):
+    """Scheduled event privacy level"""
+
+    guild_only = 2
+
+    def __int__(self):
+        return self.value
+
+
+class ScheduledEventLocationType(Enum):
+    """Scheduled event location type"""
+
+    stage_instance = 1
+    voice = 2
+    external = 3
+
+
+class AutoModTriggerType(Enum):
+    """Automod trigger type"""
+
+    keyword = 1
+    harmful_link = 2
+    spam = 3
+    keyword_preset = 4
+    mention_spam = 5
+
+
+class AutoModEventType(Enum):
+    """Automod event type"""
+
+    message_send = 1
+
+
+class AutoModActionType(Enum):
+    """Automod action type"""
+
+    block_message = 1
+    send_alert_message = 2
+    timeout = 3
+
+
+class AutoModKeywordPresetType(Enum):
+    """Automod keyword preset type"""
+
+    profanity = 1
+    sexual_content = 2
+    slurs = 3
+
+
+class ApplicationRoleConnectionMetadataType(Enum):
+    """Application role connection metadata type"""
+
+    integer_less_than_or_equal = 1
+    integer_greater_than_or_equal = 2
+    integer_equal = 3
+    integer_not_equal = 4
+    datetime_less_than_or_equal = 5
+    datetime_greater_than_or_equal = 6
+    boolean_equal = 7
+    boolean_not_equal = 8
+
+
+T = TypeVar("T")
+
+
+def create_unknown_value(cls: type[T], val: Any) -> T:
+    value_cls = cls._enum_value_cls_  # type: ignore
+    name = f"unknown_{val}"
+    return value_cls(name=name, value=val)
+
+
+def try_enum(cls: type[T], val: Any) -> T:
+    """A function that tries to turn the value into enum ``cls``.
+
+    If it fails it returns a proxy invalid value instead.
+    """
+
+    try:
+        return cls._enum_value_map_[val]  # type: ignore
+    except (KeyError, TypeError, AttributeError):
+        return create_unknown_value(cls, val)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,1421 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-2021 Rapptz
+Copyright (c) 2021-present Pycord Development
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+from __future__ import annotations
+from textwrap import TextWrapper
+import array
+import asyncio
+import collections.abc
+import datetime
+import functools
+import itertools
+import json
+import re
+import sys
+import types
+import unicodedata
+import warnings
+from base64 import b64encode
+from bisect import bisect_left
+from dataclasses import field
+from inspect import isawaitable as _isawaitable
+from inspect import signature as _signature
+from operator import attrgetter
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Coroutine,
+    ForwardRef,
+    Generic,
+    Iterable,
+    Iterator,
+    Literal,
+    Mapping,
+    NewType,
+    Protocol,
+    Sequence,
+    TypeVar,
+    Union,
+    overload,
+)
+
+from .errors import HTTPException, InvalidArgument
+
+try:
+    import orjson
+except ModuleNotFoundError:
+    HAS_ORJSON = False
+else:
+    HAS_ORJSON = True
+
+
+__all__ = (
+    "parse_time",
+    "warn_deprecated",
+    "deprecated",
+    "oauth_url",
+    "snowflake_time",
+    "time_snowflake",
+    "find",
+    "get",
+    "get_or_fetch",
+    "sleep_until",
+    "utcnow",
+    "resolve_invite",
+    "resolve_template",
+    "remove_markdown",
+    "escape_markdown",
+    "escape_mentions",
+    "raw_mentions",
+    "raw_channel_mentions",
+    "raw_role_mentions",
+    "as_chunks",
+    "format_dt",
+    "generate_snowflake",
+    "basic_autocomplete",
+    "filter_params",
+)
+
+DISCORD_EPOCH = 1420070400000
+
+
+class _MissingSentinel:
+    def __eq__(self, other) -> bool:
+        return False
+
+    def __bool__(self) -> bool:
+        return False
+
+    def __repr__(self) -> str:
+        return "..."
+
+
+MISSING: Any = _MissingSentinel()
+# As of 3.11, directly setting a dataclass field to MISSING causes a ValueError. Using
+# field(default=MISSING) produces the same error, but passing a lambda to
+# default_factory produces the same behavior as default=MISSING and does not raise an
+# error.
+MissingField = field(default_factory=lambda: MISSING)
+
+
+class _cached_property:
+    def __init__(self, function):
+        self.function = function
+        self.__doc__ = getattr(function, "__doc__")
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
+        value = self.function(instance)
+        setattr(instance, self.function.__name__, value)
+
+        return value
+
+
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    from .abc import Snowflake
+    from .commands.context import AutocompleteContext
+    from .invite import Invite
+    from .permissions import Permissions
+    from .template import Template
+
+    class _RequestLike(Protocol):
+        headers: Mapping[str, Any]
+
+    cached_property = NewType("cached_property", property)
+
+    P = ParamSpec("P")
+
+else:
+    cached_property = _cached_property
+    AutocompleteContext = Any
+
+
+T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
+_Iter = Union[Iterator[T], AsyncIterator[T]]
+
+
+class CachedSlotProperty(Generic[T, T_co]):
+    def __init__(self, name: str, function: Callable[[T], T_co]) -> None:
+        self.name = name
+        self.function = function
+        self.__doc__ = getattr(function, "__doc__")
+
+    @overload
+    def __get__(self, instance: None, owner: type[T]) -> CachedSlotProperty[T, T_co]:
+        ...
+
+    @overload
+    def __get__(self, instance: T, owner: type[T]) -> T_co:
+        ...
+
+    def __get__(self, instance: T | None, owner: type[T]) -> Any:
+        if instance is None:
+            return self
+
+        try:
+            return getattr(instance, self.name)
+        except AttributeError:
+            value = self.function(instance)
+            setattr(instance, self.name, value)
+            return value
+
+
+class classproperty(Generic[T_co]):
+    def __init__(self, fget: Callable[[Any], T_co]) -> None:
+        self.fget = fget
+
+    def __get__(self, instance: Any | None, owner: type[Any]) -> T_co:
+        return self.fget(owner)
+
+    def __set__(self, instance, value) -> None:
+        raise AttributeError("cannot set attribute")
+
+
+def cached_slot_property(
+    name: str,
+) -> Callable[[Callable[[T], T_co]], CachedSlotProperty[T, T_co]]:
+    def decorator(func: Callable[[T], T_co]) -> CachedSlotProperty[T, T_co]:
+        return CachedSlotProperty(name, func)
+
+    return decorator
+
+
+class SequenceProxy(Generic[T_co], collections.abc.Sequence):
+    """Read-only proxy of a Sequence."""
+
+    def __init__(self, proxied: Sequence[T_co]):
+        self.__proxied = proxied
+
+    def __getitem__(self, idx: int) -> T_co:
+        return self.__proxied[idx]
+
+    def __len__(self) -> int:
+        return len(self.__proxied)
+
+    def __contains__(self, item: Any) -> bool:
+        return item in self.__proxied
+
+    def __iter__(self) -> Iterator[T_co]:
+        return iter(self.__proxied)
+
+    def __reversed__(self) -> Iterator[T_co]:
+        return reversed(self.__proxied)
+
+    def index(self, value: Any, *args, **kwargs) -> int:
+        return self.__proxied.index(value, *args, **kwargs)
+
+    def count(self, value: Any) -> int:
+        return self.__proxied.count(value)
+
+
+def delay_task(delay: float, func: Coroutine):
+    async def inner_call():
+        await asyncio.sleep(delay)
+        try:
+            await func
+        except HTTPException:
+            pass
+
+    asyncio.create_task(inner_call())
+
+
+@overload
+def parse_time(timestamp: None) -> None:
+    ...
+
+
+@overload
+def parse_time(timestamp: str) -> datetime.datetime:
+    ...
+
+
+@overload
+def parse_time(timestamp: str | None) -> datetime.datetime | None:
+    ...
+
+
+def parse_time(timestamp: str | None) -> datetime.datetime | None:
+    """A helper function to convert an ISO 8601 timestamp to a datetime object.
+
+    Parameters
+    ----------
+    timestamp: Optional[:class:`str`]
+        The timestamp to convert.
+
+    Returns
+    -------
+    Optional[:class:`datetime.datetime`]
+        The converted datetime object.
+    """
+    if timestamp:
+        return datetime.datetime.fromisoformat(timestamp)
+    return None
+
+
+def copy_doc(original: Callable) -> Callable[[T], T]:
+    def decorator(overridden: T) -> T:
+        overridden.__doc__ = original.__doc__
+        overridden.__signature__ = _signature(original)  # type: ignore
+        return overridden
+
+    return decorator
+
+
+def warn_deprecated(
+    name: str,
+    instead: str | None = None,
+    since: str | None = None,
+    removed: str | None = None,
+    reference: str | None = None,
+) -> None:
+    """Warn about a deprecated function, with the ability to specify details about the deprecation. Emits a
+    DeprecationWarning.
+
+    Parameters
+    ----------
+    name: str
+        The name of the deprecated function.
+    instead: Optional[:class:`str`]
+        A recommended alternative to the function.
+    since: Optional[:class:`str`]
+        The version in which the function was deprecated. This should be in the format ``major.minor(.patch)``, where
+        the patch version is optional.
+    removed: Optional[:class:`str`]
+        The version in which the function is planned to be removed. This should be in the format
+        ``major.minor(.patch)``, where the patch version is optional.
+    reference: Optional[:class:`str`]
+        A reference that explains the deprecation, typically a URL to a page such as a changelog entry or a GitHub
+        issue/PR.
+    """
+    warnings.simplefilter("always", DeprecationWarning)  # turn off filter
+    message = f"{name} is deprecated"
+    if since:
+        message += f" since version {since}"
+    if removed:
+        message += f" and will be removed in version {removed}"
+    if instead:
+        message += f", consider using {instead} instead"
+    message += "."
+    if reference:
+        message += f" See {reference} for more information."
+
+    warnings.warn(message, stacklevel=3, category=DeprecationWarning)
+    warnings.simplefilter("default", DeprecationWarning)  # reset filter
+
+
+def deprecated(
+    instead: str | None = None,
+    since: str | None = None,
+    removed: str | None = None,
+    reference: str | None = None,
+    *,
+    use_qualname: bool = True,
+) -> Callable[[Callable[[P], T]], Callable[[P], T]]:
+    """A decorator implementation of :func:`warn_deprecated`. This will automatically call :func:`warn_deprecated` when
+    the decorated function is called.
+
+    Parameters
+    ----------
+    instead: Optional[:class:`str`]
+        A recommended alternative to the function.
+    since: Optional[:class:`str`]
+        The version in which the function was deprecated. This should be in the format ``major.minor(.patch)``, where
+        the patch version is optional.
+    removed: Optional[:class:`str`]
+        The version in which the function is planned to be removed. This should be in the format
+        ``major.minor(.patch)``, where the patch version is optional.
+    reference: Optional[:class:`str`]
+        A reference that explains the deprecation, typically a URL to a page such as a changelog entry or a GitHub
+        issue/PR.
+    use_qualname: :class:`bool`
+        Whether to use the qualified name of the function in the deprecation warning. If ``False``, the short name of
+        the function will be used instead. For example, __qualname__ will display as ``Client.login`` while __name__
+        will display as ``login``. Defaults to ``True``.
+    """
+
+    def actual_decorator(func: Callable[[P], T]) -> Callable[[P], T]:
+        @functools.wraps(func)
+        def decorated(*args: P.args, **kwargs: P.kwargs) -> T:
+            warn_deprecated(
+                name=func.__qualname__ if use_qualname else func.__name__,
+                instead=instead,
+                since=since,
+                removed=removed,
+                reference=reference,
+            )
+            return func(*args, **kwargs)
+
+        return decorated
+
+    return actual_decorator
+
+
+def oauth_url(
+    client_id: int | str,
+    *,
+    permissions: Permissions = MISSING,
+    guild: Snowflake = MISSING,
+    redirect_uri: str = MISSING,
+    scopes: Iterable[str] = MISSING,
+    disable_guild_select: bool = False,
+) -> str:
+    """A helper function that returns the OAuth2 URL for inviting the bot
+    into guilds.
+
+    Parameters
+    ----------
+    client_id: Union[:class:`int`, :class:`str`]
+        The client ID for your bot.
+    permissions: :class:`~discord.Permissions`
+        The permissions you're requesting. If not given then you won't be requesting any
+        permissions.
+    guild: :class:`~discord.abc.Snowflake`
+        The guild to pre-select in the authorization screen, if available.
+    redirect_uri: :class:`str`
+        An optional valid redirect URI.
+    scopes: Iterable[:class:`str`]
+        An optional valid list of scopes. Defaults to ``('bot',)``.
+
+        .. versionadded:: 1.7
+    disable_guild_select: :class:`bool`
+        Whether to disallow the user from changing the guild dropdown.
+
+        .. versionadded:: 2.0
+
+    Returns
+    -------
+    :class:`str`
+        The OAuth2 URL for inviting the bot into guilds.
+    """
+    url = f"https://discord.com/oauth2/authorize?client_id={client_id}"
+    url += f"&scope={'+'.join(scopes or ('bot',))}"
+    if permissions is not MISSING:
+        url += f"&permissions={permissions.value}"
+    if guild is not MISSING:
+        url += f"&guild_id={guild.id}"
+    if redirect_uri is not MISSING:
+        from urllib.parse import urlencode
+
+        url += f"&response_type=code&{urlencode({'redirect_uri': redirect_uri})}"
+    if disable_guild_select:
+        url += "&disable_guild_select=true"
+    return url
+
+
+def snowflake_time(id: int) -> datetime.datetime:
+    """Converts a Discord snowflake ID to a UTC-aware datetime object.
+
+    Parameters
+    ----------
+    id: :class:`int`
+        The snowflake ID.
+
+    Returns
+    -------
+    :class:`datetime.datetime`
+        An aware datetime in UTC representing the creation time of the snowflake.
+    """
+    timestamp = ((id >> 22) + DISCORD_EPOCH) / 1000
+    return datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
+
+
+def time_snowflake(dt: datetime.datetime, high: bool = False) -> int:
+    """Returns a numeric snowflake pretending to be created at the given date.
+
+    When using as the lower end of a range, use ``time_snowflake(high=False) - 1``
+    to be inclusive, ``high=True`` to be exclusive.
+
+    When using as the higher end of a range, use ``time_snowflake(high=True) + 1``
+    to be inclusive, ``high=False`` to be exclusive
+
+    Parameters
+    ----------
+    dt: :class:`datetime.datetime`
+        A datetime object to convert to a snowflake.
+        If naive, the timezone is assumed to be local time.
+    high: :class:`bool`
+        Whether to set the lower 22 bit to high or low.
+
+    Returns
+    -------
+    :class:`int`
+        The snowflake representing the time given.
+    """
+    discord_millis = int(dt.timestamp() * 1000 - DISCORD_EPOCH)
+    return (discord_millis << 22) + (2**22 - 1 if high else 0)
+
+
+def find(predicate: Callable[[T], Any], seq: Iterable[T]) -> T | None:
+    """A helper to return the first element found in the sequence
+    that meets the predicate. For example: ::
+
+        member = discord.utils.find(lambda m: m.name == 'Mighty', channel.guild.members)
+
+    would find the first :class:`~discord.Member` whose name is 'Mighty' and return it.
+    If an entry is not found, then ``None`` is returned.
+
+    This is different from :func:`py:filter` due to the fact it stops the moment it finds
+    a valid entry.
+
+    Parameters
+    ----------
+    predicate
+        A function that returns a boolean-like result.
+    seq: :class:`collections.abc.Iterable`
+        The iterable to search through.
+    """
+
+    for element in seq:
+        if predicate(element):
+            return element
+    return None
+
+
+def get(iterable: Iterable[T], **attrs: Any) -> T | None:
+    r"""A helper that returns the first element in the iterable that meets
+    all the traits passed in ``attrs``. This is an alternative for
+    :func:`~discord.utils.find`.
+
+    When multiple attributes are specified, they are checked using
+    logical AND, not logical OR. Meaning they have to meet every
+    attribute passed in and not one of them.
+
+    To have a nested attribute search (i.e. search by ``x.y``) then
+    pass in ``x__y`` as the keyword argument.
+
+    If nothing is found that matches the attributes passed, then
+    ``None`` is returned.
+
+    Examples
+    ---------
+
+    Basic usage:
+
+    .. code-block:: python3
+
+        member = discord.utils.get(message.guild.members, name='Foo')
+
+    Multiple attribute matching:
+
+    .. code-block:: python3
+
+        channel = discord.utils.get(guild.voice_channels, name='Foo', bitrate=64000)
+
+    Nested attribute matching:
+
+    .. code-block:: python3
+
+        channel = discord.utils.get(client.get_all_channels(), guild__name='Cool', name='general')
+
+    Parameters
+    -----------
+    iterable
+        An iterable to search through.
+    \*\*attrs
+        Keyword arguments that denote attributes to search with.
+    """
+
+    # global -> local
+    _all = all
+    attrget = attrgetter
+
+    # Special case the single element call
+    if len(attrs) == 1:
+        k, v = attrs.popitem()
+        pred = attrget(k.replace("__", "."))
+        for elem in iterable:
+            if pred(elem) == v:
+                return elem
+        return None
+
+    converted = [
+        (attrget(attr.replace("__", ".")), value) for attr, value in attrs.items()
+    ]
+
+    for elem in iterable:
+        if _all(pred(elem) == value for pred, value in converted):
+            return elem
+    return None
+
+
+async def get_or_fetch(obj, attr: str, id: int, *, default: Any = MISSING) -> Any:
+    """|coro|
+
+    Attempts to get an attribute from the object in cache. If it fails, it will attempt to fetch it.
+    If the fetch also fails, an error will be raised.
+
+    Parameters
+    ----------
+    obj: Any
+        The object to use the get or fetch methods in
+    attr: :class:`str`
+        The attribute to get or fetch. Note the object must have both a ``get_`` and ``fetch_`` method for this attribute.
+    id: :class:`int`
+        The ID of the object
+    default: Any
+        The default value to return if the object is not found, instead of raising an error.
+
+    Returns
+    -------
+    Any
+        The object found or the default value.
+
+    Raises
+    ------
+    :exc:`AttributeError`
+        The object is missing a ``get_`` or ``fetch_`` method
+    :exc:`NotFound`
+        Invalid ID for the object
+    :exc:`HTTPException`
+        An error occurred fetching the object
+    :exc:`Forbidden`
+        You do not have permission to fetch the object
+
+    Examples
+    --------
+
+    Getting a guild from a guild ID: ::
+
+        guild = await utils.get_or_fetch(client, 'guild', guild_id)
+
+    Getting a channel from the guild. If the channel is not found, return None: ::
+
+        channel = await utils.get_or_fetch(guild, 'channel', channel_id, default=None)
+    """
+    getter = getattr(obj, f"get_{attr}")(id)
+    if getter is None:
+        try:
+            getter = await getattr(obj, f"fetch_{attr}")(id)
+        except AttributeError:
+            getter = await getattr(obj, f"_fetch_{attr}")(id)
+            if getter is None:
+                raise ValueError(f"Could not find {attr} with id {id} on {obj}")
+        except (HTTPException, ValueError):
+            if default is not MISSING:
+                return default
+            else:
+                raise
+    return getter
+
+
+def _unique(iterable: Iterable[T]) -> list[T]:
+    return [x for x in dict.fromkeys(iterable)]
+
+
+def _get_as_snowflake(data: Any, key: str) -> int | None:
+    try:
+        value = data[key]
+    except KeyError:
+        return None
+    else:
+        return value and int(value)
+
+
+def _get_mime_type_for_image(data: bytes):
+    if data.startswith(b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a"):
+        return "image/png"
+    elif data[0:3] == b"\xff\xd8\xff" or data[6:10] in (b"JFIF", b"Exif"):
+        return "image/jpeg"
+    elif data.startswith((b"\x47\x49\x46\x38\x37\x61", b"\x47\x49\x46\x38\x39\x61")):
+        return "image/gif"
+    elif data.startswith(b"RIFF") and data[8:12] == b"WEBP":
+        return "image/webp"
+    else:
+        raise InvalidArgument("Unsupported image type given")
+
+
+def _bytes_to_base64_data(data: bytes) -> str:
+    fmt = "data:{mime};base64,{data}"
+    mime = _get_mime_type_for_image(data)
+    b64 = b64encode(data).decode("ascii")
+    return fmt.format(mime=mime, data=b64)
+
+
+if HAS_ORJSON:
+
+    def _to_json(obj: Any) -> str:  # type: ignore
+        return orjson.dumps(obj).decode("utf-8")
+
+    _from_json = orjson.loads  # type: ignore
+
+else:
+
+    def _to_json(obj: Any) -> str:
+        return json.dumps(obj, separators=(",", ":"), ensure_ascii=True)
+
+    _from_json = json.loads
+
+
+def _parse_ratelimit_header(request: Any, *, use_clock: bool = False) -> float:
+    reset_after: str | None = request.headers.get("X-Ratelimit-Reset-After")
+    if not use_clock and reset_after:
+        return float(reset_after)
+    utc = datetime.timezone.utc
+    now = datetime.datetime.now(utc)
+    reset = datetime.datetime.fromtimestamp(
+        float(request.headers["X-Ratelimit-Reset"]), utc
+    )
+    return (reset - now).total_seconds()
+
+
+async def maybe_coroutine(f, *args, **kwargs):
+    value = f(*args, **kwargs)
+    if _isawaitable(value):
+        return await value
+    else:
+        return value
+
+
+async def async_all(gen, *, check=_isawaitable):
+    for elem in gen:
+        if check(elem):
+            elem = await elem
+        if not elem:
+            return False
+    return True
+
+
+async def sane_wait_for(futures, *, timeout):
+    ensured = [asyncio.ensure_future(fut) for fut in futures]
+    done, pending = await asyncio.wait(
+        ensured, timeout=timeout, return_when=asyncio.ALL_COMPLETED
+    )
+
+    if len(pending) != 0:
+        raise asyncio.TimeoutError()
+
+    return done
+
+
+def get_slots(cls: type[Any]) -> Iterator[str]:
+    for mro in reversed(cls.__mro__):
+        try:
+            yield from mro.__slots__
+        except AttributeError:
+            continue
+
+
+def compute_timedelta(dt: datetime.datetime):
+    if dt.tzinfo is None:
+        dt = dt.astimezone()
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return max((dt - now).total_seconds(), 0)
+
+
+async def sleep_until(when: datetime.datetime, result: T | None = None) -> T | None:
+    """|coro|
+
+    Sleep until a specified time.
+
+    If the time supplied is in the past this function will yield instantly.
+
+    .. versionadded:: 1.3
+
+    Parameters
+    ----------
+    when: :class:`datetime.datetime`
+        The timestamp in which to sleep until. If the datetime is naive then
+        it is assumed to be local time.
+    result: Any
+        If provided is returned to the caller when the coroutine completes.
+    """
+    delta = compute_timedelta(when)
+    return await asyncio.sleep(delta, result)
+
+
+def utcnow() -> datetime.datetime:
+    """A helper function to return an aware UTC datetime representing the current time.
+
+    This should be preferred to :meth:`datetime.datetime.utcnow` since it is an aware
+    datetime, compared to the naive datetime in the standard library.
+
+    .. versionadded:: 2.0
+
+    Returns
+    -------
+    :class:`datetime.datetime`
+        The current aware datetime in UTC.
+    """
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def valid_icon_size(size: int) -> bool:
+    """Icons must be power of 2 within [16, 4096]."""
+    return not size & (size - 1) and 4096 >= size >= 16
+
+
+class SnowflakeList(array.array):
+    """Internal data storage class to efficiently store a list of snowflakes.
+
+    This should have the following characteristics:
+
+    - Low memory usage
+    - O(n) iteration (obviously)
+    - O(n log n) initial creation if data is unsorted
+    - O(log n) search and indexing
+    - O(n) insertion
+    """
+
+    __slots__ = ()
+
+    if TYPE_CHECKING:
+
+        def __init__(self, data: Iterable[int], *, is_sorted: bool = False):
+            ...
+
+    def __new__(cls, data: Iterable[int], *, is_sorted: bool = False):
+        return array.array.__new__(cls, "Q", data if is_sorted else sorted(data))  # type: ignore
+
+    def add(self, element: int) -> None:
+        i = bisect_left(self, element)
+        self.insert(i, element)
+
+    def get(self, element: int) -> int | None:
+        i = bisect_left(self, element)
+        return self[i] if i != len(self) and self[i] == element else None
+
+    def has(self, element: int) -> bool:
+        i = bisect_left(self, element)
+        return i != len(self) and self[i] == element
+
+
+_IS_ASCII = re.compile(r"^[\x00-\x7f]+$")
+
+
+def _string_width(string: str, *, _IS_ASCII=_IS_ASCII) -> int:
+    """Returns string's width."""
+    match = _IS_ASCII.match(string)
+    if match:
+        return match.endpos
+
+    UNICODE_WIDE_CHAR_TYPE = "WFA"
+    func = unicodedata.east_asian_width
+    return sum(2 if func(char) in UNICODE_WIDE_CHAR_TYPE else 1 for char in string)
+
+
+def resolve_invite(invite: Invite | str) -> str:
+    """
+    Resolves an invite from a :class:`~discord.Invite`, URL or code.
+
+    Parameters
+    ----------
+    invite: Union[:class:`~discord.Invite`, :class:`str`]
+        The invite.
+
+    Returns
+    -------
+    :class:`str`
+        The invite code.
+    """
+    from .invite import Invite  # circular import
+
+    if isinstance(invite, Invite):
+        return invite.code
+    rx = r"(?:https?\:\/\/)?discord(?:\.gg|(?:app)?\.com\/invite)\/(.+)"
+    m = re.match(rx, invite)
+    if m:
+        return m.group(1)
+    return invite
+
+
+def resolve_template(code: Template | str) -> str:
+    """
+    Resolves a template code from a :class:`~discord.Template`, URL or code.
+
+    .. versionadded:: 1.4
+
+    Parameters
+    ----------
+    code: Union[:class:`~discord.Template`, :class:`str`]
+        The code.
+
+    Returns
+    -------
+    :class:`str`
+        The template code.
+    """
+    from .template import Template  # circular import
+
+    if isinstance(code, Template):
+        return code.code
+    rx = r"(?:https?\:\/\/)?discord(?:\.new|(?:app)?\.com\/template)\/(.+)"
+    m = re.match(rx, code)
+    if m:
+        return m.group(1)
+    return code
+
+
+_MARKDOWN_ESCAPE_SUBREGEX = "|".join(
+    r"\{0}(?=([\s\S]*((?<!\{0})\{0})))".format(c) for c in ("*", "`", "_", "~", "|")
+)
+
+# regular expression for finding and escaping links in markdown
+# note: technically, brackets are allowed in link text.
+# perhaps more concerning, parentheses are also allowed in link destination.
+# this regular expression matches neither of those.
+# this page provides a good reference: http://blog.michaelperrin.fr/2019/02/04/advanced-regular-expressions/
+_MARKDOWN_ESCAPE_LINKS = r"""
+\[  # matches link text
+    [^\[\]]* # link text can contain anything but brackets
+\]
+\(  # matches link destination
+    [^\(\)]+ # link destination cannot contain parentheses
+\)"""  # note 2: make sure this regex is consumed in re.X (extended mode) since it has whitespace and comments
+
+_MARKDOWN_ESCAPE_COMMON = rf"^>(?:>>)?\s|{_MARKDOWN_ESCAPE_LINKS}"
+
+_MARKDOWN_ESCAPE_REGEX = re.compile(
+    rf"(?P<markdown>{_MARKDOWN_ESCAPE_SUBREGEX}|{_MARKDOWN_ESCAPE_COMMON})",
+    re.MULTILINE | re.X,
+)
+
+_URL_REGEX = r"(?P<url><[^: >]+:\/[^ >]+>|(?:https?|steam):\/\/[^\s<]+[^<.,:;\"\'\]\s])"
+
+_MARKDOWN_STOCK_REGEX = rf"(?P<markdown>[_\\~|\*`]|{_MARKDOWN_ESCAPE_COMMON})"
+
+
+def remove_markdown(text: str, *, ignore_links: bool = True) -> str:
+    """A helper function that removes markdown characters.
+
+    .. versionadded:: 1.7
+
+    .. note::
+            This function is not markdown aware and may remove meaning from the original text. For example,
+            if the input contains ``10 * 5`` then it will be converted into ``10  5``.
+
+    Parameters
+    ----------
+    text: :class:`str`
+        The text to remove markdown from.
+    ignore_links: :class:`bool`
+        Whether to leave links alone when removing markdown. For example,
+        if a URL in the text contains characters such as ``_`` then it will
+        be left alone. Defaults to ``True``.
+
+    Returns
+    -------
+    :class:`str`
+        The text with the markdown special characters removed.
+    """
+
+    def replacement(match):
+        groupdict = match.groupdict()
+        return groupdict.get("url", "")
+
+    regex = _MARKDOWN_STOCK_REGEX
+    if ignore_links:
+        regex = f"(?:{_URL_REGEX}|{regex})"
+    return re.sub(regex, replacement, text, 0, re.MULTILINE)
+
+
+def escape_markdown(
+    text: str, *, as_needed: bool = False, ignore_links: bool = True
+) -> str:
+    r"""A helper function that escapes Discord's markdown.
+
+    Parameters
+    -----------
+    text: :class:`str`
+        The text to escape markdown from.
+    as_needed: :class:`bool`
+        Whether to escape the markdown characters as needed. This
+        means that it does not escape extraneous characters if it's
+        not necessary, e.g. ``**hello**`` is escaped into ``\*\*hello**``
+        instead of ``\*\*hello\*\*``. Note however that this can open
+        you up to some clever syntax abuse. Defaults to ``False``.
+    ignore_links: :class:`bool`
+        Whether to leave links alone when escaping markdown. For example,
+        if a URL in the text contains characters such as ``_`` then it will
+        be left alone. This option is not supported with ``as_needed``.
+        Defaults to ``True``.
+
+    Returns
+    --------
+    :class:`str`
+        The text with the markdown special characters escaped with a slash.
+    """
+
+    if not as_needed:
+
+        def replacement(match):
+            groupdict = match.groupdict()
+            is_url = groupdict.get("url")
+            if is_url:
+                return is_url
+            return f"\\{groupdict['markdown']}"
+
+        regex = _MARKDOWN_STOCK_REGEX
+        if ignore_links:
+            regex = f"(?:{_URL_REGEX}|{regex})"
+        return re.sub(regex, replacement, text, 0, re.MULTILINE | re.X)
+    else:
+        text = re.sub(r"\\", r"\\\\", text)
+        return _MARKDOWN_ESCAPE_REGEX.sub(r"\\\1", text)
+
+
+def escape_mentions(text: str) -> str:
+    """A helper function that escapes everyone, here, role, and user mentions.
+
+    .. note::
+
+        This does not include channel mentions.
+
+    .. note::
+
+        For more granular control over what mentions should be escaped
+        within messages, refer to the :class:`~discord.AllowedMentions`
+        class.
+
+    Parameters
+    ----------
+    text: :class:`str`
+        The text to escape mentions from.
+
+    Returns
+    -------
+    :class:`str`
+        The text with the mentions removed.
+    """
+    return re.sub(r"@(everyone|here|[!&]?[0-9]{17,20})", "@\u200b\\1", text)
+
+
+def raw_mentions(text: str) -> list[int]:
+    """Returns a list of user IDs matching ``<@user_id>`` in the string.
+
+    .. versionadded:: 2.2
+
+    Parameters
+    ----------
+    text: :class:`str`
+        The string to get user mentions from.
+
+    Returns
+    -------
+    List[:class:`int`]
+        A list of user IDs found in the string.
+    """
+    return [int(x) for x in re.findall(r"<@!?([0-9]+)>", text)]
+
+
+def raw_channel_mentions(text: str) -> list[int]:
+    """Returns a list of channel IDs matching ``<@#channel_id>`` in the string.
+
+    .. versionadded:: 2.2
+
+    Parameters
+    ----------
+    text: :class:`str`
+        The string to get channel mentions from.
+
+    Returns
+    -------
+    List[:class:`int`]
+        A list of channel IDs found in the string.
+    """
+    return [int(x) for x in re.findall(r"<#([0-9]+)>", text)]
+
+
+def raw_role_mentions(text: str) -> list[int]:
+    """Returns a list of role IDs matching ``<@&role_id>`` in the string.
+
+    .. versionadded:: 2.2
+
+    Parameters
+    ----------
+    text: :class:`str`
+        The string to get role mentions from.
+
+    Returns
+    -------
+    List[:class:`int`]
+        A list of role IDs found in the string.
+    """
+    return [int(x) for x in re.findall(r"<@&([0-9]+)>", text)]
+
+
+def _chunk(iterator: Iterator[T], max_size: int) -> Iterator[list[T]]:
+    ret = []
+    n = 0
+    for item in iterator:
+        ret.append(item)
+        n += 1
+        if n == max_size:
+            yield ret
+            ret = []
+            n = 0
+    if ret:
+        yield ret
+
+
+async def _achunk(iterator: AsyncIterator[T], max_size: int) -> AsyncIterator[list[T]]:
+    ret = []
+    n = 0
+    async for item in iterator:
+        ret.append(item)
+        n += 1
+        if n == max_size:
+            yield ret
+            ret = []
+            n = 0
+    if ret:
+        yield ret
+
+
+@overload
+def as_chunks(iterator: Iterator[T], max_size: int) -> Iterator[list[T]]:
+    ...
+
+
+@overload
+def as_chunks(iterator: AsyncIterator[T], max_size: int) -> AsyncIterator[list[T]]:
+    ...
+
+
+def as_chunks(iterator: _Iter[T], max_size: int) -> _Iter[list[T]]:
+    """A helper function that collects an iterator into chunks of a given size.
+
+    .. versionadded:: 2.0
+
+    .. warning::
+
+        The last chunk collected may not be as large as ``max_size``.
+
+    Parameters
+    ----------
+    iterator: Union[:class:`collections.abc.Iterator`, :class:`collections.abc.AsyncIterator`]
+        The iterator to chunk, can be sync or async.
+    max_size: :class:`int`
+        The maximum chunk size.
+
+    Returns
+    -------
+    Union[:class:`collections.abc.Iterator`, :class:`collections.abc.AsyncIterator`]
+        A new iterator which yields chunks of a given size.
+    """
+    if max_size <= 0:
+        raise ValueError("Chunk sizes must be greater than 0.")
+
+    if isinstance(iterator, AsyncIterator):
+        return _achunk(iterator, max_size)
+    return _chunk(iterator, max_size)
+
+
+PY_310 = sys.version_info >= (3, 10)
+
+
+def flatten_literal_params(parameters: Iterable[Any]) -> tuple[Any, ...]:
+    params = []
+    literal_cls = type(Literal[0])
+    for p in parameters:
+        if isinstance(p, literal_cls):
+            params.extend(p.__args__)
+        else:
+            params.append(p)
+    return tuple(params)
+
+
+def normalise_optional_params(parameters: Iterable[Any]) -> tuple[Any, ...]:
+    none_cls = type(None)
+    return tuple(p for p in parameters if p is not none_cls) + (none_cls,)
+
+
+def evaluate_annotation(
+    tp: Any,
+    globals: dict[str, Any],
+    locals: dict[str, Any],
+    cache: dict[str, Any],
+    *,
+    implicit_str: bool = True,
+):
+    if isinstance(tp, ForwardRef):
+        tp = tp.__forward_arg__
+        # ForwardRefs always evaluate their internals
+        implicit_str = True
+
+    if implicit_str and isinstance(tp, str):
+        if tp in cache:
+            return cache[tp]
+        evaluated = eval(tp, globals, locals)
+        cache[tp] = evaluated
+        return evaluate_annotation(evaluated, globals, locals, cache)
+
+    if hasattr(tp, "__args__"):
+        implicit_str = True
+        is_literal = False
+        args = tp.__args__
+        if not hasattr(tp, "__origin__"):
+            if PY_310 and tp.__class__ is types.UnionType:  # type: ignore
+                converted = Union[args]  # type: ignore
+                return evaluate_annotation(converted, globals, locals, cache)
+
+            return tp
+        if tp.__origin__ is Union:
+            try:
+                if args.index(type(None)) != len(args) - 1:
+                    args = normalise_optional_params(tp.__args__)
+            except ValueError:
+                pass
+        if tp.__origin__ is Literal:
+            if not PY_310:
+                args = flatten_literal_params(tp.__args__)
+            implicit_str = False
+            is_literal = True
+
+        evaluated_args = tuple(
+            evaluate_annotation(arg, globals, locals, cache, implicit_str=implicit_str)
+            for arg in args
+        )
+
+        if is_literal and not all(
+            isinstance(x, (str, int, bool, type(None))) for x in evaluated_args
+        ):
+            raise TypeError(
+                "Literal arguments must be of type str, int, bool, or NoneType."
+            )
+
+        if evaluated_args == args:
+            return tp
+
+        try:
+            return tp.copy_with(evaluated_args)
+        except AttributeError:
+            return tp.__origin__[evaluated_args]
+
+    return tp
+
+
+def resolve_annotation(
+    annotation: Any,
+    globalns: dict[str, Any],
+    localns: dict[str, Any] | None,
+    cache: dict[str, Any] | None,
+) -> Any:
+    if annotation is None:
+        return type(None)
+    if isinstance(annotation, str):
+        annotation = ForwardRef(annotation)
+
+    locals = globalns if localns is None else localns
+    if cache is None:
+        cache = {}
+    return evaluate_annotation(annotation, globalns, locals, cache)
+
+
+TimestampStyle = Literal["f", "F", "d", "D", "t", "T", "R"]
+
+
+def format_dt(dt: datetime.datetime, /, style: TimestampStyle | None = None) -> str:
+    """A helper function to format a :class:`datetime.datetime` for presentation within Discord.
+
+    This allows for a locale-independent way of presenting data using Discord specific Markdown.
+
+    +-------------+----------------------------+-----------------+
+    |    Style    |       Example Output       |   Description   |
+    +=============+============================+=================+
+    | t           | 22:57                      | Short Time      |
+    +-------------+----------------------------+-----------------+
+    | T           | 22:57:58                   | Long Time       |
+    +-------------+----------------------------+-----------------+
+    | d           | 17/05/2016                 | Short Date      |
+    +-------------+----------------------------+-----------------+
+    | D           | 17 May 2016                | Long Date       |
+    +-------------+----------------------------+-----------------+
+    | f (default) | 17 May 2016 22:57          | Short Date Time |
+    +-------------+----------------------------+-----------------+
+    | F           | Tuesday, 17 May 2016 22:57 | Long Date Time  |
+    +-------------+----------------------------+-----------------+
+    | R           | 5 years ago                | Relative Time   |
+    +-------------+----------------------------+-----------------+
+
+    Note that the exact output depends on the user's locale setting in the client. The example output
+    presented is using the ``en-GB`` locale.
+
+    .. versionadded:: 2.0
+
+    Parameters
+    ----------
+    dt: :class:`datetime.datetime`
+        The datetime to format.
+    style: :class:`str`
+        The style to format the datetime with.
+
+    Returns
+    -------
+    :class:`str`
+        The formatted string.
+    """
+    if style is None:
+        return f"<t:{int(dt.timestamp())}>"
+    return f"<t:{int(dt.timestamp())}:{style}>"
+
+
+def generate_snowflake(dt: datetime.datetime | None = None) -> int:
+    """Returns a numeric snowflake pretending to be created at the given date but more accurate and random
+    than :func:`time_snowflake`. If dt is not passed, it makes one from the current time using utcnow.
+
+    Parameters
+    ----------
+    dt: :class:`datetime.datetime`
+        A datetime object to convert to a snowflake.
+        If naive, the timezone is assumed to be local time.
+
+    Returns
+    -------
+    :class:`int`
+        The snowflake representing the time given.
+    """
+
+    dt = dt or utcnow()
+    return int(dt.timestamp() * 1000 - DISCORD_EPOCH) << 22 | 0x3FFFFF
+
+
+V = Union[Iterable[str], Iterable[int], Iterable[float]]
+AV = Awaitable[V]
+Values = Union[V, Callable[[AutocompleteContext], Union[V, AV]], AV]
+AutocompleteFunc = Callable[[AutocompleteContext], AV]
+
+
+def basic_autocomplete(values: Values) -> AutocompleteFunc:
+    """A helper function to make a basic autocomplete for slash commands. This is a pretty standard autocomplete and
+    will return any options that start with the value from the user, case-insensitive. If the ``values`` parameter is
+    callable, it will be called with the AutocompleteContext.
+
+    This is meant to be passed into the :attr:`discord.Option.autocomplete` attribute.
+
+    Parameters
+    ----------
+    values: Union[Union[Iterable[:class:`.OptionChoice`], Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]], Callable[[:class:`.AutocompleteContext`], Union[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]], Awaitable[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]], Awaitable[Union[Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]
+        Possible values for the option. Accepts an iterable of :class:`str`, a callable (sync or async) that takes a
+        single argument of :class:`.AutocompleteContext`, or a coroutine. Must resolve to an iterable of :class:`str`.
+
+    Returns
+    -------
+    Callable[[:class:`.AutocompleteContext`], Awaitable[Union[Iterable[:class:`.OptionChoice`], Iterable[:class:`str`], Iterable[:class:`int`], Iterable[:class:`float`]]]]
+        A wrapped callback for the autocomplete.
+
+    Note
+    ----
+    Autocomplete cannot be used for options that have specified choices.
+
+    Example
+    -------
+
+    .. code-block:: python3
+
+        Option(str, "color", autocomplete=basic_autocomplete(("red", "green", "blue")))
+
+        # or
+
+        async def autocomplete(ctx):
+            return "foo", "bar", "baz", ctx.interaction.user.name
+
+        Option(str, "name", autocomplete=basic_autocomplete(autocomplete))
+
+    .. versionadded:: 2.0
+    """
+
+    async def autocomplete_callback(ctx: AutocompleteContext) -> V:
+        _values = values  # since we reassign later, python considers it local if we don't do this
+
+        if callable(_values):
+            _values = _values(ctx)
+        if asyncio.iscoroutine(_values):
+            _values = await _values
+
+        def check(item: Any) -> bool:
+            item = getattr(item, "name", item)
+            return str(item).lower().startswith(str(ctx.value or "").lower())
+
+        gen = (val for val in _values if check(val))
+        return iter(itertools.islice(gen, 25))
+
+    return autocomplete_callback
+
+
+def filter_params(params, **kwargs):
+    """A helper function to filter out and replace certain keyword parameters
+
+    Parameters
+    ----------
+    params: Dict[str, Any]
+        The initial parameters to filter.
+    **kwargs: Dict[str, Optional[str]]
+        Key to value pairs where the key's contents would be moved to the
+        value, or if the value is None, remove key's contents (see code example).
+
+    Example
+    -------
+    .. code-block:: python3
+
+        >>> params = {"param1": 12, "param2": 13}
+        >>> filter_params(params, param1="param3", param2=None)
+        {'param3': 12}
+        # values of 'param1' is moved to 'param3'
+        # and values of 'param2' are completely removed.
+    """
+    for old_param, new_param in kwargs.items():
+        if old_param in params:
+            if new_param is None:
+                params.pop(old_param)
+            else:
+                params[new_param] = params.pop(old_param)
+
+
+    return params
+def is_inside_class(func: Callable[..., Any]) -> bool:
+    # For methods defined in a class, the qualname has a dotted path
+    # denoting which class it belongs to. So, e.g. for A.foo the qualname
+    # would be A.foo while a global foo() would just be foo.
+    #
+    # Unfortunately, for nested functions this breaks. So inside an outer
+    # function named outer, those two would end up having a qualname with
+    # outer.<locals>.A.foo and outer.<locals>.foo
+
+    if func.__qualname__ == func.__name__:
+        return False
+    (remaining, _, _) = func.__qualname__.rpartition('.')
+    return not remaining.endswith('<locals>')
+def _shorten(
+    input: str,
+    *,
+    _wrapper: TextWrapper = TextWrapper(width=100, max_lines=1, replace_whitespace=True, placeholder='…'),
+) -> str:
+    try:
+        # split on the first double newline since arguments may appear after that
+        input, _ = re.split(r'\n\s*\n', input, maxsplit=1)
+    except ValueError:
+        pass
+    return _wrapper.fill(' '.join(input.strip().split()))
+def _to_kebab_case(text: str) -> str:
+    return CAMEL_CASE_REGEX.sub('-', text).lower()
+def _is_submodule(parent: str, child: str) -> bool:
+    return parent == child or child.startswith(parent + '.')


### PR DESCRIPTION
in discord.py==2.3.2 missing a lot class of used for app_commands due cannot import  'appcommandoptiontype' from 'discord.enums' and others

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
