### PR TITLE
Add detailed docstrings for row and width properties in the Item class

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -874,7 +874,13 @@ class AuditLogEntry(Hashable):
     def _convert_target_emoji(self, target_id: int) -> Union[Emoji, Object]:
         return self._state.get_emoji(target_id) or Object(id=target_id, type=Emoji)
 
-    def _convert_target_message(self, target_id: int) -> Union[Member, User, Object]:
+    def _convert_target_message(self, target_id: Optional[int]) -> Union[Member, User, Object, None]:
+        # Safeguard against target_id being None for actions like message_pin and message_unpin
+        if target_id is None:
+            # Handle the None case (provide a fallback Object or return None)
+            return Object(id=-1, type=Member)  # Use a default ID like -1 if needed
+        
+        # If target_id is not None, proceed normally
         return self._get_member(target_id) or Object(id=target_id, type=Member)
 
     def _convert_target_stage_instance(self, target_id: int) -> Union[StageInstance, Object]:

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -874,13 +874,7 @@ class AuditLogEntry(Hashable):
     def _convert_target_emoji(self, target_id: int) -> Union[Emoji, Object]:
         return self._state.get_emoji(target_id) or Object(id=target_id, type=Emoji)
 
-    def _convert_target_message(self, target_id: Optional[int]) -> Union[Member, User, Object, None]:
-        # Safeguard against target_id being None for actions like message_pin and message_unpin
-        if target_id is None:
-            # Handle the None case (provide a fallback Object or return None)
-            return Object(id=-1, type=Member)  # Use a default ID like -1 if needed
-        
-        # If target_id is not None, proceed normally
+    def _convert_target_message(self, target_id: int) -> Union[Member, User, Object]:
         return self._get_member(target_id) or Object(id=target_id, type=Member)
 
     def _convert_target_stage_instance(self, target_id: int) -> Union[StageInstance, Object]:

--- a/discord/ui/item.py
+++ b/discord/ui/item.py
@@ -100,6 +100,16 @@ class Item(Generic[V]):
 
     @property
     def row(self) -> Optional[int]:
+        """Optional[:class:`int`]: The action row this item belongs to.
+
+        An action row can have up to 5 components. Valid values for the row are
+        integers in the range 0–4 or ``None`` to indicate no specific row.
+    
+        Raises
+        ------
+        ValueError
+            If set to a value less than 0 or greater than or equal to 5.
+        """
         return self._row
 
     @row.setter
@@ -113,6 +123,16 @@ class Item(Generic[V]):
 
     @property
     def width(self) -> int:
+        """int: The width of this item in a Discord UI layout.
+
+        The width determines how much space this item occupies in an action row.
+        This value is primarily used internally by Discord.py to calculate layout constraints.
+
+        Returns
+        -------
+        :class:`int`
+            The width of the item, defaulting to 1.
+        """
         return 1
 
     @property


### PR DESCRIPTION
## Summary

This pull request adds detailed docstrings to the `row` and `width` properties of the `Item` class in the Discord.py library. These docstrings provide clear explanations of their purpose, valid values, constraints, and usage within the framework, improving overall code clarity and documentation.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, ...).
