### PR TITLE
Flags positional (consume rest)

### DIFF
--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -534,7 +534,7 @@ class FlagConverter(metaclass=FlagsMeta):
             if match is not None:
                 begin, end = match.span(0)
                 value = argument[:begin].strip()
-                last_position = begin - 1
+                last_position = begin
             else:
                 value = argument.strip()
                 last_position = len(argument)

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -533,19 +533,22 @@ class FlagConverter(metaclass=FlagsMeta):
             match = cls.__commands_flag_regex__.search(argument)
             if match is not None:
                 begin, end = match.span(0)
-                value = argument[:begin]
-                if value:
-                    name = positional.name
-                    if case_insensitive:
-                        name = name.casefold()
-                    try:
-                        values = result[name]
-                    except KeyError:
-                        result[name] = [value]
-                    else:
-                        values.append(value)
-                last_position = end
-                last_flag = positional
+                value = argument[:begin].strip()
+                last_position = begin - 1
+            else:
+                value = argument.strip()
+                last_position = len(argument)
+
+            if value:
+                name = positional.name
+                if case_insensitive:
+                    name = name.casefold()
+                try:
+                    values = result[name]
+                except KeyError:
+                    result[name] = [value]
+                else:
+                    values.append(value)
 
         for match in cls.__commands_flag_regex__.finditer(argument):
             begin, end = match.span(0)

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -540,9 +540,8 @@ class FlagConverter(metaclass=FlagsMeta):
                 last_position = len(argument)
 
             if value:
-                name = positional.name
-                if case_insensitive:
-                    name = name.casefold()
+                name = positional.name.casefold() if case_insensitive else positional.name
+
                 try:
                     values = result[name]
                 except KeyError:

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -196,10 +196,9 @@ def get_flags(namespace: Dict[str, Any], globals: Dict[str, Any], locals: Dict[s
             flag.name = name
 
         if flag.positional:
-            if positional is None:
-                positional = flag
-            else:
+            if positional is not None:
                 raise TypeError(f"{flag.name!r} positional flag conflicts with {positional.name!r} flag.")
+            positional = flag
 
         annotation = flag.annotation = resolve_annotation(flag.annotation, globals, locals, cache)
 
@@ -540,13 +539,7 @@ class FlagConverter(metaclass=FlagsMeta):
 
             if value:
                 name = positional_flag.name.casefold() if case_insensitive else positional_flag.name
-
-                try:
-                    values = result[name]
-                except KeyError:
-                    result[name] = [value]
-                else:
-                    values.append(value)
+                result[name] = [value]
 
         for match in cls.__commands_flag_regex__.finditer(argument):
             begin, end = match.span(0)

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -527,7 +527,6 @@ class FlagConverter(metaclass=FlagsMeta):
         last_flag = cls.__commands_flag_positional__
 
         case_insensitive = cls.__commands_flag_case_insensitive__
-
         for match in cls.__commands_flag_regex__.finditer(argument):
             begin, end = match.span(0)
             key = match.group('flag')

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -534,7 +534,6 @@ class FlagConverter(metaclass=FlagsMeta):
             if match is not None:
                 begin, end = match.span(0)
                 value = argument[:begin].strip()
-                last_position = begin
             else:
                 value = argument.strip()
                 last_position = len(argument)

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -542,7 +542,7 @@ class FlagConverter(metaclass=FlagsMeta):
                 if last_position:
                     value = argument[last_position : begin - 1].lstrip()
                 else:
-                    value = argument[last_position : begin].strip()
+                    value = argument[last_position:begin].strip()
 
                 if not value and last_position:
                     raise MissingFlagArgument(last_flag)

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -523,31 +523,10 @@ class FlagConverter(metaclass=FlagsMeta):
         result: Dict[str, List[str]] = {}
         flags = cls.__commands_flags__
         aliases = cls.__commands_flag_aliases__
-        positional = cls.__commands_flag_positional__
         last_position = 0
-        last_flag: Optional[Flag] = None
+        last_flag = cls.__commands_flag_positional__
 
         case_insensitive = cls.__commands_flag_case_insensitive__
-
-        if positional is not None:
-            match = cls.__commands_flag_regex__.search(argument)
-            if match is not None:
-                begin, end = match.span(0)
-                value = argument[:begin].strip()
-                last_position = begin
-            else:
-                value = argument.strip()
-                last_position = len(argument)
-
-            if value:
-                name = positional.name.casefold() if case_insensitive else positional.name
-
-                try:
-                    values = result[name]
-                except KeyError:
-                    result[name] = [value]
-                else:
-                    values.append(value)
 
         for match in cls.__commands_flag_regex__.finditer(argument):
             begin, end = match.span(0)

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -542,7 +542,7 @@ class FlagConverter(metaclass=FlagsMeta):
                 if last_position:
                     value = argument[last_position : begin - 1].lstrip()
                 else:
-                    value = argument[last_position:begin].strip()
+                    value = argument[:begin].strip()
 
                 if not value and last_position:
                     raise MissingFlagArgument(last_flag)

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -523,32 +523,10 @@ class FlagConverter(metaclass=FlagsMeta):
         result: Dict[str, List[str]] = {}
         flags = cls.__commands_flags__
         aliases = cls.__commands_flag_aliases__
-        positional_flag = cls.__commands_flag_positional__
         last_position = 0
-        last_flag: Optional[Flag] = None
+        last_flag = cls.__commands_flag_positional__
 
         case_insensitive = cls.__commands_flag_case_insensitive__
-
-        if positional_flag is not None:
-            match = cls.__commands_flag_regex__.search(argument)
-            if match is not None:
-                begin, end = match.span(0)
-                value = argument[:begin].strip()
-                last_position = begin
-            else:
-                value = argument.strip()
-                last_position = len(argument)
-
-            if value:
-                name = positional_flag.name.casefold() if case_insensitive else positional_flag.name
-
-                try:
-                    values = result[name]
-                except KeyError:
-                    result[name] = [value]
-                else:
-                    values.append(value)
-
         for match in cls.__commands_flag_regex__.finditer(argument):
             begin, end = match.span(0)
             key = match.group('flag')
@@ -559,19 +537,25 @@ class FlagConverter(metaclass=FlagsMeta):
                 key = aliases[key]
 
             flag = flags.get(key)
-            if last_position and last_flag is not None:
-                value = argument[last_position : begin - 1].lstrip()
-                if not value:
+
+            if last_flag is not None and (last_position or last_flag.positional):
+                if last_position:
+                    value = argument[last_position : begin - 1].lstrip()
+                else:
+                    value = argument[last_position : begin].strip()
+
+                if not value and last_position:
                     raise MissingFlagArgument(last_flag)
 
-                name = last_flag.name.casefold() if case_insensitive else last_flag.name
+                if last_position or value:
+                    name = last_flag.name.casefold() if case_insensitive else last_flag.name
 
-                try:
-                    values = result[name]
-                except KeyError:
-                    result[name] = [value]
-                else:
-                    values.append(value)
+                    try:
+                        values = result[name]
+                    except KeyError:
+                        result[name] = [value]
+                    else:
+                        values.append(value)
 
             last_position = end
             last_flag = flag

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -778,6 +778,19 @@ This tells the parser that the ``members`` attribute is mapped to a flag named `
 the default value is an empty list. For greater customisability, the default can either be a value or a callable
 that takes the :class:`~ext.commands.Context` as a sole parameter. This callable can either be a function or a coroutine.
 
+A positional flag can be defined by setting the :attr:`~ext.commands.Flag.positional` attribute to ``True``. This
+tells the parser that the content provided before the parsing occurs is part of the flag. This is useful for commands that
+require a parameter to be used first and the flags are optional, such as the following:
+
+.. code-block:: python3
+
+    class BanFlags(commands.FlagConverter):
+        members: List[discord.Member] = commands.flag(name='member', positional=True, default=lambda ctx: [])
+        reason: Optional[str] = None
+
+.. note::
+    Only one positional flag is allowed in a flag converter.
+
 In order to customise the flag syntax we also have a few options that can be passed to the class parameter list:
 
 .. code-block:: python3
@@ -796,12 +809,17 @@ In order to customise the flag syntax we also have a few options that can be pas
         topic: Optional[str]
         nsfw: Optional[bool]
         slowmode: Optional[int]
+    
+    # Hello there --bold True
+    class Greeting(commands.FlagConverter):
+        text: str = commands.flag(positional=True)
+        bold: bool = False
 
 .. note::
 
     Despite the similarities in these examples to command like arguments, the syntax and parser is not
     a command line parser. The syntax is mainly inspired by Discord's search bar input and as a result
-    all flags need a corresponding value.
+    all flags need a corresponding value unless part of a positional flag.
 
 Flag converters will only raise :exc:`~ext.commands.FlagError` derived exceptions. If an error is raised while
 converting a flag, :exc:`~ext.commands.BadFlagArgument` is raised instead and the original exception


### PR DESCRIPTION
## Summary

Implemented positional for flags, this should allow to perform flags after the parameter we're intending to use while still remaining compatible with slash commands.
 
For example (Assuming `--message` is the positional flag, and defaults to `"Hi"` ): 

`?say Hello`
`?say Hello --ping True`
`?say --message Hello --ping True`
`?say --ping True`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
