### PR TITLE
Fix silent errors in tasks

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -45,9 +45,10 @@ import inspect
 
 from collections.abc import Sequence
 from discord.backoff import ExponentialBackoff
-from discord.utils import MISSING
+from discord.utils import MISSING, setup_logging
 
 _log = logging.getLogger(__name__)
+setup_logging()
 
 # fmt: off
 __all__ = (


### PR DESCRIPTION
## Summary
By default, the logger in discord.ext.tasks is not configured. This commit ensures that errors are not passed silently.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
