### PR TITLE
feat: Add support for ``POLL_RESULT`` messages

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -256,6 +256,7 @@ class MessageType(Enum):
     guild_incident_alert_mode_disabled = 37
     guild_incident_report_raid = 38
     guild_incident_report_false_alarm = 39
+    poll_result = 46
 
 
 class SpeakingState(Enum):

--- a/discord/message.py
+++ b/discord/message.py
@@ -2269,10 +2269,11 @@ class Message(PartialMessage, Hashable):
                     ref.resolved = self.__class__(channel=chan, data=resolved, state=state)  # type: ignore
 
             if self.type is MessageType.poll_result:
-                if self.reference.resolved is not None:
+                if isinstance(self.reference.resolved, self.__class__):
                     self._state._update_poll_results(self, self.reference.resolved)
                 else:
-                    self._state._update_poll_results(self, self.reference.message_id)
+                    if self.reference.message_id:
+                        self._state._update_poll_results(self, self.reference.message_id)
 
         self.application: Optional[MessageApplication] = None
         try:

--- a/discord/message.py
+++ b/discord/message.py
@@ -2426,12 +2426,12 @@ class Message(PartialMessage, Hashable):
             return f'{self.author.name} reported a false alarm in {self.guild}.'
 
         if self.type is MessageType.poll_result:
-            embed = self.embeds[0]  # Will always have 1
-            poll_title = utils.find(
-                lambda f: f.name == 'poll_question_text',
+            embed = self.embeds[0]  # Will always have 1 embed
+            poll_title = utils.get(
                 embed.fields,
+                name='poll_question_text',
             )
-            return f'The poll {poll_title} has closed.'
+            return f'{self.author.display_name}\'s poll {poll_title.value} has closed.'
 
         # Fallback for unknown message types
         return ''

--- a/discord/message.py
+++ b/discord/message.py
@@ -1844,7 +1844,6 @@ class Message(PartialMessage, Hashable):
             self.poll = Poll._from_data(data=data['poll'], message=self, state=state)
         except KeyError:
             self.poll = state._get_poll(self.id)
-            self.poll._update_results_from_message(self)
 
         try:
             # if the channel doesn't have a guild attribute, we handle that
@@ -1909,6 +1908,9 @@ class Message(PartialMessage, Hashable):
 
                     # the channel will be the correct type here
                     ref.resolved = self.__class__(channel=chan, data=resolved, state=state)  # type: ignore
+
+                    if self.type is MessageType.poll_result and ref.resolved.poll:
+                        ref.resolved.poll._update_results_from_message(self)
 
         self.application: Optional[MessageApplication] = None
         try:

--- a/discord/message.py
+++ b/discord/message.py
@@ -2431,7 +2431,7 @@ class Message(PartialMessage, Hashable):
                 embed.fields,
                 name='poll_question_text',
             )
-            return f'{self.author.display_name}\'s poll {poll_title.value} has closed.'
+            return f'{self.author.display_name}\'s poll {poll_title.value} has closed.'  # type: ignore
 
         # Fallback for unknown message types
         return ''

--- a/discord/message.py
+++ b/discord/message.py
@@ -1844,6 +1844,7 @@ class Message(PartialMessage, Hashable):
             self.poll = Poll._from_data(data=data['poll'], message=self, state=state)
         except KeyError:
             self.poll = state._get_poll(self.id)
+            self.poll._update_results_from_message(self)
 
         try:
             # if the channel doesn't have a guild attribute, we handle that
@@ -2260,6 +2261,7 @@ class Message(PartialMessage, Hashable):
             MessageType.chat_input_command,
             MessageType.context_menu_command,
             MessageType.thread_starter_message,
+            MessageType.poll_result,
         )
 
     @utils.cached_slot_property('_cs_system_content')
@@ -2414,6 +2416,14 @@ class Message(PartialMessage, Hashable):
 
         if self.type is MessageType.guild_incident_report_false_alarm:
             return f'{self.author.name} reported a false alarm in {self.guild}.'
+
+        if self.type is MessageType.poll_result:
+            embed = self.embeds[0]  # Will always have 1
+            poll_title = utils.find(
+                lambda f: f.name == 'poll_question_text',
+                embed.fields,
+            )
+            return f'The poll {poll_title} has closed.'
 
         # Fallback for unknown message types
         return ''

--- a/discord/message.py
+++ b/discord/message.py
@@ -1915,8 +1915,11 @@ class Message(PartialMessage, Hashable):
                     # the channel will be the correct type here
                     ref.resolved = self.__class__(channel=chan, data=resolved, state=state)  # type: ignore
 
-                    if self.type is MessageType.poll_result and ref.resolved.poll:
-                        ref.resolved.poll._update_results_from_message(self)
+            if self.type is MessageType.poll_result:
+                if self.reference.resolved is not None:
+                    self._state._update_poll_results(self, self.reference.resolved)
+                else:
+                    self._state._update_poll_results(self, self.reference.message_id)
 
         self.application: Optional[MessageApplication] = None
         try:

--- a/discord/poll.py
+++ b/discord/poll.py
@@ -488,6 +488,15 @@ class Poll:
         return list(self._answers.values())
 
     @property
+    def victor_answer(self) -> Optional[PollAnswer]:
+        """Optional[:class:`PollAnswer`]: The victor answer if the poll has finished.
+        If the poll has not yet ended or didn't have a winner this will always be ``None``.
+        """
+        if not self.is_finalised():
+            return None
+        return utils.get(self.answers, _victor=True)
+
+    @property
     def expires_at(self) -> Optional[datetime.datetime]:
         """Optional[:class:`datetime.datetime`]: A datetime object representing the poll expiry.
 

--- a/discord/poll.py
+++ b/discord/poll.py
@@ -536,7 +536,7 @@ class Poll:
 
     @property
     def message(self) -> Optional[Message]:
-        """:class:`Message`: The message this poll is from."""
+        """Optional[:class:`Message`]: The message this poll is from."""
         return self._message
 
     @property
@@ -544,6 +544,9 @@ class Poll:
         """:class:`int`: Returns the sum of all the answer votes.
 
         If the poll has not yet finished, this is an approximate vote count.
+
+        .. versionchanged:: 2.5
+            This now returns an exact vote count when updated from its poll results message.
         """
         if self._total_votes is not None:
             return self._total_votes

--- a/discord/poll.py
+++ b/discord/poll.py
@@ -225,6 +225,8 @@ class PollAnswer:
         """:class:`bool`: Whether the answer is the one that had the most
         votes when the poll ended.
 
+        .. versionadded:: 2.5
+
         .. note::
 
             If the poll has not ended, this will always return ``False``.
@@ -487,11 +489,11 @@ class Poll:
     def victor_answer_id(self) -> Optional[int]:
         """Optional[:class:`int`]: The victor answer ID.
 
+        .. versionadded:: 2.5
+
         .. note::
 
             This will **always** be ``None`` for polls that have not yet finished.
-
-        .. versionadded:: 2.5
         """
         return self._victor_answer_id
 
@@ -499,11 +501,11 @@ class Poll:
     def victor_answer(self) -> Optional[PollAnswer]:
         """Optional[:class:`PollAnswer`]: The victor answer.
 
+        .. versionadded:: 2.5
+
         .. note::
 
             This will **always** be ``None`` for polls that have not yet finished.
-
-        .. versionadded:: 2.5
         """
         if self.victor_answer_id is None:
             return None

--- a/discord/poll.py
+++ b/discord/poll.py
@@ -490,6 +490,8 @@ class Poll:
         .. note::
 
             This will **always** be ``None`` for polls that have not yet finished.
+
+        .. versionadded:: 2.5
         """
         return self._victor_answer_id
 
@@ -500,6 +502,8 @@ class Poll:
         .. note::
 
             This will **always** be ``None`` for polls that have not yet finished.
+
+        .. versionadded:: 2.5
         """
         if self.victor_answer_id is None:
             return None

--- a/discord/poll.py
+++ b/discord/poll.py
@@ -396,7 +396,7 @@ class Poll:
             name='total_votes',
         )
         if total_votes_field is not None:
-            self._total_votes = int(total_votes_field.value)
+            self._total_votes = int(total_votes_field.value)  # type: ignore
 
         victor_answer_id = utils.get(
             result_embed.fields,
@@ -408,7 +408,7 @@ class Poll:
         if victor_answer_id is None:
             return  # Just return because the rest is based of the victor answer
 
-        self._victor_answer_id = int(victor_answer_id.value)
+        self._victor_answer_id = int(victor_answer_id.value)  # type: ignore
         victor_answer_votes = utils.get(
             result_embed.fields,
             name='victor_answer_votes',
@@ -416,7 +416,7 @@ class Poll:
 
         answer = self._answers[self._victor_answer_id]
         answer._victor = True
-        answer._vote_count = int(victor_answer_votes.value)
+        answer._vote_count = int(victor_answer_votes.value)  # type: ignore
         self._answers[self._victor_answer_id] = answer
 
     def _update_results(self, data: PollResultPayload) -> None:

--- a/discord/poll.py
+++ b/discord/poll.py
@@ -508,7 +508,9 @@ class Poll:
 
             This will **always** be ``None`` for polls that have not yet finished.
         """
-        return self.victor_answer_id and self.get_answer(self.victor_answer_id)
+        if self.victor_answer_id is None:
+            return None
+        return self.get_answer(self.victor_answer_id)
 
     @property
     def expires_at(self) -> Optional[datetime.datetime]:

--- a/discord/state.py
+++ b/discord/state.py
@@ -547,6 +547,27 @@ class ConnectionState(Generic[ClientT]):
         poll._handle_vote(answer_id, added, self_voted)
         return poll
 
+    def _update_poll_results(self, from_: Message, to: Union[Message, int]) -> None:
+        if isinstance(to, Message):
+            cached = self._get_message(to.id)
+        elif isinstance(to, int):
+            cached = self._get_message(to)
+
+            if cached is None:
+                return
+
+            to = cached
+        else:
+            return
+
+        if to.poll is None:
+            return
+
+        to.poll._update_results_from_message(from_)
+
+        if cached is not None and cached.poll:
+            cached.poll._update_results_from_message(from_)
+
     async def chunker(
         self, guild_id: int, query: str = '', limit: int = 0, presences: bool = False, *, nonce: Optional[str] = None
     ) -> None:

--- a/discord/types/embed.py
+++ b/discord/types/embed.py
@@ -71,7 +71,7 @@ class EmbedAuthor(TypedDict, total=False):
     proxy_icon_url: str
 
 
-EmbedType = Literal['rich', 'image', 'video', 'gifv', 'article', 'link']
+EmbedType = Literal['rich', 'image', 'video', 'gifv', 'article', 'link', 'poll_result']
 
 
 class Embed(TypedDict, total=False):

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -151,6 +151,7 @@ MessageType = Literal[
     37,
     38,
     39,
+    46,
 ]
 
 

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -189,8 +189,7 @@ class MessageSnapshot(TypedDict):
     mentions: List[UserWithMember]
     mention_roles: SnowflakeList
     stickers_items: NotRequired[List[StickerItem]]
-    components: NotRequired[List[Component]    46,
-]
+    components: NotRequired[List[Component]]
 
 
 class Message(PartialMessage):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1887,6 +1887,10 @@ of :class:`enum.Enum`.
 
         .. versionadded:: 2.5
 
+    .. attribute:: poll_result
+
+        The system message sent when a poll has closed.
+
 .. class:: UserFlags
 
     Represents Discord User flags.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds support for ``POLL_RESULT`` message types.

This also adds more things to ``Poll``, such as ``Poll.victor_answer``, exact vote count on ``Poll.total_votes``, etc.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
