### PR TITLE
Revert "Set socket family of connector to AF_INET"

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -48,7 +48,6 @@ from typing import (
 from urllib.parse import quote as _uriquote
 from collections import deque
 import datetime
-import socket
 
 import aiohttp
 
@@ -798,8 +797,7 @@ class HTTPClient:
     async def static_login(self, token: str) -> user.User:
         # Necessary to get aiohttp to stop complaining about session creation
         if self.connector is MISSING:
-            # discord does not support ipv6
-            self.connector = aiohttp.TCPConnector(limit=0, family=socket.AF_INET)
+            self.connector = aiohttp.TCPConnector(limit=0)
 
         self.__session = aiohttp.ClientSession(
             connector=self.connector,


### PR DESCRIPTION
This change was made since Discord doesn't support IPv6, and there were concerns about clients with DNS64 enabled without NAT64.

However, this breaks hosts who don't have v4 connectivity and are _actually_ running NAT64 (me!)

Having DNS64 without NAT64 is really an issue on the client's end. It would break far more than just discord.py, so I don't think we should be concerned about those cases. I'm proposing this change be reverted.
