### PR TITLE
Fix `AutoModRule.edit` handling of `AutoModRuleEventType` enum.

### DIFF
--- a/discord/automod.py
+++ b/discord/automod.py
@@ -518,7 +518,7 @@ class AutoModRule:
             payload['name'] = name
 
         if event_type is not MISSING:
-            payload['event_type'] = event_type
+            payload['event_type'] = event_type.value
 
         if trigger is not MISSING:
             trigger_metadata = trigger.to_metadata_dict()


### PR DESCRIPTION
## Summary
Fixes #9797 

This PR fixes the above issue by correctly handling passed enums to the method, currently it passes the enum whole, not the value.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

Testing proof:-

![DiscordCanary_PGX6OAweyM](https://github.com/Rapptz/discord.py/assets/16031716/4ee2553e-4431-4d7c-baa4-62b2d0aaa612)

