### PR TITLE
Fix ``SessionStartLimits`` and ``SKU.subscriptions`` docstrings

### DIFF
--- a/discord/shard.py
+++ b/discord/shard.py
@@ -310,7 +310,7 @@ class SessionStartLimits:
     max_concurrency: :class:`int`
         The number of identify requests allowed per 5 seconds
 
-    .. versionadded:: 2.5
+        .. versionadded:: 2.5
     """
 
     __slots__ = ("total", "remaining", "reset_after", "max_concurrency")

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -299,6 +299,8 @@ class ShardInfo:
 class SessionStartLimits:
     """A class that holds info about session start limits
 
+    .. versionadded:: 2.5
+
     Attributes
     ----------
     total: :class:`int`
@@ -309,8 +311,6 @@ class SessionStartLimits:
         The number of milliseconds until the limit resets
     max_concurrency: :class:`int`
         The number of identify requests allowed per 5 seconds
-
-        .. versionadded:: 2.5
     """
 
     __slots__ = ("total", "remaining", "reset_after", "max_concurrency")

--- a/discord/sku.py
+++ b/discord/sku.py
@@ -146,12 +146,12 @@ class SKU:
 
         Usage ::
 
-            async for subscription in sku.subscriptions(limit=100):
+            async for subscription in sku.subscriptions(limit=100, user=user):
                 print(subscription.user_id, subscription.current_period_end)
 
         Flattening into a list ::
 
-            subscriptions = [subscription async for subscription in sku.subscriptions(limit=100)]
+            subscriptions = [subscription async for subscription in sku.subscriptions(limit=100, user=user)]
             # subscriptions is now a list of Subscription...
 
         All parameters are optional.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This fixes a misindentation on ``SessionStartLimits``, also fixes the examples on ``SKU.subscriptions`` to also pass the required ``user`` parameter.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
