### PR TITLE
fix target id being None raising an error

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -874,7 +874,12 @@ class AuditLogEntry(Hashable):
     def _convert_target_emoji(self, target_id: int) -> Union[Emoji, Object]:
         return self._state.get_emoji(target_id) or Object(id=target_id, type=Emoji)
 
-    def _convert_target_message(self, target_id: int) -> Union[Member, User, Object]:
+    def _convert_target_message(self, target_id: Optional[int]) -> Optional[Union[Member, User, Object]]:
+        # The message_pin action type does not have a non-null target_id
+        # so safeguard against that
+        if target_id is None:
+            return None
+
         return self._get_member(target_id) or Object(id=target_id, type=Member)
 
     def _convert_target_stage_instance(self, target_id: int) -> Union[StageInstance, Object]:

--- a/discord/member.py
+++ b/discord/member.py
@@ -1076,7 +1076,7 @@ class Member(discord.abc.Messageable, _UserTag):
 
         You must have :attr:`~Permissions.manage_roles` to
         use this, and the added :class:`Role`\s must appear lower in the list
-        of roles than the highest role of the member.
+        of roles than the highest role of the client.
 
         Parameters
         -----------
@@ -1115,7 +1115,7 @@ class Member(discord.abc.Messageable, _UserTag):
 
         You must have :attr:`~Permissions.manage_roles` to
         use this, and the removed :class:`Role`\s must appear lower in the list
-        of roles than the highest role of the member.
+        of roles than the highest role of the client.
 
         Parameters
         -----------


### PR DESCRIPTION
## Summary

This PR fixes the error raised when target_id is None and AudiitLogEntry.target is used and a converter is used to return the target

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
![image](https://github.com/user-attachments/assets/f1366594-184e-4e17-a551-d4f03b72f6a0)
