### PR TITLE
Add command target to MessageInteractionMetadata

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -830,8 +830,12 @@ class MessageInteractionMetadata(Hashable):
         The metadata of the modal submit interaction that triggered this interaction, if applicable.
     target_user: Optional[:class:`User`]
         The user the command was run on, only applicable to user context menus.
+
+        .. versionadded:: 2.5
     target_message_id: Optional[:class:`int`]
         The ID of the message the command was run on, only applicable to message context menus.
+
+        .. versionadded:: 2.5
     """
 
     __slots__: Tuple[str, ...] = (
@@ -919,7 +923,10 @@ class MessageInteractionMetadata(Hashable):
 
     @property
     def target_message(self) -> Optional[Message]:
-        """Optional[:class:`~discord.Message`]: The target message, if applicable and is found in cache."""
+        """Optional[:class:`~discord.Message`]: The target message, if applicable and is found in cache.
+
+        .. versionadded:: 2.5
+        """
         if self.target_message_id:
             return self._state._get_message(self.target_message_id)
         return None

--- a/discord/message.py
+++ b/discord/message.py
@@ -865,33 +865,33 @@ class MessageInteractionMetadata(Hashable):
 
         self.original_response_message_id: Optional[int] = None
         try:
-            self.original_response_message_id = int(data['original_response_message_id'])
+            self.original_response_message_id = int(data['original_response_message_id'])  # type: ignore # EAFP
         except KeyError:
             pass
 
         self.interacted_message_id: Optional[int] = None
         try:
-            self.interacted_message_id = int(data['interacted_message_id'])
+            self.interacted_message_id = int(data['interacted_message_id'])  # type: ignore # EAFP
         except KeyError:
             pass
 
         self.modal_interaction: Optional[MessageInteractionMetadata] = None
         try:
             self.modal_interaction = MessageInteractionMetadata(
-                state=state, guild=guild, data=data['triggering_interaction_metadata']
+                state=state, guild=guild, data=data['triggering_interaction_metadata']  # type: ignore # EAFP
             )
         except KeyError:
             pass
 
         self.target_user: Optional[User] = None
         try:
-            self.target_user = state.create_user(data['target_user'])
+            self.target_user = state.create_user(data['target_user'])  # type: ignore # EAFP
         except KeyError:
             pass
 
         self.target_message_id: Optional[int] = None
         try:
-            self.target_message_id = int(data['target_message_id'])
+            self.target_message_id = int(data['target_message_id'])  # type: ignore # EAFP
         except KeyError:
             pass
 

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -260,15 +260,17 @@ class _MessageInteractionMetadata(TypedDict):
     user: User
     authorizing_integration_owners: Dict[Literal['0', '1'], Snowflake]
     original_response_message_id: NotRequired[Snowflake]
-    
+
 
 class _ApplicationCommandMessageInteractionMetadata(_MessageInteractionMetadata):
     type: Literal[2]
     # command_type: Literal[1, 2, 3, 4]
 
+
 class UserApplicationCommandMessageInteractionMetadata(_ApplicationCommandMessageInteractionMetadata):
     # command_type: Literal[2]
     target_user: User
+
 
 class MessageApplicationCommandMessageInteractionMetadata(_ApplicationCommandMessageInteractionMetadata):
     # command_type: Literal[3]
@@ -281,13 +283,17 @@ ApplicationCommandMessageInteractionMetadata = Union[
     MessageApplicationCommandMessageInteractionMetadata,
 ]
 
+
 class MessageComponentMessageInteractionMetadata(_MessageInteractionMetadata):
     type: Literal[3]
     interacted_message_id: Snowflake
 
+
 class ModalSubmitMessageInteractionMetadata(_MessageInteractionMetadata):
     type: Literal[5]
-    triggering_interaction_metadata: Union[ApplicationCommandMessageInteractionMetadata, MessageComponentMessageInteractionMetadata]
+    triggering_interaction_metadata: Union[
+        ApplicationCommandMessageInteractionMetadata, MessageComponentMessageInteractionMetadata
+    ]
 
 
 MessageInteractionMetadata = Union[

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -255,11 +255,43 @@ class MessageInteraction(TypedDict):
     member: NotRequired[Member]
 
 
-class MessageInteractionMetadata(TypedDict):
+class _MessageInteractionMetadata(TypedDict):
     id: Snowflake
-    type: InteractionType
     user: User
     authorizing_integration_owners: Dict[Literal['0', '1'], Snowflake]
     original_response_message_id: NotRequired[Snowflake]
-    interacted_message_id: NotRequired[Snowflake]
-    triggering_interaction_metadata: NotRequired[MessageInteractionMetadata]
+    
+
+class _ApplicationCommandMessageInteractionMetadata(_MessageInteractionMetadata):
+    type: Literal[2]
+    # command_type: Literal[1, 2, 3, 4]
+
+class UserApplicationCommandMessageInteractionMetadata(_ApplicationCommandMessageInteractionMetadata):
+    # command_type: Literal[2]
+    target_user: User
+
+class MessageApplicationCommandMessageInteractionMetadata(_ApplicationCommandMessageInteractionMetadata):
+    # command_type: Literal[3]
+    target_message_id: Snowflake
+
+
+ApplicationCommandMessageInteractionMetadata = Union[
+    _ApplicationCommandMessageInteractionMetadata,
+    UserApplicationCommandMessageInteractionMetadata,
+    MessageApplicationCommandMessageInteractionMetadata,
+]
+
+class MessageComponentMessageInteractionMetadata(_MessageInteractionMetadata):
+    type: Literal[3]
+    interacted_message_id: Snowflake
+
+class ModalSubmitMessageInteractionMetadata(_MessageInteractionMetadata):
+    type: Literal[5]
+    triggering_interaction_metadata: Union[ApplicationCommandMessageInteractionMetadata, MessageComponentMessageInteractionMetadata]
+
+
+MessageInteractionMetadata = Union[
+    ApplicationCommandMessageInteractionMetadata,
+    MessageComponentMessageInteractionMetadata,
+    ModalSubmitMessageInteractionMetadata,
+]


### PR DESCRIPTION
## Summary

This PR adds support for the following new fields on MessageInteractionMetdata: `target_user, target_message_id`.

I have also split up the types like the API Docs.

Relevant links:
- https://github.com/discord/discord-api-docs/pull/7181
- https://discord.com/developers/docs/resources/message#message-interaction-metadata-object

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
