### PR TITLE
Fix path sanitation for absolute Windows paths.

### DIFF
--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -28,7 +28,7 @@ from typing import Optional, Tuple, Dict
 
 import argparse
 import sys
-from pathlib import Path
+from pathlib import Path, PurePath
 
 import discord
 import importlib.metadata
@@ -225,8 +225,14 @@ def to_path(parser: argparse.ArgumentParser, name: str, *, replace_spaces: bool 
         )
         if len(name) <= 4 and name.upper() in forbidden:
             parser.error('invalid directory name given, use a different one')
-
-    name = name.translate(_translation_table)
+        path = PurePath(name)
+        if path.drive:
+            drive, rest = path.parts[0], path.parts[1:]
+            transformed = tuple(map(lambda p: p.translate(_translation_table), rest))
+            name = drive + '\\'.join(transformed)
+            
+        else:
+            name = name.translate(_translation_table)
     if replace_spaces:
         name = name.replace(' ', '-')
     return Path(name)

--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -28,7 +28,7 @@ from typing import Optional, Tuple, Dict
 
 import argparse
 import sys
-from pathlib import Path, PurePath
+from pathlib import Path, PurePath, PureWindowsPath
 
 import discord
 import importlib.metadata
@@ -225,14 +225,14 @@ def to_path(parser: argparse.ArgumentParser, name: str, *, replace_spaces: bool 
         )
         if len(name) <= 4 and name.upper() in forbidden:
             parser.error('invalid directory name given, use a different one')
-        path = PurePath(name)
-        if path.drive:
-            drive, rest = path.parts[0], path.parts[1:]
-            transformed = tuple(map(lambda p: p.translate(_translation_table), rest))
-            name = drive + '\\'.join(transformed)
+    path = PurePath(name)
+    if isinstance(path, PureWindowsPath) and path.drive:
+        drive, rest = path.parts[0], path.parts[1:]
+        transformed = tuple(map(lambda p: p.translate(_translation_table), rest))
+        name = drive + '\\'.join(transformed)
 
-        else:
-            name = name.translate(_translation_table)
+    else:
+        name = name.translate(_translation_table)
     if replace_spaces:
         name = name.replace(' ', '-')
     return Path(name)

--- a/discord/__main__.py
+++ b/discord/__main__.py
@@ -230,7 +230,7 @@ def to_path(parser: argparse.ArgumentParser, name: str, *, replace_spaces: bool 
             drive, rest = path.parts[0], path.parts[1:]
             transformed = tuple(map(lambda p: p.translate(_translation_table), rest))
             name = drive + '\\'.join(transformed)
-            
+
         else:
             name = name.translate(_translation_table)
     if replace_spaces:


### PR DESCRIPTION
When using an absolute Windows path (e.g. `C:\Users\USER\Documents\`) for the `newbot` command the translation table replaced the valid `:` character in the drive causing it to create the directory at the wrong place.

Fixes #10096

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
