### PR TITLE
Add notes about contexts and installation_types only being available for global commands

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -2374,7 +2374,7 @@ def guilds(*guild_ids: Union[Snowflake, int]) -> Callable[[T], T]:
 
     .. note ::
 
-        Due to a Discord limitation, this decorator cannot be used in conjunction with 
+        Due to a Discord limitation, this decorator cannot be used in conjunction with
         contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
         (e.g. :func:`.app_commands.allowed_installs`).
 

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -2372,6 +2372,12 @@ def guilds(*guild_ids: Union[Snowflake, int]) -> Callable[[T], T]:
         with the :meth:`CommandTree.command` or :meth:`CommandTree.context_menu` decorator
         then this must go below that decorator.
 
+    .. note ::
+
+        Due to a Discord limitation, this decorator cannot be used in conjunction with 
+        contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
+        (e.g. :func:`.app_commands.allowed_installs`).
+
     Example:
 
     .. code-block:: python3

--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -307,10 +307,24 @@ class CommandTree(Generic[ClientT]):
         guild: Optional[:class:`~discord.abc.Snowflake`]
             The guild to add the command to. If not given or ``None`` then it
             becomes a global command instead.
+
+            .. note ::
+
+                Due to a Discord limitation, this keyword argument cannot be used in conjunction with
+                contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
+                (e.g. :func:`.app_commands.allowed_installs`).
+
         guilds: List[:class:`~discord.abc.Snowflake`]
             The list of guilds to add the command to. This cannot be mixed
             with the ``guild`` parameter. If no guilds are given at all
             then it becomes a global command instead.
+
+            .. note ::
+
+                Due to a Discord limitation, this keyword argument cannot be used in conjunction with
+                contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
+                (e.g. :func:`.app_commands.allowed_installs`).
+
         override: :class:`bool`
             Whether to override a command with the same name. If ``False``
             an exception is raised. Default is ``False``.

--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -880,7 +880,7 @@ class CommandTree(Generic[ClientT]):
 
             .. note ::
 
-                Due to a Discord limitation, this kwarg cannot be used in conjunction with 
+                Due to a Discord limitation, this kwarg cannot be used in conjunction with
                 contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
                 (e.g. :func:`.app_commands.allowed_installs`).
 
@@ -891,7 +891,7 @@ class CommandTree(Generic[ClientT]):
 
             .. note ::
 
-                Due to a Discord limitation, this kwarg cannot be used in conjunction with 
+                Due to a Discord limitation, this kwarg cannot be used in conjunction with
                 contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
                 (e.g. :func:`.app_commands.allowed_installs`).
 
@@ -977,7 +977,7 @@ class CommandTree(Generic[ClientT]):
 
             .. note ::
 
-                Due to a Discord limitation, this kwarg cannot be used in conjunction with 
+                Due to a Discord limitation, this kwarg cannot be used in conjunction with
                 contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
                 (e.g. :func:`.app_commands.allowed_installs`).
 
@@ -988,7 +988,7 @@ class CommandTree(Generic[ClientT]):
 
             .. note ::
 
-                Due to a Discord limitation, this kwarg cannot be used in conjunction with 
+                Due to a Discord limitation, this kwarg cannot be used in conjunction with
                 contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
                 (e.g. :func:`.app_commands.allowed_installs`).
 

--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -894,7 +894,7 @@ class CommandTree(Generic[ClientT]):
 
             .. note ::
 
-                Due to a Discord limitation, this kwarg cannot be used in conjunction with
+                Due to a Discord limitation, this keyword argument cannot be used in conjunction with
                 contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
                 (e.g. :func:`.app_commands.allowed_installs`).
 
@@ -905,7 +905,7 @@ class CommandTree(Generic[ClientT]):
 
             .. note ::
 
-                Due to a Discord limitation, this kwarg cannot be used in conjunction with
+                Due to a Discord limitation, this keyword argument cannot be used in conjunction with
                 contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
                 (e.g. :func:`.app_commands.allowed_installs`).
 
@@ -991,7 +991,7 @@ class CommandTree(Generic[ClientT]):
 
             .. note ::
 
-                Due to a Discord limitation, this kwarg cannot be used in conjunction with
+                Due to a Discord limitation, this keyword argument cannot be used in conjunction with
                 contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
                 (e.g. :func:`.app_commands.allowed_installs`).
 
@@ -1002,7 +1002,7 @@ class CommandTree(Generic[ClientT]):
 
             .. note ::
 
-                Due to a Discord limitation, this kwarg cannot be used in conjunction with
+                Due to a Discord limitation, this keyword argument cannot be used in conjunction with
                 contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
                 (e.g. :func:`.app_commands.allowed_installs`).
 

--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -877,10 +877,24 @@ class CommandTree(Generic[ClientT]):
         guild: Optional[:class:`~discord.abc.Snowflake`]
             The guild to add the command to. If not given or ``None`` then it
             becomes a global command instead.
+
+            .. note ::
+
+                Due to a Discord limitation, this kwarg cannot be used in conjunction with 
+                contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
+                (e.g. :func:`.app_commands.allowed_installs`).
+
         guilds: List[:class:`~discord.abc.Snowflake`]
             The list of guilds to add the command to. This cannot be mixed
             with the ``guild`` parameter. If no guilds are given at all
             then it becomes a global command instead.
+
+            .. note ::
+
+                Due to a Discord limitation, this kwarg cannot be used in conjunction with 
+                contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
+                (e.g. :func:`.app_commands.allowed_installs`).
+
         auto_locale_strings: :class:`bool`
             If this is set to ``True``, then all translatable strings will implicitly
             be wrapped into :class:`locale_str` rather than :class:`str`. This could
@@ -960,10 +974,24 @@ class CommandTree(Generic[ClientT]):
         guild: Optional[:class:`~discord.abc.Snowflake`]
             The guild to add the command to. If not given or ``None`` then it
             becomes a global command instead.
+
+            .. note ::
+
+                Due to a Discord limitation, this kwarg cannot be used in conjunction with 
+                contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
+                (e.g. :func:`.app_commands.allowed_installs`).
+
         guilds: List[:class:`~discord.abc.Snowflake`]
             The list of guilds to add the command to. This cannot be mixed
             with the ``guild`` parameter. If no guilds are given at all
             then it becomes a global command instead.
+
+            .. note ::
+
+                Due to a Discord limitation, this kwarg cannot be used in conjunction with 
+                contexts (e.g. :func:`.app_commands.allowed_contexts`) or installation types
+                (e.g. :func:`.app_commands.allowed_installs`).
+
         auto_locale_strings: :class:`bool`
             If this is set to ``True``, then all translatable strings will implicitly
             be wrapped into :class:`locale_str` rather than :class:`str`. This could


### PR DESCRIPTION
## Summary

**While in preview,** only global commands can be made into user installable apps and I think the docs should note that on the guild(s) decorator and kwargs.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
