### PR TITLE
fix: Polls limiting duration at 7 days

### DIFF
--- a/discord/poll.py
+++ b/discord/poll.py
@@ -388,9 +388,6 @@ class Poll:
         # self.created_at = message.created_at
         # duration = self.created_at - expiry
 
-        if (duration.total_seconds() / 3600) > 168:  # As the duration may exceed little milliseconds then we fix it
-            duration = datetime.timedelta(days=7)
-
         self = cls(
             duration=duration,
             multiple=multiselect,


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
So Discord recently allowed polls to be 32 days long so the check in ``Poll._from_data`` that "fixes" the poll duration at 7 days should be removed.

This also makes sure that if Discord changes the maximum duration for polls again there won't be any problems.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
