### PR TITLE
Add a default state to set_author in embeds.py

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -511,7 +511,7 @@ class Embed:
         # Lying to the type checker for better developer UX.
         return EmbedProxy(getattr(self, '_author', {}))  # type: ignore
 
-    def set_author(self, *, name: Any, url: Optional[Any] = None, icon_url: Optional[Any] = None) -> Self:
+    def set_author(self, *, name: Optional[Any] = None, url: Optional[Any] = None, icon_url: Optional[Any] = None) -> Self:
         """Sets the author for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -527,7 +527,9 @@ class Embed:
             The URL of the author icon. Only HTTP(S) is supported.
             Inline attachment URLs are also supported, see :ref:`local_image`.
         """
-
+        if name is None:
+            return self
+            
         self._author = {
             'name': str(name),
         }


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Allow expected behaviour of passing None into name of not creating an author instead of creating the str "None"

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
