### PR TITLE
Add voice channel status events and permission

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -43,7 +43,7 @@ from .stage_instance import StageInstance
 from .sticker import GuildSticker
 from .threads import Thread
 from .integrations import PartialIntegration
-from .channel import ForumChannel, StageChannel, ForumTag
+from .channel import ForumChannel, StageChannel, ForumTag, VoiceChannel
 
 __all__ = (
     'AuditLogDiff',
@@ -267,6 +267,13 @@ def _transform_automod_actions(entry: AuditLogEntry, data: List[AutoModerationAc
     return [AutoModRuleAction.from_data(action) for action in data]
 
 
+def _transform_status(entry: AuditLogEntry, data: Union[int, str]) -> Union[enums.EventStatus, str]:
+    if entry.action.name.startswith('scheduled_event_'):
+        return enums.try_enum(enums.EventStatus, data)
+    else:
+        return data  # type: ignore  # voice channel status is str
+
+
 E = TypeVar('E', bound=enums.Enum)
 
 
@@ -360,7 +367,7 @@ class AuditLogChanges:
         'communication_disabled_until':          ('timed_out_until', _transform_timestamp),
         'expire_behavior':                       (None, _enum_transformer(enums.ExpireBehaviour)),
         'mfa_level':                             (None, _enum_transformer(enums.MFALevel)),
-        'status':                                (None, _enum_transformer(enums.EventStatus)),
+        'status':                                (None, _transform_status),
         'entity_type':                           (None, _enum_transformer(enums.EntityType)),
         'preferred_locale':                      (None, _enum_transformer(enums.Locale)),
         'image_hash':                            ('cover_image', _transform_cover_image),
@@ -532,6 +539,11 @@ class _AuditLogProxyMemberKickOrMemberRoleUpdate(_AuditLogProxy):
     integration_type: Optional[str]
 
 
+class _AuditLogProxyVoiceChannelStatusAction(_AuditLogProxy):
+    status: Optional[str]
+    channel: abc.GuildChannel
+
+
 class AuditLogEntry(Hashable):
     r"""Represents an Audit Log entry.
 
@@ -619,6 +631,7 @@ class AuditLogEntry(Hashable):
             _AuditLogProxyMessageBulkDelete,
             _AuditLogProxyAutoModAction,
             _AuditLogProxyMemberKickOrMemberRoleUpdate,
+            _AuditLogProxyVoiceChannelStatusAction,
             Member, User, None, PartialIntegration,
             Role, Object
         ] = None
@@ -694,6 +707,13 @@ class AuditLogEntry(Hashable):
             elif self.action.name.startswith('app_command'):
                 app_id = int(extra['application_id'])
                 self.extra = self._get_integration_by_app_id(app_id) or Object(app_id, type=PartialIntegration)
+
+            elif self.action.name.startswith('voice_channel_status'):
+                channel_id = int(extra['channel_id'])
+                status = extra.get('status')
+                self.extra = _AuditLogProxyVoiceChannelStatusAction(
+                    status=status, channel=self.guild.get_channel(channel_id) or Object(id=channel_id, type=VoiceChannel)
+                )
 
         # this key is not present when the above is present, typically.
         # It's a list of { new_value: a, old_value: b, key: c }
@@ -872,3 +892,6 @@ class AuditLogEntry(Hashable):
         from .webhook import Webhook
 
         return self._webhooks.get(target_id) or Object(target_id, type=Webhook)
+
+    def _convert_target_voice_channel_status(self, target_id: int) -> Union[abc.GuildChannel, Object]:
+        return self.guild.get_channel(target_id) or Object(id=target_id)

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -373,6 +373,8 @@ class AuditLogAction(Enum):
     automod_timeout_member                            = 145
     creator_monetization_request_created              = 150
     creator_monetization_terms_accepted               = 151
+    voice_channel_status_update                       = 192
+    voice_channel_status_delete                       = 193
     # fmt: on
 
     @property
@@ -435,6 +437,8 @@ class AuditLogAction(Enum):
             AuditLogAction.automod_timeout_member:                   None,
             AuditLogAction.creator_monetization_request_created:     None,
             AuditLogAction.creator_monetization_terms_accepted:      None,
+            AuditLogAction.voice_channel_status_update:              AuditLogActionCategory.update,
+            AuditLogAction.voice_channel_status_delete:              AuditLogActionCategory.delete,
         }
         # fmt: on
         return lookup[self]
@@ -480,6 +484,8 @@ class AuditLogAction(Enum):
             return 'user'
         elif v < 152:
             return 'creator_monetization'
+        elif v < 194:
+            return 'voice_channel_status'
 
 
 class UserFlags(Enum):

--- a/discord/types/audit_log.py
+++ b/discord/types/audit_log.py
@@ -95,6 +95,8 @@ AuditLogEvent = Literal[
     145,
     150,
     151,
+    192,
+    193,
 ]
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2839,6 +2839,40 @@ of :class:`enum.Enum`.
 
         .. versionadded:: 2.4
 
+    .. attribute:: voice_channel_status_update
+
+        The status of a voice channel was updated.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.target` is
+        a :class:`VoiceChannel`.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
+        set to an unspecified proxy object with 2 attributes:
+
+        - ``status``: The status of the voice channel.
+        - ``channel``: The channel of which the status was updated.
+
+        When this is the action, :attr:`AuditLogEntry.changes` is empty.
+
+        .. versionadded:: 2.4
+
+    .. attribute:: voice_channel_status_delete
+
+        The status of a voice channel was deleted.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.target` is
+        a :class:`VoiceChannel`.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
+        set to an unspecified proxy object with 2 attributes:
+
+        - ``status``: The status of the voice channel. For this action this is ``None``.
+        - ``channel``: The channel of which the status was updated.
+
+        When this is the action, :attr:`AuditLogEntry.changes` is empty.
+
+        .. versionadded:: 2.4
+
 .. class:: AuditLogActionCategory
 
     Represents the category that the :class:`AuditLogAction` belongs to.


### PR DESCRIPTION
## Summary
**Work in Progress**

This PR adds the events and permission for the voice channel status.

**Note:** The implementation of the endpoint to set the voice channel status is seperated into a second PR (https://github.com/Rapptz/discord.py/pull/9603) because it cannot be merged due to the experiment lock, which this PR already can.

Related PR: https://github.com/discord/discord-api-docs/pull/6398/

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
