### PR TITLE
Take ClientT inside of the ErrorFunc

### DIFF
--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -73,7 +73,7 @@ if TYPE_CHECKING:
     from .commands import ContextMenuCallback, CommandCallback, P, T
 
     ErrorFunc = Callable[
-        [Interaction, AppCommandError],
+        [Interaction[ClientT], AppCommandError],
         Coroutine[Any, Any, Any],
     ]
 
@@ -833,7 +833,7 @@ class CommandTree(Generic[ClientT]):
         else:
             _log.error('Ignoring exception in command tree', exc_info=error)
 
-    def error(self, coro: ErrorFunc) -> ErrorFunc:
+    def error(self, coro: ErrorFunc[ClientT]) -> ErrorFunc[ClientT]:
         """A decorator that registers a coroutine as a local error handler.
 
         This must match the signature of the :meth:`on_error` callback.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Currently, using `self.tree.error` inside of a Bot or another subclass with proper type checking enabled via Pylance:

```py
from discord.ext.commands import Bot
from discord import Interaction

class MyBot(Bot):
    def __init__(self, *a, **kw):
        super().__init__(*a, **kw)

        @self.tree.error
        async def tree_error(interaction: Interaction[MyBot], error: Exception):
            print("Error!")
```

Error:
```
Argument of type "(interaction: Interaction[MyBot], error: Exception) -> Coroutine[Any, Any, None]" cannot be assigned to parameter "coro" of type "ErrorFunc" in function "error"
  Type "(interaction: Interaction[MyBot], error: Exception) -> Coroutine[Any, Any, None]" is not assignable to type "ErrorFunc"
    Parameter 1: type "Interaction[Client]" is incompatible with type "Interaction[MyBot]"
      "Interaction[Client]" is not assignable to "Interaction[MyBot]"
        Type parameter "ClientT@Interaction" is covariant, but "Client" is not a subtype of "MyBot"
          "Client" is not assignable to "MyBot"Pylance[reportArgumentType](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportArgumentType)
```


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
