### PR TITLE
Parse full message for raw message edit event

### DIFF
--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -166,20 +166,22 @@ class RawMessageUpdateEvent(_RawReprMixin):
     cached_message: Optional[:class:`Message`]
         The cached message, if found in the internal message cache. Represents the message before
         it is modified by the data in :attr:`RawMessageUpdateEvent.data`.
+    message: :class:`Message`
+        The updated message.
+
+        .. versionadded:: 2.5
     """
 
-    __slots__ = ('message_id', 'channel_id', 'guild_id', 'data', 'cached_message')
+    __slots__ = ('message_id', 'channel_id', 'guild_id', 'data', 'cached_message', 'message')
 
-    def __init__(self, data: MessageUpdateEvent) -> None:
-        self.message_id: int = int(data['id'])
-        self.channel_id: int = int(data['channel_id'])
+    def __init__(self, data: MessageUpdateEvent, message: Message) -> None:
+        self.message_id: int = message.id
+        self.channel_id: int = message.channel.id
         self.data: MessageUpdateEvent = data
+        self.message: Message = message
         self.cached_message: Optional[Message] = None
 
-        try:
-            self.guild_id: Optional[int] = int(data['guild_id'])
-        except KeyError:
-            self.guild_id: Optional[int] = None
+        self.guild_id: Optional[int] = message.guild.id if message.guild else None
 
 
 class RawReactionActionEvent(_RawReprMixin):

--- a/discord/types/gateway.py
+++ b/discord/types/gateway.py
@@ -92,8 +92,7 @@ class MessageDeleteBulkEvent(TypedDict):
     guild_id: NotRequired[Snowflake]
 
 
-class MessageUpdateEvent(Message):
-    channel_id: Snowflake
+MessageUpdateEvent = MessageCreateEvent
 
 
 class MessageReactionAddEvent(TypedDict):


### PR DESCRIPTION
## Summary

Discord "announced" via a simple message in their devs server ~4 months ago that the message update event gets the full message object now: ![image](https://fretgfr.com/u/humongous-weary-chafer.png) ( https://canary.discord.com/channels/613425648685547541/697138785317814292/1273694894036353038 ) and updated their [docs](<https://discord.com/developers/docs/topics/gateway-events#message-update>).

But, dpy doesn't pass the full info to the raw event, instead, users need to parse it themselves from the `.data` attribute on RawMessageUpdateEvent. Now, ideally, dpy could pass a full `Message` object to the raw event and ditch the special object but that would be a breaking change.

This PR adds a new `.message` attribute to `RawMessageUpdateEvent` and uses the data internally.

Discussion post: https://canary.discord.com/channels/336642139381301249/1297330858361094205

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
