### PR TITLE
Fix Poll.duration rounding errors

### DIFF
--- a/discord/poll.py
+++ b/discord/poll.py
@@ -385,7 +385,7 @@ class Poll:
         question = question_data.get('text')
         expiry = utils.parse_time(data['expiry'])  # If obtained via API, then expiry is set.
         # expiry - message.created_at may be a few nanos away from the actual duration
-        duration = datetime.timedelta(hours = round((expiry - message.created_at).total_seconds() / 3600))
+        duration = datetime.timedelta(hours=round((expiry - message.created_at).total_seconds() / 3600))
         # self.created_at = message.created_at
 
         self = cls(

--- a/discord/poll.py
+++ b/discord/poll.py
@@ -384,9 +384,9 @@ class Poll:
         question_data = data.get('question')
         question = question_data.get('text')
         expiry = utils.parse_time(data['expiry'])  # If obtained via API, then expiry is set.
-        duration = expiry - message.created_at
+        # expiry - message.created_at may be a few nanos away from the actual duration
+        duration = datetime.timedelta(hours = round((expiry - message.created_at).total_seconds() / 3600))
         # self.created_at = message.created_at
-        # duration = self.created_at - expiry
 
         self = cls(
             duration=duration,


### PR DESCRIPTION
## Summary

In `Poll._from_data`, `expiry - message.created_at` may be a non-integer number of hours. If a received poll has a duration of only one hour, then `_to_dict()` may yield something like `{ ... 'duration': 0.9999991738888889 ... }` and attempting to re-send the poll would raise an an `Invalid form body` error as `duration` cannot be less than 1.
I put the fix for this in `_from_data` to maintain the current API behavior of making it the developer's responsibility to ensure that new polls have a valid duration.
 
## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
