### PR TITLE
[commands] Add perms object param to default_permissions decorator

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -2821,7 +2821,7 @@ def allowed_installs(
     return inner
 
 
-def default_permissions(**perms: bool) -> Callable[[T], T]:
+def default_permissions(perm_flags: Optional[Permissions] = None, /, **perms: bool) -> Callable[[T], T]:
     r"""A decorator that sets the default permissions needed to execute this command.
 
     When this decorator is used, by default users must have these permissions to execute the command.
@@ -2845,8 +2845,12 @@ def default_permissions(**perms: bool) -> Callable[[T], T]:
     -----------
     \*\*perms: :class:`bool`
         Keyword arguments denoting the permissions to set as the default.
+    perm_flags: :class:`~discord.Permissions`
+        A permissions object as positional argument. This can be used in combination with ``**perms``.
 
-    Example
+        .. versionadded:: 2.5
+
+    Examples
     ---------
 
     .. code-block:: python3
@@ -2855,9 +2859,23 @@ def default_permissions(**perms: bool) -> Callable[[T], T]:
         @app_commands.default_permissions(manage_messages=True)
         async def test(interaction: discord.Interaction):
             await interaction.response.send_message('You may or may not have manage messages.')
+
+    .. code-block:: python3
+
+        ADMIN_PERMS = discord.Permissions(administrator=True)
+
+        @app_commands.command()
+        @app_commands.default_permissions(ADMIN_PERMS, manage_messages=True)
+        async def test(interaction: discord.Interaction):
+            await interaction.response.send_message('You may or may not have manage messages.')
     """
 
-    permissions = Permissions(**perms)
+    if perm_flags is not None:
+        permissions = perm_flags
+        if perms:
+            permissions |= Permissions(**perms)
+    else:
+        permissions = Permissions(**perms)
 
     def decorator(func: T) -> T:
         if isinstance(func, (Command, Group, ContextMenu)):

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -2871,9 +2871,7 @@ def default_permissions(perms_obj: Optional[Permissions] = None, /, **perms: boo
     """
 
     if perms_obj is not None:
-        permissions = perms_obj
-        if perms:
-            permissions |= Permissions(**perms)
+        permissions = perms_obj | Permissions(**perms)
     else:
         permissions = Permissions(**perms)
 

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -2821,7 +2821,7 @@ def allowed_installs(
     return inner
 
 
-def default_permissions(perm_flags: Optional[Permissions] = None, /, **perms: bool) -> Callable[[T], T]:
+def default_permissions(perms_obj: Optional[Permissions] = None, /, **perms: bool) -> Callable[[T], T]:
     r"""A decorator that sets the default permissions needed to execute this command.
 
     When this decorator is used, by default users must have these permissions to execute the command.
@@ -2845,7 +2845,7 @@ def default_permissions(perm_flags: Optional[Permissions] = None, /, **perms: bo
     -----------
     \*\*perms: :class:`bool`
         Keyword arguments denoting the permissions to set as the default.
-    perm_flags: :class:`~discord.Permissions`
+    perms_obj: :class:`~discord.Permissions`
         A permissions object as positional argument. This can be used in combination with ``**perms``.
 
         .. versionadded:: 2.5
@@ -2870,8 +2870,8 @@ def default_permissions(perm_flags: Optional[Permissions] = None, /, **perms: bo
             await interaction.response.send_message('You may or may not have manage messages.')
     """
 
-    if perm_flags is not None:
-        permissions = perm_flags
+    if perms_obj is not None:
+        permissions = perms_obj
         if perms:
             permissions |= Permissions(**perms)
     else:


### PR DESCRIPTION
## Summary

Adds feature requested in #9951.
It adds a positional parameter to the `app_commands.default_permissions` decorator to allow a `Permissions` object to be passed. It can also be used in combination with `**perms` keyword arguments.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
