### PR TITLE
Add `approximate_user_install_count` to AppInfo

### DIFF
--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -147,6 +147,10 @@ class AppInfo:
         The approximate count of the guilds the bot was added to.
 
         .. versionadded:: 2.4
+    approximate_user_install_count: Optional[:class:`int`]
+        The approximate count of the user-level installations the bot has.
+
+        .. versionadded:: 2.5
     """
 
     __slots__ = (
@@ -175,6 +179,7 @@ class AppInfo:
         'interactions_endpoint_url',
         'redirect_uris',
         'approximate_guild_count',
+        'approximate_user_install_count'
     )
 
     def __init__(self, state: ConnectionState, data: AppInfoPayload):
@@ -212,6 +217,7 @@ class AppInfo:
         self.interactions_endpoint_url: Optional[str] = data.get('interactions_endpoint_url')
         self.redirect_uris: List[str] = data.get('redirect_uris', [])
         self.approximate_guild_count: int = data.get('approximate_guild_count', 0)
+        self.approximate_user_install_count: Optional[int] = data.get('approximate_user_install_count')
 
     def __repr__(self) -> str:
         return (

--- a/discord/appinfo.py
+++ b/discord/appinfo.py
@@ -179,7 +179,7 @@ class AppInfo:
         'interactions_endpoint_url',
         'redirect_uris',
         'approximate_guild_count',
-        'approximate_user_install_count'
+        'approximate_user_install_count',
     )
 
     def __init__(self, state: ConnectionState, data: AppInfoPayload):

--- a/discord/types/appinfo.py
+++ b/discord/types/appinfo.py
@@ -45,6 +45,7 @@ class BaseAppInfo(TypedDict):
     summary: str
     description: str
     flags: int
+    approximate_user_install_count: NotRequired[int]
     cover_image: NotRequired[str]
     terms_of_service_url: NotRequired[str]
     privacy_policy_url: NotRequired[str]


### PR DESCRIPTION
## Summary

See title.

[Related discord-api-docs PR](https://github.com/discord/discord-api-docs/pull/7070)

Nothing in the above docs says this will be available in PartialAppInfo so I added it to the full object instead.

![DiscordPTB_6yy2qq8szQ](https://github.com/user-attachments/assets/3cfe050f-8b66-4b70-8a6a-3a2bedef43a8)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
