### PR TITLE
Bump Sphinx to 5.3.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -374,6 +374,10 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
+# If true, create table of contents entries for domain objects (e.g. functions,
+# classes, attributes, etc.).
+toc_object_entries=False
+
 def setup(app):
   if app.config.language == 'ja':
     app.config.intersphinx_mapping['py'] = ('https://docs.python.org/ja/3', None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = { file = "requirements.txt" }
 [project.optional-dependencies]
 voice = ["PyNaCl>=1.3.0,<1.6"]
 docs = [
-    "sphinx==4.4.0",
+    "sphinx==5.3.0",
     "sphinxcontrib_trio==1.1.2",
     # TODO: bump these when migrating to a newer Sphinx version
     "sphinxcontrib-websupport==1.2.4",


### PR DESCRIPTION
## Summary

Upgrade Sphinx to 5.3.0. This version is [available in the Debian archive](https://packages.debian.org/source/stable/sphinx), but, unlike later versions, upgrading to it would not introduce significant breaking changes. This avoids the pitfalls of #9556. The only change I had to make was disabling table of contents entries for domain objects.

Sphinx 5.3.0 lacks the breaking changes to the gettext builder of the later versions, meaning builder.py doesn't need to be changed at all; it is still compatible with Python 3.8; and it doesn't require bumping any of the other dependencies (sphinxcontrib-serializinghtml, etc.).

While #9938 mentions Sphinx 7.4.7 specifically, the issue at hand was that the version of Sphinx used here (4.4.0) was not available on the Debian archive; by switching to one that is, I think we can mark that issue as closed.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
