### PR TITLE
Temporary dependency for docs extra on python 3.13+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ docs = [
     "sphinxcontrib-serializinghtml==1.1.5",
     "typing-extensions>=4.3,<5",
     "sphinx-inline-tabs==2023.4.21",
+    # TODO: Remove this when moving to Sphinx >= 6.6
+    "imghdr-lts==1.0.0; python_version>='3.13'",
 ]
 speed = [
     "orjson>=3.5.4",


### PR DESCRIPTION
## Summary

See #10052 Adds imghdr-lts, which is <200 lines of pure python [here](https://github.com/mikeshardmind/imghdr-lts)

I don't think we should keep this one long term, but this is docs-only, 3.13+, and this code should require zero changes forever (barring some breaking syntax change) as such, I've also hard-pinned the version.

If I'm reading the history on sphinx correctly, this can be removed once we are using any version of sphinx >= 6.6 for docs.


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
