### PR TITLE
Add support for embed flags and update attachment flags

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -149,7 +149,7 @@ class Embed:
         The colour code of the embed. Aliased to ``color`` as well.
         This can be set during initialisation.
     flags: Optional[:class:`EmbedFlags`]
-        This embed flags.
+        The flags of this embed.
 
         .. versionadded:: 2.5
     """

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -770,7 +770,4 @@ class Embed:
         if self.title:
             result['title'] = self.title
 
-        if self.flags:
-            result['flags'] = self.flags.value
-
         return result  # type: ignore # This payload is equivalent to the EmbedData type

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -29,7 +29,7 @@ from typing import Any, Dict, List, Mapping, Optional, Protocol, TYPE_CHECKING, 
 
 from . import utils
 from .colour import Colour
-from .flags import EmbedFlags, EmbedMediaFlags
+from .flags import AttachmentFlags, EmbedFlags
 
 # fmt: off
 __all__ = (
@@ -77,7 +77,7 @@ if TYPE_CHECKING:
         proxy_url: Optional[str]
         height: Optional[int]
         width: Optional[int]
-        flags: Optional[EmbedMediaFlags]
+        flags: Optional[AttachmentFlags]
 
     class _EmbedVideoProxy(Protocol):
         url: Optional[str]
@@ -181,7 +181,6 @@ class Embed:
         url: Optional[Any] = None,
         description: Optional[Any] = None,
         timestamp: Optional[datetime.datetime] = None,
-        flags: Optional[EmbedFlags] = None,
     ):
 
         self.colour = colour if colour is not None else color
@@ -189,7 +188,7 @@ class Embed:
         self.type: EmbedType = type
         self.url: Optional[str] = url
         self.description: Optional[str] = description
-        self.flags: Optional[EmbedFlags] = flags
+        self.flags: Optional[EmbedFlags] = None
 
         if self.title is not None:
             self.title = str(self.title)
@@ -420,10 +419,10 @@ class Embed:
         # Lying to the type checker for better developer UX.
         data = getattr(self, '_image', {})
         if 'flags' in data:
-            data['flags'] = EmbedMediaFlags._from_value(data['flags'])
+            data['flags'] = AttachmentFlags._from_value(data['flags'])
         return EmbedProxy(data)  # type: ignore
 
-    def set_image(self, *, url: Optional[Any], flags: Optional[EmbedMediaFlags] = None) -> Self:
+    def set_image(self, *, url: Optional[Any]) -> Self:
         """Sets the image for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -435,11 +434,6 @@ class Embed:
             The source URL for the image. Only HTTP(S) is supported.
             If ``None`` is passed, any existing image is removed.
             Inline attachment URLs are also supported, see :ref:`local_image`.
-        flags: Optional[:class:`EmbedMediaFlags`]
-            The flags of the image.
-            If ``None`` is passed, any existing flags are removed.
-
-            .. versionadded:: 2.5
         """
 
         if url is None:
@@ -450,7 +444,6 @@ class Embed:
         else:
             self._image = {
                 'url': str(url),
-                'flags': flags.value if flags else None,
             }
 
         return self

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -63,6 +63,7 @@ __all__ = (
     'RoleFlags',
     'AppInstallationType',
     'SKUFlags',
+    'EmbedFlags',
 )
 
 BF = TypeVar('BF', bound='BaseFlags')
@@ -2173,6 +2174,21 @@ class AttachmentFlags(BaseFlags):
         """:class:`bool`: Returns ``True`` if the attachment has been edited using the remix feature."""
         return 1 << 2
 
+    @flag_value
+    def spoiler(self):
+        """:class:`bool`: Returns ``True`` if the attachment was marked as a spoiler."""
+        return 1 << 3
+
+    @flag_value
+    def contains_explicit_media(self):
+        """:class:`bool`: Returns ``True`` if the attachment was flagged as sensitive content."""
+        return 1 << 4
+
+    @flag_value
+    def animated(self):
+        """:class:`bool`: Returns ``True`` if the attachment is an animated image."""
+        return 1 << 5
+
 
 @fill_with_flags()
 class RoleFlags(BaseFlags):
@@ -2308,3 +2324,124 @@ class SKUFlags(BaseFlags):
     def user_subscription(self):
         """:class:`bool`: Returns ``True`` if the SKU is a user subscription."""
         return 1 << 8
+
+
+@fill_with_flags()
+class EmbedFlags(BaseFlags):
+    r"""Wraps up the Discord Embed flags
+
+    .. versionadded:: 2.5
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two EmbedFlags are equal.
+
+        .. describe:: x != y
+
+            Checks if two EmbedFlags are not equal.
+
+        .. describe:: x | y, x |= y
+
+            Returns an EmbedFlags instance with all enabled flags from
+            both x and y.
+
+        .. describe:: x ^ y, x ^= y
+
+            Returns an EmbedFlags instance with only flags enabled on
+            only one of x or y, not on both.
+
+        .. describe:: ~x
+
+            Returns an EmbedFlags instance with all flags inverted from x.
+
+        .. describe:: hash(x)
+
+            Returns the flag's hash.
+
+        .. describe:: iter(x)
+
+            Returns an iterator of ``(name, value)`` pairs. This allows it
+            to be, for example, constructed as a dict or a list of pairs.
+            Note that aliases are not shown.
+
+        .. describe:: bool(b)
+
+            Returns whether any flag is set to ``True``.
+
+    Attributes
+    ----------
+    value: :class:`int`
+        The raw value. You should query flags via the properties
+        rather than using this raw value.
+    """
+
+    @flag_value
+    def contains_explicit_media(self):
+        """:class:`bool`: Returns ``True`` if the embed was flagged as sensitive content."""
+        return 1 << 4
+
+    @flag_value
+    def content_inventory_entry(self):
+        """:class:`bool`: Returns ``True`` if the embed is a reply to an activity card, and is no
+        longer displayed.
+        """
+        return 1 << 5
+
+
+@fill_with_flags()
+class EmbedMediaFlags(BaseFlags):
+    r"""Wraps up the Discord Embed Media flags
+
+    .. versionadded:: 2.5
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two EmbedMediaFlags are equal.
+
+        .. describe:: x != y
+
+            Checks if two EmbedMediaFlags are not equal.
+
+        .. describe:: x | y, x |= y
+
+            Returns an EmbedMediaFlags instance with all enabled flags from
+            both x and y.
+
+        .. describe:: x ^ y, x ^= y
+
+            Returns an EmbedMediaFlags instance with only flags enabled on
+            only one of x or y, not on both.
+
+        .. describe:: ~x
+
+            Returns an EmbedMediaFlags instance with all flags inverted from x.
+
+        .. describe:: hash(x)
+
+            Returns the flag's hash.
+
+        .. describe:: iter(x)
+
+            Returns an iterator of ``(name, value)`` pairs. This allows it
+            to be, for example, constructed as a dict or a list of pairs.
+            Note that aliases are not shown.
+
+        .. describe:: bool(b)
+
+            Returns whether any flag is set to ``True``.
+
+    Attributes
+    ----------
+    value: :class:`int`
+        The raw value. You should query flags via the properties
+        rather than using this raw value.
+    """
+
+    @flag_value
+    def animated(self):
+        """:class:`bool`: Returns ``True`` if the media is animated."""
+        return 1 << 5

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -2176,17 +2176,26 @@ class AttachmentFlags(BaseFlags):
 
     @flag_value
     def spoiler(self):
-        """:class:`bool`: Returns ``True`` if the attachment was marked as a spoiler."""
+        """:class:`bool`: Returns ``True`` if the attachment was marked as a spoiler.
+
+        .. versionadded:: 2.5
+        """
         return 1 << 3
 
     @flag_value
     def contains_explicit_media(self):
-        """:class:`bool`: Returns ``True`` if the attachment was flagged as sensitive content."""
+        """:class:`bool`: Returns ``True`` if the attachment was flagged as sensitive content.
+
+        .. versionadded:: 2.5
+        """
         return 1 << 4
 
     @flag_value
     def animated(self):
-        """:class:`bool`: Returns ``True`` if the attachment is an animated image."""
+        """:class:`bool`: Returns ``True`` if the attachment is an animated image.
+
+        .. versionadded:: 2.5
+        """
         return 1 << 5
 
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -64,6 +64,7 @@ __all__ = (
     'AppInstallationType',
     'SKUFlags',
     'EmbedFlags',
+    'EmbedMediaFlags',
 )
 
 BF = TypeVar('BF', bound='BaseFlags')

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -64,7 +64,6 @@ __all__ = (
     'AppInstallationType',
     'SKUFlags',
     'EmbedFlags',
-    'EmbedMediaFlags',
 )
 
 BF = TypeVar('BF', bound='BaseFlags')
@@ -2388,61 +2387,4 @@ class EmbedFlags(BaseFlags):
         """:class:`bool`: Returns ``True`` if the embed is a reply to an activity card, and is no
         longer displayed.
         """
-        return 1 << 5
-
-
-@fill_with_flags()
-class EmbedMediaFlags(BaseFlags):
-    r"""Wraps up the Discord Embed Media flags
-
-    .. versionadded:: 2.5
-
-    .. container:: operations
-
-        .. describe:: x == y
-
-            Checks if two EmbedMediaFlags are equal.
-
-        .. describe:: x != y
-
-            Checks if two EmbedMediaFlags are not equal.
-
-        .. describe:: x | y, x |= y
-
-            Returns an EmbedMediaFlags instance with all enabled flags from
-            both x and y.
-
-        .. describe:: x ^ y, x ^= y
-
-            Returns an EmbedMediaFlags instance with only flags enabled on
-            only one of x or y, not on both.
-
-        .. describe:: ~x
-
-            Returns an EmbedMediaFlags instance with all flags inverted from x.
-
-        .. describe:: hash(x)
-
-            Returns the flag's hash.
-
-        .. describe:: iter(x)
-
-            Returns an iterator of ``(name, value)`` pairs. This allows it
-            to be, for example, constructed as a dict or a list of pairs.
-            Note that aliases are not shown.
-
-        .. describe:: bool(b)
-
-            Returns whether any flag is set to ``True``.
-
-    Attributes
-    ----------
-    value: :class:`int`
-        The raw value. You should query flags via the properties
-        rather than using this raw value.
-    """
-
-    @flag_value
-    def animated(self):
-        """:class:`bool`: Returns ``True`` if the media is animated."""
         return 1 << 5

--- a/discord/types/embed.py
+++ b/discord/types/embed.py
@@ -50,6 +50,7 @@ class EmbedVideo(TypedDict, total=False):
     proxy_url: str
     height: int
     width: int
+    flags: int
 
 
 class EmbedImage(TypedDict, total=False):
@@ -88,3 +89,4 @@ class Embed(TypedDict, total=False):
     provider: EmbedProvider
     author: EmbedAuthor
     fields: List[EmbedField]
+    flags: int

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5708,6 +5708,22 @@ SKUFlags
 .. autoclass:: SKUFlags()
     :members:
 
+EmbedFlags
+~~~~~~~~~~
+
+.. attributetable:: EmbedFlags
+
+.. autoclass:: EmbedFlags()
+    :members:
+
+EmbedMediaFlags
+~~~~~~~~~~~~~~~
+
+.. attributetable:: EmbedMediaFlags
+
+.. autoclass:: EmbedMediaFlags()
+    :members:
+
 ForumTag
 ~~~~~~~~~
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5716,14 +5716,6 @@ EmbedFlags
 .. autoclass:: EmbedFlags()
     :members:
 
-EmbedMediaFlags
-~~~~~~~~~~~~~~~
-
-.. attributetable:: EmbedMediaFlags
-
-.. autoclass:: EmbedMediaFlags()
-    :members:
-
 ForumTag
 ~~~~~~~~~
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

- Adds ``EmbedFlags`` and ``EmbedMediaFlags``.
- New ``flags`` parameter on ``Embed.__init__`` and ``Embed.set_image``.
- New ``flags`` type hint on ``_EmbedImageProxy`` protocol.
- New flags on ``AttachmentFlags``

DDevs PR: https://github.com/discord/discord-api-docs/pull/7353

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
