### PR TITLE
Fix typo "naive" to "native"

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -141,7 +141,7 @@ class Embed:
         This can be set during initialisation.
     timestamp: Optional[:class:`datetime.datetime`]
         The timestamp of the embed content. This is an aware datetime.
-        If a naive datetime is passed, it is converted to an aware
+        If a native datetime is passed, it is converted to an aware
         datetime with the local timezone.
     colour: Optional[Union[:class:`Colour`, :class:`int`]]
         The colour code of the embed. Aliased to ``color`` as well.


### PR DESCRIPTION
Fix typo "naive" to "native"

## Summary

No issues but I was confused on VSCode and atleast fix it because why not?

![typo](https://github.com/Rapptz/discord.py/assets/83082760/d77803ef-870b-47bc-8381-47b97ccc7de4)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] this is just a edit in the docstrings of a typo