### PR TITLE
make bot.owner_ids optional

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -183,7 +183,7 @@ class BotBase(GroupMixin[None]):
         self._help_command: Optional[HelpCommand] = None
         self.description: str = inspect.cleandoc(description) if description else ''
         self.owner_id: Optional[int] = options.get('owner_id')
-        self.owner_ids: Optional[Collection[int]] = options.get('owner_ids', set())
+        self.owner_ids: Optional[Collection[int]] = options.get('owner_ids')
         self.strip_after_prefix: bool = options.get('strip_after_prefix', False)
 
         if self.owner_id and self.owner_ids:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

bot.owner_ids is typed as Optional[Collection[int]] but it defaults to an empty set when there is no team and not None

this pr makes it default to None

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
