### PR TITLE
Fix _get_command_error improperly handling some error messages

### DIFF
--- a/discord/app_commands/errors.py
+++ b/discord/app_commands/errors.py
@@ -485,6 +485,10 @@ def _get_command_error(
         if key == 'options':
             for index, d in remaining.items():
                 _get_command_error(index, d, children, messages, indent=indent + 2)
+        elif key == '_errors':
+            errors = [x.get('message', '') for x in remaining]
+
+            messages.extend(f'{indentation}  {message}' for message in errors)
         else:
             if isinstance(remaining, dict):
                 try:
@@ -493,8 +497,6 @@ def _get_command_error(
                     errors = _flatten_error_dict(remaining, key=key)
                 else:
                     errors = {key: ' '.join(x.get('message', '') for x in inner_errors)}
-            else:
-                errors = _flatten_error_dict(remaining, key=key)
 
             messages.extend(f'{indentation}  {k}: {v}' for k, v in errors.items())
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

`_get_command_error` was incorrectly handling some of the errors that discord returns. One example is the following command (credit to Soheab for the repro):
```py
@bot.tree.command()
@discord.app_commands.rename(one="two")
async def test(
    interaction: discord.Interaction,
    one: int,
    two: str
):
    ...
```
This results in an error response from discord when syncing commands with a structure that discord.py 2.4 fails to parse, resulting in an exception.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
