### PR TITLE
Add missing error for Guild.fetch_automod_rule

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -4308,6 +4308,8 @@ class Guild(Hashable):
         -------
         Forbidden
             You do not have permission to view the automod rule.
+        NotFound
+            The automod rule does not exist within this guild.
 
         Returns
         --------


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR adds a summary of potential discord.Notfound error in Guild.fetch_automod_rule.
(This is my first PR in my life. Any feedback is welcome and appreciated.)

## Checklist
- [ ] If code changes were made then they have been tested.
    - [] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)

![error info](https://github.com/user-attachments/assets/c6b46887-9377-41d2-aa6b-1565c629fd4c)
