### PR TITLE
Add Guild.acronym

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -48,6 +48,7 @@ from typing import (
     overload,
 )
 import warnings
+import re
 
 from . import utils, abc
 from .role import Role
@@ -447,6 +448,7 @@ class Guild(Hashable):
         'max_stage_video_users',
         '_incidents_data',
         '_soundboard_sounds',
+        '_acronym',
     )
 
     _PREMIUM_GUILD_LIMITS: ClassVar[Dict[Optional[int], _GuildLimit]] = {
@@ -578,6 +580,8 @@ class Guild(Hashable):
             pass
 
         self.name: str = guild.get('name', '')
+        self._acronym = re.sub(r"\s", "", re.sub(r"\w+", lambda e: e.group(0)[0], re.sub(r"'s ", " ", self.name)))
+
         self.verification_level: VerificationLevel = try_enum(VerificationLevel, guild.get('verification_level'))
         self.default_notifications: NotificationLevel = try_enum(
             NotificationLevel, guild.get('default_message_notifications')
@@ -4787,3 +4791,11 @@ class Guild(Hashable):
 
         data = await self._state.http.create_soundboard_sound(self.id, reason=reason, **payload)
         return SoundboardSound(guild=self, state=self._state, data=data)
+
+    @property
+    def acronym(self) -> str:
+        """:class:`str`: Returns the acronym that shows up in place of a guild icon
+
+        .. versionadded:: 2.5
+        """
+        return self._acronym


### PR DESCRIPTION
## Summary

This PR adds an `acronym' property to Guild that returns the characters that show up when a server has no icon set. 

The property returns a cached version of the acronym (`_acronym`) since it rarely, if ever, changes.

I got this idea from the [discord.js](<https://github.com/discordjs/discord.js/blob/a5afc406b965b39a9cc90ef9e0e7a4b460c4e04c/packages/discord.js/src/structures/BaseGuild.js#L65-L70>) library. I have converted it to Python as is.

Discussion post: https://canary.discord.com/channels/336642139381301249/1279035934192439388

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
