### PR TITLE
README: Add audioop-lts to install commands

### DIFF
--- a/README.ja.rst
+++ b/README.ja.rst
@@ -29,20 +29,32 @@ discord.py は機能豊富かつモダンで使いやすい、非同期処理に
 
 .. code:: sh
 
-    # Linux/macOS
+    # Linux/macOS (Python 3.13 以降)
+    python3 -m pip install -U discord.py audioop-lts
+
+    # Linux/macOS (Python 3.12 以前)
     python3 -m pip install -U discord.py
 
-    # Windows
+    # Windows (Python 3.13 以降)
+    py -3 -m pip install -U discord.py audioop-lts
+
+    # Windows (Python 3.12 以前)
     py -3 -m pip install -U discord.py
 
 音声サポートが必要なら、次のコマンドを実行しましょう:
 
 .. code:: sh
 
-    # Linux/macOS
-    python3 -m pip install -U discord.py[voice]
+    # Linux/macOS (Python 3.13 以降)
+    python3 -m pip install -U "discord.py[voice]" audioop-lts
 
-    # Windows
+    # Linux/macOS (Python 3.12 以前)
+    python3 -m pip install -U "discord.py[voice]"
+
+    # Windows (Python 3.13 以降)
+    py -3 -m pip install -U discord.py[voice]
+
+    # Windows (Python 3.12 以前)
     py -3 -m pip install -U discord.py[voice]
 
 

--- a/README.rst
+++ b/README.rst
@@ -29,20 +29,32 @@ To install the library without full voice support, you can just run the followin
 
 .. code:: sh
 
-    # Linux/macOS
+    # Linux/macOS (Python 3.13 or higher)
+    python3 -m pip install -U discord.py audioop-lts
+
+    # Linux/macOS (Python 3.12 or lower)
     python3 -m pip install -U discord.py
 
-    # Windows
+    # Windows (Python 3.13 or higher)
+    py -3 -m pip install -U discord.py audioop-lts
+
+    # Windows (Python 3.12 or lower)
     py -3 -m pip install -U discord.py
 
 Otherwise to get voice support you should run the following command:
 
 .. code:: sh
 
-    # Linux/macOS
+    # Linux/macOS (Python 3.13 or higher)
+    python3 -m pip install -U "discord.py[voice]" audioop-lts
+
+    # Linux/macOS (Python 3.12 or lower)
     python3 -m pip install -U "discord.py[voice]"
 
-    # Windows
+    # Windows (Python 3.13 or higher)
+    py -3 -m pip install -U discord.py[voice]
+
+    # Windows (Python 3.12 or lower)
     py -3 -m pip install -U discord.py[voice]
 
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

https://github.com/Rapptz/discord.py/blob/99a7093c340d2b768d8c7c8e216e13988ba64ec0/requirements.txt#L2

In Python 3.13 or higher, `discord.py` must be installed with `audioop-lts`.
Therefore, I add `audioop-lts` to  installation commands in `README.md`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
