### PR TITLE
Add VoiceClient.wait_until_done

### DIFF
--- a/discord/player.py
+++ b/discord/player.py
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
+
 from __future__ import annotations
 
 import threading
@@ -717,6 +718,8 @@ class AudioPlayer(threading.Thread):
         self._current_error: Optional[Exception] = None
         self._lock: threading.Lock = threading.Lock()
 
+        self._end_async: asyncio.Event = asyncio.Event(loop=client.loop)
+
         if after is not None and not callable(after):
             raise TypeError('Expected a callable for the "after" parameter.')
 
@@ -774,7 +777,8 @@ class AudioPlayer(threading.Thread):
             self.stop()
         finally:
             self._call_after()
-            self.source.cleanup()
+            self._cleanup()
+            self.client.loop.call_soon_threadsafe(self._end_async.set)
 
     def _call_after(self) -> None:
         error = self._current_error
@@ -787,6 +791,12 @@ class AudioPlayer(threading.Thread):
                 _log.exception('Calling the after function failed.', exc_info=exc)
         elif error:
             _log.exception('Exception in voice thread %s', self.name, exc_info=error)
+
+    def _cleanup(self) -> None:
+        try:
+            self.source.cleanup()
+        except Exception:
+            _log.exception("Error cleaning up audio source %s", self.source)
 
     def stop(self) -> None:
         self._end.set()
@@ -816,6 +826,10 @@ class AudioPlayer(threading.Thread):
             self.pause(update_speaking=False)
             self.source = source
             self.resume(update_speaking=False)
+
+    async def wait_async(self) -> Optional[Exception]:
+        await self._end_async.wait()
+        return self._current_error
 
     def _speak(self, speaking: SpeakingState) -> None:
         try:

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -538,6 +538,25 @@ class VoiceClient(VoiceProtocol):
 
         self._player.set_source(value)
 
+    async def wait_until_done(self) -> Optional[Exception]:
+        """|coro|
+
+        Waits for the audio player to finish playback and returns any encountered error.
+
+        Returns
+        --------
+        Optional[:class:`Exception`]
+            The exception the player encountered during playback, or ``None``.
+        """
+
+        if not self.is_connected():
+            raise ClientException('Not connected to voice.')
+
+        if self._player is None:
+            raise ValueError('Not playing anything.')
+
+        return await self._player.wait_async()
+
     def send_audio_packet(self, data: bytes, *, encode: bool = True) -> None:
         """Sends an audio packet composed of the data.
 


### PR DESCRIPTION
## Summary

Adds a new function: `VoiceClient.wait_until_done`.  As the name suggests, it waits until the player is done, similar to the other `wait_until_` functions.

There are probably some places in the docs this could be mentioned but i'll add another commit for that later.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
