### PR TITLE
Add missed permissions to permission class methods

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -237,9 +237,9 @@ class Permissions(BaseFlags):
            Added :attr:`use_soundboard`, :attr:`create_expressions` permissions.
 
         .. versionchanged:: 2.4
-            Added :attr:`send_polls` permission.
+            Added :attr:`send_polls`, :attr:`send_voice_messages` permissions.
         """
-        return cls(0b0000_0000_0000_0010_0000_0100_0111_1101_1011_0011_1111_0111_1111_1111_0101_0001)
+        return cls(0b0000_0000_0000_0010_0100_0100_0111_1101_1011_0011_1111_0111_1111_1111_0101_0001)
 
     @classmethod
     def general(cls) -> Self:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
add poll permissions to `all`, `all_channel`, and `text` class methods
adds missing `send_voice_messages` to `all_channel`
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
