### PR TITLE
Fix various code around Message.interaction(_metadata)

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -715,7 +715,7 @@ class MessageInteractionMetadata(Hashable):
 
     @property
     def original_response_message(self) -> Optional[Message]:
-        """:class:`~discord.Message`: The original response message if the message
+        """Optional[:class:`~discord.Message`]: The original response message if the message
         is a follow-up and is found in cache.
         """
         if self.original_response_message_id:
@@ -724,7 +724,7 @@ class MessageInteractionMetadata(Hashable):
 
     @property
     def interacted_message(self) -> Optional[Message]:
-        """:class:`~discord.Message`: The message that
+        """Optional[:class:`~discord.Message`]: The message that
         containes the interactive components, if applicable and is found in cache.
         """
         if self.interacted_message_id:
@@ -2194,7 +2194,7 @@ class Message(PartialMessage, Hashable):
             return self._thread or self.guild.get_thread(self.id)
 
     @property
-    @deprecated("This attribute is deprecated, please use Message.interaction_metadata instead.")
+    @deprecated('interaction_metadata')
     def interaction(self) -> Optional[MessageInteraction]:
         """Optional[:class:`~discord.MessageInteraction`]: The interaction that this message is a response to.
 

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -667,8 +667,8 @@ class ViewStore:
         msg = interaction.message
         if msg is not None:
             message_id = msg.id
-            if msg.interaction:
-                interaction_id = msg.interaction.id
+            if msg.interaction_metadata:
+                interaction_id = msg.interaction_metadata.id
 
         key = (component_type, custom_id)
 


### PR DESCRIPTION
## Summary

Fix some stuff that was missed in the initial PR:

1. The `original_response_message` and `interacted_message` properties on `MessageInteractionMetadata` are not marked as Optional.
2. A weird unformatted deprecation message emitted from `Message.interaction`.
3. The library uses the `interaction` attribute internally for dispatching views so it was always emitting the deprecation message with no way to "fix" it.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
