### PR TITLE
Handle edge case with commands.parameter default

### DIFF
--- a/discord/ext/commands/parameters.py
+++ b/discord/ext/commands/parameters.py
@@ -247,6 +247,12 @@ def parameter(
 
         .. versionadded:: 2.3
     """
+    if isinstance(default, Parameter):
+        if displayed_default is empty:
+            displayed_default = default._displayed_default
+
+        default = default._default
+
     return Parameter(
         name='empty',
         kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,


### PR DESCRIPTION
## Summary

This PR fixes an edge case with commands.paraneter where if you try to set the default to one of the defaults provided by the lib for arguments (Author, CurrentGuild, CurrentChannel), it'll return as the Parameter object. While this makes complete sense, it could throw off users who want to use ìt over a callable.
```py
@bot.command()
async def giveaura(
  ctx: Context,
  member: discord.Member = commanda.param(default=commands.Author, <other stuff>)
):
  assert isinstance(member, discord.Member), f"Expected member to be an instance of discord.Member not {type(member)}"

# user:
# !giveaura valid-user
# !giveaura
AssertionError: Expected member to be an instance of discord.Member not <class 'Parameter'>
```
See [this](https://canary.discord.com/channels/336642139381301249/1294303255815524442) bikeshedding post for more info.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
