### PR TITLE
Pass `BotT` type argument to `DeferTyping`

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -789,7 +789,7 @@ class Context(discord.abc.Messageable, Generic[BotT]):
         """
         if self.interaction is None:
             return Typing(self)
-        return DeferTyping[BotT](self, ephemeral=ephemeral)
+        return DeferTyping(self, ephemeral=ephemeral)
 
     async def defer(self, *, ephemeral: bool = False) -> None:
         """|coro|

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -751,7 +751,7 @@ class Context(discord.abc.Messageable, Generic[BotT]):
         else:
             return await self.send(content, **kwargs)
 
-    def typing(self, *, ephemeral: bool = False) -> Union[Typing, DeferTyping]:
+    def typing(self, *, ephemeral: bool = False) -> Union[Typing, DeferTyping[BotT]]:
         """Returns an asynchronous context manager that allows you to send a typing indicator to
         the destination for an indefinite period of time, or 10 seconds if the context manager
         is called using ``await``.
@@ -789,7 +789,7 @@ class Context(discord.abc.Messageable, Generic[BotT]):
         """
         if self.interaction is None:
             return Typing(self)
-        return DeferTyping(self, ephemeral=ephemeral)
+        return DeferTyping[BotT](self, ephemeral=ephemeral)
 
     async def defer(self, *, ephemeral: bool = False) -> None:
         """|coro|


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Using discord.py 2.5.0, and Pyright with strict mode, I'm getting:
```
Type of "typing" is partially unknown
Type of "typing" is "(*, ephemeral: bool = False) -> (Typing | DeferTyping[Unknown])" Pylance[reportUnknownMemberType]
```
when using `Context.typing()`.

This seems to have been introduced by 8953938a53d8191b4c69c057e57911c0e31e8d2a when making `DeferTyping` generic; this only seems to be an issue when using Pyright with strict mode enabled.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
