### PR TITLE
[commands] Add support for type statement and NewType

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -168,7 +168,6 @@ T_co = TypeVar('T_co', covariant=True)
 _Iter = Union[Iterable[T], AsyncIterable[T]]
 Coro = Coroutine[Any, Any, T]
 MaybeAwaitable = Union[T, Awaitable[T]]
-NewTypeType = type(NewType('Foo', int))
 
 
 class CachedSlotProperty(Generic[T, T_co]):
@@ -1129,7 +1128,7 @@ def evaluate_annotation(
             annotation = annotation[tp.__args__]
         return annotation
 
-    if isinstance(tp, NewTypeType):
+    if hasattr(tp, '__supertype__'):
         return evaluate_annotation(tp.__supertype__, globals, locals, cache)
 
     if hasattr(tp, '__metadata__'):

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -43,7 +43,6 @@ from typing import (
     Literal,
     Mapping,
     NamedTuple,
-    NewType,
     Optional,
     Protocol,
     Set,


### PR DESCRIPTION
## Summary

This PR adds support for `typing.NewType` and `type` statement type aliases.
Closes #9813 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
