### PR TITLE
Fix bug due to typo in async pagination of entitlements loop

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -2926,7 +2926,7 @@ class Client:
             data, state, limit = await strategy(retrieve, state, limit)
 
             # Terminate loop on next iteration; there's no data left after this
-            if len(data) < 1000:
+            if len(data) < 100:
                 limit = 0
 
             for e in data:

--- a/discord/sku.py
+++ b/discord/sku.py
@@ -239,7 +239,7 @@ class SKU:
             data, state, limit = await strategy(retrieve, state, limit)
 
             # Terminate loop on next iteration; there's no data left after this
-            if len(data) < 1000:
+            if len(data) < 100:
                 limit = 0
 
             for e in data:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

A [help thread](https://discord.com/channels/336642139381301249/1321943241347698709/1321943241347698709) in the discord.py server raised a potential issue with the `Client.entitlements` method only returning a maximum of 100 entries.
Having investigated I found this typo which would result in only 1 iteration ever (as a limit of maximum 100) will ALWAYS result in a `len` of less than 1000.

NOTE: unable to test entitlements due to not having any public nor monetized bots.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
