### PR TITLE
Add support for Interaction Callback Resource

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -54,6 +54,8 @@ __all__ = (
     'Interaction',
     'InteractionMessage',
     'InteractionResponse',
+    'InteractionCallback',
+    'InteractionCallbackActivity',
 )
 
 if TYPE_CHECKING:

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 
 
 InteractionType = Literal[1, 2, 3, 4, 5]
+InteractionResponseType = Literal[1, 4, 5, 6, 7, 8, 9, 10,]
 InteractionContextType = Literal[0, 1, 2]
 InteractionInstallationType = Literal[0, 1]
 
@@ -263,3 +264,27 @@ class MessageInteractionMetadata(TypedDict):
     original_response_message_id: NotRequired[Snowflake]
     interacted_message_id: NotRequired[Snowflake]
     triggering_interaction_metadata: NotRequired[MessageInteractionMetadata]
+
+
+class InteractionCallback(TypedDict):
+    id: Snowflake
+    type: InteractionType
+    activity_instance_id: NotRequired[str]
+    response_message_id: NotRequired[Snowflake]
+    response_message_loading: NotRequired[bool]
+    response_message_ephemeral: NotRequired[bool]
+
+
+class InteractionCallbackActivity(TypedDict):
+    id: str
+
+
+class InteractionCallbackResource(TypedDict):
+    type: InteractionResponseType
+    activity_instance: NotRequired[InteractionCallbackActivity]
+    message: NotRequired[Message]
+
+
+class InteractionCallbackResponse(TypedDict):
+    interaction: InteractionCallback
+    resource: NotRequired[InteractionCallbackResource]

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -90,6 +90,9 @@ if TYPE_CHECKING:
     )
     from ..types.emoji import PartialEmoji as PartialEmojiPayload
     from ..types.snowflake import SnowflakeList
+    from ..types.interactions import (
+        InteractionCallbackResponse as InteractionCallbackResponsePayload,
+    )
 
     BE = TypeVar('BE', bound=BaseException)
     _State = Union[ConnectionState, '_WebhookState']
@@ -434,13 +437,17 @@ class AsyncWebhookAdapter:
         proxy: Optional[str] = None,
         proxy_auth: Optional[aiohttp.BasicAuth] = None,
         params: MultipartParameters,
-    ) -> Response[None]:
+        with_response: bool = MISSING,
+    ) -> Response[Optional[InteractionCallbackResponsePayload]]:
         route = Route(
             'POST',
             '/interactions/{webhook_id}/{webhook_token}/callback',
             webhook_id=interaction_id,
             webhook_token=token,
         )
+
+        if with_response is not MISSING:
+            request_params = {'with_response': with_response}
 
         if params.files:
             return self.request(
@@ -450,9 +457,17 @@ class AsyncWebhookAdapter:
                 proxy_auth=proxy_auth,
                 files=params.files,
                 multipart=params.multipart,
+                params=request_params,
             )
         else:
-            return self.request(route, session=session, proxy=proxy, proxy_auth=proxy_auth, payload=params.payload)
+            return self.request(
+                route,
+                session=session,
+                proxy=proxy,
+                proxy_auth=proxy_auth,
+                payload=params.payload,
+                params=request_params,
+            )
 
     def get_original_interaction_response(
         self,

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -28,6 +28,22 @@ InteractionResponse
 .. autoclass:: InteractionResponse()
     :members:
 
+InteractionCallback
+~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: InteractionCallback
+
+.. autoclass:: InteractionCallback()
+    :members:
+
+InteractionCallbackActivity
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: InteractionCallbackActivity
+
+.. autoclass:: InteractionCallbackActivity()
+    :members:
+
 InteractionMessage
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This adds support for the Interaction Callback Resource returned by any ``Interaction.response`` method call by using a new parameter named ``with_response``.
This also adds the ``poll`` kwarg to ``Interaction.edit_original_response``.

**Needs testing**

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
