### PR TITLE
Fix + add test for missing discord.Permission bits

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -187,7 +187,7 @@ class Permissions(BaseFlags):
         permissions set to ``True``.
         """
         # Some of these are 0 because we don't want to set unnecessary bits
-        return cls(0b0000_0000_0000_0010_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111)
+        return cls(0b0000_0000_0000_0110_0111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111)
 
     @classmethod
     def _timeout_mask(cls) -> int:

--- a/tests/test_permissions_all.py
+++ b/tests/test_permissions_all.py
@@ -1,0 +1,7 @@
+import discord
+
+from functools import reduce
+from operator import or_
+
+def test_permissions_all():
+    assert discord.Permissions.all().value == reduce(or_, discord.Permissions.VALID_FLAGS.values())


### PR DESCRIPTION
## Summary

Resolves #9933 

It also wasn't the only missing permission bit for .all, so I've added a corresponding test.
Might be worth changing how .all() is defined to be provided by the baseflag class, and calculated once, at subclass definition, but that's a more significant change.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
