### PR TITLE
Remove entry that is yet to be released from 2.3.2 changelog

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -23,7 +23,6 @@ Bug Fixes
 - Fix :attr:`Intents.emoji` and :attr:`Intents.emojis_and_stickers` having swapped alias values (:issue:`9471`).
 - Fix ``NameError`` when using :meth:`abc.GuildChannel.create_invite` (:issue:`9505`).
 - Fix crash when disconnecting during the middle of a ``HELLO`` packet when using :class:`AutoShardedClient`.
-- Fix overly eager escape behaviour for lists and header markdown in :func:`utils.escape_markdown` (:issue:`9516`).
 - Fix voice websocket not being closed before being replaced by a new one (:issue:`9518`).
 - |commands| Fix the wrong :meth:`~ext.commands.HelpCommand.on_help_command_error` being called when ejected from a cog.
 - |commands| Fix ``=None`` being displayed in :attr:`~ext.commands.Command.signature`.


### PR DESCRIPTION
## Summary

This corresponds to:
https://github.com/Rapptz/discord.py/commit/e5da7f23cb1405c341431d1592538880e4d54d4d

which has not actually been included in 2.3.2:
https://github.com/Rapptz/discord.py/compare/v2.3.1...v2.3.2
https://github.com/Rapptz/discord.py/blob/v2.3.2/discord/utils.py#L908

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
