### PR TITLE
Add support for hang statuses

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -74,6 +74,7 @@ __all__ = (
     'EntitlementType',
     'EntitlementOwnerType',
     'PollLayoutType',
+    'HangStatusType',
 )
 
 
@@ -525,9 +526,21 @@ class ActivityType(Enum):
     watching = 3
     custom = 4
     competing = 5
+    hang = 6
 
     def __int__(self) -> int:
         return self.value
+
+
+class HangStatusType(Enum):
+    chilling = 'chilling'
+    gaming = 'gaming'
+    focusing = 'focusing'
+    brb = 'brb'
+    eating = 'eating'
+    in_transit = 'in-transit'
+    watching = 'watching'
+    custom = 'custom'
 
 
 class TeamMembershipState(Enum):

--- a/discord/types/activity.py
+++ b/discord/types/activity.py
@@ -76,7 +76,7 @@ class ActivityEmoji(TypedDict):
     animated: NotRequired[bool]
 
 
-ActivityType = Literal[0, 1, 2, 4, 5]
+ActivityType = Literal[0, 1, 2, 4, 5, 6]
 
 
 class SendableActivity(TypedDict):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1911,6 +1911,12 @@ of :class:`enum.Enum`.
 
         .. versionadded:: 1.5
 
+    .. attribute:: hang
+
+        A hang status activity type.
+
+        .. versionadded:: 2.5
+
 .. class:: VerificationLevel
 
     Specifies a :class:`Guild`\'s verification level, which is the criteria in
@@ -3663,6 +3669,45 @@ of :class:`enum.Enum`.
         A burst reaction, also known as a "super reaction".
 
 
+.. class:: HangStatusType
+
+    Represents the type of an hang status.
+
+    .. versionadded:: 2.5
+
+    .. attribute:: chilling
+
+        The default hang status "Chilling".
+
+    .. attribute:: gaming
+
+        The default hang status "GAMING".
+
+    .. attribute:: focusing
+
+        The default hang status "In the zone".
+
+    .. attribute:: brb
+
+        The default hang status "Gonna BRB".
+
+    .. attribute:: eating
+
+        The default hang status "Grubbin".
+
+    .. attribute:: in_transit
+
+        The default hang status "Wandering IRL".
+
+    .. attribute:: watching
+
+        The default hang status "Watchin' stuff".
+
+    .. attribute:: custom
+
+        A custom hang status set by the user.
+
+
 .. _discord-api-audit-logs:
 
 Audit Log Data
@@ -5308,6 +5353,14 @@ CustomActivity
 .. attributetable:: CustomActivity
 
 .. autoclass:: CustomActivity
+    :members:
+
+HangStatus
+~~~~~~~~~~~
+
+.. attributetable:: HangStatus
+
+.. autoclass:: HangStatus
     :members:
 
 Permissions


### PR DESCRIPTION
## Summary

This PR adds support for hang statuses, which can be set while being in a voice channel. This is typically displayed via `Right now, I’m -` on the client.

Since there's no Discord PR yet, it's on draft. Though, it's partially rolled out already (33%).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
