### PR TITLE
[commands] Correct ExtensionNotFound error message

### DIFF
--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -1080,7 +1080,7 @@ class ExtensionNotFound(ExtensionError):
     """
 
     def __init__(self, name: str) -> None:
-        msg = f'Extension {name!r} could not be loaded.'
+        msg = f'Extension {name!r} could not be found at the specified location.'
         super().__init__(msg, name=name)
 
 

--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -1080,7 +1080,7 @@ class ExtensionNotFound(ExtensionError):
     """
 
     def __init__(self, name: str) -> None:
-        msg = f'Extension {name!r} could not be found at the specified location.'
+        msg = f'Extension {name!r} could not be loaded or found.'
         super().__init__(msg, name=name)
 
 


### PR DESCRIPTION
## Summary

I noticed that attempting to reload a nonexistent extension resulted in the library raising an `ExtensionNotFound` error with the message "Extension 'foo' could not be loaded." This phrasing might be misinterpreted by some as indicating a loading failure, when in fact it denotes that the extension was not found. This PR refines the message for improved clarity.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
