### PR TITLE
Add support for AEAD XChaCha20 Poly1305 encryption mode.

### DIFF
--- a/discord/types/voice.py
+++ b/discord/types/voice.py
@@ -29,7 +29,12 @@ from .snowflake import Snowflake
 from .member import MemberWithUser
 
 
-SupportedModes = Literal['xsalsa20_poly1305_lite', 'xsalsa20_poly1305_suffix', 'xsalsa20_poly1305']
+SupportedModes = Literal[
+    'aead_xchacha20_poly1305_rtpsize',
+    'xsalsa20_poly1305_lite',
+    'xsalsa20_poly1305_suffix',
+    'xsalsa20_poly1305',
+]
 
 
 class _VoiceState(TypedDict):


### PR DESCRIPTION
## Summary

Adds support for the `AEAD XChaCha20 Poly1305 (RTP Size)` voice encryption mode.
All but two encryption modes are set for removal on the 18th Nov 2024.

This adds the only required mode from the remaining two. Currently (as far as I can tell) `AEAD AES256-GCM` can not be supported without additional libraries as PyNacl does not expose bindings to libsodium for this mode.

https://discord.com/developers/docs/topics/voice-connections#transport-encryption-modes

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
