### PR TITLE
Add a check for when guild.default_role is none in member.roles

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -561,8 +561,9 @@ class Member(discord.abc.Messageable, _UserTag):
             role = g.get_role(role_id)
             if role:
                 result.append(role)
-        if g.default_role:
-            result.append(g.default_role)
+        default_role = g.default_role
+        if default_role:
+            result.append(default_role)
         result.sort()
         return result
 

--- a/discord/member.py
+++ b/discord/member.py
@@ -28,7 +28,19 @@ import datetime
 import inspect
 import itertools
 from operator import attrgetter
-from typing import Any, Awaitable, Callable, Collection, Dict, List, Optional, TYPE_CHECKING, Tuple, TypeVar, Union
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Collection,
+    Dict,
+    List,
+    Optional,
+    TYPE_CHECKING,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import discord.abc
 
@@ -45,11 +57,11 @@ from .flags import MemberFlags
 from .presences import ClientStatus
 
 __all__ = (
-    'VoiceState',
-    'Member',
+    "VoiceState",
+    "Member",
 )
 
-T = TypeVar('T', bound=type)
+T = TypeVar("T", bound=type)
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -122,54 +134,65 @@ class VoiceState:
     """
 
     __slots__ = (
-        'session_id',
-        'deaf',
-        'mute',
-        'self_mute',
-        'self_stream',
-        'self_video',
-        'self_deaf',
-        'afk',
-        'channel',
-        'requested_to_speak_at',
-        'suppress',
+        "session_id",
+        "deaf",
+        "mute",
+        "self_mute",
+        "self_stream",
+        "self_video",
+        "self_deaf",
+        "afk",
+        "channel",
+        "requested_to_speak_at",
+        "suppress",
     )
 
     def __init__(
-        self, *, data: Union[VoiceStatePayload, GuildVoiceStatePayload], channel: Optional[VocalGuildChannel] = None
+        self,
+        *,
+        data: Union[VoiceStatePayload, GuildVoiceStatePayload],
+        channel: Optional[VocalGuildChannel] = None,
     ):
-        self.session_id: Optional[str] = data.get('session_id')
+        self.session_id: Optional[str] = data.get("session_id")
         self._update(data, channel)
 
-    def _update(self, data: Union[VoiceStatePayload, GuildVoiceStatePayload], channel: Optional[VocalGuildChannel]):
-        self.self_mute: bool = data.get('self_mute', False)
-        self.self_deaf: bool = data.get('self_deaf', False)
-        self.self_stream: bool = data.get('self_stream', False)
-        self.self_video: bool = data.get('self_video', False)
-        self.afk: bool = data.get('suppress', False)
-        self.mute: bool = data.get('mute', False)
-        self.deaf: bool = data.get('deaf', False)
-        self.suppress: bool = data.get('suppress', False)
-        self.requested_to_speak_at: Optional[datetime.datetime] = utils.parse_time(data.get('request_to_speak_timestamp'))
+    def _update(
+        self,
+        data: Union[VoiceStatePayload, GuildVoiceStatePayload],
+        channel: Optional[VocalGuildChannel],
+    ):
+        self.self_mute: bool = data.get("self_mute", False)
+        self.self_deaf: bool = data.get("self_deaf", False)
+        self.self_stream: bool = data.get("self_stream", False)
+        self.self_video: bool = data.get("self_video", False)
+        self.afk: bool = data.get("suppress", False)
+        self.mute: bool = data.get("mute", False)
+        self.deaf: bool = data.get("deaf", False)
+        self.suppress: bool = data.get("suppress", False)
+        self.requested_to_speak_at: Optional[datetime.datetime] = utils.parse_time(
+            data.get("request_to_speak_timestamp")
+        )
         self.channel: Optional[VocalGuildChannel] = channel
 
     def __repr__(self) -> str:
         attrs = [
-            ('self_mute', self.self_mute),
-            ('self_deaf', self.self_deaf),
-            ('self_stream', self.self_stream),
-            ('suppress', self.suppress),
-            ('requested_to_speak_at', self.requested_to_speak_at),
-            ('channel', self.channel),
+            ("self_mute", self.self_mute),
+            ("self_deaf", self.self_deaf),
+            ("self_stream", self.self_stream),
+            ("suppress", self.suppress),
+            ("requested_to_speak_at", self.requested_to_speak_at),
+            ("channel", self.channel),
         ]
-        inner = ' '.join('%s=%r' % t for t in attrs)
-        return f'<{self.__class__.__name__} {inner}>'
+        inner = " ".join("%s=%r" % t for t in attrs)
+        return f"<{self.__class__.__name__} {inner}>"
 
 
 def flatten_user(cls: T) -> T:
-    for attr, value in itertools.chain(BaseUser.__dict__.items(), User.__dict__.items()):
+    for attr, value in itertools.chain(
+        BaseUser.__dict__.items(), User.__dict__.items()
+    ):
         # ignore private/special methods
-        if attr.startswith('_'):
+        if attr.startswith("_"):
             continue
 
         # don't override what we already have
@@ -178,9 +201,11 @@ def flatten_user(cls: T) -> T:
 
         # if it's a slotted attribute or a property, redirect it
         # slotted members are implemented as member_descriptors in Type.__dict__
-        if not hasattr(value, '__annotations__'):
-            getter = attrgetter('_user.' + attr)
-            setattr(cls, attr, property(getter, doc=f'Equivalent to :attr:`User.{attr}`'))
+        if not hasattr(value, "__annotations__"):
+            getter = attrgetter("_user." + attr)
+            setattr(
+                cls, attr, property(getter, doc=f"Equivalent to :attr:`User.{attr}`")
+            )
         else:
             # Technically, this can also use attrgetter
             # However I'm not sure how I feel about "functions" returning properties
@@ -271,22 +296,22 @@ class Member(discord.abc.Messageable, _UserTag):
     """
 
     __slots__ = (
-        '_roles',
-        'joined_at',
-        'premium_since',
-        'activities',
-        'guild',
-        'pending',
-        'nick',
-        'timed_out_until',
-        '_permissions',
-        'client_status',
-        '_user',
-        '_state',
-        '_avatar',
-        '_banner',
-        '_flags',
-        '_avatar_decoration_data',
+        "_roles",
+        "joined_at",
+        "premium_since",
+        "activities",
+        "guild",
+        "pending",
+        "nick",
+        "timed_out_until",
+        "_permissions",
+        "client_status",
+        "_user",
+        "_state",
+        "_avatar",
+        "_banner",
+        "_flags",
+        "_avatar_decoration_data",
     )
 
     if TYPE_CHECKING:
@@ -309,36 +334,46 @@ class Member(discord.abc.Messageable, _UserTag):
         avatar_decoration: Optional[Asset]
         avatar_decoration_sku_id: Optional[int]
 
-    def __init__(self, *, data: MemberWithUserPayload, guild: Guild, state: ConnectionState):
+    def __init__(
+        self, *, data: MemberWithUserPayload, guild: Guild, state: ConnectionState
+    ):
         self._state: ConnectionState = state
-        self._user: User = state.store_user(data['user'])
+        self._user: User = state.store_user(data["user"])
         self.guild: Guild = guild
-        self.joined_at: Optional[datetime.datetime] = utils.parse_time(data.get('joined_at'))
-        self.premium_since: Optional[datetime.datetime] = utils.parse_time(data.get('premium_since'))
-        self._roles: utils.SnowflakeList = utils.SnowflakeList(map(int, data['roles']))
+        self.joined_at: Optional[datetime.datetime] = utils.parse_time(
+            data.get("joined_at")
+        )
+        self.premium_since: Optional[datetime.datetime] = utils.parse_time(
+            data.get("premium_since")
+        )
+        self._roles: utils.SnowflakeList = utils.SnowflakeList(map(int, data["roles"]))
         self.client_status: ClientStatus = ClientStatus()
         self.activities: Tuple[ActivityTypes, ...] = ()
-        self.nick: Optional[str] = data.get('nick', None)
-        self.pending: bool = data.get('pending', False)
-        self._avatar: Optional[str] = data.get('avatar')
-        self._banner: Optional[str] = data.get('banner')
+        self.nick: Optional[str] = data.get("nick", None)
+        self.pending: bool = data.get("pending", False)
+        self._avatar: Optional[str] = data.get("avatar")
+        self._banner: Optional[str] = data.get("banner")
         self._permissions: Optional[int]
-        self._flags: int = data['flags']
-        self._avatar_decoration_data: Optional[AvatarDecorationData] = data.get('avatar_decoration_data')
+        self._flags: int = data["flags"]
+        self._avatar_decoration_data: Optional[AvatarDecorationData] = data.get(
+            "avatar_decoration_data"
+        )
         try:
-            self._permissions = int(data['permissions'])
+            self._permissions = int(data["permissions"])
         except KeyError:
             self._permissions = None
 
-        self.timed_out_until: Optional[datetime.datetime] = utils.parse_time(data.get('communication_disabled_until'))
+        self.timed_out_until: Optional[datetime.datetime] = utils.parse_time(
+            data.get("communication_disabled_until")
+        )
 
     def __str__(self) -> str:
         return str(self._user)
 
     def __repr__(self) -> str:
         return (
-            f'<Member id={self._user.id} name={self._user.name!r} global_name={self._user.global_name!r}'
-            f' bot={self._user.bot} nick={self.nick!r} guild={self.guild!r}>'
+            f"<Member id={self._user.id} name={self._user.name!r} global_name={self._user.global_name!r}"
+            f" bot={self._user.bot} nick={self.nick!r} guild={self.guild!r}>"
         )
 
     def __eq__(self, other: object) -> bool:
@@ -353,36 +388,42 @@ class Member(discord.abc.Messageable, _UserTag):
     @classmethod
     def _from_message(cls, *, message: Message, data: MemberPayload) -> Self:
         author = message.author
-        data['user'] = author._to_minimal_user_json()  # type: ignore
+        data["user"] = author._to_minimal_user_json()  # type: ignore
         return cls(data=data, guild=message.guild, state=message._state)  # type: ignore
 
     @classmethod
-    def _from_client_user(cls, *, user: ClientUser, guild: Guild, state: ConnectionState) -> Self:
+    def _from_client_user(
+        cls, *, user: ClientUser, guild: Guild, state: ConnectionState
+    ) -> Self:
         data = {
-            'roles': [],
-            'user': user._to_minimal_user_json(),
-            'flags': 0,
+            "roles": [],
+            "user": user._to_minimal_user_json(),
+            "flags": 0,
         }
         return cls(data=data, guild=guild, state=state)  # type: ignore
 
     def _update_from_message(self, data: MemberPayload) -> None:
-        self.joined_at = utils.parse_time(data.get('joined_at'))
-        self.premium_since = utils.parse_time(data.get('premium_since'))
-        self._roles = utils.SnowflakeList(map(int, data['roles']))
-        self.nick = data.get('nick', None)
-        self.pending = data.get('pending', False)
-        self.timed_out_until = utils.parse_time(data.get('communication_disabled_until'))
-        self._flags = data.get('flags', 0)
+        self.joined_at = utils.parse_time(data.get("joined_at"))
+        self.premium_since = utils.parse_time(data.get("premium_since"))
+        self._roles = utils.SnowflakeList(map(int, data["roles"]))
+        self.nick = data.get("nick", None)
+        self.pending = data.get("pending", False)
+        self.timed_out_until = utils.parse_time(
+            data.get("communication_disabled_until")
+        )
+        self._flags = data.get("flags", 0)
 
     @classmethod
-    def _try_upgrade(cls, *, data: UserWithMemberPayload, guild: Guild, state: ConnectionState) -> Union[User, Self]:
+    def _try_upgrade(
+        cls, *, data: UserWithMemberPayload, guild: Guild, state: ConnectionState
+    ) -> Union[User, Self]:
         # A User object with a 'member' key
         try:
-            member_data = data.pop('member')
+            member_data = data.pop("member")
         except KeyError:
             return state.create_user(data)
         else:
-            member_data['user'] = data  # type: ignore
+            member_data["user"] = data  # type: ignore
             return cls(data=member_data, guild=guild, state=state)  # type: ignore
 
     @classmethod
@@ -418,24 +459,28 @@ class Member(discord.abc.Messageable, _UserTag):
         # the nickname change is optional,
         # if it isn't in the payload then it didn't change
         try:
-            self.nick = data['nick']
+            self.nick = data["nick"]
         except KeyError:
             pass
 
         try:
-            self.pending = data['pending']
+            self.pending = data["pending"]
         except KeyError:
             pass
 
-        self.premium_since = utils.parse_time(data.get('premium_since'))
-        self.timed_out_until = utils.parse_time(data.get('communication_disabled_until'))
-        self._roles = utils.SnowflakeList(map(int, data['roles']))
-        self._avatar = data.get('avatar')
-        self._banner = data.get('banner')
-        self._flags = data.get('flags', 0)
-        self._avatar_decoration_data = data.get('avatar_decoration_data')
+        self.premium_since = utils.parse_time(data.get("premium_since"))
+        self.timed_out_until = utils.parse_time(
+            data.get("communication_disabled_until")
+        )
+        self._roles = utils.SnowflakeList(map(int, data["roles"]))
+        self._avatar = data.get("avatar")
+        self._banner = data.get("banner")
+        self._flags = data.get("flags", 0)
+        self._avatar_decoration_data = data.get("avatar_decoration_data")
 
-    def _presence_update(self, raw: RawPresenceUpdateEvent, user: UserPayload) -> Optional[Tuple[User, User]]:
+    def _presence_update(
+        self, raw: RawPresenceUpdateEvent, user: UserPayload
+    ) -> Optional[Tuple[User, User]]:
         self.activities = raw.activities
         self.client_status = raw.client_status
 
@@ -450,27 +495,36 @@ class Member(discord.abc.Messageable, _UserTag):
             u._avatar,
             u.global_name,
             u._public_flags,
-            u._avatar_decoration_data['sku_id'] if u._avatar_decoration_data is not None else None,
+            u._avatar_decoration_data["sku_id"]
+            if u._avatar_decoration_data is not None
+            else None,
         )
 
-        decoration_payload = user.get('avatar_decoration_data')
+        decoration_payload = user.get("avatar_decoration_data")
         # These keys seem to always be available
         modified = (
-            user['username'],
-            user['discriminator'],
-            user['avatar'],
-            user.get('global_name'),
-            user.get('public_flags', 0),
-            decoration_payload['sku_id'] if decoration_payload is not None else None,
+            user["username"],
+            user["discriminator"],
+            user["avatar"],
+            user.get("global_name"),
+            user.get("public_flags", 0),
+            decoration_payload["sku_id"] if decoration_payload is not None else None,
         )
         if original != modified:
             to_return = User._copy(self._user)
-            u.name, u.discriminator, u._avatar, u.global_name, u._public_flags, u._avatar_decoration_data = (
-                user['username'],
-                user['discriminator'],
-                user['avatar'],
-                user.get('global_name'),
-                user.get('public_flags', 0),
+            (
+                u.name,
+                u.discriminator,
+                u._avatar,
+                u.global_name,
+                u._public_flags,
+                u._avatar_decoration_data,
+            ) = (
+                user["username"],
+                user["discriminator"],
+                user["avatar"],
+                user.get("global_name"),
+                user.get("public_flags", 0),
                 decoration_payload,
             )
             # Signal to dispatch on_user_update
@@ -561,7 +615,8 @@ class Member(discord.abc.Messageable, _UserTag):
             role = g.get_role(role_id)
             if role:
                 result.append(role)
-        result.append(g.default_role)
+        if g.default_role:
+            result.append(g.default_role)
         result.sort()
         return result
 
@@ -584,7 +639,7 @@ class Member(discord.abc.Messageable, _UserTag):
     @property
     def mention(self) -> str:
         """:class:`str`: Returns a string that allows you to mention the member."""
-        return f'<@{self._user.id}>'
+        return f"<@{self._user.id}>"
 
     @property
     def display_name(self) -> str:
@@ -617,7 +672,9 @@ class Member(discord.abc.Messageable, _UserTag):
         """
         if self._avatar is None:
             return None
-        return Asset._from_guild_avatar(self._state, self.guild.id, self.id, self._avatar)
+        return Asset._from_guild_avatar(
+            self._state, self.guild.id, self.id, self._avatar
+        )
 
     @property
     def display_banner(self) -> Optional[Asset]:
@@ -639,7 +696,9 @@ class Member(discord.abc.Messageable, _UserTag):
         """
         if self._banner is None:
             return None
-        return Asset._from_guild_banner(self._state, self.guild.id, self.id, self._banner)
+        return Asset._from_guild_banner(
+            self._state, self.guild.id, self.id, self._banner
+        )
 
     @property
     def activity(self) -> Optional[ActivityTypes]:
@@ -882,56 +941,58 @@ class Member(discord.abc.Messageable, _UserTag):
         payload: Dict[str, Any] = {}
 
         if nick is not MISSING:
-            nick = nick or ''
+            nick = nick or ""
             if me:
                 await http.change_my_nickname(guild_id, nick, reason=reason)
             else:
-                payload['nick'] = nick
+                payload["nick"] = nick
 
         if deafen is not MISSING:
-            payload['deaf'] = deafen
+            payload["deaf"] = deafen
 
         if mute is not MISSING:
-            payload['mute'] = mute
+            payload["mute"] = mute
 
         if suppress is not MISSING:
             voice_state_payload: Dict[str, Any] = {
-                'suppress': suppress,
+                "suppress": suppress,
             }
 
             if self.voice is not None and self.voice.channel is not None:
-                voice_state_payload['channel_id'] = self.voice.channel.id
+                voice_state_payload["channel_id"] = self.voice.channel.id
 
             if suppress or self.bot:
-                voice_state_payload['request_to_speak_timestamp'] = None
+                voice_state_payload["request_to_speak_timestamp"] = None
 
             if me:
                 await http.edit_my_voice_state(guild_id, voice_state_payload)
             else:
                 if not suppress:
-                    voice_state_payload['request_to_speak_timestamp'] = datetime.datetime.utcnow().isoformat()
+                    voice_state_payload["request_to_speak_timestamp"] = (
+                        datetime.datetime.utcnow().isoformat()
+                    )
                 await http.edit_voice_state(guild_id, self.id, voice_state_payload)
 
         if voice_channel is not MISSING:
-            payload['channel_id'] = voice_channel and voice_channel.id
+            payload["channel_id"] = voice_channel and voice_channel.id
 
         if roles is not MISSING:
-            payload['roles'] = tuple(r.id for r in roles)
+            payload["roles"] = tuple(r.id for r in roles)
 
         if timed_out_until is not MISSING:
             if timed_out_until is None:
-                payload['communication_disabled_until'] = None
+                payload["communication_disabled_until"] = None
             else:
                 if timed_out_until.tzinfo is None:
                     raise TypeError(
-                        'timed_out_until must be an aware datetime. Consider using discord.utils.utcnow() or datetime.datetime.now().astimezone() for local time.'
+                        "timed_out_until must be an aware datetime. Consider using discord.utils.utcnow() or datetime.datetime.now().astimezone() for local time."
                     )
-                payload['communication_disabled_until'] = timed_out_until.isoformat()
+                payload["communication_disabled_until"] = timed_out_until.isoformat()
 
         if bypass_verification is not MISSING:
             flags = MemberFlags._from_value(self._flags)
             flags.bypasses_verification = bypass_verification
-            payload['flags'] = flags.value
+            payload["flags"] = flags.value
 
         if payload:
             data = await http.edit_member(guild_id, self.id, reason=reason, **payload)
@@ -961,20 +1022,24 @@ class Member(discord.abc.Messageable, _UserTag):
             The operation failed.
         """
         if self.voice is None or self.voice.channel is None:
-            raise ClientException('Cannot request to speak while not connected to a voice channel.')
+            raise ClientException(
+                "Cannot request to speak while not connected to a voice channel."
+            )
 
         payload = {
-            'channel_id': self.voice.channel.id,
-            'request_to_speak_timestamp': datetime.datetime.utcnow().isoformat(),
+            "channel_id": self.voice.channel.id,
+            "request_to_speak_timestamp": datetime.datetime.utcnow().isoformat(),
         }
 
         if self._state.self_id != self.id:
-            payload['suppress'] = False
+            payload["suppress"] = False
             await self._state.http.edit_voice_state(self.guild.id, self.id, payload)
         else:
             await self._state.http.edit_my_voice_state(self.guild.id, payload)
 
-    async def move_to(self, channel: Optional[VocalGuildChannel], *, reason: Optional[str] = None) -> None:
+    async def move_to(
+        self, channel: Optional[VocalGuildChannel], *, reason: Optional[str] = None
+    ) -> None:
         """|coro|
 
         Moves a member to a new voice channel (they must be connected first).
@@ -997,7 +1062,11 @@ class Member(discord.abc.Messageable, _UserTag):
         await self.edit(voice_channel=channel, reason=reason)
 
     async def timeout(
-        self, until: Optional[Union[datetime.timedelta, datetime.datetime]], /, *, reason: Optional[str] = None
+        self,
+        until: Optional[Union[datetime.timedelta, datetime.datetime]],
+        /,
+        *,
+        reason: Optional[str] = None,
     ) -> None:
         """|coro|
 
@@ -1031,11 +1100,15 @@ class Member(discord.abc.Messageable, _UserTag):
         elif isinstance(until, datetime.datetime):
             timed_out_until = until
         else:
-            raise TypeError(f'expected None, datetime.datetime, or datetime.timedelta not {until.__class__.__name__}')
+            raise TypeError(
+                f"expected None, datetime.datetime, or datetime.timedelta not {until.__class__.__name__}"
+            )
 
         await self.edit(timed_out_until=timed_out_until, reason=reason)
 
-    async def add_roles(self, *roles: Snowflake, reason: Optional[str] = None, atomic: bool = True) -> None:
+    async def add_roles(
+        self, *roles: Snowflake, reason: Optional[str] = None, atomic: bool = True
+    ) -> None:
         r"""|coro|
 
         Gives the member a number of :class:`Role`\s.
@@ -1065,7 +1138,9 @@ class Member(discord.abc.Messageable, _UserTag):
         """
 
         if not atomic:
-            new_roles = utils._unique(Object(id=r.id) for s in (self.roles[1:], roles) for r in s)
+            new_roles = utils._unique(
+                Object(id=r.id) for s in (self.roles[1:], roles) for r in s
+            )
             await self.edit(roles=new_roles, reason=reason)
         else:
             req = self._state.http.add_role
@@ -1074,7 +1149,9 @@ class Member(discord.abc.Messageable, _UserTag):
             for role in roles:
                 await req(guild_id, user_id, role.id, reason=reason)
 
-    async def remove_roles(self, *roles: Snowflake, reason: Optional[str] = None, atomic: bool = True) -> None:
+    async def remove_roles(
+        self, *roles: Snowflake, reason: Optional[str] = None, atomic: bool = True
+    ) -> None:
         r"""|coro|
 
         Removes :class:`Role`\s from this member.
@@ -1146,7 +1223,7 @@ class Member(discord.abc.Messageable, _UserTag):
         else:
             data = await self._state.http.get_voice_state(guild_id, self.id)
 
-        channel_id = data.get('channel_id')
+        channel_id = data.get("channel_id")
         channel: Optional[VocalGuildChannel] = None
         if channel_id is not None:
             channel = self.guild.get_channel(int(channel_id))  # type: ignore # must be voice channel here

--- a/discord/member.py
+++ b/discord/member.py
@@ -28,19 +28,7 @@ import datetime
 import inspect
 import itertools
 from operator import attrgetter
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Collection,
-    Dict,
-    List,
-    Optional,
-    TYPE_CHECKING,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import Any, Awaitable, Callable, Collection, Dict, List, Optional, TYPE_CHECKING, Tuple, TypeVar, Union
 
 import discord.abc
 
@@ -57,11 +45,11 @@ from .flags import MemberFlags
 from .presences import ClientStatus
 
 __all__ = (
-    "VoiceState",
-    "Member",
+    'VoiceState',
+    'Member',
 )
 
-T = TypeVar("T", bound=type)
+T = TypeVar('T', bound=type)
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -134,65 +122,54 @@ class VoiceState:
     """
 
     __slots__ = (
-        "session_id",
-        "deaf",
-        "mute",
-        "self_mute",
-        "self_stream",
-        "self_video",
-        "self_deaf",
-        "afk",
-        "channel",
-        "requested_to_speak_at",
-        "suppress",
+        'session_id',
+        'deaf',
+        'mute',
+        'self_mute',
+        'self_stream',
+        'self_video',
+        'self_deaf',
+        'afk',
+        'channel',
+        'requested_to_speak_at',
+        'suppress',
     )
 
     def __init__(
-        self,
-        *,
-        data: Union[VoiceStatePayload, GuildVoiceStatePayload],
-        channel: Optional[VocalGuildChannel] = None,
+        self, *, data: Union[VoiceStatePayload, GuildVoiceStatePayload], channel: Optional[VocalGuildChannel] = None
     ):
-        self.session_id: Optional[str] = data.get("session_id")
+        self.session_id: Optional[str] = data.get('session_id')
         self._update(data, channel)
 
-    def _update(
-        self,
-        data: Union[VoiceStatePayload, GuildVoiceStatePayload],
-        channel: Optional[VocalGuildChannel],
-    ):
-        self.self_mute: bool = data.get("self_mute", False)
-        self.self_deaf: bool = data.get("self_deaf", False)
-        self.self_stream: bool = data.get("self_stream", False)
-        self.self_video: bool = data.get("self_video", False)
-        self.afk: bool = data.get("suppress", False)
-        self.mute: bool = data.get("mute", False)
-        self.deaf: bool = data.get("deaf", False)
-        self.suppress: bool = data.get("suppress", False)
-        self.requested_to_speak_at: Optional[datetime.datetime] = utils.parse_time(
-            data.get("request_to_speak_timestamp")
-        )
+    def _update(self, data: Union[VoiceStatePayload, GuildVoiceStatePayload], channel: Optional[VocalGuildChannel]):
+        self.self_mute: bool = data.get('self_mute', False)
+        self.self_deaf: bool = data.get('self_deaf', False)
+        self.self_stream: bool = data.get('self_stream', False)
+        self.self_video: bool = data.get('self_video', False)
+        self.afk: bool = data.get('suppress', False)
+        self.mute: bool = data.get('mute', False)
+        self.deaf: bool = data.get('deaf', False)
+        self.suppress: bool = data.get('suppress', False)
+        self.requested_to_speak_at: Optional[datetime.datetime] = utils.parse_time(data.get('request_to_speak_timestamp'))
         self.channel: Optional[VocalGuildChannel] = channel
 
     def __repr__(self) -> str:
         attrs = [
-            ("self_mute", self.self_mute),
-            ("self_deaf", self.self_deaf),
-            ("self_stream", self.self_stream),
-            ("suppress", self.suppress),
-            ("requested_to_speak_at", self.requested_to_speak_at),
-            ("channel", self.channel),
+            ('self_mute', self.self_mute),
+            ('self_deaf', self.self_deaf),
+            ('self_stream', self.self_stream),
+            ('suppress', self.suppress),
+            ('requested_to_speak_at', self.requested_to_speak_at),
+            ('channel', self.channel),
         ]
-        inner = " ".join("%s=%r" % t for t in attrs)
-        return f"<{self.__class__.__name__} {inner}>"
+        inner = ' '.join('%s=%r' % t for t in attrs)
+        return f'<{self.__class__.__name__} {inner}>'
 
 
 def flatten_user(cls: T) -> T:
-    for attr, value in itertools.chain(
-        BaseUser.__dict__.items(), User.__dict__.items()
-    ):
+    for attr, value in itertools.chain(BaseUser.__dict__.items(), User.__dict__.items()):
         # ignore private/special methods
-        if attr.startswith("_"):
+        if attr.startswith('_'):
             continue
 
         # don't override what we already have
@@ -201,11 +178,9 @@ def flatten_user(cls: T) -> T:
 
         # if it's a slotted attribute or a property, redirect it
         # slotted members are implemented as member_descriptors in Type.__dict__
-        if not hasattr(value, "__annotations__"):
-            getter = attrgetter("_user." + attr)
-            setattr(
-                cls, attr, property(getter, doc=f"Equivalent to :attr:`User.{attr}`")
-            )
+        if not hasattr(value, '__annotations__'):
+            getter = attrgetter('_user.' + attr)
+            setattr(cls, attr, property(getter, doc=f'Equivalent to :attr:`User.{attr}`'))
         else:
             # Technically, this can also use attrgetter
             # However I'm not sure how I feel about "functions" returning properties
@@ -296,22 +271,22 @@ class Member(discord.abc.Messageable, _UserTag):
     """
 
     __slots__ = (
-        "_roles",
-        "joined_at",
-        "premium_since",
-        "activities",
-        "guild",
-        "pending",
-        "nick",
-        "timed_out_until",
-        "_permissions",
-        "client_status",
-        "_user",
-        "_state",
-        "_avatar",
-        "_banner",
-        "_flags",
-        "_avatar_decoration_data",
+        '_roles',
+        'joined_at',
+        'premium_since',
+        'activities',
+        'guild',
+        'pending',
+        'nick',
+        'timed_out_until',
+        '_permissions',
+        'client_status',
+        '_user',
+        '_state',
+        '_avatar',
+        '_banner',
+        '_flags',
+        '_avatar_decoration_data',
     )
 
     if TYPE_CHECKING:
@@ -334,46 +309,36 @@ class Member(discord.abc.Messageable, _UserTag):
         avatar_decoration: Optional[Asset]
         avatar_decoration_sku_id: Optional[int]
 
-    def __init__(
-        self, *, data: MemberWithUserPayload, guild: Guild, state: ConnectionState
-    ):
+    def __init__(self, *, data: MemberWithUserPayload, guild: Guild, state: ConnectionState):
         self._state: ConnectionState = state
-        self._user: User = state.store_user(data["user"])
+        self._user: User = state.store_user(data['user'])
         self.guild: Guild = guild
-        self.joined_at: Optional[datetime.datetime] = utils.parse_time(
-            data.get("joined_at")
-        )
-        self.premium_since: Optional[datetime.datetime] = utils.parse_time(
-            data.get("premium_since")
-        )
-        self._roles: utils.SnowflakeList = utils.SnowflakeList(map(int, data["roles"]))
+        self.joined_at: Optional[datetime.datetime] = utils.parse_time(data.get('joined_at'))
+        self.premium_since: Optional[datetime.datetime] = utils.parse_time(data.get('premium_since'))
+        self._roles: utils.SnowflakeList = utils.SnowflakeList(map(int, data['roles']))
         self.client_status: ClientStatus = ClientStatus()
         self.activities: Tuple[ActivityTypes, ...] = ()
-        self.nick: Optional[str] = data.get("nick", None)
-        self.pending: bool = data.get("pending", False)
-        self._avatar: Optional[str] = data.get("avatar")
-        self._banner: Optional[str] = data.get("banner")
+        self.nick: Optional[str] = data.get('nick', None)
+        self.pending: bool = data.get('pending', False)
+        self._avatar: Optional[str] = data.get('avatar')
+        self._banner: Optional[str] = data.get('banner')
         self._permissions: Optional[int]
-        self._flags: int = data["flags"]
-        self._avatar_decoration_data: Optional[AvatarDecorationData] = data.get(
-            "avatar_decoration_data"
-        )
+        self._flags: int = data['flags']
+        self._avatar_decoration_data: Optional[AvatarDecorationData] = data.get('avatar_decoration_data')
         try:
-            self._permissions = int(data["permissions"])
+            self._permissions = int(data['permissions'])
         except KeyError:
             self._permissions = None
 
-        self.timed_out_until: Optional[datetime.datetime] = utils.parse_time(
-            data.get("communication_disabled_until")
-        )
+        self.timed_out_until: Optional[datetime.datetime] = utils.parse_time(data.get('communication_disabled_until'))
 
     def __str__(self) -> str:
         return str(self._user)
 
     def __repr__(self) -> str:
         return (
-            f"<Member id={self._user.id} name={self._user.name!r} global_name={self._user.global_name!r}"
-            f" bot={self._user.bot} nick={self.nick!r} guild={self.guild!r}>"
+            f'<Member id={self._user.id} name={self._user.name!r} global_name={self._user.global_name!r}'
+            f' bot={self._user.bot} nick={self.nick!r} guild={self.guild!r}>'
         )
 
     def __eq__(self, other: object) -> bool:
@@ -388,42 +353,36 @@ class Member(discord.abc.Messageable, _UserTag):
     @classmethod
     def _from_message(cls, *, message: Message, data: MemberPayload) -> Self:
         author = message.author
-        data["user"] = author._to_minimal_user_json()  # type: ignore
+        data['user'] = author._to_minimal_user_json()  # type: ignore
         return cls(data=data, guild=message.guild, state=message._state)  # type: ignore
 
     @classmethod
-    def _from_client_user(
-        cls, *, user: ClientUser, guild: Guild, state: ConnectionState
-    ) -> Self:
+    def _from_client_user(cls, *, user: ClientUser, guild: Guild, state: ConnectionState) -> Self:
         data = {
-            "roles": [],
-            "user": user._to_minimal_user_json(),
-            "flags": 0,
+            'roles': [],
+            'user': user._to_minimal_user_json(),
+            'flags': 0,
         }
         return cls(data=data, guild=guild, state=state)  # type: ignore
 
     def _update_from_message(self, data: MemberPayload) -> None:
-        self.joined_at = utils.parse_time(data.get("joined_at"))
-        self.premium_since = utils.parse_time(data.get("premium_since"))
-        self._roles = utils.SnowflakeList(map(int, data["roles"]))
-        self.nick = data.get("nick", None)
-        self.pending = data.get("pending", False)
-        self.timed_out_until = utils.parse_time(
-            data.get("communication_disabled_until")
-        )
-        self._flags = data.get("flags", 0)
+        self.joined_at = utils.parse_time(data.get('joined_at'))
+        self.premium_since = utils.parse_time(data.get('premium_since'))
+        self._roles = utils.SnowflakeList(map(int, data['roles']))
+        self.nick = data.get('nick', None)
+        self.pending = data.get('pending', False)
+        self.timed_out_until = utils.parse_time(data.get('communication_disabled_until'))
+        self._flags = data.get('flags', 0)
 
     @classmethod
-    def _try_upgrade(
-        cls, *, data: UserWithMemberPayload, guild: Guild, state: ConnectionState
-    ) -> Union[User, Self]:
+    def _try_upgrade(cls, *, data: UserWithMemberPayload, guild: Guild, state: ConnectionState) -> Union[User, Self]:
         # A User object with a 'member' key
         try:
-            member_data = data.pop("member")
+            member_data = data.pop('member')
         except KeyError:
             return state.create_user(data)
         else:
-            member_data["user"] = data  # type: ignore
+            member_data['user'] = data  # type: ignore
             return cls(data=member_data, guild=guild, state=state)  # type: ignore
 
     @classmethod
@@ -459,28 +418,24 @@ class Member(discord.abc.Messageable, _UserTag):
         # the nickname change is optional,
         # if it isn't in the payload then it didn't change
         try:
-            self.nick = data["nick"]
+            self.nick = data['nick']
         except KeyError:
             pass
 
         try:
-            self.pending = data["pending"]
+            self.pending = data['pending']
         except KeyError:
             pass
 
-        self.premium_since = utils.parse_time(data.get("premium_since"))
-        self.timed_out_until = utils.parse_time(
-            data.get("communication_disabled_until")
-        )
-        self._roles = utils.SnowflakeList(map(int, data["roles"]))
-        self._avatar = data.get("avatar")
-        self._banner = data.get("banner")
-        self._flags = data.get("flags", 0)
-        self._avatar_decoration_data = data.get("avatar_decoration_data")
+        self.premium_since = utils.parse_time(data.get('premium_since'))
+        self.timed_out_until = utils.parse_time(data.get('communication_disabled_until'))
+        self._roles = utils.SnowflakeList(map(int, data['roles']))
+        self._avatar = data.get('avatar')
+        self._banner = data.get('banner')
+        self._flags = data.get('flags', 0)
+        self._avatar_decoration_data = data.get('avatar_decoration_data')
 
-    def _presence_update(
-        self, raw: RawPresenceUpdateEvent, user: UserPayload
-    ) -> Optional[Tuple[User, User]]:
+    def _presence_update(self, raw: RawPresenceUpdateEvent, user: UserPayload) -> Optional[Tuple[User, User]]:
         self.activities = raw.activities
         self.client_status = raw.client_status
 
@@ -495,36 +450,27 @@ class Member(discord.abc.Messageable, _UserTag):
             u._avatar,
             u.global_name,
             u._public_flags,
-            u._avatar_decoration_data["sku_id"]
-            if u._avatar_decoration_data is not None
-            else None,
+            u._avatar_decoration_data['sku_id'] if u._avatar_decoration_data is not None else None,
         )
 
-        decoration_payload = user.get("avatar_decoration_data")
+        decoration_payload = user.get('avatar_decoration_data')
         # These keys seem to always be available
         modified = (
-            user["username"],
-            user["discriminator"],
-            user["avatar"],
-            user.get("global_name"),
-            user.get("public_flags", 0),
-            decoration_payload["sku_id"] if decoration_payload is not None else None,
+            user['username'],
+            user['discriminator'],
+            user['avatar'],
+            user.get('global_name'),
+            user.get('public_flags', 0),
+            decoration_payload['sku_id'] if decoration_payload is not None else None,
         )
         if original != modified:
             to_return = User._copy(self._user)
-            (
-                u.name,
-                u.discriminator,
-                u._avatar,
-                u.global_name,
-                u._public_flags,
-                u._avatar_decoration_data,
-            ) = (
-                user["username"],
-                user["discriminator"],
-                user["avatar"],
-                user.get("global_name"),
-                user.get("public_flags", 0),
+            u.name, u.discriminator, u._avatar, u.global_name, u._public_flags, u._avatar_decoration_data = (
+                user['username'],
+                user['discriminator'],
+                user['avatar'],
+                user.get('global_name'),
+                user.get('public_flags', 0),
                 decoration_payload,
             )
             # Signal to dispatch on_user_update
@@ -639,7 +585,7 @@ class Member(discord.abc.Messageable, _UserTag):
     @property
     def mention(self) -> str:
         """:class:`str`: Returns a string that allows you to mention the member."""
-        return f"<@{self._user.id}>"
+        return f'<@{self._user.id}>'
 
     @property
     def display_name(self) -> str:
@@ -672,9 +618,7 @@ class Member(discord.abc.Messageable, _UserTag):
         """
         if self._avatar is None:
             return None
-        return Asset._from_guild_avatar(
-            self._state, self.guild.id, self.id, self._avatar
-        )
+        return Asset._from_guild_avatar(self._state, self.guild.id, self.id, self._avatar)
 
     @property
     def display_banner(self) -> Optional[Asset]:
@@ -696,9 +640,7 @@ class Member(discord.abc.Messageable, _UserTag):
         """
         if self._banner is None:
             return None
-        return Asset._from_guild_banner(
-            self._state, self.guild.id, self.id, self._banner
-        )
+        return Asset._from_guild_banner(self._state, self.guild.id, self.id, self._banner)
 
     @property
     def activity(self) -> Optional[ActivityTypes]:
@@ -941,58 +883,56 @@ class Member(discord.abc.Messageable, _UserTag):
         payload: Dict[str, Any] = {}
 
         if nick is not MISSING:
-            nick = nick or ""
+            nick = nick or ''
             if me:
                 await http.change_my_nickname(guild_id, nick, reason=reason)
             else:
-                payload["nick"] = nick
+                payload['nick'] = nick
 
         if deafen is not MISSING:
-            payload["deaf"] = deafen
+            payload['deaf'] = deafen
 
         if mute is not MISSING:
-            payload["mute"] = mute
+            payload['mute'] = mute
 
         if suppress is not MISSING:
             voice_state_payload: Dict[str, Any] = {
-                "suppress": suppress,
+                'suppress': suppress,
             }
 
             if self.voice is not None and self.voice.channel is not None:
-                voice_state_payload["channel_id"] = self.voice.channel.id
+                voice_state_payload['channel_id'] = self.voice.channel.id
 
             if suppress or self.bot:
-                voice_state_payload["request_to_speak_timestamp"] = None
+                voice_state_payload['request_to_speak_timestamp'] = None
 
             if me:
                 await http.edit_my_voice_state(guild_id, voice_state_payload)
             else:
                 if not suppress:
-                    voice_state_payload["request_to_speak_timestamp"] = (
-                        datetime.datetime.utcnow().isoformat()
-                    )
+                    voice_state_payload['request_to_speak_timestamp'] = datetime.datetime.utcnow().isoformat()
                 await http.edit_voice_state(guild_id, self.id, voice_state_payload)
 
         if voice_channel is not MISSING:
-            payload["channel_id"] = voice_channel and voice_channel.id
+            payload['channel_id'] = voice_channel and voice_channel.id
 
         if roles is not MISSING:
-            payload["roles"] = tuple(r.id for r in roles)
+            payload['roles'] = tuple(r.id for r in roles)
 
         if timed_out_until is not MISSING:
             if timed_out_until is None:
-                payload["communication_disabled_until"] = None
+                payload['communication_disabled_until'] = None
             else:
                 if timed_out_until.tzinfo is None:
                     raise TypeError(
-                        "timed_out_until must be an aware datetime. Consider using discord.utils.utcnow() or datetime.datetime.now().astimezone() for local time."
+                        'timed_out_until must be an aware datetime. Consider using discord.utils.utcnow() or datetime.datetime.now().astimezone() for local time.'
                     )
-                payload["communication_disabled_until"] = timed_out_until.isoformat()
+                payload['communication_disabled_until'] = timed_out_until.isoformat()
 
         if bypass_verification is not MISSING:
             flags = MemberFlags._from_value(self._flags)
             flags.bypasses_verification = bypass_verification
-            payload["flags"] = flags.value
+            payload['flags'] = flags.value
 
         if payload:
             data = await http.edit_member(guild_id, self.id, reason=reason, **payload)
@@ -1022,24 +962,20 @@ class Member(discord.abc.Messageable, _UserTag):
             The operation failed.
         """
         if self.voice is None or self.voice.channel is None:
-            raise ClientException(
-                "Cannot request to speak while not connected to a voice channel."
-            )
+            raise ClientException('Cannot request to speak while not connected to a voice channel.')
 
         payload = {
-            "channel_id": self.voice.channel.id,
-            "request_to_speak_timestamp": datetime.datetime.utcnow().isoformat(),
+            'channel_id': self.voice.channel.id,
+            'request_to_speak_timestamp': datetime.datetime.utcnow().isoformat(),
         }
 
         if self._state.self_id != self.id:
-            payload["suppress"] = False
+            payload['suppress'] = False
             await self._state.http.edit_voice_state(self.guild.id, self.id, payload)
         else:
             await self._state.http.edit_my_voice_state(self.guild.id, payload)
 
-    async def move_to(
-        self, channel: Optional[VocalGuildChannel], *, reason: Optional[str] = None
-    ) -> None:
+    async def move_to(self, channel: Optional[VocalGuildChannel], *, reason: Optional[str] = None) -> None:
         """|coro|
 
         Moves a member to a new voice channel (they must be connected first).
@@ -1062,11 +998,7 @@ class Member(discord.abc.Messageable, _UserTag):
         await self.edit(voice_channel=channel, reason=reason)
 
     async def timeout(
-        self,
-        until: Optional[Union[datetime.timedelta, datetime.datetime]],
-        /,
-        *,
-        reason: Optional[str] = None,
+        self, until: Optional[Union[datetime.timedelta, datetime.datetime]], /, *, reason: Optional[str] = None
     ) -> None:
         """|coro|
 
@@ -1100,15 +1032,11 @@ class Member(discord.abc.Messageable, _UserTag):
         elif isinstance(until, datetime.datetime):
             timed_out_until = until
         else:
-            raise TypeError(
-                f"expected None, datetime.datetime, or datetime.timedelta not {until.__class__.__name__}"
-            )
+            raise TypeError(f'expected None, datetime.datetime, or datetime.timedelta not {until.__class__.__name__}')
 
         await self.edit(timed_out_until=timed_out_until, reason=reason)
 
-    async def add_roles(
-        self, *roles: Snowflake, reason: Optional[str] = None, atomic: bool = True
-    ) -> None:
+    async def add_roles(self, *roles: Snowflake, reason: Optional[str] = None, atomic: bool = True) -> None:
         r"""|coro|
 
         Gives the member a number of :class:`Role`\s.
@@ -1138,9 +1066,7 @@ class Member(discord.abc.Messageable, _UserTag):
         """
 
         if not atomic:
-            new_roles = utils._unique(
-                Object(id=r.id) for s in (self.roles[1:], roles) for r in s
-            )
+            new_roles = utils._unique(Object(id=r.id) for s in (self.roles[1:], roles) for r in s)
             await self.edit(roles=new_roles, reason=reason)
         else:
             req = self._state.http.add_role
@@ -1149,9 +1075,7 @@ class Member(discord.abc.Messageable, _UserTag):
             for role in roles:
                 await req(guild_id, user_id, role.id, reason=reason)
 
-    async def remove_roles(
-        self, *roles: Snowflake, reason: Optional[str] = None, atomic: bool = True
-    ) -> None:
+    async def remove_roles(self, *roles: Snowflake, reason: Optional[str] = None, atomic: bool = True) -> None:
         r"""|coro|
 
         Removes :class:`Role`\s from this member.
@@ -1223,7 +1147,7 @@ class Member(discord.abc.Messageable, _UserTag):
         else:
             data = await self._state.http.get_voice_state(guild_id, self.id)
 
-        channel_id = data.get("channel_id")
+        channel_id = data.get('channel_id')
         channel: Optional[VocalGuildChannel] = None
         if channel_id is not None:
             channel = self.guild.get_channel(int(channel_id))  # type: ignore # must be voice channel here


### PR DESCRIPTION
## Summary

This PR adds a check in discord.Member.roles for when guild.default_role is None to avoid failure in something like discord.Member.guild_permissions which expects only roles and not None.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
