### PR TITLE
Fix SKU return type and documentation

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -2441,7 +2441,7 @@ class HTTPClient:
             json=payload,
         )
 
-    def delete_entitlement(self, application_id: Snowflake, entitlement_id: Snowflake) -> Response[sku.Entitlement]:
+    def delete_entitlement(self, application_id: Snowflake, entitlement_id: Snowflake) -> Response[None]:
         return self.request(
             Route(
                 'DELETE',

--- a/discord/sku.py
+++ b/discord/sku.py
@@ -92,7 +92,7 @@ class SKU:
 
     @property
     def flags(self) -> SKUFlags:
-        """Returns the flags of the SKU."""
+        """:class:`SKUFlags`: Returns the flags of the SKU."""
         return SKUFlags._from_value(self._flags)
 
     @property
@@ -158,14 +158,14 @@ class Entitlement:
 
     @property
     def user(self) -> Optional[User]:
-        """The user that is granted access to the entitlement"""
+        """Optional[:class:`User`]: The user that is granted access to the entitlement."""
         if self.user_id is None:
             return None
         return self._state.get_user(self.user_id)
 
     @property
     def guild(self) -> Optional[Guild]:
-        """The guild that is granted access to the entitlement"""
+        """Optional[:class:`Guild`]: The guild that is granted access to the entitlement."""
         return self._state._get_guild(self.guild_id)
 
     @property

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4804,14 +4804,6 @@ SKU
 .. autoclass:: SKU()
     :members:
 
-SKUFlags
-~~~~~~~~~~~
-
-.. attributetable:: SKUFlags
-
-.. autoclass:: SKUFlags()
-    :members:
-
 Entitlement
 ~~~~~~~~~~~
 
@@ -5187,6 +5179,14 @@ RoleFlags
 .. attributetable:: RoleFlags
 
 .. autoclass:: RoleFlags
+    :members:
+
+SKUFlags
+~~~~~~~~~~~
+
+.. attributetable:: SKUFlags
+
+.. autoclass:: SKUFlags()
     :members:
 
 ForumTag


### PR DESCRIPTION
## Summary

This PR fixes following things:
* Wrong return type of `delete_entitlement` in `http.py` 
* Missing types and dots in docs of `SKU` and `Entitlement`
* Wrong position in documentation of `SKUFlags`


## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
