### PR TITLE
Add support for sending views in stateless webhooks

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -214,6 +214,13 @@ class View:
             # Wait N seconds to see if timeout data has been refreshed
             await asyncio.sleep(self.__timeout_expiry - now)
 
+    def _is_stateless(self) -> bool:
+        # this is used by webhooks to check whether a view requires a state attached
+        # or not, this simply is, whether a view has a component other than a url button
+        from .button import Button
+
+        return all(isinstance(ch, Button) and ch.url is not None for ch in self.children)
+
     def to_components(self) -> List[Dict[str, Any]]:
         def key(item: Item) -> int:
             return item._rendered_row or 0

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -214,12 +214,10 @@ class View:
             # Wait N seconds to see if timeout data has been refreshed
             await asyncio.sleep(self.__timeout_expiry - now)
 
-    def _is_stateless(self) -> bool:
+    def is_dispatchable(self) -> bool:
         # this is used by webhooks to check whether a view requires a state attached
         # or not, this simply is, whether a view has a component other than a url button
-        from .button import Button
-
-        return all(isinstance(ch, Button) and ch.url is not None for ch in self.children)
+        return any(item.is_dispatchable() for item in self.children)
 
     def to_components(self) -> List[Dict[str, Any]]:
         def key(item: Item) -> int:

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -310,8 +310,9 @@ class AsyncWebhookAdapter:
         files: Optional[Sequence[File]] = None,
         thread_id: Optional[int] = None,
         wait: bool = False,
+        has_view: bool = False,
     ) -> Response[Optional[MessagePayload]]:
-        params = {'wait': int(wait)}
+        params = {'wait': int(wait), 'with_components': int(has_view)}
         if thread_id:
             params['thread_id'] = thread_id
         route = Route('POST', '/webhooks/{webhook_id}/{webhook_token}', webhook_id=webhook_id, webhook_token=token)
@@ -1710,10 +1711,9 @@ class Webhook(BaseWebhook):
 
             .. versionadded:: 1.4
         view: :class:`discord.ui.View`
-            The view to send with the message. You can only send a view
-            if this webhook is not partial and has state attached. A
-            webhook has state attached if the webhook is managed by the
-            library.
+            The view to send with the message. If the webhook is partial or
+            is not managed by the library, then you can only send URL buttons.
+            Otherwise, you can send views with any type of components.
 
             .. versionadded:: 2.0
         thread: :class:`~discord.abc.Snowflake`
@@ -1765,7 +1765,8 @@ class Webhook(BaseWebhook):
             The length of ``embeds`` was invalid, there was no token
             associated with this webhook or ``ephemeral`` was passed
             with the improper webhook type or there was no state
-            attached with this webhook when giving it a view.
+            attached with this webhook when giving it a view that had
+            components other than URL buttons.
 
         Returns
         ---------
@@ -1795,13 +1796,15 @@ class Webhook(BaseWebhook):
             wait = True
 
         if view is not MISSING:
-            if isinstance(self._state, _WebhookState):
-                raise ValueError('Webhook views require an associated state with the webhook')
-
             if not hasattr(view, '__discord_ui_view__'):
                 raise TypeError(f'expected view parameter to be of type View not {view.__class__.__name__}')
 
-            if ephemeral is True and view.timeout is None:
+            if isinstance(self._state, _WebhookState) and not view._is_stateless():
+                raise ValueError(
+                    'Webhook views with any component other than URL buttons require an associated state with the webhook'
+                )
+
+            if ephemeral is True and view.timeout is None and not view._is_stateless():
                 view.timeout = 15 * 60.0
 
         if thread_name is not MISSING and thread is not MISSING:
@@ -1845,6 +1848,7 @@ class Webhook(BaseWebhook):
                 files=params.files,
                 thread_id=thread_id,
                 wait=wait,
+                has_view=view is not MISSING,
             )
 
         msg = None

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -310,9 +310,9 @@ class AsyncWebhookAdapter:
         files: Optional[Sequence[File]] = None,
         thread_id: Optional[int] = None,
         wait: bool = False,
-        has_view: bool = False,
+        with_components: bool = False,
     ) -> Response[Optional[MessagePayload]]:
-        params = {'wait': int(wait), 'with_components': int(has_view)}
+        params = {'wait': int(wait), 'with_components': int(with_components)}
         if thread_id:
             params['thread_id'] = thread_id
         route = Route('POST', '/webhooks/{webhook_id}/{webhook_token}', webhook_id=webhook_id, webhook_token=token)
@@ -1799,12 +1799,12 @@ class Webhook(BaseWebhook):
             if not hasattr(view, '__discord_ui_view__'):
                 raise TypeError(f'expected view parameter to be of type View not {view.__class__.__name__}')
 
-            if isinstance(self._state, _WebhookState) and not view._is_stateless():
+            if isinstance(self._state, _WebhookState) and view.is_dispatchable():
                 raise ValueError(
                     'Webhook views with any component other than URL buttons require an associated state with the webhook'
                 )
 
-            if ephemeral is True and view.timeout is None and not view._is_stateless():
+            if ephemeral is True and view.timeout is None and view.is_dispatchable():
                 view.timeout = 15 * 60.0
 
         if thread_name is not MISSING and thread is not MISSING:
@@ -1848,7 +1848,7 @@ class Webhook(BaseWebhook):
                 files=params.files,
                 thread_id=thread_id,
                 wait=wait,
-                has_view=view is not MISSING,
+                with_components=view is not MISSING,
             )
 
         msg = None

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -291,9 +291,9 @@ class WebhookAdapter:
         files: Optional[Sequence[File]] = None,
         thread_id: Optional[int] = None,
         wait: bool = False,
-        has_view: bool = False,
+        with_components: bool = False,
     ) -> MessagePayload:
-        params = {'wait': int(wait), 'with_components': int(has_view)}
+        params = {'wait': int(wait), 'with_components': int(with_components)}
         if thread_id:
             params['thread_id'] = thread_id
         route = Route('POST', '/webhooks/{webhook_id}/{webhook_token}', webhook_id=webhook_id, webhook_token=token)
@@ -1042,7 +1042,7 @@ class SyncWebhook(BaseWebhook):
             if not hasattr(view, '__discord_ui_view__'):
                 raise TypeError(f'expected view parameter to be of type View not {view.__class__.__name__}')
 
-            if not view._is_stateless():
+            if view.is_dispatchable():
                 raise ValueError('SyncWebhook views can only contain URL buttons')
 
         if thread_name is not MISSING and thread is not MISSING:
@@ -1084,7 +1084,7 @@ class SyncWebhook(BaseWebhook):
                 files=params.files,
                 thread_id=thread_id,
                 wait=wait,
-                has_view=view is not MISSING,
+                with_components=view is not MISSING,
             )
 
         msg = None

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
     from ..message import Attachment
     from ..abc import Snowflake
     from ..state import ConnectionState
+    from ..ui import View
     from ..types.webhook import (
         Webhook as WebhookPayload,
     )
@@ -290,8 +291,9 @@ class WebhookAdapter:
         files: Optional[Sequence[File]] = None,
         thread_id: Optional[int] = None,
         wait: bool = False,
+        has_view: bool = False,
     ) -> MessagePayload:
-        params = {'wait': int(wait)}
+        params = {'wait': int(wait), 'with_components': int(has_view)}
         if thread_id:
             params['thread_id'] = thread_id
         route = Route('POST', '/webhooks/{webhook_id}/{webhook_token}', webhook_id=webhook_id, webhook_token=token)
@@ -919,6 +921,7 @@ class SyncWebhook(BaseWebhook):
         silent: bool = False,
         applied_tags: List[ForumTag] = MISSING,
         poll: Poll = MISSING,
+        view: View = MISSING,
     ) -> Optional[SyncWebhookMessage]:
         """Sends a message using the webhook.
 
@@ -991,6 +994,13 @@ class SyncWebhook(BaseWebhook):
                 When sending a Poll via webhook, you cannot manually end it.
 
             .. versionadded:: 2.4
+        view: :class:`~discord.ui.View`
+            The view to send with the message. This can only have URL buttons, which donnot
+            require a state to be attached to it.
+
+            If you want to send a view with any component attached to it, check :meth:`Webhook.send`.
+
+            .. versionadded:: 2.5
 
         Raises
         --------
@@ -1004,8 +1014,9 @@ class SyncWebhook(BaseWebhook):
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
             or ``thread`` and ``thread_name``.
         ValueError
-            The length of ``embeds`` was invalid or
-            there was no token associated with this webhook.
+            The length of ``embeds`` was invalid, there was no token
+            associated with this webhook or you tried to send a view
+            with components other than URL buttons.
 
         Returns
         ---------
@@ -1026,6 +1037,13 @@ class SyncWebhook(BaseWebhook):
             flags.suppress_notifications = silent
         else:
             flags = MISSING
+
+        if view is not MISSING:
+            if not hasattr(view, '__discord_ui_view__'):
+                raise TypeError(f'expected view parameter to be of type View not {view.__class__.__name__}')
+
+            if not view._is_stateless():
+                raise ValueError('SyncWebhook views can only contain URL buttons')
 
         if thread_name is not MISSING and thread is not MISSING:
             raise TypeError('Cannot mix thread_name and thread keyword arguments.')
@@ -1050,6 +1068,7 @@ class SyncWebhook(BaseWebhook):
             flags=flags,
             applied_tags=applied_tag_ids,
             poll=poll,
+            view=view,
         ) as params:
             adapter: WebhookAdapter = _get_webhook_adapter()
             thread_id: Optional[int] = None
@@ -1065,6 +1084,7 @@ class SyncWebhook(BaseWebhook):
                 files=params.files,
                 thread_id=thread_id,
                 wait=wait,
+                has_view=view is not MISSING,
             )
 
         msg = None


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds support for sending views that only have URL buttons on stateless views.

This is also done with the new ``with_components`` query parameter on the Execute Webhook endpoint.

Related DDevs PR: https://github.com/discord/discord-api-docs/pull/7368

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
