### PR TITLE
fix sticker URL for GIF stickers

### DIFF
--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -277,7 +277,10 @@ class Sticker(_StickerTag):
         self.name: str = data['name']
         self.description: str = data['description']
         self.format: StickerFormatType = try_enum(StickerFormatType, data['format_type'])
-        self.url: str = f'{Asset.BASE}/stickers/{self.id}.{self.format.file_extension}'
+        if self.format is StickerFormatType.gif:
+            self.url: str = f'https://media.discordapp.net/stickers/{self.id}.gif'
+        else:
+            self.url: str = f'{Asset.BASE}/stickers/{self.id}.{self.format.file_extension}'
 
     def __repr__(self) -> str:
         return f'<Sticker id={self.id} name={self.name!r}>'


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
fixes `url` attr and `sticker.read()` method for GIF stickers.
https://github.com/discord/discord-api-docs/issues/6675#issuecomment-1954755672 as confirmed by Discord.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
