### PR TITLE
Fix typo in `Guild.vanity_invite` documentation

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3868,7 +3868,7 @@ class Guild(Hashable):
 
         The guild must have ``VANITY_URL`` in :attr:`~Guild.features`.
 
-        You must have :attr:`~Permissions.manage_guild` to do this.as well.
+        You must have :attr:`~Permissions.manage_guild` to do this as well.
 
         Raises
         -------


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Just a small typo I noticed while reading the docs.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
