### PR TITLE
Fix clone implementations

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1039,10 +1039,6 @@ class GuildChannel:
 
         .. versionadded:: 1.1
 
-        .. versionchanged:: 2.5
-
-            The ``category`` keyword-only parameter was added.
-
         Parameters
         ------------
         name: Optional[:class:`str`]
@@ -1051,6 +1047,8 @@ class GuildChannel:
         category: Optional[:class:`~discord.CategoryChannel`]
             The category the new channel belongs to.
             This parameter is ignored if cloning a category channel.
+
+            .. versionadded:: 2.5
         reason: Optional[:class:`str`]
             The reason for cloning this channel. Shows up on the audit log.
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2066,6 +2066,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
         self,
         *,
         name: Optional[str] = None,
+        category: Optional[CategoryChannel] = None,
         reason: Optional[str] = None,
     ) -> CategoryChannel:
         return await self._clone_impl({'nsfw': self.nsfw}, name=name, reason=reason)

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -532,14 +532,14 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         category: Optional[CategoryChannel] = None,
         reason: Optional[str] = None,
     ) -> TextChannel:
+        base: Dict[Any, Any] = {
+            'topic': self.topic,
+            'nsfw': self.nsfw,
+            'default_auto_archive_duration': self.default_auto_archive_duration,
+        if not self.is_news():
+            base['rate_limit_per_user'] = self.slowmode_delay
         return await self._clone_impl(
-            {
-                'topic': self.topic,
-                'rate_limit_per_user': self.slowmode_delay,
-                'nsfw': self.nsfw,
-                'default_auto_archive_duration': self.default_auto_archive_duration,
-                'default_thread_rate_limit_per_user': self.default_thread_slowmode_delay,
-            },
+            base,
             name=name,
             category=category,
             reason=reason,
@@ -1395,7 +1395,13 @@ class VocalGuildChannel(discord.abc.Messageable, discord.abc.Connectable, discor
         return Webhook.from_state(data, state=self._state)
 
     @utils.copy_doc(discord.abc.GuildChannel.clone)
-    async def clone(self, *, name: Optional[str] = None, reason: Optional[str] = None) -> Self:
+    async def clone(
+        self,
+        *,
+        name: Optional[str] = None,
+        category: Optional[CategoryChannel] = None,
+        reason: Optional[str] = None
+    ) -> Self:
         base = {
             'bitrate': self.bitrate,
             'user_limit': self.user_limit,
@@ -1409,6 +1415,7 @@ class VocalGuildChannel(discord.abc.Messageable, discord.abc.Connectable, discor
         return await self._clone_impl(
             base,
             name=name,
+            category=category,
             reason=reason,
         )
 
@@ -1505,18 +1512,6 @@ class VoiceChannel(VocalGuildChannel):
     def type(self) -> Literal[ChannelType.voice]:
         """:class:`ChannelType`: The channel's Discord type."""
         return ChannelType.voice
-
-    @utils.copy_doc(discord.abc.GuildChannel.clone)
-    async def clone(
-        self,
-        *,
-        name: Optional[str] = None,
-        category: Optional[CategoryChannel] = None,
-        reason: Optional[str] = None,
-    ) -> VoiceChannel:
-        return await self._clone_impl(
-            {'bitrate': self.bitrate, 'user_limit': self.user_limit}, name=name, category=category, reason=reason
-        )
 
     @overload
     async def edit(self) -> None:
@@ -1787,16 +1782,6 @@ class StageChannel(VocalGuildChannel):
     def type(self) -> Literal[ChannelType.stage_voice]:
         """:class:`ChannelType`: The channel's Discord type."""
         return ChannelType.stage_voice
-
-    @utils.copy_doc(discord.abc.GuildChannel.clone)
-    async def clone(
-        self,
-        *,
-        name: Optional[str] = None,
-        category: Optional[CategoryChannel] = None,
-        reason: Optional[str] = None,
-    ) -> StageChannel:
-        return await self._clone_impl({}, name=name, category=category, reason=reason)
 
     @property
     def instance(self) -> Optional[StageInstance]:
@@ -2079,7 +2064,6 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
         self,
         *,
         name: Optional[str] = None,
-        category: Optional[CategoryChannel] = None,
         reason: Optional[str] = None,
     ) -> CategoryChannel:
         return await self._clone_impl({'nsfw': self.nsfw}, name=name, reason=reason)

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -1398,11 +1398,7 @@ class VocalGuildChannel(discord.abc.Messageable, discord.abc.Connectable, discor
 
     @utils.copy_doc(discord.abc.GuildChannel.clone)
     async def clone(
-        self,
-        *,
-        name: Optional[str] = None,
-        category: Optional[CategoryChannel] = None,
-        reason: Optional[str] = None
+        self, *, name: Optional[str] = None, category: Optional[CategoryChannel] = None, reason: Optional[str] = None
     ) -> Self:
         base = {
             'bitrate': self.bitrate,

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -536,6 +536,8 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             'topic': self.topic,
             'nsfw': self.nsfw,
             'default_auto_archive_duration': self.default_auto_archive_duration,
+            'default_thread_rate_limit_per_user': self.default_thread_slowmode_delay,
+        }
         if not self.is_news():
             base['rate_limit_per_user'] = self.slowmode_delay
         return await self._clone_impl(


### PR DESCRIPTION
## Summary

Vague title since I don't know better.

### What this PR includes:
1. Fix `TextChannel.clone` always sending `rate_limit_per_user` when that's not available for announcement/news channels.

The following are fixes for stuff caused by [`"Add category parameter to abc.GuildChannel.clone" @ a5f9350`](https://github.com/rapptz/discord.py/commit/a5f9350ff2a58738035194136d4a3bbde38b07a6):

2. Add missing `category` kwarg to `VocalGuildChannel.clone`.
3. Remove oudated clone implementations from `VoiceChannel` & `StageChannel` as it's handled on `VocalGuildChannel` since [`"Update all channel clone implementations" @ 053f29c`](https://github.com/Rapptz/discord.py/commit/053f29c96c01c96f209a2e78efdbc767f2251958).
4. Replace `.. versionchanged` with `.. versionadded` for the added category kwarg for consistency.

### Relevant API Docs:
- [Guild -> Create Guild Channel -> JSON Params](https://discord.com/developers/docs/resources/guild#create-guild-channel-json-params)



## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
