### PR TITLE
Remove incorrect role increase

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -436,8 +436,7 @@ class Guild(Hashable):
 
     def _remove_role(self, role_id: int, /) -> Role:
         # this raises KeyError if it fails..
-        role = self._roles.pop(role_id)
-        return role
+        return self._roles.pop(role_id)
 
     @classmethod
     def _create_unavailable(cls, *, state: ConnectionState, guild_id: int, data: Optional[Dict[str, Any]]) -> Guild:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -432,26 +432,11 @@ class Guild(Hashable):
         return member, before, after
 
     def _add_role(self, role: Role, /) -> None:
-        # roles get added to the bottom (position 1, pos 0 is @everyone)
-        # so since self.roles has the @everyone role, we can't increment
-        # its position because it's stuck at position 0. Luckily x += False
-        # is equivalent to adding 0. So we cast the position to a bool and
-        # increment it.
-        for r in self._roles.values():
-            r.position += not r.is_default()
-
         self._roles[role.id] = role
 
     def _remove_role(self, role_id: int, /) -> Role:
         # this raises KeyError if it fails..
         role = self._roles.pop(role_id)
-
-        # since it didn't, we can change the positions now
-        # basically the same as above except we only decrement
-        # the position if we're above the role we deleted.
-        for r in self._roles.values():
-            r.position -= r.position > role.position
-
         return role
 
     @classmethod


### PR DESCRIPTION
## Summary

This PR removes code that increases the internal cache's role position when a role is created or deleted. This fixes an issue where every time a role is made, the bot's internal cache drifts away from the API's role position every time a role is created or deleted.

![image](https://leo.might-be.gay/STD9NB.png)

I was able to reproduce this exact scenario, here are the [debug logs](https://mystb.in/d2b000a6019d6b1c43)

Also, running this eval in guilds after creating and moving roles around will show mismatched positions:
```py
ret = []
# Fetching so the roles are sorted how the client sees them.
for role in reversed(sorted(await guild.fetch_roles())):
    r = discord.utils.get(guild.roles, id=role.id)
    ret.append(f'`{role.position: >2}` `{r.position: >2}` {r.name}') 
return '\n'.join(ret)
```
Here's code I made to purposefully mess up the cache's percieved role order while I was testing:

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
