### PR TITLE
Add approximate_guild_count to AppInfo

### DIFF
--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -143,6 +143,10 @@ class AppInfo:
         A list of authentication redirect URIs.
 
         .. versionadded:: 2.4
+    approximate_guild_count: :class:`int`
+        The approximate count of the guilds the bot was added to.
+
+        .. versionadded:: 2.4
     """
 
     __slots__ = (
@@ -170,6 +174,7 @@ class AppInfo:
         'role_connections_verification_url',
         'interactions_endpoint_url',
         'redirect_uris',
+        'approximate_guild_count',
     )
 
     def __init__(self, state: ConnectionState, data: AppInfoPayload):
@@ -206,6 +211,7 @@ class AppInfo:
         self.install_params: Optional[AppInstallParams] = AppInstallParams(params) if params else None
         self.interactions_endpoint_url: Optional[str] = data.get('interactions_endpoint_url')
         self.redirect_uris: List[str] = data.get('redirect_uris', [])
+        self.approximate_guild_count: int = data.get('approximate_guild_count', 0)
 
     def __repr__(self) -> str:
         return (


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds the `approximate_guild_count` to AppInfo as [Documented](https://discord.com/developers/docs/resources/application#application-object-application-structure)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
