### PR TITLE
add `reason` kwarg to thread delete method

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -846,12 +846,20 @@ class Thread(Messageable, Hashable):
         members = await self._state.http.get_thread_members(self.id)
         return [ThreadMember(parent=self, data=data) for data in members]
 
-    async def delete(self) -> None:
+    async def delete(self, *, reason: Optional[str] = None) -> None:
         """|coro|
 
         Deletes this thread.
 
         You must have :attr:`~Permissions.manage_threads` to delete threads.
+
+        Parameters
+        -----------
+        reason: Optional[:class:`str`]
+            The reason for deleting this thread.
+            Shows up on the audit log.
+
+            .. versionadded:: 2.4
 
         Raises
         -------
@@ -860,7 +868,7 @@ class Thread(Messageable, Hashable):
         HTTPException
             Deleting the thread failed.
         """
-        await self._state.http.delete_channel(self.id)
+        await self._state.http.delete_channel(self.id, reason=reason)
 
     def get_partial_message(self, message_id: int, /) -> PartialMessage:
         """Creates a :class:`PartialMessage` from the message ID.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Adds the missing `reason` keyword-only argument to delete method for `discord.Thread` instances. As per discord API [docs](https://discord.com/developers/docs/resources/channel#deleteclose-channel), deleting the channel endpoint already supports `X-Audit-Log-Reason` header.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
