### PR TITLE
Fix MessageReferenceType not being public

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -76,6 +76,7 @@ __all__ = (
     'PollLayoutType',
     'VoiceChannelEffectAnimationType',
     'SubscriptionStatus',
+    'MessageReferenceType',
 )
 
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
`MessageReferenceType` was not included in `__all__`
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
