### PR TITLE
[docs] Fix typehint for Embed.set_(image,thumbnail)

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -413,8 +413,9 @@ class Embed:
 
         Parameters
         -----------
-        url: :class:`str`
+        url: Optional[:class:`str`]
             The source URL for the image. Only HTTP(S) is supported.
+            If ``None`` is passed, any existing image is removed.
             Inline attachment URLs are also supported, see :ref:`local_image`.
         """
 
@@ -457,8 +458,9 @@ class Embed:
 
         Parameters
         -----------
-        url: :class:`str`
+        url: Optional[:class:`str`]
             The source URL for the thumbnail. Only HTTP(S) is supported.
+            If ``None`` is passed, any existing thumbnail is removed.
             Inline attachment URLs are also supported, see :ref:`local_image`.
         """
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This commit explicitly documents that passing `None` to the `url` parameter removes existing images.
Though this does change the documented signature of public methods, this behaviour has existed since 2.0, so I don't think it's breaking.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
