### PR TITLE
Add set voice channel status endpoint

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -500,6 +500,13 @@ class GuildChannel:
                 raise TypeError('type field must be of type ChannelType')
             options['type'] = ch_type.value
 
+        try:
+            status = options.pop('status')
+        except KeyError:
+            pass
+        else:
+            await self._state.http.edit_voice_channel_status(status, channel_id=self.id, reason=reason)
+
         if options:
             return await self._state.http.edit_channel(self.id, reason=reason, **options)
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1370,6 +1370,7 @@ class VoiceChannel(VocalGuildChannel):
         rtc_region: Optional[str] = ...,
         video_quality_mode: VideoQualityMode = ...,
         slowmode_delay: int = ...,
+        status: Optional[str] = ...,
         reason: Optional[str] = ...,
     ) -> VoiceChannel:
         ...
@@ -1429,6 +1430,11 @@ class VoiceChannel(VocalGuildChannel):
             The camera video quality for the voice channel's participants.
 
             .. versionadded:: 2.0
+        status: Optional[:class:`str`]
+            The new voice channel status. It can be up to 500 characters.
+            Can be ``None`` to remove the status.
+
+            .. versionadded:: 2.4
 
         Raises
         ------

--- a/discord/http.py
+++ b/discord/http.py
@@ -1155,6 +1155,13 @@ class HTTPClient:
         payload = {k: v for k, v in options.items() if k in valid_keys}
         return self.request(r, reason=reason, json=payload)
 
+    def edit_voice_channel_status(
+        self, status: Optional[str], *, channel_id: int, reason: Optional[str] = None
+    ) -> Response[None]:
+        r = Route('PUT', '/channels/{channel_id}/voice-status', channel_id=channel_id)
+        payload = {'status': status}
+        return self.request(r, reason=reason, json=payload)
+
     def bulk_channel_update(
         self,
         guild_id: Snowflake,


### PR DESCRIPTION
## Summary

This PR adds a new parameter `status` to `VoiceChannel.edit` to set the voice channel status via the endpoint `/channels/{channel_id}/voice-status`

**Note:** The implementation of the events and permission is seperated into a second PR (https://github.com/Rapptz/discord.py/pull/9604) because it can already be merged, which this PR cannot due to the experiment lock.

Related PR: https://github.com/discord/discord-api-docs/pull/6400

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
