### PR TITLE
[commands] fix HelpCommand not carrying over checks

### DIFF
--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -297,6 +297,11 @@ class _HelpCommandImpl(Command):
         # Revert `on_error` to use the original one in case of race conditions
         self.on_error = self._injected.on_help_command_error
 
+    def update(self, **kwargs: Any) -> None:
+        cog = self.cog
+        self.__init__(self._original, **dict(self.__original_kwargs__, **kwargs))
+        self.cog = cog
+
 
 class HelpCommand:
     r"""The base implementation for help command formatting.
@@ -377,9 +382,8 @@ class HelpCommand:
         return obj
 
     def _add_to_bot(self, bot: BotBase) -> None:
-        command = _HelpCommandImpl(self, **self.command_attrs)
-        bot.add_command(command)
-        self._command_impl = command
+        self._command_impl.update(**self.command_attrs)
+        bot.add_command(self._command_impl)
 
     def _remove_from_bot(self, bot: BotBase) -> None:
         bot.remove_command(self._command_impl.name)


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Calling `HelpCommand.add_check` before setting the help command would not carry over checks since a new command_impl is created.

Fixes #9827 
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
