### PR TITLE
Fix NameError in sku.py

### DIFF
--- a/discord/sku.py
+++ b/discord/sku.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 from typing import AsyncIterator, Optional, TYPE_CHECKING
 
+from datetime import datetime
+
 from . import utils
 from .enums import try_enum, SKUType, EntitlementType
 from .flags import SKUFlags
@@ -34,8 +36,6 @@ from .object import Object
 from .subscription import Subscription
 
 if TYPE_CHECKING:
-    from datetime import datetime
-
     from .abc import SnowflakeTime, Snowflake
     from .guild import Guild
     from .state import ConnectionState


### PR DESCRIPTION
## Summary

Fixes the following
```py
File "...\site-packages\discord\sku.py", line 224, in subscriptions
    if isinstance(before, datetime):
                          ^^^^^^^^
NameError: name 'datetime' is not defined
```

Reported in the discord.py server [here](https://discord.com/channels/336642139381301249/336642776609456130/1296222685453615217)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
