### PR TITLE
Future proof usage of async_timeout

### DIFF
--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -45,7 +45,10 @@ import asyncio
 import logging
 import threading
 
-import async_timeout
+try:
+    from asyncio import timeout as atimeout  # type: ignore
+except ImportError:
+    from async_timeout import timeout as atimeout  # type: ignore
 
 from typing import TYPE_CHECKING, Optional, Dict, List, Callable, Coroutine, Any, Tuple
 
@@ -378,7 +381,7 @@ class VoiceConnectionState:
     async def _connect(self, reconnect: bool, timeout: float, self_deaf: bool, self_mute: bool, resume: bool) -> None:
         _log.info('Connecting to voice...')
 
-        async with async_timeout.timeout(timeout):
+        async with atimeout(timeout):
             for i in range(5):
                 _log.info('Starting voice handshake... (connection attempt %d)', i + 1)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 aiohttp>=3.7.4,<4
+async-timeout>=4.0,<5.0; python_version<"3.11"


### PR DESCRIPTION
## Summary
Apparently aiohttp is dropping async_timeout as a dep, so we use the asyncio version if possible.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
