### PR TITLE
Add proxy variable

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1231,6 +1231,7 @@ class Webhook(BaseWebhook):
         cls,
         url: str,
         *,
+        proxy: Optional[str] = None,
         session: aiohttp.ClientSession = MISSING,
         client: Client = MISSING,
         bot_token: Optional[str] = None,
@@ -1291,7 +1292,7 @@ class Webhook(BaseWebhook):
 
         data: Dict[str, Any] = m.groupdict()
         data['type'] = 1
-        return cls(data, session, token=bot_token, state=state)  # type: ignore  # Casting dict[str, Any] to WebhookPayload
+        return cls(data, session, token=bot_token, state=state, proxy=proxy)  # type: ignore  # Casting dict[str, Any] to WebhookPayload
 
     @classmethod
     def _as_follower(cls, data, *, channel, user) -> Self:

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1247,6 +1247,10 @@ class Webhook(BaseWebhook):
         ------------
         url: :class:`str`
             The URL of the webhook.
+        proxy: Optional[:class:`str`]
+            Proxy URL.
+        proxy_auth: Optional[:class:`aiohttp.BasicAuth`]
+            An object that represents proxy HTTP Basic Authorization.
         session: :class:`aiohttp.ClientSession`
             The session to use to send requests with. Note
             that the library does not manage the session and

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1232,6 +1232,7 @@ class Webhook(BaseWebhook):
         url: str,
         *,
         proxy: Optional[str] = None,
+        proxy_auth: Optional[aiohttp.BasicAuth] = None,
         session: aiohttp.ClientSession = MISSING,
         client: Client = MISSING,
         bot_token: Optional[str] = None,
@@ -1292,7 +1293,7 @@ class Webhook(BaseWebhook):
 
         data: Dict[str, Any] = m.groupdict()
         data['type'] = 1
-        return cls(data, session, token=bot_token, state=state, proxy=proxy)  # type: ignore  # Casting dict[str, Any] to WebhookPayload
+        return cls(data, session, token=bot_token, state=state, proxy=proxy, proxy_auth=proxy_auth)  # type: ignore  # Casting dict[str, Any] to WebhookPayload
 
     @classmethod
     def _as_follower(cls, data, *, channel, user) -> Self:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Add the use of the proxy variable to the from_url function of the webhook class.

During use, I found that the from_url function did not provide a proxy parameter to pass in. My area requires a proxy to access discord, so I added this parameter.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
