### PR TITLE
Fix Embed type attribute ddocs link

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -131,7 +131,7 @@ class Embed:
         The type of embed. Usually "rich".
         This can be set during initialisation.
         Possible strings for embed types can be found on discord's
-        :ddocs:`api docs <resources/channel#embed-object-embed-types>`
+        :ddocs:`api docs <resources/message#embed-object-embed-types>`
     description: Optional[:class:`str`]
         The description of the embed.
         This can be set during initialisation.

--- a/docs/locale/ja/LC_MESSAGES/api.po
+++ b/docs/locale/ja/LC_MESSAGES/api.po
@@ -19427,8 +19427,8 @@ msgid "The title of the embed. This can be set during initialisation. Can only b
 msgstr "埋め込みのタイトル。初期化中に設定できます。最大256文字までです。"
 
 #: ../../../discord/embeds.py:docstring of discord.embeds.Embed:38
-msgid "The type of embed. Usually \"rich\". This can be set during initialisation. Possible strings for embed types can be found on discord's :ddocs:`api docs <resources/channel#embed-object-embed-types>`"
-msgstr "埋め込みのタイプ。通常は「rich」です。初期化時に設定できます。 埋め込みのタイプとして可能な文字列は Discordの :ddocs:`API 説明書 <resources/channel#embed-object-embed-types>` にあります。"
+msgid "The type of embed. Usually \"rich\". This can be set during initialisation. Possible strings for embed types can be found on discord's :ddocs:`api docs <resources/message#embed-object-embed-types>`"
+msgstr "埋め込みのタイプ。通常は「rich」です。初期化時に設定できます。 埋め込みのタイプとして可能な文字列は Discordの :ddocs:`API 説明書 <resources/message#embed-object-embed-types>` にあります。"
 
 #: ../../../discord/embeds.py:docstring of discord.embeds.Embed:47
 msgid "The description of the embed. This can be set during initialisation. Can only be up to 4096 characters."

--- a/docs/locale/ja/LC_MESSAGES/api.po
+++ b/docs/locale/ja/LC_MESSAGES/api.po
@@ -19427,8 +19427,8 @@ msgid "The title of the embed. This can be set during initialisation. Can only b
 msgstr "埋め込みのタイトル。初期化中に設定できます。最大256文字までです。"
 
 #: ../../../discord/embeds.py:docstring of discord.embeds.Embed:38
-msgid "The type of embed. Usually \"rich\". This can be set during initialisation. Possible strings for embed types can be found on discord's :ddocs:`api docs <resources/message#embed-object-embed-types>`"
-msgstr "埋め込みのタイプ。通常は「rich」です。初期化時に設定できます。 埋め込みのタイプとして可能な文字列は Discordの :ddocs:`API 説明書 <resources/message#embed-object-embed-types>` にあります。"
+msgid "The type of embed. Usually \"rich\". This can be set during initialisation. Possible strings for embed types can be found on discord's :ddocs:`api docs <resources/channel#embed-object-embed-types>`"
+msgstr "埋め込みのタイプ。通常は「rich」です。初期化時に設定できます。 埋め込みのタイプとして可能な文字列は Discordの :ddocs:`API 説明書 <resources/channel#embed-object-embed-types>` にあります。"
 
 #: ../../../discord/embeds.py:docstring of discord.embeds.Embed:47
 msgid "The description of the embed. This can be set during initialisation. Can only be up to 4096 characters."


### PR DESCRIPTION
Not sure when this happened but the Embed types are now found under the /message resource instead of /channel.

Note: I am not sure if I was supposed to edit the .po files in this way but I made sure that the docstring itself and the msgid in the .po file match exactly.

## Summary

Fixed the Discord API docs link for Embed types.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
