### PR TITLE
Add support for applied_tags in Webhook.send overloaded methods

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1596,6 +1596,7 @@ class Webhook(BaseWebhook):
         wait: Literal[True],
         suppress_embeds: bool = MISSING,
         silent: bool = MISSING,
+        applied_tags: List[ForumTag] = MISSING,
     ) -> WebhookMessage:
         ...
 
@@ -1619,6 +1620,7 @@ class Webhook(BaseWebhook):
         wait: Literal[False] = ...,
         suppress_embeds: bool = MISSING,
         silent: bool = MISSING,
+        applied_tags: List[ForumTag] = MISSING,
     ) -> None:
         ...
 


### PR DESCRIPTION
## Summary

The overloads of Webhook.send currently lack the applied_tags

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
