### PR TITLE
Add ConversionCancelled command error

### DIFF
--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -146,6 +146,25 @@ class ConversionError(CommandError):
         self.original: Exception = original
 
 
+class ConversionCancelled(CommandError):
+    """Exception raised when a Converter class intentionally cancels the conversion.
+
+    This indicates that the conversion was *cancelled* under expected conditions,
+    rather than *failed* due to an invalid input or an error in the conversion logic.
+    This is useful for handling user interventions and timeouts in custom converters.
+
+    This inherits from :exc:`CommandError`.
+
+    Attributes
+    -----------
+    converter: :class:`discord.ext.commands.Converter`
+        The converter that was cancelled.
+    """
+
+    def __init__(self, converter: Converter[Any]) -> None:
+        self.converter: Converter[Any] = converter
+
+
 class UserInputError(CommandError):
     """The base exception type for errors that involve errors
     regarding user input.


### PR DESCRIPTION
## Summary

This introduces a new `CommandError` subclass, `ConversionCancelled`.

Fixes #9719

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
