### PR TITLE
Fix multiple arguments can't be parsed to a flag with List annotation

### DIFF
--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -618,12 +618,14 @@ class FlagConverter(metaclass=FlagsMeta):
                 setattr(self, flag.attribute, value)
                 continue
 
-            # Another special case, tuple parsing.
-            # Tuple parsing is basically converting arguments within the flag
+            # Another special case, list and tuple parsing.
+            # List and Tuple parsing is basically converting arguments within the flag
             # So, given flag: hello 20 as the input and Tuple[str, int] as the type hint
             # We would receive ('hello', 20) as the resulting value
+            # Another given flag: hello there as the input and List[str] as the type hint
+            # We would receive ['hello', 'there'] as the resulting value
             # This uses the same whitespace and quoting rules as regular parameters.
-            values = [await convert_flag(ctx, value, flag) for value in values]
+            values = await convert_flag(ctx, values[0], flag)
 
             if flag.cast_to_dict:
                 values = dict(values)

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -353,7 +353,7 @@ class FlagsMeta(type):
         return type.__new__(cls, name, bases, attrs)
 
 
-async def tuple_convert_all(ctx: Context[BotT], argument: str, flag: Flag, converter: Any) -> Tuple[Any, ...]:
+async def list_convert_flag(ctx: Context[BotT], argument: str, flag: Flag, converter: Any) -> List[Any]:
     view = StringView(argument)
     results = []
     param: Parameter = ctx.current_parameter  # type: ignore
@@ -373,7 +373,7 @@ async def tuple_convert_all(ctx: Context[BotT], argument: str, flag: Flag, conve
         else:
             results.append(converted)
 
-    return tuple(results)
+    return results
 
 
 async def tuple_convert_flag(ctx: Context[BotT], argument: str, flag: Flag, converters: Any) -> Tuple[Any, ...]:
@@ -412,13 +412,13 @@ async def convert_flag(ctx: Context[BotT], argument: str, flag: Flag, annotation
     else:
         if origin is tuple:
             if annotation.__args__[-1] is Ellipsis:
-                return await tuple_convert_all(ctx, argument, flag, annotation.__args__[0])
+                return tuple(await list_convert_flag(ctx, argument, flag, annotation.__args__[0]))
             else:
                 return await tuple_convert_flag(ctx, argument, flag, annotation.__args__)
         elif origin is list:
             # typing.List[x]
             annotation = annotation.__args__[0]
-            return await convert_flag(ctx, argument, flag, annotation)
+            return await list_convert_flag(ctx, argument, flag, annotation)
         elif origin is Union and type(None) in annotation.__args__:
             # typing.Optional[x]
             annotation = Union[tuple(arg for arg in annotation.__args__ if arg is not type(None))]  # type: ignore


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Currently, flags with List annotation will only parse flags if there's only one argument, else it will return a
`BadFlagArgument: Could not convert to 'List' for flag 'flag'`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
