### PR TITLE
Alternative handling for close fixes

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -763,8 +763,12 @@ class Client:
         that it only runs once when called directly
         """
         if cls.close is not Client.close:
-            # This is a bound method in __init_subclass__
+            # This is not a bound method in __init_subclass__
+            # assigning it as a classvar at this stage in type creation
+            # results in this properly being a bound method on all instances
             # There's no way to type this properly currently,
+            # pyright sees one as a variable, the other as a method
+            # each with the same callable signature.
             cls._user_close_method = cls.close  # type: ignore
             cls.close = Client.close
 

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -465,7 +465,7 @@ class AutoShardedClient(Client):
             elif item.type == EventType.clean_close:
                 return
 
-    async def close(self) -> None:
+    async def _internal_close(self) -> None:
         """|coro|
 
         Closes the connection to Discord.


### PR DESCRIPTION
## Summary

See #9769 And discussion https://discord.com/channels/336642139381301249/1222571653272309842/1222915657046167687

Presented for comparison and testability of options.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
