### PR TITLE
Add support for get voice state

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -93,6 +93,7 @@ if TYPE_CHECKING:
         welcome_screen,
         sku,
         poll,
+        voice,
     )
     from .types.snowflake import Snowflake, SnowflakeList
 
@@ -1147,6 +1148,12 @@ class HTTPClient:
     ) -> Response[member.MemberWithUser]:
         r = Route('PATCH', '/guilds/{guild_id}/members/{user_id}', guild_id=guild_id, user_id=user_id)
         return self.request(r, json=fields, reason=reason)
+
+    def get_my_voice_state(self, guild_id: Snowflake) -> Response[voice.GuildVoiceState]:
+        return self.request(Route('GET', '/guilds/{guild_id}/voice-states/@me', guild_id=guild_id))
+
+    def get_voice_state(self, guild_id: Snowflake, user_id: Snowflake) -> Response[voice.GuildVoiceState]:
+        return self.request(Route('GET', '/guilds/{guild_id}/voice-states/{user_id}', guild_id=guild_id, user_id=user_id))
 
     # Channel management
 

--- a/discord/member.py
+++ b/discord/member.py
@@ -1162,6 +1162,8 @@ class Member(discord.abc.Messageable, _UserTag):
 
         Raises
         -------
+        NotFound
+            The member is not in a voice channel.
         Forbidden
             You do not have permissions to get a voice state.
         HTTPException

--- a/discord/member.py
+++ b/discord/member.py
@@ -1153,6 +1153,38 @@ class Member(discord.abc.Messageable, _UserTag):
             for role in roles:
                 await req(guild_id, user_id, role.id, reason=reason)
 
+    async def fetch_voice(self) -> VoiceState:
+        """|coro|
+
+        Retrieves the current voice state from this member.
+
+        .. versionadded:: 2.5
+
+        Raises
+        -------
+        Forbidden
+            You do not have permissions to get a voice state.
+        HTTPException
+            Retrieving the voice state failed.
+
+        Returns
+        -------
+        :class:`VoiceState`
+            The current voice state of the member.
+        """
+        guild_id = self.guild.id
+        if self._state.self_id == self.id:
+            data = await self._state.http.get_my_voice_state(guild_id)
+        else:
+            data = await self._state.http.get_voice_state(guild_id, self.id)
+
+        channel_id = data.get('channel_id')
+        channel: Optional[VocalGuildChannel] = None
+        if channel_id is not None:
+            channel = self.guild.get_channel(int(channel_id))  # type: ignore # must be voice channel here
+
+        return VoiceState(data=data, channel=channel)
+
     def get_role(self, role_id: int, /) -> Optional[Role]:
         """Returns a role with the given ID from roles which the member has.
 


### PR DESCRIPTION
## Summary

This PR adds the functionality to get the voice state over the http endpoints.

Related PR: 
- https://github.com/discord/discord-api-docs/pull/7061

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
