### PR TITLE
feat(audio): migrate 'audioop.mul' functionality using numpy (corresponds to patch 3.13)

### DIFF
--- a/discord/player.py
+++ b/discord/player.py
@@ -26,11 +26,6 @@ from __future__ import annotations
 import threading
 import subprocess
 import warnings
-if sys.version_info < (3, 13):
-    import audioop
-else:
-    import numpy as np
-
 import asyncio
 import logging
 import shlex
@@ -39,6 +34,11 @@ import json
 import sys
 import re
 import io
+
+if sys.version_info < (3, 13):
+    import audioop
+else:
+    import numpy as np
 
 from typing import Any, Callable, Generic, IO, Optional, TYPE_CHECKING, Tuple, TypeVar, Union
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp>=3.7.4,<4
-audioop-lts; python_version>='3.13'
+numpy>=2.2.0


### PR DESCRIPTION
## Summary

This pull request migrates the functionality of audioop.mul to use numpy, as the audioop module has been removed in Python 3.13. The migration ensures compatibility with Python 3.13 while preserving the functionality of volume scaling for audio data. 

It replaces the deprecated functionality with an implementation using numpy for data manipulation, including clipping to the correct range based on the bit depth. 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
