### PR TITLE
Some docs fixes for polls

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -807,6 +807,10 @@ class InteractionResponse(Generic[ClientT]):
             then it is silently ignored.
 
             .. versionadded:: 2.1
+        poll: :class:`~discord.Poll`
+            The poll to send with this message.
+
+            .. versionadded:: 2.4
 
         Raises
         -------

--- a/discord/poll.py
+++ b/discord/poll.py
@@ -202,7 +202,7 @@ class PollAnswer:
 
     @property
     def poll(self) -> Poll:
-        """:class:`Poll`: Returns the parent poll of this answer"""
+        """:class:`Poll`: Returns the parent poll of this answer."""
         return self._poll
 
     def _to_dict(self) -> PollAnswerPayload:

--- a/discord/poll.py
+++ b/discord/poll.py
@@ -310,7 +310,7 @@ class Poll:
         The duration of the poll. Duration must be in hours.
     multiple: :class:`bool`
         Whether users are allowed to select more than one answer.
-        Defaultsto ``False``.
+        Defaults to ``False``.
     layout_type: :class:`PollLayoutType`
         The layout type of the poll. Defaults to :attr:`PollLayoutType.default`.
     """

--- a/discord/poll.py
+++ b/discord/poll.py
@@ -431,7 +431,7 @@ class Poll:
 
     @property
     def answers(self) -> List[PollAnswer]:
-        """List[:class:`PollAnswer`]: Returns a read-only copy of the answers"""
+        """List[:class:`PollAnswer`]: Returns a read-only copy of the answers."""
         return list(self._answers.values())
 
     @property

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5077,6 +5077,15 @@ PartialWebhookChannel
 .. autoclass:: PartialWebhookChannel()
     :members:
 
+PollAnswer
+~~~~~~~~~~
+
+.. attributetable:: PollAnswer
+
+.. autoclass:: PollAnswer()
+    :members:
+    :inherited-members:
+
 .. _discord_api_data:
 
 Data Classes
@@ -5350,11 +5359,8 @@ Poll
 .. autoclass:: Poll
     :members:
 
-.. attributetable:: PollAnswer
-
-.. autoclass:: PollAnswer()
-    :members:
-    :inherited-members:
+PollMedia
+~~~~~~~~~
 
 .. attributetable:: PollMedia
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3615,7 +3615,7 @@ of :class:`enum.Enum`.
 
 .. class:: PollLayoutType
 
-    Represents how a poll answers are shown
+    Represents how a poll answers are shown.
 
     .. versionadded:: 2.4
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5084,7 +5084,6 @@ PollAnswer
 
 .. autoclass:: PollAnswer()
     :members:
-    :inherited-members:
 
 .. _discord_api_data:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5347,7 +5347,7 @@ Poll
 
 .. attributetable:: Poll
 
-.. autoclass:: Poll()
+.. autoclass:: Poll
     :members:
 
 .. attributetable:: PollAnswer
@@ -5358,7 +5358,7 @@ Poll
 
 .. attributetable:: PollMedia
 
-.. autoclass:: PollMedia()
+.. autoclass:: PollMedia
     :members:
 
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

### 1st fix: Poll & PollMedia in docs
This is how it actually looks:
![how it looks now - POLLMEDIA](https://github.com/Rapptz/discord.py/assets/108473820/7238d8d5-485d-497b-a414-3d62c5bff127)
It it shown like it is a non-constructable class, when it is, same with `discord.Poll`.

And this is how it should look (using ForumTag as an example):
![how it should look - POLLMEDIA](https://github.com/Rapptz/discord.py/assets/108473820/72b88d50-48dc-47d8-ac7c-70874707c3f6)

### 2nd fix: Missing dot in PollLayoutType & Poll.answers
Like... a missing dot.
![missing dot](https://github.com/Rapptz/discord.py/assets/108473820/cc6963ef-f8cc-495b-9cf8-adb624d1b3be)
![missing dot 2](https://github.com/Rapptz/discord.py/assets/108473820/987b16ac-7669-427b-9c15-e92e3fbfdb4f)
![missing dot 3](https://github.com/Rapptz/discord.py/assets/108473820/8fa1563d-4e3f-4c6d-9846-afe902b00d62)

### 3rd fix: Move PollAnswer to Discord Models
As PollAnswer is not meant to be user constructable it has been moved to Discord Models

### 4th fix: Make PollMedia have its own reference
Just makes ``PollMedia`` has its own reference... as said.

### 5th fix: Missing space in Poll docs
It is missing a space between "Default" and "to":
![missing space](https://github.com/Rapptz/discord.py/assets/108473820/55be87b7-1215-48a1-96da-8bced76d664d)

### 6th fix: ``poll`` being undocumented in ``InteractionResponse.send_message``
Well... that.
![missing poll](https://github.com/Rapptz/discord.py/assets/108473820/20367dc4-1183-4e5e-8364-c3cfc68d9106)


I have not found further errors, so the PR is ready to be merged.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
