### PR TITLE
Add support for Entry Point Command

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -767,6 +767,7 @@ class AppCommandType(Enum):
     chat_input = 1
     user = 2
     message = 3
+    primary_entry_point = 4
 
 
 class AppCommandPermissionType(Enum):
@@ -860,6 +861,11 @@ class SubscriptionStatus(Enum):
     active = 0
     ending = 1
     inactive = 2
+
+
+class EntryPointCommandHandlerType(Enum):
+    app_handler = 1
+    discord_launch_activity = 2
 
 
 def create_unknown_value(cls: Type[E], val: Any) -> E:

--- a/discord/types/command.py
+++ b/discord/types/command.py
@@ -31,7 +31,7 @@ from .channel import ChannelType
 from .snowflake import Snowflake
 from .interactions import InteractionContextType
 
-ApplicationCommandType = Literal[1, 2, 3]
+ApplicationCommandType = Literal[1, 2, 3, 4]
 ApplicationCommandOptionType = Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 ApplicationIntegrationType = Literal[0, 1]
 
@@ -162,6 +162,15 @@ class _ChatInputApplicationCommand(_BaseApplicationCommand, total=False):
     ]
 
 
+EntryPointCommandHandlerType = Literal[1, 2]
+
+
+class _PrimaryEntryPointApplicationCommand(_BaseApplicationCommand):
+    description: Required[str]
+    type: Literal[4]
+    handler: EntryPointCommandHandlerType
+
+
 class _BaseContextMenuApplicationCommand(_BaseApplicationCommand):
     description: Literal[""]
 
@@ -178,6 +187,7 @@ GlobalApplicationCommand = Union[
     _ChatInputApplicationCommand,
     _UserApplicationCommand,
     _MessageApplicationCommand,
+    _PrimaryEntryPointApplicationCommand,
 ]
 
 

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -430,6 +430,11 @@ Enumerations
     .. attribute:: message
 
         A message context menu command.
+    .. attribute:: primary_entry_point
+
+        .. versionadded:: 2.5
+        
+        A command that represents the primary way to invoke an app's Activity
 
 .. class:: AppCommandPermissionType
 
@@ -446,6 +451,21 @@ Enumerations
     .. attribute:: user
 
         The permission is for a user.
+
+.. class:: EntryPointCommandHandlerType
+
+    Represents the type of an entry point command handler.
+
+    .. versionadded:: 2.5
+
+    .. attribute:: app_handler
+
+	    The app handles the interaction using an interaction token.
+
+    .. attribute:: discord_launch_activity
+
+        Discord handles the interaction by launching an Activity and 
+        sending a follow-up message without coordinating with the app.
 
 .. _discord_ui_kit:
 


### PR DESCRIPTION
## Summary

This PR adds the relevant fields and types for the Entry Point Command.

Relevant API Docs:
- [Application Commands // Entry Point Commands](https://discord.com/developers/docs/interactions/application-commands#entry-point-commands)

Classes:
- `EntryPointCommandHandlerType` (enum)
- `_PrimaryEntryPointApplicationCommand` (type @ discord/types/command.py)

Attributes:
- `AppCommandType.primary_entry_point`
- `AppCommand.handler` -> EntryPointCommandHandlerType | None

Methods:
- `AppCommand.is_default_entry_point_command()` -> bool
  I added this one.. it may be useful? I don't know.



## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
