### PR TITLE
Document all limits in discord.ui

### DIFF
--- a/discord/components.py
+++ b/discord/components.py
@@ -318,8 +318,8 @@ class SelectOption:
         Can only be up to 100 characters.
     value: :class:`str`
         The value of the option. This is not displayed to users.
-        If not provided when constructed then it defaults to the
-        label. Can only be up to 100 characters.
+        If not provided when constructed then it defaults to the label.
+        Can only be up to 100 characters.
     description: Optional[:class:`str`]
         An additional description of the option, if any.
         Can only be up to 100 characters.
@@ -332,14 +332,12 @@ class SelectOption:
     -----------
     label: :class:`str`
         The label of the option. This is displayed to users.
-        Can only be up to 100 characters.
     value: :class:`str`
         The value of the option. This is not displayed to users.
         If not provided when constructed then it defaults to the
-        label. Can only be up to 100 characters.
+        label.
     description: Optional[:class:`str`]
         An additional description of the option, if any.
-        Can only be up to 100 characters.
     default: :class:`bool`
         Whether this option is selected by default.
     """

--- a/discord/ui/button.py
+++ b/discord/ui/button.py
@@ -61,12 +61,14 @@ class Button(Item[V]):
     custom_id: Optional[:class:`str`]
         The ID of the button that gets received during an interaction.
         If this button is for a URL, it does not have a custom ID.
+        Can only be up to 100 characters.
     url: Optional[:class:`str`]
         The URL this button sends you to.
     disabled: :class:`bool`
         Whether the button is disabled or not.
     label: Optional[:class:`str`]
         The label of the button, if any.
+        Can only be up to 80 characters.
     emoji: Optional[Union[:class:`.PartialEmoji`, :class:`.Emoji`, :class:`str`]]
         The emoji of the button, if available.
     row: Optional[:class:`int`]
@@ -258,9 +260,11 @@ def button(
     ------------
     label: Optional[:class:`str`]
         The label of the button, if any.
+        Can only be up to 80 characters.
     custom_id: Optional[:class:`str`]
         The ID of the button that gets received during an interaction.
         It is recommended not to set this parameter to prevent conflicts.
+        Can only be up to 100 characters.
     style: :class:`.ButtonStyle`
         The style of the button. Defaults to :attr:`.ButtonStyle.grey`.
     disabled: :class:`bool`

--- a/discord/ui/modal.py
+++ b/discord/ui/modal.py
@@ -77,7 +77,8 @@ class Modal(View):
     Parameters
     -----------
     title: :class:`str`
-        The title of the modal. Can only be up to 45 characters.
+        The title of the modal.
+        Can only be up to 45 characters.
     timeout: Optional[:class:`float`]
         Timeout in seconds from last interaction with the UI before no longer accepting input.
         If ``None`` then there is no timeout.

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -366,8 +366,10 @@ class Select(BaseSelect[V]):
     custom_id: :class:`str`
         The ID of the select menu that gets received during an interaction.
         If not given then one is generated for you.
+        Can only be up to 100 characters.
     placeholder: Optional[:class:`str`]
         The placeholder text that is shown if nothing is selected, if any.
+        Can only be up to 150 characters.
     min_values: :class:`int`
         The minimum number of items that must be chosen for this select menu.
         Defaults to 1 and must be between 0 and 25.
@@ -376,6 +378,7 @@ class Select(BaseSelect[V]):
         Defaults to 1 and must be between 1 and 25.
     options: List[:class:`discord.SelectOption`]
         A list of options that can be selected in this menu.
+        Can only contain up to 25 items.
     disabled: :class:`bool`
         Whether the select is disabled or not.
     row: Optional[:class:`int`]
@@ -455,7 +458,8 @@ class Select(BaseSelect[V]):
             Can only be up to 100 characters.
         value: :class:`str`
             The value of the option. This is not displayed to users.
-            If not given, defaults to the label. Can only be up to 100 characters.
+            If not given, defaults to the label.
+            Can only be up to 100 characters.
         description: Optional[:class:`str`]
             An additional description of the option, if any.
             Can only be up to 100 characters.
@@ -515,8 +519,10 @@ class UserSelect(BaseSelect[V]):
     custom_id: :class:`str`
         The ID of the select menu that gets received during an interaction.
         If not given then one is generated for you.
+        Can only be up to 100 characters.
     placeholder: Optional[:class:`str`]
         The placeholder text that is shown if nothing is selected, if any.
+        Can only be up to 150 characters.
     min_values: :class:`int`
         The minimum number of items that must be chosen for this select menu.
         Defaults to 1 and must be between 0 and 25.
@@ -527,6 +533,7 @@ class UserSelect(BaseSelect[V]):
         Whether the select is disabled or not.
     default_values: Sequence[:class:`~discord.abc.Snowflake`]
         A list of objects representing the users that should be selected by default.
+        Number of items must be in range of ``min_values`` and ``max_values``.
 
         .. versionadded:: 2.4
     row: Optional[:class:`int`]
@@ -604,8 +611,10 @@ class RoleSelect(BaseSelect[V]):
     custom_id: :class:`str`
         The ID of the select menu that gets received during an interaction.
         If not given then one is generated for you.
+        Can only be up to 100 characters.
     placeholder: Optional[:class:`str`]
         The placeholder text that is shown if nothing is selected, if any.
+        Can only be up to 150 characters.
     min_values: :class:`int`
         The minimum number of items that must be chosen for this select menu.
         Defaults to 1 and must be between 0 and 25.
@@ -616,6 +625,7 @@ class RoleSelect(BaseSelect[V]):
         Whether the select is disabled or not.
     default_values: Sequence[:class:`~discord.abc.Snowflake`]
         A list of objects representing the roles that should be selected by default.
+        Number of items must be in range of ``min_values`` and ``max_values``.
 
         .. versionadded:: 2.4
     row: Optional[:class:`int`]
@@ -688,8 +698,10 @@ class MentionableSelect(BaseSelect[V]):
     custom_id: :class:`str`
         The ID of the select menu that gets received during an interaction.
         If not given then one is generated for you.
+        Can only be up to 100 characters.
     placeholder: Optional[:class:`str`]
         The placeholder text that is shown if nothing is selected, if any.
+        Can only be up to 150 characters.
     min_values: :class:`int`
         The minimum number of items that must be chosen for this select menu.
         Defaults to 1 and must be between 0 and 25.
@@ -701,6 +713,7 @@ class MentionableSelect(BaseSelect[V]):
     default_values: Sequence[:class:`~discord.abc.Snowflake`]
         A list of objects representing the users/roles that should be selected by default.
         if :class:`.Object` is passed, then the type must be specified in the constructor.
+        Number of items must be in range of ``min_values`` and ``max_values``.
 
         .. versionadded:: 2.4
     row: Optional[:class:`int`]
@@ -778,10 +791,12 @@ class ChannelSelect(BaseSelect[V]):
     custom_id: :class:`str`
         The ID of the select menu that gets received during an interaction.
         If not given then one is generated for you.
+        Can only be up to 100 characters.
     channel_types: List[:class:`~discord.ChannelType`]
         The types of channels to show in the select menu. Defaults to all channels.
     placeholder: Optional[:class:`str`]
         The placeholder text that is shown if nothing is selected, if any.
+        Can only be up to 150 characters.
     min_values: :class:`int`
         The minimum number of items that must be chosen for this select menu.
         Defaults to 1 and must be between 0 and 25.
@@ -792,6 +807,7 @@ class ChannelSelect(BaseSelect[V]):
         Whether the select is disabled or not.
     default_values: Sequence[:class:`~discord.abc.Snowflake`]
         A list of objects representing the channels that should be selected by default.
+        Number of items must be in range of ``min_values`` and ``max_values``.
 
         .. versionadded:: 2.4
     row: Optional[:class:`int`]
@@ -1011,9 +1027,11 @@ def select(
         get overridden.
     placeholder: Optional[:class:`str`]
         The placeholder text that is shown if nothing is selected, if any.
+        Can only be up to 150 characters.
     custom_id: :class:`str`
         The ID of the select menu that gets received during an interaction.
         It is recommended not to set this parameter to prevent conflicts.
+        Can only be up to 100 characters.
     row: Optional[:class:`int`]
         The relative row this select menu belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -1029,6 +1047,7 @@ def select(
     options: List[:class:`discord.SelectOption`]
         A list of options that can be selected in this menu. This can only be used with
         :class:`Select` instances.
+        Can only contain up to 25 items.
     channel_types: List[:class:`~discord.ChannelType`]
         The types of channels to show in the select menu. Defaults to all channels. This can only be used
         with :class:`ChannelSelect` instances.
@@ -1037,6 +1056,7 @@ def select(
     default_values: Sequence[:class:`~discord.abc.Snowflake`]
         A list of objects representing the default values for the select menu. This cannot be used with regular :class:`Select` instances.
         If ``cls`` is :class:`MentionableSelect` and :class:`.Object` is passed, then the type must be specified in the constructor.
+        Number of items must be in range of ``min_values`` and ``max_values``.
 
         .. versionadded:: 2.4
     """

--- a/discord/ui/text_input.py
+++ b/discord/ui/text_input.py
@@ -65,21 +65,27 @@ class TextInput(Item[V]):
     ------------
     label: :class:`str`
         The label to display above the text input.
+        Can only be up to 45 characters.
     custom_id: :class:`str`
         The ID of the text input that gets received during an interaction.
         If not given then one is generated for you.
+        Can only be up to 100 characters.
     style: :class:`discord.TextStyle`
         The style of the text input.
     placeholder: Optional[:class:`str`]
         The placeholder text to display when the text input is empty.
+        Can only be up to 100 characters.
     default: Optional[:class:`str`]
         The default value of the text input.
+        Can only be up to 4000 characters.
     required: :class:`bool`
         Whether the text input is required.
     min_length: Optional[:class:`int`]
         The minimum length of the text input.
+        Must be between 0 and 4000.
     max_length: Optional[:class:`int`]
         The maximum length of the text input.
+        Must be between 1 and 4000.
     row: Optional[:class:`int`]
         The relative row this text input belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd


### PR DESCRIPTION
## Summary

Title. [As requested by Danny in the docs channel](https://discord.com/channels/336642139381301249/714516540720152728/1199339935535206450).

All limits are from the [API Docs](https://discord.com/developers/docs/interactions/message-components).

For consistency, I have placed them all on a newline (in code) and removed any from the `Attributes` headers since I don't think it's necessary there.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
