### PR TITLE
[types] Fix signature for `commands.hybrid_command()` decorator when decorating free functions.

### DIFF
--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -859,6 +859,8 @@ class HybridGroup(Group[CogT, P, T]):
 if TYPE_CHECKING:
     # Using a class to emulate a function allows for overloading the inner function in the decorator.
 
+    from typing import overload
+
     class _HybridCommandDecorator:
         @overload
         def __call__(self, func: Callable[Concatenate[CogT, ContextT, P], Coro[T]], /) -> HybridCommand[CogT, P, T]:

--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -856,12 +856,28 @@ class HybridGroup(Group[CogT, P, T]):
         return decorator
 
 
+if TYPE_CHECKING:
+    # Using a class to emulate a function allows for overloading the inner function in the decorator.
+
+    class _HybridCommandDecorator:
+        @overload
+        def __call__(self, func: Callable[Concatenate[CogT, ContextT, P], Coro[T]], /) -> HybridCommand[CogT, P, T]:
+            ...
+
+        @overload
+        def __call__(self, func: Callable[Concatenate[ContextT, P], Coro[T]], /) -> HybridCommand[None, P, T]:
+            ...
+
+        def __call__(self, func: Callable[..., Coro[T]], /) -> Any:
+            ...
+
+
 def hybrid_command(
     name: Union[str, app_commands.locale_str] = MISSING,
     *,
     with_app_command: bool = True,
     **attrs: Any,
-) -> Callable[[CommandCallback[CogT, ContextT, P, T]], HybridCommand[CogT, P, T]]:
+) -> _HybridCommandDecorator:
     r"""A decorator that transforms a function into a :class:`.HybridCommand`.
 
     A hybrid command is one that functions both as a regular :class:`.Command`


### PR DESCRIPTION
## Summary
This fixes an error from pyright that considers the resolved value of `CogT` to be `Unknown` when it should be None, specificallly for a the first type parameter of `HybridCommand` when created via `commands.hybrid_command()` decorating a free function.

Uses the same callback trick that `commands.command()` does:
https://github.com/Rapptz/discord.py/blob/425edd2e10b9be3d7799c0df0cd1d43a1a34654e/discord/ext/commands/core.py#L1700-L1713

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
