### PR TITLE
add specialcase for AutoMod triggers in audit log diff

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -521,8 +521,9 @@ class AuditLogChanges:
         self._create_trigger(first, entry)
         trigger = self._create_trigger(second, entry)
         try:
-            getattr(trigger, attr, []).extend(data)
-        except AttributeError:
+            # guard unexpecte non list attributes or non iterable data
+            getattr(trigger, attr).extend(data)
+        except (AttributeError, TypeError):
             pass
 
     def _create_trigger(self, diff: AuditLogDiff, entry: AuditLogEntry) -> AutoModTrigger:

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -494,7 +494,7 @@ class AuditLogChanges:
             # try to find trigger type in the full list of changes
             for _elem in full_data:
                 if _elem['key'] == 'trigger_type':
-                    trigger_value = _elem.get('old_value', _elem.get('new_value'))
+                    trigger_value = _elem.get('old_value', _elem.get('new_value'))  # type: ignore  # trigger type values should be int
                     break
 
             if trigger_value is None:
@@ -512,8 +512,8 @@ class AuditLogChanges:
                     # some unknown type
                     trigger_value = -1
 
-        self.before.trigger = AutoModTrigger.from_data(trigger_value, data.get('old_value'))
-        self.after.trigger = AutoModTrigger.from_data(trigger_value, data.get('new_value'))
+        self.before.trigger = AutoModTrigger.from_data(trigger_value, data.get('old_value')) # type: ignore  # data values should be trigger metadata
+        self.after.trigger = AutoModTrigger.from_data(trigger_value, data.get('new_value')) # type: ignore  # data values should be trigger metadata
 
     def _handle_trigger_attr_update(
         self, first: AuditLogDiff, second: AuditLogDiff, entry: AuditLogEntry, attr: str, data: List[str]

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -512,8 +512,8 @@ class AuditLogChanges:
                     # some unknown type
                     trigger_value = -1
 
-        self.before.trigger = AutoModTrigger.from_data(trigger_value, data.get('old_value')) # type: ignore  # data values should be trigger metadata
-        self.after.trigger = AutoModTrigger.from_data(trigger_value, data.get('new_value')) # type: ignore  # data values should be trigger metadata
+        self.before.trigger = AutoModTrigger.from_data(trigger_value, data.get('old_value'))  # type: ignore  # data values should be trigger metadata
+        self.after.trigger = AutoModTrigger.from_data(trigger_value, data.get('new_value'))  # type: ignore  # data values should be trigger metadata
 
     def _handle_trigger_attr_update(
         self, first: AuditLogDiff, second: AuditLogDiff, entry: AuditLogEntry, attr: str, data: List[str]

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
     from .types.audit_log import (
         AuditLogChange as AuditLogChangePayload,
         AuditLogEntry as AuditLogEntryPayload,
-        _AuditLogChange_TriggerMetadata as AuditLogChangeTriggerMetadataPayload
+        _AuditLogChange_TriggerMetadata as AuditLogChangeTriggerMetadataPayload,
     )
     from .types.channel import (
         PermissionOverwrite as PermissionOverwritePayload,

--- a/discord/types/audit_log.py
+++ b/discord/types/audit_log.py
@@ -37,6 +37,7 @@ from .role import Role
 from .channel import ChannelType, DefaultReaction, PrivacyLevel, VideoQualityMode, PermissionOverwrite, ForumTag
 from .threads import Thread
 from .command import ApplicationCommand, ApplicationCommandPermissions
+from.automod import AutoModerationTriggerMetadata
 
 AuditLogEvent = Literal[
     1,
@@ -278,6 +279,12 @@ class _AuditLogChange_DefaultReactionEmoji(TypedDict):
     old_value: Optional[DefaultReaction]
 
 
+class _AuditLogChange_TriggerMetadata(TypedDict):
+    key: Literal['trigger_metadata']
+    new_value: Optional[AutoModerationTriggerMetadata]
+    old_value: Optional[AutoModerationTriggerMetadata]
+
+
 AuditLogChange = Union[
     _AuditLogChange_Str,
     _AuditLogChange_AssetHash,
@@ -300,6 +307,7 @@ AuditLogChange = Union[
     _AuditLogChange_AppliedTags,
     _AuditLogChange_AvailableTags,
     _AuditLogChange_DefaultReactionEmoji,
+    _AuditLogChange_TriggerMetadata,
 ]
 
 

--- a/discord/types/audit_log.py
+++ b/discord/types/audit_log.py
@@ -37,7 +37,7 @@ from .role import Role
 from .channel import ChannelType, DefaultReaction, PrivacyLevel, VideoQualityMode, PermissionOverwrite, ForumTag
 from .threads import Thread
 from .command import ApplicationCommand, ApplicationCommandPermissions
-from.automod import AutoModerationTriggerMetadata
+from .automod import AutoModerationTriggerMetadata
 
 AuditLogEvent = Literal[
     1,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4132,6 +4132,12 @@ AuditLogDiff
 
         The trigger for the automod rule.
 
+        .. note ::
+
+            The :attr:`~AutoModTrigger.type` of the trigger may be incorrect.
+            Some attributes such as :attr:`~AutoModTrigger.keyword_filter`, :attr:`~AutoModTrigger.regex_patterns`,
+            and :attr:`~AutoModTrigger.allow_list` will only have the added or removed values.
+
         :type: :class:`AutoModTrigger`
 
     .. attribute:: actions


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Add special case for AutoModTrigger attributes in audit log diff.
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
