### PR TITLE
fix typo in documentation; "users" -> "roles"

### DIFF
--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -615,7 +615,7 @@ class RoleSelect(BaseSelect[V]):
     disabled: :class:`bool`
         Whether the select is disabled or not.
     default_values: Sequence[:class:`~discord.abc.Snowflake`]
-        A list of objects representing the users that should be selected by default.
+        A list of objects representing the roles that should be selected by default.
 
         .. versionadded:: 2.4
     row: Optional[:class:`int`]


### PR DESCRIPTION
## Summary

Fixes a typo in the documentation. `discord.ui.RoleSelect`'s `default_values` was incorrectly described as being a list of users when it should be a list of roles. 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
