### PR TITLE
Add ForumChannel.members property

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2493,6 +2493,14 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         return ChannelType.text.value
 
     @property
+    def members(self) -> List[Member]:
+        """List[:class:`Member`]: Returns all members that can see this channel.
+
+        .. versionadded:: 2.5
+        """
+        return [m for m in self.guild.members if self.permissions_for(m).read_messages]
+
+    @property
     def _scheduled_event_entity_type(self) -> Optional[EntityType]:
         return None
 


### PR DESCRIPTION
## Summary

Allows more easily checking who can see a particular forum channel.
This can be especially useful when using `thread.parent.members`, since previously only `TextChannel` had this property.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
