### PR TITLE
Add warning to VoiceProtocol.on_voice_state_update

### DIFF
--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -104,7 +104,7 @@ class VoiceProtocol:
 
         An abstract method that is called when the client's voice state
         has changed. This corresponds to ``VOICE_STATE_UPDATE``.
-        
+
         .. warning::
 
             This method is not the same as the event. See: :func:`on_voice_state_update`

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -110,7 +110,6 @@ class VoiceProtocol:
         data: :class:`dict`
             The raw :ddocs:`voice state payload <resources/voice#voice-state-object>`.
 
-
         .. warning ::
         
             This method is not the same as the event. See: :func:`on_voice_state_update`

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -110,7 +110,8 @@ class VoiceProtocol:
         data: :class:`dict`
             The raw :ddocs:`voice state payload <resources/voice#voice-state-object>`.
 
-        .. warning ::
+        .. warning::
+
             This method is not the same as the event. See: :func:`on_voice_state_update`
         """
         raise NotImplementedError

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -104,15 +104,15 @@ class VoiceProtocol:
 
         An abstract method that is called when the client's voice state
         has changed. This corresponds to ``VOICE_STATE_UPDATE``.
+        
+        .. warning::
+
+            This method is not the same as the event. See: :func:`on_voice_state_update`
 
         Parameters
         ------------
         data: :class:`dict`
             The raw :ddocs:`voice state payload <resources/voice#voice-state-object>`.
-
-        .. warning::
-
-            This method is not the same as the event. See: :func:`on_voice_state_update`
         """
         raise NotImplementedError
 

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -111,7 +111,6 @@ class VoiceProtocol:
             The raw :ddocs:`voice state payload <resources/voice#voice-state-object>`.
 
         .. warning ::
-        
             This method is not the same as the event. See: :func:`on_voice_state_update`
         """
         raise NotImplementedError

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -109,6 +109,11 @@ class VoiceProtocol:
         ------------
         data: :class:`dict`
             The raw :ddocs:`voice state payload <resources/voice#voice-state-object>`.
+
+
+        .. warning ::
+        
+            This method is not the same as the event. See: :func:`on_voice_state_update`
         """
         raise NotImplementedError
 


### PR DESCRIPTION
## Summary

Adds a warning to the `VoiceProtocol.on_voice_state_update` documentation to avoid confusion around the event of the same name.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
