### PR TITLE
Fix Member.get_role returning None for the @everyone role

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -1099,6 +1099,8 @@ class Member(discord.abc.Messageable, _UserTag):
         """Returns a role with the given ID from roles which the member has.
 
         .. versionadded:: 2.0
+        .. versionchanged:: 2.4
+            This can now return :attr:`Guild.default_role` if ``role_id`` is the same as the member's guild ID.
 
         Parameters
         -----------
@@ -1110,6 +1112,9 @@ class Member(discord.abc.Messageable, _UserTag):
         Optional[:class:`Role`]
             The role or ``None`` if not found in the member's roles.
         """
+        if role_id == self.guild.id:
+            return self.guild.default_role
+
         return self.guild.get_role(role_id) if self._roles.has(role_id) else None
 
     def is_timed_out(self) -> bool:


### PR DESCRIPTION
## Summary

This was noticed by "snawe" in their [help post](https://discord.com/channels/336642139381301249/1197947439064297575) in the discord.py server.

The problem here is that the library currently does not store the guild (`@everyone` role) ID in `Member._roles` thus doing `.has(guild_id)` (used in `Member.get_role`) return `None`. This is fixed by adding an if-statement in `Member.get_role` that checks whether the input equals to the member's guild ID and returns `Guild.default_role` instead.

I'm not sure whether the `versionchanged` is necessary here.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
