### PR TITLE
Add support for one-time purchases

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -796,11 +796,20 @@ class SelectDefaultValueType(Enum):
 
 
 class SKUType(Enum):
+    durable = 2
+    consumable = 3
     subscription = 5
     subscription_group = 6
 
 
 class EntitlementType(Enum):
+    purchase = 1
+    premium_subscription = 2
+    developer_gift = 3
+    test_mode_purchase = 4
+    free_purchase = 5
+    user_gift = 6
+    premium_purchase = 7
     application_subscription = 8
 
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -2454,6 +2454,16 @@ class HTTPClient:
             ),
         )
 
+    def consume_entitlement(self, application_id: Snowflake, entitlement_id: Snowflake) -> Response[None]:
+        return self.request(
+            Route(
+                'POST',
+                '/applications/{application_id}/entitlements/{entitlement_id}/consume',
+                application_id=application_id,
+                entitlement_id=entitlement_id,
+            ),
+        )
+
     def create_entitlement(
         self, application_id: Snowflake, sku_id: Snowflake, owner_id: Snowflake, owner_type: sku.EntitlementOwnerType
     ) -> Response[sku.Entitlement]:

--- a/discord/sku.py
+++ b/discord/sku.py
@@ -126,7 +126,7 @@ class Entitlement:
         A UTC date which entitlement is no longer valid. Not present when using test entitlements.
     guild_id: Optional[:class:`int`]
         The ID of the guild that is granted access to the entitlement
-    consumed:
+    consumed: :class:`bool`
         For consumable items, whether the entitlement has been consumed.
     """
 
@@ -155,7 +155,7 @@ class Entitlement:
         self.starts_at: Optional[datetime] = utils.parse_time(data.get('starts_at', None))
         self.ends_at: Optional[datetime] = utils.parse_time(data.get('ends_at', None))
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, 'guild_id')
-        self.consumed: Optional[bool] = data.get('consumed', None)
+        self.consumed: bool = data.get('consumed', False)
 
     def __repr__(self) -> str:
         return f'<Entitlement id={self.id} type={self.type!r} user_id={self.user_id}>'

--- a/discord/sku.py
+++ b/discord/sku.py
@@ -126,6 +126,8 @@ class Entitlement:
         A UTC date which entitlement is no longer valid. Not present when using test entitlements.
     guild_id: Optional[:class:`int`]
         The ID of the guild that is granted access to the entitlement
+    consumed:
+        For consumable items, whether the entitlement has been consumed.
     """
 
     __slots__ = (
@@ -139,6 +141,7 @@ class Entitlement:
         'starts_at',
         'ends_at',
         'guild_id',
+        'consumed',
     )
 
     def __init__(self, state: ConnectionState, data: EntitlementPayload):
@@ -152,6 +155,7 @@ class Entitlement:
         self.starts_at: Optional[datetime] = utils.parse_time(data.get('starts_at', None))
         self.ends_at: Optional[datetime] = utils.parse_time(data.get('ends_at', None))
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, 'guild_id')
+        self.consumed: Optional[bool] = data.get('consumed', None)
 
     def __repr__(self) -> str:
         return f'<Entitlement id={self.id} type={self.type!r} user_id={self.user_id}>'
@@ -178,6 +182,26 @@ class Entitlement:
         if self.ends_at is None:
             return False
         return utils.utcnow() >= self.ends_at
+
+    async def consume(self) -> None:
+        """|coro|
+
+        Marks a one-time purchase entitlement as consumed.
+
+        Raises
+        -------
+        MissingApplicationID
+            The application ID could not be found.
+        NotFound
+            The entitlement could not be found.
+        HTTPException
+            Consuming the entitlement failed.
+        """
+
+        if self.application_id is None:
+            raise MissingApplicationID
+
+        await self._state.http.consume_entitlement(self.application_id, self.id)
 
     async def delete(self) -> None:
         """|coro|

--- a/discord/types/sku.py
+++ b/discord/types/sku.py
@@ -46,7 +46,7 @@ class Entitlement(TypedDict):
     deleted: bool
     starts_at: NotRequired[str]
     ends_at: NotRequired[str]
-    guild_id: Optional[str]
+    guild_id: NotRequired[str]
     consumed: NotRequired[bool]
 
 

--- a/discord/types/sku.py
+++ b/discord/types/sku.py
@@ -47,6 +47,7 @@ class Entitlement(TypedDict):
     starts_at: NotRequired[str]
     ends_at: NotRequired[str]
     guild_id: Optional[str]
+    consumed: NotRequired[bool]
 
 
 EntitlementOwnerType = Literal[1, 2]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3506,6 +3506,14 @@ of :class:`enum.Enum`.
 
     .. versionadded:: 2.4
 
+    .. attribute:: durable
+
+        The SKU is a durable one-time purchase.
+
+    .. attribute:: consumable
+
+        The SKU is a consumable one-time purchase.
+
     .. attribute:: subscription
 
         The SKU is a recurring subscription.
@@ -3520,6 +3528,34 @@ of :class:`enum.Enum`.
     Represents the type of an entitlement.
 
     .. versionadded:: 2.4
+
+    .. attribute:: purchase
+
+        The entitlement was purchased by the user.
+
+    .. attribute:: premium_subscription
+
+        The entitlement is for a nitro subscription.
+
+    .. attribute:: developer_gift
+
+        The entitlement was gifted by the developer.
+
+    .. attribute:: test_mode_purchase
+
+        The entitlement was purchased by a developer in application test mode.
+
+    .. attribute:: free_purchase
+
+        The entitlement was granted, when the SKU was free.
+
+    .. attribute:: user_gift
+
+        The entitlement was gifted by a another user.
+
+    .. attribute:: premium_purchase
+
+        The entitlement was claimed for free by a nitro subscriber.
 
     .. attribute:: application_subscription
 


### PR DESCRIPTION
## Summary

This pull request adds support for the recently added [one-time purchases for premium apps](https://discord.com/developers/docs/change-log#premium-apps-onetime-purchases-and-store).

This includes:
- New `SKUType`s
- New `EntitlementType`s
- A new `consumed` attribute for `Entitlement`
- A new `consume` method for `Entitlement`

## Checklist

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
