### PR TITLE
Fix broken image paths in docs

### DIFF
--- a/docs/discord.rst
+++ b/docs/discord.rst
@@ -13,12 +13,12 @@ Creating a Bot account is a pretty straightforward process.
 2. Navigate to the `application page <https://discord.com/developers/applications>`_
 3. Click on the "New Application" button.
 
-    .. image:: /images/discord_create_app_button.png
+    .. image:: /docs/images/discord_create_app_button.png
         :alt: The new application button.
 
 4. Give the application a name and click "Create".
 
-    .. image:: /images/discord_create_app_form.png
+    .. image:: /docs/images/discord_create_app_form.png
         :alt: The new application form filled in.
 
 5. Navigate to the "Bot" tab to configure it.
@@ -27,7 +27,7 @@ Creating a Bot account is a pretty straightforward process.
     - You should also make sure that **Require OAuth2 Code Grant** is unchecked unless you
       are developing a service that needs it. If you're unsure, then **leave it unchecked**.
 
-    .. image:: /images/discord_bot_user_options.png
+    .. image:: /docs/images/discord_bot_user_options.png
         :alt: How the Bot User options should look like for most people.
 
 7. Copy the token using the "Copy" button.
@@ -63,12 +63,12 @@ If you want to invite your bot you must create an invite URL for it.
 3. Click on your bot's page.
 4. Go to the "OAuth2 > URL Generator" tab.
 
-    .. image:: /images/discord_oauth2.png
+    .. image:: /docs/images/discord_oauth2.png
         :alt: How the OAuth2 page should look like.
 
 5. Tick the "bot" checkbox under "scopes".
 
-    .. image:: /images/discord_oauth2_scope.png
+    .. image:: /docs/images/discord_oauth2_scope.png
         :alt: The scopes checkbox with "bot" ticked.
 
 6. Tick the permissions required for your bot to function under "Bot Permissions".
@@ -77,7 +77,7 @@ If you want to invite your bot you must create an invite URL for it.
 
     - Bot owners must have 2FA enabled for certain actions and permissions when added in servers that have Server-Wide 2FA enabled. Check the `2FA support page <https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication>`_ for more information.
 
-    .. image:: /images/discord_oauth2_perms.png
+    .. image:: /docs/images/discord_oauth2_perms.png
         :alt: The permission checkboxes with some permissions checked.
 
 7. Now the resulting URL can be used to add your bot to a server. Copy and paste the URL into your browser, choose a server to invite the bot to, and click "Authorize".

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -94,15 +94,15 @@ The most basic form of parameter passing is the positional parameter. This is wh
 
 On the bot using side, you can provide positional arguments by just passing a regular string:
 
-.. image:: /images/commands/positional1.png
+.. image:: /docs/images/commands/positional1.png
 
 To make use of a word with spaces in between, you should quote it:
 
-.. image:: /images/commands/positional2.png
+.. image:: /docs/images/commands/positional2.png
 
 As a note of warning, if you omit the quotes, you will only get the first word:
 
-.. image:: /images/commands/positional3.png
+.. image:: /docs/images/commands/positional3.png
 
 Since positional arguments are just regular Python arguments, you can have as many as you want:
 
@@ -130,16 +130,16 @@ so multi-word parameters should be quoted.
 
 For example, on the bot side:
 
-.. image:: /images/commands/variable1.png
+.. image:: /docs/images/commands/variable1.png
 
 If the user wants to input a multi-word argument, they have to quote it like earlier:
 
-.. image:: /images/commands/variable2.png
+.. image:: /docs/images/commands/variable2.png
 
 Do note that similar to the Python function behaviour, a user can technically pass no arguments
 at all:
 
-.. image:: /images/commands/variable3.png
+.. image:: /docs/images/commands/variable3.png
 
 Since the ``args`` variable is a :class:`py:tuple`,
 you can do anything you would usually do with one.
@@ -163,11 +163,11 @@ seen below:
 
 On the bot side, we do not need to quote input with spaces:
 
-.. image:: /images/commands/keyword1.png
+.. image:: /docs/images/commands/keyword1.png
 
 Do keep in mind that wrapping it in quotes leaves it as-is:
 
-.. image:: /images/commands/keyword2.png
+.. image:: /docs/images/commands/keyword2.png
 
 By default, the keyword-only arguments are stripped of white space to make it easier to work with. This behaviour can be
 toggled by the :attr:`.Command.rest_is_raw` argument in the decorator.
@@ -522,7 +522,7 @@ Consider the following example:
         await ctx.send(f'{amount} bottles of {liquid} on the wall!')
 
 
-.. image:: /images/commands/optional1.png
+.. image:: /docs/images/commands/optional1.png
 
 In this example, since the argument could not be converted into an ``int``, the default of ``99`` is passed and the parser
 resumes handling, which in this case would be to pass it into the ``liquid`` parameter.
@@ -596,7 +596,7 @@ Consider the following example:
 
 When invoked, it allows for any number of members to be passed in:
 
-.. image:: /images/commands/greedy1.png
+.. image:: /docs/images/commands/greedy1.png
 
 The type passed when using this converter depends on the parameter type that it is being attached to:
 
@@ -752,7 +752,7 @@ For example, the following code:
 
 Allows the user to invoke the command using a simple flag-like syntax:
 
-.. image:: /images/commands/flags1.png
+.. image:: /docs/images/commands/flags1.png
 
 Flags use a syntax that allows the user to not require quotes when passing in values to the flag. The goal of the
 flag syntax is to be as user-friendly as possible. This makes flags a good choice for complicated commands that can have
@@ -858,7 +858,7 @@ For example, augmenting the example above:
 
 This is called by repeatedly specifying the flag:
 
-.. image:: /images/commands/flags2.png
+.. image:: /docs/images/commands/flags2.png
 
 typing.Tuple
 ^^^^^^^^^^^^^
@@ -879,7 +879,7 @@ allows for "greedy-like" semantics using a variadic tuple:
 
 This allows the previous ``ban`` command to be called like this:
 
-.. image:: /images/commands/flags3.png
+.. image:: /docs/images/commands/flags3.png
 
 The :class:`py:tuple` annotation also allows for parsing of pairs. For example, given the following code:
 
@@ -1225,8 +1225,8 @@ The above command can be invoked as both text and slash command. Note that you h
 sync your :class:`~app_commands.CommandTree` by calling :class:`~app_commands.CommandTree.sync` in order
 for slash commands to appear.
 
-.. image:: /images/commands/hybrid1.png
-.. image:: /images/commands/hybrid2.png
+.. image:: /docs/images/commands/hybrid1.png
+.. image:: /docs/images/commands/hybrid2.png
 
 You can create hybrid command groups and sub-commands using the :meth:`.Bot.hybrid_group`
 decorator.
@@ -1244,8 +1244,8 @@ decorator.
 Due to a Discord limitation, slash command groups cannot be invoked directly so the ``fallback``
 parameter allows you to create a sub-command that will be bound to callback of parent group.
 
-.. image:: /images/commands/hybrid3.png
-.. image:: /images/commands/hybrid4.png
+.. image:: /docs/images/commands/hybrid3.png
+.. image:: /docs/images/commands/hybrid4.png
 
 Due to certain limitations on slash commands, some features of text commands are not supported
 on hybrid commands. You can define a hybrid command as long as it meets the same subset that is

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,8 +6,8 @@
 Welcome to discord.py
 ===========================
 
-.. image:: /images/snake.svg
-.. image:: /images/snake_dark.svg
+.. image:: /docs/images/snake.svg
+.. image:: /docs/images/snake_dark.svg
 
 discord.py is a modern, easy to use, feature-rich, and async ready API wrapper
 for Discord.


### PR DESCRIPTION
## Summary

I noticed the images in some of the documentation weren't loading, so I added /docs to the start of all the paths.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
