### PR TITLE
Add optional dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ test = [
 dev = [
     "black==22.6",
     "typing_extensions>=4.3,<5",
-    "pyright==1.1.351",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,11 @@ test = [
     "typing-extensions>=4.3,<5",
     "tzdata; sys_platform == 'win32'",
 ]
+dev = [
+    "black==22.6",
+    "typing_extensions>=4.3,<5",
+    "pyright==1.1.351",
+]
 
 [tool.setuptools]
 packages = [


### PR DESCRIPTION
## Summary

I noticed that discord.py doesn't have a optional list of dependencies needed to develop the library. So here it is.

Black and Pyright versions are straight from the [lint workflow](<https://github.com/Rapptz/discord.py/blob/9806aeb83179d0d1e90d903e30db7e69e0d492e5/.github/workflows/lint.yml>).

Edit: The `pyright` dependency was removed; it is not intended for this use case, per [this review](https://github.com/Rapptz/discord.py/pull/10032#discussion_r1875060129).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
