### PR TITLE
Fix Webhook.send raising AttributeError if instated via Webhook.from_url

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -721,6 +721,11 @@ class _WebhookState:
             return self._parent._get_guild(guild_id)
         return None
 
+    def _get_poll(self, msg_id: Optional[int]) -> Optional[Poll]:
+        if self._parent is not None:
+            return self._parent._get_poll(msg_id)
+        return None
+
     def store_user(self, data: Union[UserPayload, PartialUserPayload], *, cache: bool = True) -> BaseUser:
         if self._parent is not None:
             return self._parent.store_user(data, cache=cache)


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

When using ``discord.Webhook.from_url`` and passing ``session`` instead of ``bot``, and then sending a message it raises an ``AttributeError``.

This fixes that by adding a "false" ``_get_poll`` method in ``_WebhookState``.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
