### PR TITLE
Support commands.parameter for hybrid app commands

### DIFF
--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -271,7 +271,11 @@ def replace_parameters(
 ) -> List[inspect.Parameter]:
     # Need to convert commands.Parameter back to inspect.Parameter so this will be a bit ugly
     params = signature.parameters.copy()
+
+    pending_rename: Dict[str, str] = {}
+    pending_description: Dict[str, str] = {}
     for name, parameter in parameters.items():
+
         converter = parameter.converter
         # Parameter.converter properly infers from the default and has a str default
         # This allows the actual signature to inherit this property
@@ -281,6 +285,12 @@ def replace_parameters(
         if parameter.default is not parameter.empty:
             default = _CallableDefault(parameter.default) if callable(parameter.default) else parameter.default
             param = param.replace(default=default)
+
+        if parameter.description:
+            pending_description[name] = parameter.description
+
+        if parameter.displayed_name:
+            pending_rename[name] = parameter.displayed_name
 
         if isinstance(param.default, Parameter):
             # If we're here, then then it hasn't been handled yet so it should be removed completely
@@ -292,6 +302,12 @@ def replace_parameters(
             continue
 
         params[name] = param
+
+    if pending_description:
+        app_commands.describe(**pending_description)(callback)
+
+    if pending_rename:
+        app_commands.rename(**pending_rename)(callback)
 
     return list(params.values())
 


### PR DESCRIPTION
## Summary

Bit of a misleiding title but what this PR basically does it copy over the displayed_name and description from commands.Parameter if `commands.(param)eter` is used in a hybrid command because most people expect this to happen anyways and I think it makes sense.

I don't know if any docs changes are needed here.

### Breaking changes
This *could* be a breaking change for people that don't expect this to happen and may want a different description for the prefix part of the hybrid command or don't want `displayed_name` to rename it... should there maybe be a toggle for this?

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
