### PR TITLE
Store app commands ids on CommandTree

### DIFF
--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -276,10 +276,9 @@ class CommandTree(Generic[ClientT]):
 
         if isinstance(command, AppCommand):
             return command.id
-        elif isinstance(command, (Command, Group)):
-            name = (command.root_parent or command).name
-        elif isinstance(command, ContextMenu):
-            name = command.name
+        
+        if isinstance(command, (Command, Group, ContextMenu)):
+            name = (command.root_parent or command).name if not isinstance(command, ContextMenu) else command.name
         elif isinstance(command, str):
             name = command.split()[0]
 
@@ -311,10 +310,8 @@ class CommandTree(Generic[ClientT]):
         if command_id is None:
             return None
 
-        if isinstance(command, (Command, Group)):
+        if isinstance(command, (Command, Group, ContextMenu)):
             full_name = command.qualified_name
-        elif isinstance(command, ContextMenu):
-            full_name = command.name
         elif isinstance(command, str):
             full_name = command
 


### PR DESCRIPTION
## Summary

[As it was desired](https://discord.com/channels/336642139381301249/1011485943737360404/1122825846399455272), I have written an implementation that stores app command ids on the CommandTree and keeps them updated via sync, fetch and on callback. Also added two new methods to get the ID and return the mention format.

Currently as a draft because I am not sure if the current impl is the best way to this and would like some feedback on it, ignoring the left over comments/methods but it does work.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
