### PR TITLE
Fix member_profile triggers not having attributes filled

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -33,7 +33,7 @@ from .invite import Invite
 from .mixins import Hashable
 from .object import Object
 from .permissions import PermissionOverwrite, Permissions
-from .automod import AutoModTrigger, AutoModRuleAction, AutoModPresets, AutoModRule
+from .automod import AutoModTrigger, AutoModRuleAction, AutoModRule
 from .role import Role
 from .emoji import Emoji
 from .partial_emoji import PartialEmoji

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -244,23 +244,18 @@ def _transform_automod_trigger_metadata(
             pass
 
     # Try to infer trigger type from available keys in data
+    _type = None
     if 'presets' in data:
-        return AutoModTrigger(
-            type=enums.AutoModRuleTriggerType.keyword_preset,
-            presets=AutoModPresets._from_value(data['presets']),  # type: ignore
-            allow_list=data.get('allow_list'),
-        )
-    elif 'keyword_filter' in data:
-        return AutoModTrigger(
-            type=enums.AutoModRuleTriggerType.keyword,
-            keyword_filter=data['keyword_filter'],  # type: ignore
-            allow_list=data.get('allow_list'),
-            regex_patterns=data.get('regex_patterns'),
-        )
-    elif 'mention_total_limit' in data:
-        return AutoModTrigger(type=enums.AutoModRuleTriggerType.mention_spam, mention_limit=data['mention_total_limit'])  # type: ignore
+        _type = enums.AutoModRuleTriggerType.keyword_preset
+    elif 'keyword_filter' in data or 'regex_patterns' in data:
+        _type = enums.AutoModRuleTriggerType.keyword
+    elif 'mention_total_limit' in data or 'mention_raid_protection_enabled' in data:
+        _type = enums.AutoModRuleTriggerType.mention_spam
     else:
-        return AutoModTrigger(type=enums.AutoModRuleTriggerType.spam)
+        _type = enums.AutoModRuleTriggerType.spam
+
+    if _type:
+        return AutoModTrigger.from_data(type=_type.value, data=data)
 
 
 def _transform_automod_actions(entry: AuditLogEntry, data: List[AutoModerationAction]) -> List[AutoModRuleAction]:

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -260,7 +260,7 @@ class AutoModTrigger:
         regex_patterns: Optional[List[str]] = None,
         mention_raid_protection: Optional[bool] = None,
     ) -> None:
-        unique_args = (keyword_filter or regex_patterns, presets, mention_limit or mention_raid_protection is not None)
+        unique_args = (keyword_filter or regex_patterns, presets, mention_limit or mention_raid_protection)
         if type is None and sum(arg is not None for arg in unique_args) > 1:
             raise ValueError(
                 'Please pass only one of keyword_filter/regex_patterns, presets, or mention_limit/mention_raid_protection.'
@@ -358,6 +358,8 @@ class AutoModRule:
         The IDs of the roles that are exempt from the rule.
     exempt_channel_ids: Set[:class:`int`]
         The IDs of the channels that are exempt from the rule.
+    event_type: :class:`AutoModRuleEventType`
+        The type of event that will trigger the the rule.
     """
 
     __slots__ = (

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -260,8 +260,8 @@ class AutoModTrigger:
         regex_patterns: Optional[List[str]] = None,
         mention_raid_protection: Optional[bool] = None,
     ) -> None:
-        if type is None and sum(arg is not None for arg in (keyword_filter or regex_patterns, presets, mention_limit)) > 1:
-            raise ValueError('Please pass only one of keyword_filter, regex_patterns, presets, or mention_limit.')
+        if type is None and sum(arg is not None for arg in (keyword_filter or regex_patterns, presets, mention_limit or mention_raid_protection is not None)) > 1:
+            raise ValueError('Please pass only one of keyword_filter/regex_patterns, presets, or mention_limit/mention_raid_protection.')
 
         if type is not None:
             self.type = type
@@ -273,7 +273,7 @@ class AutoModTrigger:
             self.type = AutoModRuleTriggerType.mention_spam
         else:
             raise ValueError(
-                'Please pass the trigger type explicitly if not using keyword_filter, presets, or mention_limit.'
+                'Please pass the trigger type explicitly if not using keyword_filter, regex_patterns, presets, mention_limit, or mention_raid_protection.'
             )
 
         self.keyword_filter: List[str] = keyword_filter if keyword_filter is not None else []
@@ -296,7 +296,7 @@ class AutoModTrigger:
         type_ = try_enum(AutoModRuleTriggerType, type)
         if data is None:
             return cls(type=type_)
-        elif type_ is AutoModRuleTriggerType.keyword:
+        elif type_ in (AutoModRuleTriggerType.keyword, AutoModRuleTriggerType.member_profile):
             return cls(
                 type=type_,
                 keyword_filter=data.get('keyword_filter'),
@@ -317,7 +317,7 @@ class AutoModTrigger:
             return cls(type=type_)
 
     def to_metadata_dict(self) -> Optional[Dict[str, Any]]:
-        if self.type is AutoModRuleTriggerType.keyword:
+        if self.type in (AutoModRuleTriggerType.keyword, AutoModRuleTriggerType.member_profile):
             return {
                 'keyword_filter': self.keyword_filter,
                 'regex_patterns': self.regex_patterns,

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -213,8 +213,8 @@ class AutoModTrigger:
     type: :class:`AutoModRuleTriggerType`
         The type of trigger.
     keyword_filter: List[:class:`str`]
-        The list of strings that will trigger the keyword filter. Maximum of 1000.
-        Keywords can only be up to 60 characters in length.
+        The list of strings that will trigger the filter.
+        Maximum of 1000. Keywords can only be up to 60 characters in length.
 
         This could be combined with :attr:`regex_patterns`.
     regex_patterns: List[:class:`str`]
@@ -260,8 +260,11 @@ class AutoModTrigger:
         regex_patterns: Optional[List[str]] = None,
         mention_raid_protection: Optional[bool] = None,
     ) -> None:
-        if type is None and sum(arg is not None for arg in (keyword_filter or regex_patterns, presets, mention_limit or mention_raid_protection is not None)) > 1:
-            raise ValueError('Please pass only one of keyword_filter/regex_patterns, presets, or mention_limit/mention_raid_protection.')
+        unique_args = (keyword_filter or regex_patterns, presets, mention_limit or mention_raid_protection is not None)
+        if type is None and sum(arg is not None for arg in unique_args) > 1:
+            raise ValueError(
+                'Please pass only one of keyword_filter/regex_patterns, presets, or mention_limit/mention_raid_protection.'
+            )
 
         if type is not None:
             self.type = type


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Attributes would not be correctly set for member_profile triggers from fetched rules or when trying to edit/create automod rules.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
