### PR TITLE
Add reaction type to raw events and users iterator

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -823,6 +823,11 @@ class PollLayoutType(Enum):
     default = 1
 
 
+class ReactionType(Enum):
+    normal = 0
+    burst = 1
+
+
 def create_unknown_value(cls: Type[E], val: Any) -> E:
     value_cls = cls._enum_value_cls_  # type: ignore # This is narrowed below
     name = f'unknown_{val}'

--- a/discord/http.py
+++ b/discord/http.py
@@ -953,10 +953,13 @@ class HTTPClient:
 
         params: Dict[str, Any] = {
             'limit': limit,
-            'type': type,
         }
         if after:
             params['after'] = after
+
+        if type is not None:
+            params['type'] = type
+
         return self.request(r, params=params)
 
     def clear_reactions(self, channel_id: Snowflake, message_id: Snowflake) -> Response[None]:

--- a/discord/http.py
+++ b/discord/http.py
@@ -941,6 +941,7 @@ class HTTPClient:
         emoji: str,
         limit: int,
         after: Optional[Snowflake] = None,
+        type: Optional[message.ReactionType] = None,
     ) -> Response[List[user.User]]:
         r = Route(
             'GET',
@@ -952,6 +953,7 @@ class HTTPClient:
 
         params: Dict[str, Any] = {
             'limit': limit,
+            'type': type,
         }
         if after:
             params['after'] = after

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, Literal, Optional, Set, List, Tuple, Union
 
-from .enums import ChannelType, try_enum
+from .enums import ChannelType, try_enum, ReactionType
 from .utils import _get_as_snowflake
 from .app_commands import AppCommandPermissions
 from .colour import Colour
@@ -221,6 +221,10 @@ class RawReactionActionEvent(_RawReprMixin):
         and if ``event_type`` is ``REACTION_ADD``.
 
         .. versionadded:: 2.0
+    type: :class:`ReactionType`
+        The type of the reaction.
+
+        .. versionadded:: 2.4
     """
 
     __slots__ = (
@@ -234,6 +238,7 @@ class RawReactionActionEvent(_RawReprMixin):
         'message_author_id',
         'burst',
         'burst_colours',
+        'type',
     )
 
     def __init__(self, data: ReactionActionEvent, emoji: PartialEmoji, event_type: ReactionActionType) -> None:
@@ -246,6 +251,7 @@ class RawReactionActionEvent(_RawReprMixin):
         self.message_author_id: Optional[int] = _get_as_snowflake(data, 'message_author_id')
         self.burst: bool = data.get('burst', False)
         self.burst_colours: List[Colour] = [Colour.from_str(c) for c in data.get('burst_colours', [])]
+        self.type: ReactionType = try_enum(ReactionType, data['type'])
 
         try:
             self.guild_id: Optional[int] = int(data['guild_id'])

--- a/discord/reaction.py
+++ b/discord/reaction.py
@@ -223,7 +223,7 @@ class Reaction:
             For pagination, reactions are sorted by member.
         type: Optional[:class:`ReactionType`]
             The type of reaction to return users from.
-            If not provided, returns users of reactions with type ``normal``.
+            If not provided, Discord only returns users of reactions with type ``normal``.
 
             .. versionadded:: 2.4
 
@@ -249,9 +249,6 @@ class Reaction:
         if limit is None:
             limit = self.count
 
-        if type is None:
-            type = ReactionType.normal
-
         while limit > 0:
             retrieve = min(limit, 100)
 
@@ -261,7 +258,12 @@ class Reaction:
             after_id = after.id if after else None
 
             data = await state.http.get_reaction_users(
-                message.channel.id, message.id, emoji, retrieve, after=after_id, type=type.value
+                message.channel.id,
+                message.id,
+                emoji,
+                retrieve,
+                after=after_id,
+                type=type.value if type is not None else None,
             )
 
             if data:

--- a/discord/reaction.py
+++ b/discord/reaction.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, AsyncIterator, Union, Optional
 
 from .user import User
 from .object import Object
+from .enums import ReactionType
 
 # fmt: off
 __all__ = (
@@ -185,7 +186,7 @@ class Reaction:
         await self.message.clear_reaction(self.emoji)
 
     async def users(
-        self, *, limit: Optional[int] = None, after: Optional[Snowflake] = None
+        self, *, limit: Optional[int] = None, after: Optional[Snowflake] = None, type: Optional[ReactionType] = None
     ) -> AsyncIterator[Union[Member, User]]:
         """Returns an :term:`asynchronous iterator` representing the users that have reacted to the message.
 
@@ -220,6 +221,11 @@ class Reaction:
             reacted to the message.
         after: Optional[:class:`abc.Snowflake`]
             For pagination, reactions are sorted by member.
+        type: Optional[:class:`ReactionType`]
+            The type of reaction to return users from.
+            If not provided, returns users of reactions with type ``normal``.
+
+            .. versionadded:: 2.4
 
         Raises
         --------
@@ -243,6 +249,9 @@ class Reaction:
         if limit is None:
             limit = self.count
 
+        if type is None:
+            type = ReactionType.normal
+
         while limit > 0:
             retrieve = min(limit, 100)
 
@@ -251,7 +260,9 @@ class Reaction:
             state = message._state
             after_id = after.id if after else None
 
-            data = await state.http.get_reaction_users(message.channel.id, message.id, emoji, retrieve, after=after_id)
+            data = await state.http.get_reaction_users(
+                message.channel.id, message.id, emoji, retrieve, after=after_id, type=type.value
+            )
 
             if data:
                 limit -= len(data)

--- a/discord/types/gateway.py
+++ b/discord/types/gateway.py
@@ -37,7 +37,7 @@ from .invite import InviteTargetType
 from .emoji import Emoji, PartialEmoji
 from .member import MemberWithUser
 from .snowflake import Snowflake
-from .message import Message
+from .message import Message, ReactionType
 from .sticker import GuildSticker
 from .appinfo import GatewayAppInfo, PartialAppInfo
 from .guild import Guild, UnavailableGuild
@@ -104,6 +104,7 @@ class MessageReactionAddEvent(TypedDict):
     message_author_id: NotRequired[Snowflake]
     burst: bool
     burst_colors: NotRequired[List[str]]
+    type: ReactionType
 
 
 class MessageReactionRemoveEvent(TypedDict):
@@ -113,6 +114,7 @@ class MessageReactionRemoveEvent(TypedDict):
     emoji: PartialEmoji
     guild_id: NotRequired[Snowflake]
     burst: bool
+    type: ReactionType
 
 
 class MessageReactionRemoveAllEvent(TypedDict):

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -57,6 +57,9 @@ class ReactionCountDetails(TypedDict):
     normal: int
 
 
+ReactionType = Literal[0, 1]
+
+
 class Reaction(TypedDict):
     count: int
     me: bool

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3623,6 +3623,21 @@ of :class:`enum.Enum`.
 
         The default layout.
 
+
+.. class:: ReactionType
+
+    Represents the type of a reaction.
+
+    .. versionadded:: 2.4
+
+    .. attribute:: normal
+
+        A normal reaction.
+
+    .. attribute:: burst
+
+        A burst reaction, also known as a "super reaction".
+
 .. _discord-api-audit-logs:
 
 Audit Log Data


### PR DESCRIPTION
## Summary

This PR adds the reaction type to `RawReactionActionEvent` and `reaction.users` async iterator.

Related PRs:
- https://github.com/discord/discord-api-docs/pull/6377/
- https://github.com/discord/discord-api-docs/pull/6873/

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
