### PR TITLE
Add support for get sticker pack

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -2919,6 +2919,33 @@ class Client:
         data = await self.http.list_premium_sticker_packs()
         return [StickerPack(state=self._connection, data=pack) for pack in data['sticker_packs']]
 
+    async def fetch_premium_sticker_pack(self, sticker_pack_id: int, /) -> StickerPack:
+        """|coro|
+
+        Retrieves a premium sticker pack with the specified ID.
+
+        .. versionadded:: 2.5
+
+        Parameters
+        ----------
+        sticker_pack_id: :class:`int`
+            The sticker pack's ID to fetch from.
+
+        Raises
+        -------
+        NotFound
+            A sticker pack with this ID does not exist.
+        HTTPException
+            Retrieving the sticker pack failed.
+
+        Returns
+        -------
+        :class:`StickerPack`
+            The retrieved premium sticker pack.
+        """
+        data = await self.http.get_sticker_pack(sticker_pack_id)
+        return StickerPack(state=self._connection, data=data)
+
     async def create_dm(self, user: Snowflake) -> DMChannel:
         """|coro|
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -2940,7 +2940,7 @@ class Client:
 
         Returns
         -------
-        :class:`StickerPack`
+        :class:`.StickerPack`
             The retrieved premium sticker pack.
         """
         data = await self.http.get_sticker_pack(sticker_pack_id)

--- a/discord/http.py
+++ b/discord/http.py
@@ -1611,6 +1611,9 @@ class HTTPClient:
     def get_sticker(self, sticker_id: Snowflake) -> Response[sticker.Sticker]:
         return self.request(Route('GET', '/stickers/{sticker_id}', sticker_id=sticker_id))
 
+    def get_sticker_pack(self, sticker_pack_id: Snowflake) -> Response[sticker.StickerPack]:
+        return self.request(Route('GET', '/sticker-packs/{sticker_pack_id}', sticker_pack_id=sticker_pack_id))
+
     def list_premium_sticker_packs(self) -> Response[sticker.ListPremiumStickerPacks]:
         return self.request(Route('GET', '/sticker-packs'))
 

--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -28,8 +28,7 @@ import unicodedata
 
 from .mixins import Hashable
 from .asset import Asset, AssetMixin
-from .utils import cached_slot_property, find, snowflake_time, get, MISSING, _get_as_snowflake
-from .errors import InvalidData
+from .utils import cached_slot_property, snowflake_time, get, MISSING, _get_as_snowflake
 from .enums import StickerType, StickerFormatType, try_enum
 
 __all__ = (
@@ -51,7 +50,6 @@ if TYPE_CHECKING:
         Sticker as StickerPayload,
         StandardSticker as StandardStickerPayload,
         GuildSticker as GuildStickerPayload,
-        ListPremiumStickerPacks as ListPremiumStickerPacksPayload,
     )
 
 
@@ -352,9 +350,12 @@ class StandardSticker(Sticker):
 
         Retrieves the sticker pack that this sticker belongs to.
 
+        .. versionchanged:: 2.5
+            Now raises ``NotFound`` instead of ``InvalidData``.
+
         Raises
         --------
-        InvalidData
+        NotFound
             The corresponding sticker pack was not found.
         HTTPException
             Retrieving the sticker pack failed.
@@ -364,13 +365,8 @@ class StandardSticker(Sticker):
         :class:`StickerPack`
             The retrieved sticker pack.
         """
-        data: ListPremiumStickerPacksPayload = await self._state.http.list_premium_sticker_packs()
-        packs = data['sticker_packs']
-        pack = find(lambda d: int(d['id']) == self.pack_id, packs)
-
-        if pack:
-            return StickerPack(state=self._state, data=pack)
-        raise InvalidData(f'Could not find corresponding sticker pack for {self!r}')
+        data = await self._state.http.get_sticker_pack(self.pack_id)
+        return StickerPack(state=self._state, data=data)
 
 
 class GuildSticker(Sticker):


### PR DESCRIPTION
## Summary

This PR adds support for the get sticker pack endpoint.
This also changes the way in which the `StickerPack` is retrieved in the `StandardSticker.pack` method.

Related PRs:
* https://github.com/discord/discord-api-docs/pull/7065

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
