### PR TITLE
Attach command on Choice for translator

### DIFF
--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -474,7 +474,7 @@ class Choice(Generic[ChoiceT]):
         self._locale_name: Optional[locale_str] = locale
         self.value: ChoiceT = value
         self.name_localizations: Dict[Locale, str] = {}
-        self.__command: Optional[Command] = None
+        self.__command: Optional[Command[Any, ..., Any]] = None
 
     @classmethod
     def from_dict(cls, data: ApplicationCommandOptionChoice) -> Choice[ChoiceT]:
@@ -507,12 +507,12 @@ class Choice(Generic[ChoiceT]):
             )
 
     @property
-    def command(self) -> Optional[Command]:
+    def command(self) -> Optional[Command[Any, ..., Any]]:
         """Optional[:class:`Command`]: The command this choice belongs to.
         This is only set when used in a :class:`.app_commands.Translator` context."""
         return self.__command
 
-    async def get_translated_payload(self, translator: Translator, command: Command) -> Dict[str, Any]:
+    async def get_translated_payload(self, translator: Translator, command: Command[Any, ..., Any]) -> Dict[str, Any]:
         base = self.to_dict()
         name_localizations: Dict[str, str] = {}
         context = TranslationContext(location=TranslationContextLocation.choice_name, data=self)

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -115,7 +115,7 @@ class CommandParameter:
                     description_localizations[locale.value] = translation
 
         if self.choices:
-            base['choices'] = [await choice.get_translated_payload(translator) for choice in self.choices]
+            base['choices'] = [await choice.get_translated_payload(translator, data.command) for choice in self.choices]
 
         if name_localizations:
             base['name_localizations'] = name_localizations

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -1075,8 +1075,11 @@ class InteractionResponse(Generic[ClientT]):
         translator = self._parent._state._translator
         if translator is not None:
             user_locale = self._parent.locale
+            command: Command[Any, ..., Any] = self._parent.command  # type: ignore # only chat input commands can have autocomplete
             payload: Dict[str, Any] = {
-                'choices': [await option.get_translated_payload_for_locale(translator, user_locale) for option in choices],
+                'choices': [
+                    await option.get_translated_payload_for_locale(translator, user_locale, command) for option in choices
+                ],
             }
         else:
             payload: Dict[str, Any] = {


### PR DESCRIPTION
## Summary

This PR adds a `command` property to `app_commands.Choice` that can only be used to access the.. command inside the translator's translate method. 

I wasn't sure on always attaching the command on the Choice since it doesn't store any state and is pretty lightweight.

### Why?

Currently, there is no way to access the command if `context.location` is `TranslationContextLocation.choice_name` in `app_commands.Translator.translate` which is useful for implementations that store the strings per command name.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
