### PR TITLE
Update pyright version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run Pyright
         uses: jakebailey/pyright-action@v1
         with:
-          version: '1.1.316'
+          version: '1.1.342'
           warnings: false
           no-comments: ${{ matrix.python-version != '3.x' }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run Pyright
         uses: jakebailey/pyright-action@v1
         with:
-          version: '1.1.342'
+          version: '1.1.351'
           warnings: false
           no-comments: ${{ matrix.python-version != '3.x' }}
 

--- a/discord/app_commands/checks.py
+++ b/discord/app_commands/checks.py
@@ -186,7 +186,7 @@ class Cooldown:
         :class:`Cooldown`
             A new instance of this cooldown.
         """
-        return Cooldown(self.rate, self.per)
+        return self.__class__(self.rate, self.per)
 
     def __repr__(self) -> str:
         return f'<Cooldown rate: {self.rate} per: {self.per} window: {self._window} tokens: {self._tokens}>'

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -638,7 +638,7 @@ class BaseChannelTransformer(Transformer):
                 except KeyError:
                     raise TypeError('Union type of channels must be entirely made up of channels') from None
 
-        self._types: Tuple[Type[Any]] = channel_types
+        self._types: Tuple[Type[Any], ...] = channel_types
         self._channel_types: List[ChannelType] = types
         self._display_name = display_name
 
@@ -780,11 +780,11 @@ def get_supported_annotation(
     # Check if there's an origin
     origin = getattr(annotation, '__origin__', None)
     if origin is Literal:
-        args = annotation.__args__  # type: ignore
+        args = annotation.__args__
         return (LiteralTransformer(args), MISSING, True)
 
     if origin is Choice:
-        arg = annotation.__args__[0]  # type: ignore
+        arg = annotation.__args__[0]
         return (ChoiceTransformer(arg), MISSING, True)
 
     if origin is not Union:
@@ -792,7 +792,7 @@ def get_supported_annotation(
         raise TypeError(f'unsupported type annotation {annotation!r}')
 
     default = MISSING
-    args = annotation.__args__  # type: ignore
+    args = annotation.__args__
     if args[-1] is _none:
         if len(args) == 2:
             underlying = args[0]

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -420,7 +420,7 @@ class Asset(AssetMixin):
             url = url.with_query(url.raw_query_string)
 
         url = str(url)
-        return Asset(state=self._state, url=url, key=self._key, animated=self._animated)
+        return self.__class__(state=self._state, url=url, key=self._key, animated=self._animated)
 
     def with_size(self, size: int, /) -> Self:
         """Returns a new asset with the specified size.
@@ -448,7 +448,7 @@ class Asset(AssetMixin):
             raise ValueError('size must be a power of 2 between 16 and 4096')
 
         url = str(yarl.URL(self._url).with_query(size=size))
-        return Asset(state=self._state, url=url, key=self._key, animated=self._animated)
+        return self.__class__(state=self._state, url=url, key=self._key, animated=self._animated)
 
     def with_format(self, format: ValidAssetFormatTypes, /) -> Self:
         """Returns a new asset with the specified format.
@@ -483,7 +483,7 @@ class Asset(AssetMixin):
         url = yarl.URL(self._url)
         path, _ = os.path.splitext(url.path)
         url = str(url.with_path(f'{path}.{format}').with_query(url.raw_query_string))
-        return Asset(state=self._state, url=url, key=self._key, animated=self._animated)
+        return self.__class__(state=self._state, url=url, key=self._key, animated=self._animated)
 
     def with_static_format(self, format: ValidStaticFormatTypes, /) -> Self:
         """Returns a new asset with the specified static format.

--- a/discord/automod.py
+++ b/discord/automod.py
@@ -541,7 +541,7 @@ class AutoModRule:
             **payload,
         )
 
-        return AutoModRule(data=data, guild=self.guild, state=self._state)
+        return self.__class__(data=data, guild=self.guild, state=self._state)
 
     async def delete(self, *, reason: str = MISSING) -> None:
         """|coro|

--- a/discord/client.py
+++ b/discord/client.py
@@ -315,7 +315,7 @@ class Client:
     def _get_websocket(self, guild_id: Optional[int] = None, *, shard_id: Optional[int] = None) -> DiscordWebSocket:
         return self.ws
 
-    def _get_state(self, **options: Any) -> ConnectionState:
+    def _get_state(self, **options: Any) -> ConnectionState[Self]:
         return ConnectionState(dispatch=self.dispatch, handlers=self._handlers, hooks=self._hooks, http=self.http, **options)
 
     def _handle_ready(self) -> None:

--- a/discord/colour.py
+++ b/discord/colour.py
@@ -175,7 +175,7 @@ class Colour:
         return cls.from_rgb(*(int(x * 255) for x in rgb))
 
     @classmethod
-    def from_str(cls, value: str) -> Self:
+    def from_str(cls, value: str) -> Colour:
         """Constructs a :class:`Colour` from a string.
 
         The following formats are accepted:

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -75,9 +75,6 @@ __all__ = (
     'EntitlementOwnerType',
 )
 
-if TYPE_CHECKING:
-    from typing_extensions import Self
-
 
 def _create_value_cls(name: str, comparable: bool):
     # All the type ignores here are due to the type checker being unable to recognise
@@ -104,7 +101,14 @@ class EnumMeta(type):
         _enum_member_map_: ClassVar[Dict[str, Any]]
         _enum_value_map_: ClassVar[Dict[Any, Any]]
 
-    def __new__(cls, name: str, bases: Tuple[type, ...], attrs: Dict[str, Any], *, comparable: bool = False) -> Self:
+    def __new__(
+        cls,
+        name: str,
+        bases: Tuple[type, ...],
+        attrs: Dict[str, Any],
+        *,
+        comparable: bool = False,
+    ) -> EnumMeta:
         value_mapping = {}
         member_mapping = {}
         member_names = []

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -366,7 +366,7 @@ class Cog(metaclass=CogMeta):
                                 child.wrapped = lookup[child.qualified_name]  # type: ignore
 
                     if self.__cog_app_commands_group__:
-                        children.append(app_command)  # type: ignore # Somehow it thinks it can be None here
+                        children.append(app_command)
 
         if Cog._get_overridden_method(self.cog_app_command_error) is not None:
             error_handler = self.cog_app_command_error

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -169,7 +169,7 @@ class CogMeta(type):
     __cog_app_commands__: List[Union[app_commands.Group, app_commands.Command[Any, ..., Any]]]
     __cog_listeners__: List[Tuple[str, str]]
 
-    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
+    def __new__(cls, *args: Any, **kwargs: Any) -> CogMeta:
         name, bases, attrs = args
         if any(issubclass(base, app_commands.Group) for base in bases):
             raise TypeError(

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -1045,7 +1045,7 @@ class Greedy(List[T]):
             raise TypeError('Greedy[...] expects a type or a Converter instance.')
 
         if converter in (str, type(None)) or origin is Greedy:
-            raise TypeError(f'Greedy[{converter.__name__}] is invalid.')
+            raise TypeError(f'Greedy[{converter.__name__}] is invalid.')  # type: ignore
 
         if origin is Union and type(None) in args:
             raise TypeError(f'Greedy[{converter!r}] is invalid.')

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -1045,7 +1045,7 @@ class Greedy(List[T]):
             raise TypeError('Greedy[...] expects a type or a Converter instance.')
 
         if converter in (str, type(None)) or origin is Greedy:
-            raise TypeError(f'Greedy[{converter.__name__}] is invalid.')  # type: ignore
+            raise TypeError(f'Greedy[{converter.__name__}] is invalid.')
 
         if origin is Union and type(None) in args:
             raise TypeError(f'Greedy[{converter!r}] is invalid.')
@@ -1185,7 +1185,7 @@ def _convert_to_bool(argument: str) -> bool:
         raise BadBoolArgument(lowered)
 
 
-_GenericAlias = type(List[T])
+_GenericAlias = type(List[T])  # type: ignore
 
 
 def is_generic_type(tp: Any, *, _GenericAlias: type = _GenericAlias) -> bool:

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -461,7 +461,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
         # bandaid for the fact that sometimes parent can be the bot instance
         parent: Optional[GroupMixin[Any]] = kwargs.get('parent')
-        self.parent: Optional[GroupMixin[Any]] = parent if isinstance(parent, _BaseCommand) else None  # type: ignore # Does not recognise mixin usage
+        self.parent: Optional[GroupMixin[Any]] = parent if isinstance(parent, _BaseCommand) else None
 
         self._before_invoke: Optional[Hook] = None
         try:

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -776,7 +776,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         command = self
         # command.parent is type-hinted as GroupMixin some attributes are resolved via MRO
         while command.parent is not None:  # type: ignore
-            command = command.parent
+            command = command.parent  # type: ignore
             entries.append(command.name)  # type: ignore
 
         return ' '.join(reversed(entries))
@@ -794,7 +794,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         entries = []
         command = self
         while command.parent is not None:  # type: ignore
-            command = command.parent
+            command = command.parent  # type: ignore
             entries.append(command)
 
         return entries

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -280,7 +280,7 @@ class FlagsMeta(type):
         case_insensitive: bool = MISSING,
         delimiter: str = MISSING,
         prefix: str = MISSING,
-    ) -> Self:
+    ) -> FlagsMeta:
         attrs['__commands_is_flag__'] = True
 
         try:

--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -902,7 +902,7 @@ def hybrid_command(
     def decorator(func: CommandCallback[CogT, ContextT, P, T]) -> HybridCommand[CogT, P, T]:
         if isinstance(func, Command):
             raise TypeError('Callback is already a command.')
-        return HybridCommand(func, name=name, with_app_command=with_app_command, **attrs)  # type: ignore  # ???
+        return HybridCommand(func, name=name, with_app_command=with_app_command, **attrs)
 
     return decorator
 

--- a/discord/file.py
+++ b/discord/file.py
@@ -111,7 +111,7 @@ class File:
             else:
                 filename = getattr(fp, 'name', 'untitled')
 
-        self._filename, filename_spoiler = _strip_spoiler(filename)
+        self._filename, filename_spoiler = _strip_spoiler(filename)  # type: ignore  # pyright doesn't understand the above getattr
         if spoiler is MISSING:
             spoiler = filename_spoiler
 

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -69,7 +69,7 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias, Self, TypeGuard
+    from typing_extensions import TypeAlias, TypeGuard
 
     from .view import View
     from ..types.components import SelectMenu as SelectMenuPayload
@@ -342,7 +342,7 @@ class BaseSelect(Item[V]):
         return True
 
     @classmethod
-    def from_component(cls, component: SelectMenu) -> Self:
+    def from_component(cls, component: SelectMenu) -> BaseSelect[V]:
         type_to_cls: Dict[ComponentType, Type[BaseSelect[Any]]] = {
             ComponentType.string_select: Select,
             ComponentType.user_select: UserSelect,
@@ -871,7 +871,7 @@ class ChannelSelect(BaseSelect[V]):
 @overload
 def select(
     *,
-    cls: Type[SelectT] = Select[V],
+    cls: Type[SelectT] = Select[Any],
     options: List[SelectOption] = MISSING,
     channel_types: List[ChannelType] = ...,
     placeholder: Optional[str] = ...,
@@ -887,7 +887,7 @@ def select(
 @overload
 def select(
     *,
-    cls: Type[UserSelectT] = UserSelect[V],
+    cls: Type[UserSelectT] = UserSelect[Any],
     options: List[SelectOption] = MISSING,
     channel_types: List[ChannelType] = ...,
     placeholder: Optional[str] = ...,
@@ -904,7 +904,7 @@ def select(
 @overload
 def select(
     *,
-    cls: Type[RoleSelectT] = RoleSelect[V],
+    cls: Type[RoleSelectT] = RoleSelect[Any],
     options: List[SelectOption] = MISSING,
     channel_types: List[ChannelType] = ...,
     placeholder: Optional[str] = ...,
@@ -921,7 +921,7 @@ def select(
 @overload
 def select(
     *,
-    cls: Type[ChannelSelectT] = ChannelSelect[V],
+    cls: Type[ChannelSelectT] = ChannelSelect[Any],
     options: List[SelectOption] = MISSING,
     channel_types: List[ChannelType] = ...,
     placeholder: Optional[str] = ...,
@@ -938,7 +938,7 @@ def select(
 @overload
 def select(
     *,
-    cls: Type[MentionableSelectT] = MentionableSelect[V],
+    cls: Type[MentionableSelectT] = MentionableSelect[Any],
     options: List[SelectOption] = MISSING,
     channel_types: List[ChannelType] = MISSING,
     placeholder: Optional[str] = ...,
@@ -954,7 +954,7 @@ def select(
 
 def select(
     *,
-    cls: Type[BaseSelectT] = Select[V],
+    cls: Type[BaseSelectT] = Select[Any],
     options: List[SelectOption] = MISSING,
     channel_types: List[ChannelType] = MISSING,
     placeholder: Optional[str] = None,

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -721,7 +721,7 @@ async def sane_wait_for(futures: Iterable[Awaitable[T]], *, timeout: Optional[fl
 def get_slots(cls: Type[Any]) -> Iterator[str]:
     for mro in reversed(cls.__mro__):
         try:
-            yield from mro.__slots__  # type: ignore
+            yield from mro.__slots__
         except AttributeError:
             continue
 

--- a/discord/welcome_screen.py
+++ b/discord/welcome_screen.py
@@ -214,4 +214,4 @@ class WelcomeScreen:
             fields['enabled'] = enabled
 
         data = await self._state.http.edit_welcome_screen(self._guild.id, reason=reason, **fields)
-        return WelcomeScreen(data=data, guild=self._guild)
+        return self.__class__(data=data, guild=self._guild)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,12 @@ exclude = [
 ]
 reportUnnecessaryTypeIgnoreComment = "warning"
 reportUnusedImport = "error"
+reportOverlappingOverload = "none"
+reportIncompatibleVariableOverride = "none"
+reportIncompatibleMethodOverride = "none"
+reportFunctionMemberAccess = "none"
 pythonVersion = "3.8"
-typeCheckingMode = "basic"
+typeCheckingMode = "standard"
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,12 +43,8 @@ exclude = [
 ]
 reportUnnecessaryTypeIgnoreComment = "warning"
 reportUnusedImport = "error"
-reportOverlappingOverload = "none"
-reportIncompatibleVariableOverride = "none"
-reportIncompatibleMethodOverride = "none"
-reportFunctionMemberAccess = "none"
 pythonVersion = "3.8"
-typeCheckingMode = "standard"
+typeCheckingMode = "basic"
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"


### PR DESCRIPTION
## Summary

~This Pull Request migrates dpy to pyright's new "Standard" type checking mode.
In doing so, due to some internal mocking in dpy all additional type-checking features have been disabled.~

Update: Pyright's standard mode in my opinion isn't tennable in Dpy's case due to complex overloads, the use of additional attributes on functions for decorators and private inheritance changing method signatures, moving to standard has been rolled back.

This also updates pyright to v1.1.351

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
