### PR TITLE
Add support for getting and editing integration_types_config application field

### DIFF
--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -478,7 +478,6 @@ class AppInfo:
         if integration_types_config:
             payload['integration_types_config'] = integration_types_config
 
-        print("payload: ", integration_types_config)
         data = await self._state.http.edit_application_info(reason=reason, payload=payload)
         return AppInfo(data=data, state=self._state)
 

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -423,7 +423,7 @@ class AppInfo:
 
         else:
             if install_params_permissions is not MISSING:
-                raise ValueError("install_params_scopes must be set if install_params_permissions is set")
+                raise ValueError('install_params_scopes must be set if install_params_permissions is set')
 
         if flags is not MISSING:
             if flags is None:
@@ -455,7 +455,7 @@ class AppInfo:
             if guild_install_scopes in (None, MISSING):
                 guild_install_scopes = []
 
-            if "bot" not in guild_install_scopes and guild_install_permissions is not MISSING:
+            if 'bot' not in guild_install_scopes and guild_install_permissions is not MISSING:
                 raise ValueError("'bot' must be in guild_install_scopes if guild_install_permissions is set")
 
             if guild_install_permissions in (None, MISSING):
@@ -468,14 +468,14 @@ class AppInfo:
             integration_types_config['0'] = {'oauth2_install_params': guild_install_params or None}
         else:
             if guild_install_permissions is not MISSING:
-                raise ValueError("guild_install_scopes must be set if guild_install_permissions is set")
+                raise ValueError('guild_install_scopes must be set if guild_install_permissions is set')
 
         if user_install_scopes is not MISSING or user_install_permissions is not MISSING:
             user_install_params: Optional[Dict[str, Any]] = {}
             if user_install_scopes in (None, MISSING):
                 user_install_scopes = []
 
-            if "bot" not in user_install_scopes and user_install_permissions is not MISSING:
+            if 'bot' not in user_install_scopes and user_install_permissions is not MISSING:
                 raise ValueError("'bot' must be in user_install_scopes if user_install_permissions is set")
 
             if user_install_permissions in (None, MISSING):
@@ -488,7 +488,7 @@ class AppInfo:
             integration_types_config['1'] = {'oauth2_install_params': user_install_params or None}
         else:
             if user_install_permissions is not MISSING:
-                raise ValueError("user_install_scopes must be set if user_install_permissions is set")
+                raise ValueError('user_install_scopes must be set if user_install_permissions is set')
 
         if integration_types_config:
             payload['integration_types_config'] = integration_types_config

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -221,7 +221,7 @@ class AppInfo:
         self.redirect_uris: List[str] = data.get('redirect_uris', [])
         self.approximate_guild_count: int = data.get('approximate_guild_count', 0)
         self.approximate_user_install_count: Optional[int] = data.get('approximate_user_install_count')
-        self._integration_types_config: Dict[Literal["0", "1"], AppIntegrationTypeConfigPayload] = data.get(
+        self._integration_types_config: Dict[Literal['0', '1'], AppIntegrationTypeConfigPayload] = data.get(
             'integration_types_config', {}
         )
 
@@ -382,7 +382,7 @@ class AppInfo:
             Editing the application failed
         ValueError
             The image format passed in to ``icon`` or ``cover_image`` is invalid. This is also raised
-            when ``install_params_scopes`` and ``install_params_permissions`` are incompatible with each other.
+            when ``install_params_scopes`` and ``install_params_permissions`` are incompatible with each other,
             or when ``guild_install_scopes`` and ``guild_install_permissions`` are incompatible with each other.
 
         Returns

--- a/discord/http.py
+++ b/discord/http.py
@@ -2508,6 +2508,7 @@ class HTTPClient:
             'cover_image',
             'interactions_endpoint_url ',
             'tags',
+            'integration_types_config',
         )
 
         payload = {k: v for k, v in payload.items() if k in valid_keys}

--- a/discord/types/appinfo.py
+++ b/discord/types/appinfo.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TypedDict, List, Optional
+from typing import Literal, Dict, TypedDict, List, Optional
 from typing_extensions import NotRequired
 
 from .user import User
@@ -35,6 +35,10 @@ from .snowflake import Snowflake
 class InstallParams(TypedDict):
     scopes: List[str]
     permissions: str
+
+
+class AppIntegrationTypeConfig(TypedDict):
+    oauth2_install_params: NotRequired[InstallParams]
 
 
 class BaseAppInfo(TypedDict):
@@ -67,6 +71,7 @@ class AppInfo(BaseAppInfo):
     tags: NotRequired[List[str]]
     install_params: NotRequired[InstallParams]
     custom_install_url: NotRequired[str]
+    integration_types_config: NotRequired[Dict[Literal["0", "1"], AppIntegrationTypeConfig]]
 
 
 class PartialAppInfo(BaseAppInfo, total=False):

--- a/discord/types/appinfo.py
+++ b/discord/types/appinfo.py
@@ -73,7 +73,7 @@ class AppInfo(BaseAppInfo):
     tags: NotRequired[List[str]]
     install_params: NotRequired[InstallParams]
     custom_install_url: NotRequired[str]
-    integration_types_config: NotRequired[Dict[Literal["0", "1"], AppIntegrationTypeConfig]]
+    integration_types_config: NotRequired[Dict[Literal['0', '1'], AppIntegrationTypeConfig]]
 
 
 class PartialAppInfo(BaseAppInfo, total=False):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -80,6 +80,14 @@ AppInstallParams
 .. autoclass:: AppInstallParams()
     :members:
 
+IntegrationTypeConfig
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: IntegrationTypeConfig
+
+.. autoclass:: IntegrationTypeConfig()
+    :members:
+
 Team
 ~~~~~
 


### PR DESCRIPTION
## Summary

This PR adds support for getting and editing the `integration_types_config` field for applications.

I exposed it as `default_x_install_params` properties instead of an object that parses it because I find the inner `oauth2_install_params` object very unnecessary. 

Something to note, setting `default_guild_install_x` and not `default_user_install_x` will disable `default_user_install_x` and I'm not sure if discord.py should handle or tell the user that, if, where and how.

Relevant API Docs:

- https://discord.com/developers/docs/change-log#march-18-2024-api-changes
- https://discord.com/developers/docs/resources/application#application-object

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
