### PR TITLE
Fix stacklevel for Message.interaction deprecation warning

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -2236,7 +2236,7 @@ class Message(PartialMessage, Hashable):
             return self._thread or self.guild.get_thread(self.id)
 
     @property
-    @deprecated('interaction_metadata', stacklevel=2)
+    @deprecated('interaction_metadata')
     def interaction(self) -> Optional[MessageInteraction]:
         """Optional[:class:`~discord.MessageInteraction`]: The interaction that this message is a response to.
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -2236,7 +2236,7 @@ class Message(PartialMessage, Hashable):
             return self._thread or self.guild.get_thread(self.id)
 
     @property
-    @deprecated('interaction_metadata')
+    @deprecated('interaction_metadata', stacklevel=2)
     def interaction(self) -> Optional[MessageInteraction]:
         """Optional[:class:`~discord.MessageInteraction`]: The interaction that this message is a response to.
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -292,7 +292,7 @@ def copy_doc(original: Callable[..., Any]) -> Callable[[T], T]:
     return decorator
 
 
-def deprecated(instead: Optional[str] = None) -> Callable[[Callable[P, T]], Callable[P, T]]:
+def deprecated(instead: Optional[str] = None, stacklevel: int = 3) -> Callable[[Callable[P, T]], Callable[P, T]]:
     def actual_decorator(func: Callable[P, T]) -> Callable[P, T]:
         @functools.wraps(func)
         def decorated(*args: P.args, **kwargs: P.kwargs) -> T:
@@ -302,7 +302,7 @@ def deprecated(instead: Optional[str] = None) -> Callable[[Callable[P, T]], Call
             else:
                 fmt = '{0.__name__} is deprecated.'
 
-            warnings.warn(fmt.format(func, instead), stacklevel=3, category=DeprecationWarning)
+            warnings.warn(fmt.format(func, instead), stacklevel=stacklevel, category=DeprecationWarning)
             warnings.simplefilter('default', DeprecationWarning)  # reset filter
             return func(*args, **kwargs)
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -292,7 +292,7 @@ def copy_doc(original: Callable[..., Any]) -> Callable[[T], T]:
     return decorator
 
 
-def deprecated(instead: Optional[str] = None, stacklevel: int = 3) -> Callable[[Callable[P, T]], Callable[P, T]]:
+def deprecated(instead: Optional[str] = None) -> Callable[[Callable[P, T]], Callable[P, T]]:
     def actual_decorator(func: Callable[P, T]) -> Callable[P, T]:
         @functools.wraps(func)
         def decorated(*args: P.args, **kwargs: P.kwargs) -> T:
@@ -302,7 +302,7 @@ def deprecated(instead: Optional[str] = None, stacklevel: int = 3) -> Callable[[
             else:
                 fmt = '{0.__name__} is deprecated.'
 
-            warnings.warn(fmt.format(func, instead), stacklevel=stacklevel, category=DeprecationWarning)
+            warnings.warn(fmt.format(func, instead), stacklevel=2, category=DeprecationWarning)
             warnings.simplefilter('default', DeprecationWarning)  # reset filter
             return func(*args, **kwargs)
 


### PR DESCRIPTION
## Summary

There is no frame between the `decorated()` function (which calls `warnings.warn()`) and the call to it (`interaction.message` property access) so you only need to bump the default stack level (`1`) by `1`, not by `2`.
This is not specific to properties - the same applies to function calls - so I just updated the implementation of the `deprecated()` function instead of adding a new parameter to it.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
