### PR TITLE
Return new instance in Poll.end to avoid inconsistencies

### DIFF
--- a/discord/poll.py
+++ b/discord/poll.py
@@ -568,6 +568,5 @@ class Poll:
         if not self._message or not self._state:  # Make type checker happy
             raise ClientException('This poll has no attached message.')
 
-        self._message = await self._message.end_poll()
-
-        return self
+        message = await self._message.end_poll()
+        return message.poll

--- a/discord/poll.py
+++ b/discord/poll.py
@@ -547,7 +547,7 @@ class Poll:
 
         return self._answers.get(id)
 
-    async def end(self) -> Self:
+    async def end(self) -> Poll:
         """|coro|
 
         Ends the poll.

--- a/discord/poll.py
+++ b/discord/poll.py
@@ -359,6 +359,7 @@ class Poll:
         # The message's poll contains the more up to date data.
         self._expiry = message.poll.expires_at
         self._finalized = message.poll._finalized
+        self._answers = message.poll._answers
 
     def _update_results(self, data: PollResultPayload) -> None:
         self._finalized = data['is_finalized']
@@ -547,7 +548,7 @@ class Poll:
 
         return self._answers.get(id)
 
-    async def end(self) -> Poll:
+    async def end(self) -> Self:
         """|coro|
 
         Ends the poll.
@@ -569,4 +570,6 @@ class Poll:
             raise ClientException('This poll has no attached message.')
 
         message = await self._message.end_poll()
-        return message.poll
+        self._update(message)
+
+        return self


### PR DESCRIPTION
## Summary

Currently, the `Poll.end` method updates the `Poll.message` attribute with the response from the API call, but still returns the current instance. This can cause `Poll.message` to be newer than the rest of the data stored in `Poll`. This also means that the the instance is being updated in-place regardless of whether it is from the state, which I can't find an intentional reason for. Both of these seem inconsistent with usual library behavior.

The following example shows this behavior:
```python

poll = discord.Poll(question="What pet is better?", duration=datetime.timedelta(hours=1))
poll.add_answer(text="Dogs")
poll.add_answer(text="Cats")
message = await messageable.send(poll=poll)

# after waiting for a bit
stopped_poll = await poll.end()
stopped_poll.answers[0].vote_count == stopped_poll.message.poll.answers[0].vote_count # false if people voted
message is poll.message # always false
```

This PR changes the behavior to instead return the poll created from the API call inside `Poll.end`. This means that making an API call will not modify the instance used to make it, instead returning a fresh one, with more updated and consistent data.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
