### PR TITLE
Fix File(...) not accepting bytes as a source

### DIFF
--- a/discord/file.py
+++ b/discord/file.py
@@ -93,6 +93,10 @@ class File:
             self.fp: io.BufferedIOBase = fp
             self._original_pos = fp.tell()
             self._owner = False
+        elif isinstance(fp, bytes):
+            self.fp = io.BytesIO(fp)
+            self._original_pos = 0
+            self._owner = True
         else:
             self.fp = open(fp, 'rb')
             self._original_pos = 0

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -127,3 +127,8 @@ def test_file_not_spoiler_with_overriding_name_double_spoiler():
     f.filename = 'SPOILER_SPOILER_.gitignore'
     assert f.filename == 'SPOILER_.gitignore'
     assert f.spoiler == True
+
+def test_file_from_bytes():
+    f = discord.File(b'file_content', 'test')
+    assert f.filename == 'test'
+    assert f.fp.read() == b'file_content'


### PR DESCRIPTION
## Summary

Type hints in `discord.File()` included `bytes` as a possible value for the `fp` parameter, but it actually wasn't supported. This PR handles `bytes` input and adds a test to ensure this bug won't happen again.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
