### PR TITLE
Clear up add_roles and remove_roles documentation

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -1076,7 +1076,7 @@ class Member(discord.abc.Messageable, _UserTag):
 
         You must have :attr:`~Permissions.manage_roles` to
         use this, and the added :class:`Role`\s must appear lower in the list
-        of roles than the highest role of the member.
+        of roles than the highest role of the client.
 
         Parameters
         -----------
@@ -1115,7 +1115,7 @@ class Member(discord.abc.Messageable, _UserTag):
 
         You must have :attr:`~Permissions.manage_roles` to
         use this, and the removed :class:`Role`\s must appear lower in the list
-        of roles than the highest role of the member.
+        of roles than the highest role of the client.
 
         Parameters
         -----------


### PR DESCRIPTION
Using "member" here can mislead a reader into believing this restriction is referring to the member being edited rather than the client/bot that is executing the edit.

## Summary

Changed "member" to "client" to clarify the docstring of `discord.Member.add_roles` and `discord.Member.remove_roles`.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
