### PR TITLE
add `DummyCookieJar`

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -805,6 +805,7 @@ class HTTPClient:
             connector=self.connector,
             ws_response_class=DiscordClientWebSocketResponse,
             trace_configs=None if self.http_trace is None else [self.http_trace],
+            cookie_jar=aiohttp.DummyCookieJar(),
         )
         self._global_over = asyncio.Event()
         self._global_over.set()


### PR DESCRIPTION
## Summary

The Discord API does not use cookies and setting the cookie_jar to DummyCookieJar() brings significant performance improvements since CookieJar is blocking.

## Checklist


- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
