### PR TITLE
Fix typo in voice server update state handling

### DIFF
--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -344,7 +344,7 @@ class VoiceConnectionState:
 
         elif self.state is not ConnectionFlowState.disconnected:
             # eventual consistency
-            if previous_token == self.token and previous_server_id == self.server_id and previous_token == self.token:
+            if previous_token == self.token and previous_server_id == self.server_id and previous_endpoint == self.endpoint:
                 return
 
             _log.debug('Unexpected server update event, attempting to handle')


### PR DESCRIPTION
## Summary

Fixes a typo in the voice server update state handling, where `previous_token` is checked twice instead of `previous_endpoint`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
