### PR TITLE
Fix ``InteractionCallbackResponse.resource`` being created with the wrong state when it was a ``InteractionMessage``

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -727,7 +727,7 @@ class InteractionCallbackResponse(Generic[ClientT]):
             activity_instance = resource.get('activity_instance')
             if message is not None:
                 self.resource = InteractionMessage(
-                    state=self._state,
+                    state=_InteractionMessageState(self._parent, self._state),  # pyright: ignore[reportArgumentType]
                     channel=self._parent.channel,  # type: ignore # channel should be the correct type here
                     data=message,
                 )


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes ``InteractionCallbackResponse.resource`` being created with a ``ConnectionState`` object instead of ``_InteractionMessageState``.

Sorry Danny.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
