### PR TITLE
Fix `MessageSnapshot` `sticker_items`

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -528,7 +528,7 @@ class MessageSnapshot:
         self.created_at: datetime.datetime = utils.parse_time(data['timestamp'])
         self._edited_timestamp: Optional[datetime.datetime] = utils.parse_time(data['edited_timestamp'])
         self.flags: MessageFlags = MessageFlags._from_value(data.get('flags', 0))
-        self.stickers: List[StickerItem] = [StickerItem(data=d, state=state) for d in data.get('stickers_items', [])]
+        self.stickers: List[StickerItem] = [StickerItem(data=d, state=state) for d in data.get('sticker_items', [])]
 
         self.components: List[MessageComponentType] = []
         for component_data in data.get('components', []):

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -187,7 +187,7 @@ class MessageSnapshot(TypedDict):
     flags: NotRequired[int]
     mentions: List[UserWithMember]
     mention_roles: SnowflakeList
-    stickers_items: NotRequired[List[StickerItem]]
+    sticker_items: NotRequired[List[StickerItem]]
     components: NotRequired[List[Component]]
 
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

`MessageSnapshot`s were creating their list of sticker items from the `stickers_items` attribute which does not exist in the incoming data (the correct attribute is called `sticker_items`), and as such message snapshots did not properly reflect the stickers contained in the forwarded message.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (N/A)
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
