### PR TITLE
[docs] Remove pack_id attribute from Sticker

### DIFF
--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -258,8 +258,6 @@ class Sticker(_StickerTag):
         The id of the sticker.
     description: :class:`str`
         The description of the sticker.
-    pack_id: :class:`int`
-        The id of the sticker's pack.
     format: :class:`StickerFormatType`
         The format for the sticker's image.
     url: :class:`str`


### PR DESCRIPTION
## Summary

This PR removes unnecessary `pack_id` attribute from `Sticker` (left-over)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
