### PR TITLE
More voice fixes

### DIFF
--- a/discord/player.py
+++ b/discord/player.py
@@ -763,7 +763,8 @@ class AudioPlayer(threading.Thread):
             delay = max(0, self.DELAY + (next_time - time.perf_counter()))
             time.sleep(delay)
 
-        self.send_silence()
+        if client.is_connected():
+            self.send_silence()
 
     def run(self) -> None:
         try:

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -337,7 +337,7 @@ class VoiceClient(VoiceProtocol):
         Disconnects this voice client from voice.
         """
         self.stop()
-        await self._connection.disconnect(force=force)
+        await self._connection.disconnect(force=force, wait=True)
         self.cleanup()
 
     async def move_to(self, channel: Optional[abc.Snowflake], *, timeout: Optional[float] = 30.0) -> None:
@@ -567,6 +567,6 @@ class VoiceClient(VoiceProtocol):
         try:
             self._connection.send_packet(packet)
         except OSError:
-            _log.info('A packet has been dropped (seq: %s, timestamp: %s)', self.sequence, self.timestamp)
+            _log.debug('A packet has been dropped (seq: %s, timestamp: %s)', self.sequence, self.timestamp)
 
         self.checked_add('timestamp', opus.Encoder.SAMPLES_PER_FRAME, 4294967295)

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -436,7 +436,7 @@ class VoiceConnectionState:
         if not self._runner:
             self._runner = self.voice_client.loop.create_task(self._poll_voice_ws(reconnect), name='Voice websocket poller')
 
-    async def disconnect(self, *, force: bool = True, cleanup: bool = True) -> None:
+    async def disconnect(self, *, force: bool = True, cleanup: bool = True, wait: bool = False) -> None:
         if not force and not self.is_connected():
             return
 
@@ -447,23 +447,26 @@ class VoiceConnectionState:
         except Exception:
             _log.debug('Ignoring exception disconnecting from voice', exc_info=True)
         finally:
-            self.ip = MISSING
-            self.port = MISSING
             self.state = ConnectionFlowState.disconnected
             self._socket_reader.pause()
+
+            # Stop threads before we unlock waiters so they end properly
+            if cleanup:
+                self._socket_reader.stop()
+                self.voice_client.stop()
 
             # Flip the connected event to unlock any waiters
             self._connected.set()
             self._connected.clear()
 
-            if cleanup:
-                self._socket_reader.stop()
-
             if self.socket:
                 self.socket.close()
 
+            self.ip = MISSING
+            self.port = MISSING
+
             # Skip this part if disconnect was called from the poll loop task
-            if self._runner and asyncio.current_task() != self._runner:
+            if wait and not self._inside_runner():
                 # Wait for the voice_state_update event confirming the bot left the voice channel.
                 # This prevents a race condition caused by disconnecting and immediately connecting again.
                 # The new VoiceConnectionState object receives the voice_state_update event containing channel=None while still
@@ -472,7 +475,9 @@ class VoiceConnectionState:
                     async with atimeout(self.timeout):
                         await self._disconnected.wait()
                 except TimeoutError:
-                    _log.debug('Timed out waiting for disconnect confirmation event')
+                    _log.debug('Timed out waiting for voice disconnection confirmation')
+                except asyncio.CancelledError:
+                    pass
 
             if cleanup:
                 self.voice_client.cleanup()
@@ -490,23 +495,26 @@ class VoiceConnectionState:
         except Exception:
             _log.debug('Ignoring exception soft disconnecting from voice', exc_info=True)
         finally:
-            self.ip = MISSING
-            self.port = MISSING
             self.state = with_state
             self._socket_reader.pause()
 
             if self.socket:
                 self.socket.close()
 
+            self.ip = MISSING
+            self.port = MISSING
+
     async def move_to(self, channel: Optional[abc.Snowflake], timeout: Optional[float]) -> None:
         if channel is None:
-            await self.disconnect()
+            # This function should only be called externally so its ok to wait for the disconnect.
+            await self.disconnect(wait=True)
             return
 
         if self.voice_client.channel and channel.id == self.voice_client.channel.id:
             return
 
         previous_state = self.state
+
         # this is only an outgoing ws request
         # if it fails, nothing happens and nothing changes (besides self.state)
         await self._move_to(channel)
@@ -518,7 +526,6 @@ class VoiceConnectionState:
             _log.warning('Timed out trying to move to channel %s in guild %s', channel.id, self.guild.id)
             if self.state is last_state:
                 _log.debug('Reverting to previous state %s', previous_state.name)
-
                 self.state = previous_state
 
     def wait(self, timeout: Optional[float] = None) -> bool:
@@ -540,6 +547,9 @@ class VoiceConnectionState:
     def remove_socket_listener(self, callback: SocketReaderCallback) -> None:
         _log.debug('Unregistering socket listener callback %s', callback)
         self._socket_reader.unregister(callback)
+
+    def _inside_runner(self) -> bool:
+        return self._runner is not None and asyncio.current_task() == self._runner
 
     async def _wait_for_state(
         self, state: ConnectionFlowState, *other_states: ConnectionFlowState, timeout: Optional[float] = None
@@ -604,11 +614,21 @@ class VoiceConnectionState:
                         break
 
                     if exc.code == 4014:
+                        # We were disconnected by discord
+                        # This condition is a race between the main ws event and the voice ws closing
+                        if self._disconnected.is_set():
+                            _log.info('Disconnected from voice by discord, close code %d.', exc.code)
+                            await self.disconnect()
+                            break
+
+                        # We may have been moved to a different channel
                         _log.info('Disconnected from voice by force... potentially reconnecting.')
                         successful = await self._potential_reconnect()
                         if not successful:
                             _log.info('Reconnect was unsuccessful, disconnecting from voice normally...')
-                            await self.disconnect()
+                            # Don't bother to disconnect if already disconnected
+                            if self.state is not ConnectionFlowState.disconnected:
+                                await self.disconnect()
                             break
                         else:
                             continue
@@ -640,10 +660,16 @@ class VoiceConnectionState:
     async def _potential_reconnect(self) -> bool:
         try:
             await self._wait_for_state(
-                ConnectionFlowState.got_voice_server_update, ConnectionFlowState.got_both_voice_updates, timeout=self.timeout
+                ConnectionFlowState.got_voice_server_update,
+                ConnectionFlowState.got_both_voice_updates,
+                ConnectionFlowState.disconnected,
+                timeout=self.timeout,
             )
         except asyncio.TimeoutError:
             return False
+        else:
+            if self.state is ConnectionFlowState.disconnected:
+                return False
 
         previous_ws = self.ws
         try:


### PR DESCRIPTION
## Summary

I have a few more things to add so don't merge this yet.

- Adds OSError to list of errors to ignore for reader loop
- Starts the reader loop paused, waits for the socket to be created
- Eventual Consistency TM fix
- Fixes some 4014 close handling
- Fixes sending silence packets when a player stops while not connected

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
