### PR TITLE
feat: Removed endpoints that are no longer usable by bots.

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -131,7 +131,6 @@ if TYPE_CHECKING:
         StageChannel as StageChannelPayload,
         ForumChannel as ForumChannelPayload,
     )
-    from .types.integration import IntegrationType
     from .types.snowflake import SnowflakeList
     from .types.widget import EditWidgetSettings
     from .types.audit_log import AuditLogEvent
@@ -1842,7 +1841,6 @@ class Guild(Hashable):
         default_notifications: NotificationLevel = MISSING,
         verification_level: VerificationLevel = MISSING,
         explicit_content_filter: ContentFilter = MISSING,
-        vanity_code: str = MISSING,
         system_channel: Optional[TextChannel] = MISSING,
         system_channel_flags: SystemChannelFlags = MISSING,
         preferred_locale: Locale = MISSING,
@@ -1920,8 +1918,6 @@ class Guild(Hashable):
             The new default notification level for the guild.
         explicit_content_filter: :class:`ContentFilter`
             The new explicit content filter for the guild.
-        vanity_code: :class:`str`
-            The new vanity code for the guild.
         system_channel: Optional[:class:`TextChannel`]
             The new channel that is used for the system channel. Could be ``None`` for no system channel.
         system_channel_flags: :class:`SystemChannelFlags`
@@ -2019,9 +2015,6 @@ class Guild(Hashable):
         """
 
         http = self._state.http
-
-        if vanity_code is not MISSING:
-            await http.change_vanity_code(self.id, vanity_code, reason=reason)
 
         fields: Dict[str, Any] = {}
         if name is not MISSING:
@@ -2784,31 +2777,6 @@ class Guild(Hashable):
         data = await self._state.http.create_template(self.id, payload)
 
         return Template(state=self._state, data=data)
-
-    async def create_integration(self, *, type: IntegrationType, id: int) -> None:
-        """|coro|
-
-        Attaches an integration to the guild.
-
-        You must have :attr:`~Permissions.manage_guild` to do this.
-
-        .. versionadded:: 1.4
-
-        Parameters
-        -----------
-        type: :class:`str`
-            The integration type (e.g. Twitch).
-        id: :class:`int`
-            The integration ID.
-
-        Raises
-        -------
-        Forbidden
-            You do not have permission to create the integration.
-        HTTPException
-            The account could not be found.
-        """
-        await self._state.http.create_integration(self.id, type, id)
 
     async def integrations(self) -> List[Integration]:
         """|coro|

--- a/discord/http.py
+++ b/discord/http.py
@@ -1722,38 +1722,6 @@ class HTTPClient:
 
         return self.request(r)
 
-    def create_integration(self, guild_id: Snowflake, type: integration.IntegrationType, id: int) -> Response[None]:
-        payload = {
-            'type': type,
-            'id': id,
-        }
-
-        r = Route('POST', '/guilds/{guild_id}/integrations', guild_id=guild_id)
-        return self.request(r, json=payload)
-
-    def edit_integration(self, guild_id: Snowflake, integration_id: Snowflake, **payload: Any) -> Response[None]:
-        r = Route(
-            'PATCH', '/guilds/{guild_id}/integrations/{integration_id}', guild_id=guild_id, integration_id=integration_id
-        )
-
-        return self.request(r, json=payload)
-
-    def sync_integration(self, guild_id: Snowflake, integration_id: Snowflake) -> Response[None]:
-        r = Route(
-            'POST', '/guilds/{guild_id}/integrations/{integration_id}/sync', guild_id=guild_id, integration_id=integration_id
-        )
-
-        return self.request(r)
-
-    def delete_integration(
-        self, guild_id: Snowflake, integration_id: Snowflake, *, reason: Optional[str] = None
-    ) -> Response[None]:
-        r = Route(
-            'DELETE', '/guilds/{guild_id}/integrations/{integration_id}', guild_id=guild_id, integration_id=integration_id
-        )
-
-        return self.request(r, reason=reason)
-
     def get_audit_logs(
         self,
         guild_id: Snowflake,


### PR DESCRIPTION
## Summary

There were a few API methods that are no longer usable by bots left in the library. As this library no longer supports self-bots, these should be removed.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
