### PR TITLE
Fix callable FlagConverter defaults on hybrid commands

### DIFF
--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -234,6 +234,12 @@ def replace_parameter(
                     descriptions[name] = flag.description
                 if flag.name != flag.attribute:
                     renames[name] = flag.name
+                if pseudo.default is not pseudo.empty:
+                    # This ensures the default is wrapped around _CallableDefault if callable
+                    # else leaves it as-is.
+                    pseudo = pseudo.replace(
+                        default=_CallableDefault(flag.default) if callable(flag.default) else flag.default
+                    )
 
                 mapping[name] = pseudo
 
@@ -283,7 +289,7 @@ def replace_parameters(
             param = param.replace(default=default)
 
         if isinstance(param.default, Parameter):
-            # If we're here, then then it hasn't been handled yet so it should be removed completely
+            # If we're here, then it hasn't been handled yet so it should be removed completely
             param = param.replace(default=parameter.empty)
 
         # Flags are flattened out and thus don't get their parameter in the actual mapping


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This fixes a bug in which callable defaults on FlagConverters were returned as functions (instead of calling it) if it was not provided. See [the bikeshedding post](https://discord.com/channels/336642139381301249/1315371640497897492) for more information.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
