### PR TITLE
Add `platform` property to `Activity` and `Game`

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -358,14 +358,18 @@ class Game(BaseActivity):
         The game's name.
     platform: Optional[:class:`str`]
         Where the user is playing from (ie. PS5, Xbox).
+
+    assets: Optional[:class:`ActivityAssets`]
+        A dictionary representing the images and their hover text of a game.
     """
 
-    __slots__ = ('name', '_end', '_start', 'platform')
+    __slots__ = ('name', '_end', '_start', 'platform', 'assets')
 
     def __init__(self, name: str, **extra: Any) -> None:
         super().__init__(**extra)
         self.name: str = name
         self.platform: Optional[str] = extra.get('platform')
+        self.assets: Optional[ActivityAssets] = extra.get('assets')
 
         try:
             timestamps: ActivityTimestamps = extra['timestamps']
@@ -417,6 +421,7 @@ class Game(BaseActivity):
             'name': str(self.name),
             'timestamps': timestamps,
             'platform': str(self.platform) if self.platform else None,
+            'assets': self.assets,
         }
 
     def __eq__(self, other: object) -> bool:

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -164,6 +164,8 @@ class Activity(BaseActivity):
         The detail of the user's current activity.
     platform: Optional[:class:`str`]
         The user's current platform.
+
+        .. versionadded:: 2.4
     timestamps: :class:`dict`
         A dictionary of timestamps. It contains the following optional keys:
 
@@ -359,8 +361,12 @@ class Game(BaseActivity):
     platform: Optional[:class:`str`]
         Where the user is playing from (ie. PS5, Xbox).
 
+        .. versionadded:: 2.4
+
     assets: Optional[:class:`ActivityAssets`]
         A dictionary representing the images and their hover text of a game.
+
+        .. versionadded:: 2.4
     """
 
     __slots__ = ('name', '_end', '_start', 'platform', 'assets')

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -363,7 +363,7 @@ class Game(BaseActivity):
 
         .. versionadded:: 2.4
 
-    assets: Optional[:class:`ActivityAssets`]
+    assets: :class:`dict`
         A dictionary representing the images and their hover text of a game.
 
         .. versionadded:: 2.4
@@ -375,7 +375,7 @@ class Game(BaseActivity):
         super().__init__(**extra)
         self.name: str = name
         self.platform: Optional[str] = extra.get('platform')
-        self.assets: Optional[ActivityAssets] = extra.get('assets')
+        self.assets: ActivityAssets = extra.get('assets', {}) or {}
 
         try:
             timestamps: ActivityTimestamps = extra['timestamps']

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -365,6 +365,12 @@ class Game(BaseActivity):
 
     assets: :class:`dict`
         A dictionary representing the images and their hover text of a game.
+        It contains the following optional keys:
+
+        - ``large_image``: A string representing the ID for the large image asset.
+        - ``large_text``: A string representing the text when hovering over the large image asset.
+        - ``small_image``: A string representing the ID for the small image asset.
+        - ``small_text``: A string representing the text when hovering over the small image asset.
 
         .. versionadded:: 2.4
     """

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -425,15 +425,13 @@ class Game(BaseActivity):
         }
 
     def __eq__(self, other: object) -> bool:
-        return (isinstance(other, Game)
-                and other.name == self.name
-                and other.platform == self.platform)
+        return isinstance(other, Game) and other.name == self.name
 
     def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
 
     def __hash__(self) -> int:
-        return hash((self.name, self.platform))
+        return hash(self.name)
 
 
 class Streaming(BaseActivity):

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -162,6 +162,8 @@ class Activity(BaseActivity):
         The user's current state. For example, "In Game".
     details: Optional[:class:`str`]
         The detail of the user's current activity.
+    platform: Optional[:class:`str`]
+        The user's current platform.
     timestamps: :class:`dict`
         A dictionary of timestamps. It contains the following optional keys:
 
@@ -197,6 +199,7 @@ class Activity(BaseActivity):
         'state',
         'details',
         'timestamps',
+        'platform',
         'assets',
         'party',
         'flags',
@@ -215,6 +218,7 @@ class Activity(BaseActivity):
         self.state: Optional[str] = kwargs.pop('state', None)
         self.details: Optional[str] = kwargs.pop('details', None)
         self.timestamps: ActivityTimestamps = kwargs.pop('timestamps', {})
+        self.platform: Optional[str] = kwargs.pop('platform', None)
         self.assets: ActivityAssets = kwargs.pop('assets', {})
         self.party: ActivityParty = kwargs.pop('party', {})
         self.application_id: Optional[int] = _get_as_snowflake(kwargs, 'application_id')
@@ -238,6 +242,7 @@ class Activity(BaseActivity):
             ('type', self.type),
             ('name', self.name),
             ('url', self.url),
+            ('platform', self.platform),
             ('details', self.details),
             ('application_id', self.application_id),
             ('session_id', self.session_id),

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -351,13 +351,16 @@ class Game(BaseActivity):
     -----------
     name: :class:`str`
         The game's name.
+    platform: Optional[:class:`str`]
+        Where the user is playing from (ie. PS5, Xbox).
     """
 
-    __slots__ = ('name', '_end', '_start')
+    __slots__ = ('name', '_end', '_start', 'platform')
 
     def __init__(self, name: str, **extra: Any) -> None:
         super().__init__(**extra)
         self.name: str = name
+        self.platform: Optional[str] = extra.get('platform')
 
         try:
             timestamps: ActivityTimestamps = extra['timestamps']
@@ -408,6 +411,7 @@ class Game(BaseActivity):
             'type': ActivityType.playing.value,
             'name': str(self.name),
             'timestamps': timestamps,
+            'platform': str(self.platform) if self.platform else None,
         }
 
     def __eq__(self, other: object) -> bool:

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -415,13 +415,15 @@ class Game(BaseActivity):
         }
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, Game) and other.name == self.name
+        return (isinstance(other, Game)
+                and other.name == self.name
+                and other.platform == self.platform)
 
     def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
 
     def __hash__(self) -> int:
-        return hash(self.name)
+        return hash((self.name, self.platform))
 
 
 class Streaming(BaseActivity):

--- a/discord/types/activity.py
+++ b/discord/types/activity.py
@@ -93,6 +93,7 @@ class Activity(_BaseActivity, total=False):
     state: Optional[str]
     details: Optional[str]
     timestamps: ActivityTimestamps
+    platform: Optional[str]
     assets: ActivityAssets
     party: ActivityParty
     application_id: Snowflake


### PR DESCRIPTION
## Summary

This PR adds `platform` property to `Game`.

When users play games from consoles. The Discord Activity API returns the below response. 

```json
{
  "type": 0,
  "timestamps": {
    "start": 1702191977428
  },
  "platform": "ps5",
  "name": "Sonic Superstars",
  "id": "20ac8563beebf2ec",
  "flags": 0,
  "created_at": 1702191977427,
  "assets": {
    "small_image": "mp:external/at5adOeXGcCj4jN9_zB0SiIL3FR8wOxq_d39CDh9Pqo/https/cdn.discordapp.com/assets/playstation-logo-rich-presence.png"
  }
}
```

However, `platform` fields are omitted when down-casted to `Game`. therefore we can't access the value from `Game` instances.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
