### PR TITLE
Fix url for StickerItem

### DIFF
--- a/discord/sticker.py
+++ b/discord/sticker.py
@@ -203,7 +203,10 @@ class StickerItem(_StickerTag):
         self.name: str = data['name']
         self.id: int = int(data['id'])
         self.format: StickerFormatType = try_enum(StickerFormatType, data['format_type'])
-        self.url: str = f'{Asset.BASE}/stickers/{self.id}.{self.format.file_extension}'
+        if self.format is StickerFormatType.gif:
+            self.url: str = f'https://media.discordapp.net/stickers/{self.id}.gif'
+        else:
+            self.url: str = f'{Asset.BASE}/stickers/{self.id}.{self.format.file_extension}'
 
     def __repr__(self) -> str:
         return f'<StickerItem id={self.id} name={self.name!r} format={self.format}>'


### PR DESCRIPTION
## Summary

Fixed gif url for StickerItem. Previously it was fixed with [this pr](https://github.com/Rapptz/discord.py/pull/9737) but it was not added to StickerItem class.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
