### PR TITLE
Move most static metadata to pyproject.toml.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          PYTHONPATH="$(pwd)" pytest -vs --cov=discord --cov-report term-missing:skip-covered
+          python -m pytest -vs --cov=discord --cov-report term-missing:skip-covered

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          python -m pytest -vs --cov=discord --cov-report term-missing:skip-covered
+          PYTHONPATH="$(pwd)" pytest -vs --cov=discord --cov-report term-missing:skip-covered

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,83 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "discord.py"
+description = "A Python wrapper for the Discord API"
+readme = { file = "README.rst", content-type = "text/x-rst" }
+license = { file = "LICENSE" }
+requires-python = ">=3.8"
+authors = [{ name = "Rapptz" }]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "License :: OSI Approved :: MIT License",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Internet",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Utilities",
+    "Typing :: Typed",
+]
+dynamic = ["version"]
+
+[project.urls]
+Documentation = "https://discordpy.readthedocs.io/en/latest/"
+"Issue tracker" = "https://github.com/Rapptz/discord.py/issues"
+
+[tool.setuptools.dynamic]
+dependencies = { file = "requirements.txt" }
+
+[project.optional-dependencies]
+voice = ["PyNaCl>=1.3.0,<1.6"]
+docs = [
+    "sphinx==4.4.0",
+    "sphinxcontrib_trio==1.1.2",
+    # TODO: bump these when migrating to a newer Sphinx version
+    "sphinxcontrib-websupport==1.2.4",
+    "sphinxcontrib-applehelp==1.0.4",
+    "sphinxcontrib-devhelp==1.0.2",
+    "sphinxcontrib-htmlhelp==2.0.1",
+    "sphinxcontrib-jsmath==1.0.1",
+    "sphinxcontrib-qthelp==1.0.3",
+    "sphinxcontrib-serializinghtml==1.1.5",
+    "typing-extensions>=4.3,<5",
+    "sphinx-inline-tabs==2023.4.21",
+]
+speed = [
+    "orjson>=3.5.4",
+    "aiodns>=1.1",
+    "Brotli",
+    "cchardet==2.1.7; python_version < '3.10'",
+]
+test = [
+    "coverage[toml]",
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+    "pytest-mock",
+    "typing-extensions>=4.3,<5",
+    "tzdata; sys_platform == 'win32'",
+]
+
+[tool.setuptools]
+packages = [
+    "discord",
+    "discord.types",
+    "discord.ui",
+    "discord.webhook",
+    "discord.app_commands",
+    "discord.ext.commands",
+    "discord.ext.tasks",
+]
+include-package-data = true
 
 [tool.black]
 line-length = 125
@@ -16,7 +93,7 @@ omit = [
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",
-    "@overload"
+    "@overload",
 ]
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,12 @@ include = [
     "discord/ext/commands",
     "discord/ext/tasks",
 ]
-exclude = ["**/__pycache__", "build", "dist", "docs"]
+exclude = [
+    "**/__pycache__",
+    "build",
+    "dist",
+    "docs",
+]
 reportUnnecessaryTypeIgnoreComment = "warning"
 reportUnusedImport = "error"
 pythonVersion = "3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Utilities",
     "Typing :: Typed",
 ]
-dynamic = ["version"]
+dynamic = ["version", "dependencies"]
 
 [project.urls]
 Documentation = "https://discordpy.readthedocs.io/en/latest/"
@@ -112,12 +112,7 @@ include = [
     "discord/ext/commands",
     "discord/ext/tasks",
 ]
-exclude = [
-    "**/__pycache__",
-    "build",
-    "dist",
-    "docs",
-]
+exclude = ["**/__pycache__", "build", "dist", "docs"]
 reportUnnecessaryTypeIgnoreComment = "warning"
 reportUnusedImport = "error"
 pythonVersion = "3.8"

--- a/setup.py
+++ b/setup.py
@@ -1,113 +1,33 @@
-from setuptools import setup
 import re
 
-requirements = []
-with open('requirements.txt') as f:
-    requirements = f.read().splitlines()
+from setuptools import setup
 
-version = ''
-with open('discord/__init__.py') as f:
-    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE).group(1)
 
-if not version:
-    raise RuntimeError('version is not set')
+def derive_version() -> str:
+    version = ''
+    with open('discord/__init__.py') as f:
+        version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE).group(1)
 
-if version.endswith(('a', 'b', 'rc')):
-    # append version identifier based on commit count
-    try:
-        import subprocess
+    if not version:
+        raise RuntimeError('version is not set')
 
-        p = subprocess.Popen(['git', 'rev-list', '--count', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        out, err = p.communicate()
-        if out:
-            version += out.decode('utf-8').strip()
-        p = subprocess.Popen(['git', 'rev-parse', '--short', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        out, err = p.communicate()
-        if out:
-            version += '+g' + out.decode('utf-8').strip()
-    except Exception:
-        pass
+    if version.endswith(('a', 'b', 'rc')):
+        # append version identifier based on commit count
+        try:
+            import subprocess
 
-readme = ''
-with open('README.rst') as f:
-    readme = f.read()
+            p = subprocess.Popen(['git', 'rev-list', '--count', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            out, err = p.communicate()
+            if out:
+                version += out.decode('utf-8').strip()
+            p = subprocess.Popen(['git', 'rev-parse', '--short', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            out, err = p.communicate()
+            if out:
+                version += '+g' + out.decode('utf-8').strip()
+        except Exception:
+            pass
 
-extras_require = {
-    'voice': ['PyNaCl>=1.3.0,<1.6'],
-    'docs': [
-        'sphinx==4.4.0',
-        'sphinxcontrib_trio==1.1.2',
-        # TODO: bump these when migrating to a newer Sphinx version
-        'sphinxcontrib-websupport==1.2.4',
-        'sphinxcontrib-applehelp==1.0.4',
-        'sphinxcontrib-devhelp==1.0.2',
-        'sphinxcontrib-htmlhelp==2.0.1',
-        'sphinxcontrib-jsmath==1.0.1',
-        'sphinxcontrib-qthelp==1.0.3',
-        'sphinxcontrib-serializinghtml==1.1.5',
-        'typing-extensions>=4.3,<5',
-        'sphinx-inline-tabs==2023.4.21',
-    ],
-    'speed': [
-        'orjson>=3.5.4',
-        'aiodns>=1.1',
-        'Brotli',
-        'cchardet==2.1.7; python_version < "3.10"',
-    ],
-    'test': [
-        'coverage[toml]',
-        'pytest',
-        'pytest-asyncio',
-        'pytest-cov',
-        'pytest-mock',
-        'typing-extensions>=4.3,<5',
-        'tzdata; sys_platform == "win32"',
-    ],
-}
+    return version
 
-packages = [
-    'discord',
-    'discord.types',
-    'discord.ui',
-    'discord.webhook',
-    'discord.app_commands',
-    'discord.ext.commands',
-    'discord.ext.tasks',
-]
 
-setup(
-    name='discord.py',
-    author='Rapptz',
-    url='https://github.com/Rapptz/discord.py',
-    project_urls={
-        'Documentation': 'https://discordpy.readthedocs.io/en/latest/',
-        'Issue tracker': 'https://github.com/Rapptz/discord.py/issues',
-    },
-    version=version,
-    packages=packages,
-    license='MIT',
-    description='A Python wrapper for the Discord API',
-    long_description=readme,
-    long_description_content_type='text/x-rst',
-    include_package_data=True,
-    install_requires=requirements,
-    extras_require=extras_require,
-    python_requires='>=3.8.0',
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: MIT License',
-        'Intended Audience :: Developers',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-        'Topic :: Internet',
-        'Topic :: Software Development :: Libraries',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        'Topic :: Utilities',
-        'Typing :: Typed',
-    ],
-)
+setup(version=derive_version())

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
-import re
-
 from setuptools import setup
-
+import re
 
 def derive_version() -> str:
     version = ''


### PR DESCRIPTION
## Summary

It moves most of the library's metadata to pyproject.toml from setup.py, excluding the library version due to its particular type of dynamism and the fact that code would seemingly be required for it regardless of possible alternatives like setuptools_scm.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
