### PR TITLE
Basic attempt to add user-install required fields.

### DIFF
--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -28,7 +28,7 @@ from datetime import datetime
 from .errors import MissingApplicationID
 from .translator import TranslationContextLocation, TranslationContext, locale_str, Translator
 from ..permissions import Permissions
-from ..enums import AppCommandOptionType, AppCommandType, AppCommandPermissionType, ChannelType, Locale, try_enum
+from ..enums import AppCommandOptionType, AppCommandType, AppCommandPermissionType, ChannelType, Locale, try_enum, IntegrationType, AppCommandContext
 from ..mixins import Hashable
 from ..utils import _get_as_snowflake, parse_time, snowflake_time, MISSING
 from ..object import Object
@@ -181,11 +181,15 @@ class AppCommand(Hashable):
         'dm_permission',
         'nsfw',
         '_state',
+        'integration_types',
+        'contexts',        
     )
 
     def __init__(self, *, data: ApplicationCommandPayload, state: ConnectionState) -> None:
         self._state: ConnectionState = state
         self._from_data(data)
+        self.integration_types: List[IntegrationType] = [try_enum(IntegrationType, d) for d in data.get('integration_types', [])]
+        self.contexts: List[AppCommandContext] = [try_enum(AppCommandContext, d) for d in data.get('contexts', [])]        
 
     def _from_data(self, data: ApplicationCommandPayload) -> None:
         self.id: int = int(data['id'])
@@ -224,6 +228,8 @@ class AppCommand(Hashable):
             'name_localizations': {str(k): v for k, v in self.name_localizations.items()},
             'description_localizations': {str(k): v for k, v in self.description_localizations.items()},
             'options': [opt.to_dict() for opt in self.options],
+            'integration_types': [t.value for t in self.integration_types],
+            'contexts': [c.value for c in self.contexts],            
         }  # type: ignore # Type checker does not understand this literal.
 
     def __str__(self) -> str:


### PR DESCRIPTION
Trying to add new fields, integration_types and contexts, so Python Discord Bots can be installed as user-install bots per March 18 2024 API update.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
