### PR TITLE
Add 'mention' property in PartialWebhookChannel

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -659,6 +659,11 @@ class PartialWebhookChannel(Hashable):
 
     def __repr__(self) -> str:
         return f'<PartialWebhookChannel name={self.name!r} id={self.id}>'
+    
+    @property
+    def mention(self) -> str:
+        """:class:`str`: The string that allows you to mention the channel that the webhook is following."""
+        return f'<#{self.id}>'
 
 
 class PartialWebhookGuild(Hashable):

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1607,7 +1607,8 @@ class Webhook(BaseWebhook):
         silent: bool = MISSING,
         applied_tags: List[ForumTag] = MISSING,
         poll: Poll = MISSING,
-    ) -> WebhookMessage: ...
+    ) -> WebhookMessage:
+        ...
 
     @overload
     async def send(
@@ -1631,7 +1632,8 @@ class Webhook(BaseWebhook):
         silent: bool = MISSING,
         applied_tags: List[ForumTag] = MISSING,
         poll: Poll = MISSING,
-    ) -> None: ...
+    ) -> None:
+        ...
 
     async def send(
         self,

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -659,7 +659,7 @@ class PartialWebhookChannel(Hashable):
 
     def __repr__(self) -> str:
         return f'<PartialWebhookChannel name={self.name!r} id={self.id}>'
-    
+
     @property
     def mention(self) -> str:
         """:class:`str`: The string that allows you to mention the channel that the webhook is following."""
@@ -1607,8 +1607,7 @@ class Webhook(BaseWebhook):
         silent: bool = MISSING,
         applied_tags: List[ForumTag] = MISSING,
         poll: Poll = MISSING,
-    ) -> WebhookMessage:
-        ...
+    ) -> WebhookMessage: ...
 
     @overload
     async def send(
@@ -1632,8 +1631,7 @@ class Webhook(BaseWebhook):
         silent: bool = MISSING,
         applied_tags: List[ForumTag] = MISSING,
         poll: Poll = MISSING,
-    ) -> None:
-        ...
+    ) -> None: ...
 
     async def send(
         self,


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
I was trying to make a function to follow channel(s) and found `PartialWebhookChannel` can be set when `source_channel` is not `None`. So this means `source_channel_id` also would not be `None`. So I would like to suggest to add mention property for this.

I hope you'll review it positively. Thank you.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
