### PR TITLE
Fix voice disconnect+connect race condition

### DIFF
--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -602,6 +602,8 @@ class VoiceConnectionState:
             )
         except asyncio.TimeoutError:
             return False
+
+        previous_ws = self.ws
         try:
             self.ws = await self._connect_websocket(False)
             await self._handshake_websocket()
@@ -609,6 +611,8 @@ class VoiceConnectionState:
             return False
         else:
             return True
+        finally:
+            await previous_ws.close()
 
     async def _move_to(self, channel: abc.Snowflake) -> None:
         await self.voice_client.channel.guild.change_voice_state(channel=channel)


### PR DESCRIPTION
## Summary

When disconnecting from a voice channel, the voice client does not wait to receive the corresponding voice_state_update event indicating the bot has disconnected.  Trying to immediately connect again causes a race condition which could lead to broken state and an erroneous reconnect loop.

This pr also fixes an unrelated issue where old websockets were not being closed during reconnections (moving channels, etc).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
