### PR TITLE
Added scopeless kwarg to discord.utils.oauth_url

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -328,9 +328,9 @@ def oauth_url(
     guild: Snowflake = MISSING,
     redirect_uri: str = MISSING,
     scopes: Iterable[str] = MISSING,
-    scopeless: bool = False,
     disable_guild_select: bool = False,
     state: str = MISSING,
+    scopeless: bool = False,
 ) -> str:
     """A helper function that returns the OAuth2 URL for inviting the bot
     into guilds.

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -327,10 +327,9 @@ def oauth_url(
     permissions: Permissions = MISSING,
     guild: Snowflake = MISSING,
     redirect_uri: str = MISSING,
-    scopes: Iterable[str] = MISSING,
+    scopes: Optional[Iterable[str]] = MISSING,
     disable_guild_select: bool = False,
     state: str = MISSING,
-    scopeless: bool = False,
 ) -> str:
     """A helper function that returns the OAuth2 URL for inviting the bot
     into guilds.
@@ -363,10 +362,6 @@ def oauth_url(
         The state to return after the authorization.
 
         .. versionadded:: 2.0
-    scopeless: :class:`bool`
-        Whether to have the default scopes in the OAuth2 URL.
-
-        .. versionadded:: 2.5
 
     Returns
     --------
@@ -374,7 +369,7 @@ def oauth_url(
         The OAuth2 URL for inviting the bot into guilds.
     """
     url = f'https://discord.com/oauth2/authorize?client_id={client_id}'
-    if not scopeless:
+    if scopes is not None:
         url += '&scope=' + '+'.join(scopes or ('bot', 'applications.commands'))
     if permissions is not MISSING:
         url += f'&permissions={permissions.value}'

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -328,6 +328,7 @@ def oauth_url(
     guild: Snowflake = MISSING,
     redirect_uri: str = MISSING,
     scopes: Iterable[str] = MISSING,
+    scopeless: bool = False,
     disable_guild_select: bool = False,
     state: str = MISSING,
 ) -> str:
@@ -354,6 +355,8 @@ def oauth_url(
         An optional valid list of scopes. Defaults to ``('bot', 'applications.commands')``.
 
         .. versionadded:: 1.7
+    scopeless: :class:`bool`
+        Whether to have the default scopes in the OAuth2 URL.
     disable_guild_select: :class:`bool`
         Whether to disallow the user from changing the guild dropdown.
 
@@ -369,7 +372,8 @@ def oauth_url(
         The OAuth2 URL for inviting the bot into guilds.
     """
     url = f'https://discord.com/oauth2/authorize?client_id={client_id}'
-    url += '&scope=' + '+'.join(scopes or ('bot', 'applications.commands'))
+    if not scopeless:
+        url += '&scope=' + '+'.join(scopes or ('bot', 'applications.commands'))
     if permissions is not MISSING:
         url += f'&permissions={permissions.value}'
     if guild is not MISSING:

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -355,8 +355,6 @@ def oauth_url(
         An optional valid list of scopes. Defaults to ``('bot', 'applications.commands')``.
 
         .. versionadded:: 1.7
-    scopeless: :class:`bool`
-        Whether to have the default scopes in the OAuth2 URL.
     disable_guild_select: :class:`bool`
         Whether to disallow the user from changing the guild dropdown.
 
@@ -365,6 +363,10 @@ def oauth_url(
         The state to return after the authorization.
 
         .. versionadded:: 2.0
+    scopeless: :class:`bool`
+        Whether to have the default scopes in the OAuth2 URL.
+
+        .. versionadded:: 2.5
 
     Returns
     --------


### PR DESCRIPTION
## Summary

This PR adds a scopeless kwarg to discord.utils.oauth_url. When True, the OAuth URL which was generated won't include a scope if or if not provided. By default, will be False.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
