### PR TITLE
Update Polls event docs

### DIFF
--- a/discord/poll.py
+++ b/discord/poll.py
@@ -446,7 +446,12 @@ class Poll:
 
     @property
     def created_at(self) -> Optional[datetime.datetime]:
-        """:class:`datetime.datetime`: Returns the poll's creation time, or ``None`` if user-created."""
+        """Optional[:class:`datetime.datetime`]: Returns the poll's creation time.
+
+        .. note::
+
+            This will **always** be ``None`` for stateless polls.
+        """
 
         if not self._message:
             return

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1053,8 +1053,8 @@ Polls
 .. function:: on_poll_vote_add(user, answer)
               on_poll_vote_remove(user, answer)
 
-    Called when a :class:`Poll` gains or loses a vote. If the ``user`` or ``message``
-    are not cached then this event will not be called.
+    Called when a :class:`Poll` gains or loses a vote. If the ``user`` or ``answer``'s poll
+    parent message are not cached then this event will not be called.
 
     This requires :attr:`Intents.message_content` and :attr:`Intents.polls` to be enabled.
 
@@ -1077,6 +1077,11 @@ Polls
     this is called regardless of the state of the internal user and message cache.
 
     This requires :attr:`Intents.message_content` and :attr:`Intents.polls` to be enabled.
+
+    .. note::
+
+        If the poll allows multiple answers and the user removes or adds multiple votes, this
+        event will be called as many times as votes that are added or removed.
 
     .. versionadded:: 2.4
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
``on_poll_vote_add``/``remove`` [docs page](https://discordpy.readthedocs.io/en/latest/api.html#polls) still shows ``message`` as if it was an event parameter.

This fixes that and also adds the note from ``on_poll_vote_add``/``remove`` on ``on_raw_poll_vote_add``/``remove``

P.S.: in a previous version of poll events, the signatures were ``(user, message, answer)``, that is why it was like that.

Also fixes ``Poll.created_at`` docstring.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
