### PR TITLE
Add note about `archiver_id`

### DIFF
--- a/discord/threads.py
+++ b/discord/threads.py
@@ -123,8 +123,7 @@ class Thread(Messageable, Hashable):
         The user's ID that archived this thread.
 
         .. note::
-            This field has been removed from the :ddocs:`Thread Metadata Object <resources/channel#thread-metadata-object>`.
-            The ``archiver_id``, therefore, will always be ``None`` and can only be obtained via the audit log now.
+            Due to an API change, the ``archiver_id`` will always be ``None`` and can only be obtained via the audit log now.
 
     auto_archive_duration: :class:`int`
         The duration in minutes until the thread is automatically hidden from the channel list.

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -121,6 +121,11 @@ class Thread(Messageable, Hashable):
         This is always ``True`` for public threads.
     archiver_id: Optional[:class:`int`]
         The user's ID that archived this thread.
+
+        .. note::
+            This field has been removed from the :ddocs:`Thread Metadata Object <resources/channel#thread-metadata-object>`.
+            The ``archiver_id``, therefore, will always be ``None`` and can only be obtained via the audit log now.
+
     auto_archive_duration: :class:`int`
         The duration in minutes until the thread is automatically hidden from the channel list.
         Usually a value of 60, 1440, 4320 and 10080.

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -123,7 +123,7 @@ class Thread(Messageable, Hashable):
         The user's ID that archived this thread.
 
         .. note::
-            Due to an API change, the ``archiver_id`` will always be ``None`` and can only be obtained via the audit log now.
+            Due to an API change, the ``archiver_id`` will always be ``None`` and can only be obtained via the audit log.
 
     auto_archive_duration: :class:`int`
         The duration in minutes until the thread is automatically hidden from the channel list.


### PR DESCRIPTION
## Summary

Discord removed the `archiver_id` field from their thread metadata.
See following discussion thread and api docs commit:
https://github.com/Rapptz/discord.py/discussions/9850
https://github.com/discord/discord-api-docs/commit/82c98ba5699b69706cfb493a7c6e08b67ae1a8f3

This pull request adds a note explaining that the value will always be `None` and that the id can only be acquired via the audit log now
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
