### PR TITLE
Fix merge methods for AppCommandContext and AppInstallationType

### DIFF
--- a/discord/app_commands/installs.py
+++ b/discord/app_commands/installs.py
@@ -78,8 +78,8 @@ class AppInstallationType:
     def merge(self, other: AppInstallationType) -> AppInstallationType:
         # Merging is similar to AllowedMentions where `self` is the base
         # and the `other` is the override preference
-        guild = self.guild if other.guild is None else other.guild
-        user = self.user if other.user is None else other.user
+        guild = self._guild if other._guild is None else other._guild
+        user = self._user if other._user is None else other._user
         return AppInstallationType(guild=guild, user=user)
 
     def _is_unset(self) -> bool:
@@ -170,9 +170,9 @@ class AppCommandContext:
         self._private_channel = bool(value)
 
     def merge(self, other: AppCommandContext) -> AppCommandContext:
-        guild = self.guild if other.guild is None else other.guild
-        dm_channel = self.dm_channel if other.dm_channel is None else other.dm_channel
-        private_channel = self.private_channel if other.private_channel is None else other.private_channel
+        guild = self._guild if other._guild is None else other._guild
+        dm_channel = self._dm_channel if other._dm_channel is None else other._dm_channel
+        private_channel = self._private_channel if other._private_channel is None else other._private_channel
         return AppCommandContext(guild=guild, dm_channel=dm_channel, private_channel=private_channel)
 
     def _is_unset(self) -> bool:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes an issue with the `merge()` method of the `AppCommandContext` and `AppInstallationType` classes which would cause the "other" to always override the flags with True or False even when unspecified (None value).

Its caused by the getter methods being used which always turn None values into False so the condition `other.guild is None` for example never evaluates to True.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
