### PR TITLE
Aiodns win fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ docs = [
 ]
 speed = [
     "orjson>=3.5.4",
-    "aiodns>=1.1",
+    "aiodns>=1.1; sys_platform != 'win32'",
     "Brotli",
     "cchardet==2.1.7; python_version < '3.10'",
 ]


### PR DESCRIPTION
## Summary

See bikeshedding here: https://discord.com/channels/336642139381301249/1268727114568564847

3 of the 4 possible options each have a fix here. 

2 of the 3 changes both require `import sys`, so that's been added as a separate commit in case one of these changes isn't wanted to allow quickly selectively dropping components of this.

If documentation is wanted, I can follow up with that as well

Notes on potential breakage:

Any other library relying on the parts of the windows proactor event loop that are unique to that event loop may become incompatible. with these changes, as the conditions for setting this event loop are constrained to when there was already something relying on the selector event loop's semantics that discord.py uses when available (aiodns via aiohttp) this is not newly breaking, just changing how users are notified that they specified a reliance on 2 incompatible things.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
