### PR TITLE
[Typing] Change value being set to match `Future[None]` annotation for `tasks.SleepHandle.future`

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -111,12 +111,12 @@ class SleepHandle:
         self.loop: asyncio.AbstractEventLoop = loop
         self.future: asyncio.Future[None] = loop.create_future()
         relative_delta = discord.utils.compute_timedelta(dt)
-        self.handle = loop.call_later(relative_delta, self.future.set_result, True)
+        self.handle = loop.call_later(relative_delta, self.future.set_result, None)
 
     def recalculate(self, dt: datetime.datetime) -> None:
         self.handle.cancel()
         relative_delta = discord.utils.compute_timedelta(dt)
-        self.handle: asyncio.TimerHandle = self.loop.call_later(relative_delta, self.future.set_result, True)
+        self.handle: asyncio.TimerHandle = self.loop.call_later(relative_delta, self.future.set_result, None)
 
     def wait(self) -> asyncio.Future[Any]:
         return self.future


### PR DESCRIPTION
Switch `True` to `None` within in `self.loop.call_later(..., self.future.set_result, True)`.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Randomly noticed that in this [typeshed issue](https://github.com/python/typeshed/pull/11015#issuecomment-1810496592) that's integrating `TypeVarTuple` in some spots in asyncio, discord.py popped up in mypy_primer due to having the `SleepHandle.future` expect to be set to `None`, but later setting it to `True` instead. This corrects the value being set to match the `Future[None]` annotation.

(This hasn't really been an issue before now, so . . . almost feels like a nothing change. Figured it wouldn't hurt though.)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
