### PR TITLE
[DOCS] extend create_application_emoji docs

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -3171,7 +3171,7 @@ class Client:
         Parameters
         ----------
         name: :class:`str`
-            The emoji name. Must be at least 2 characters.
+            The emoji name. Must be between 2 and 32 characters long.
         image: :class:`bytes`
             The :term:`py:bytes-like object` representing the image data to use.
             Only JPG, PNG and GIF images are supported.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This pull request updates the documentation to clarify that the emoji name must be between 2 and 32 characters long. The previous documentation did not specify the maximum length for the emoji name.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, they have been tested.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [x] This PR is **not** a code change (e.g. documentation, README, ...).
