### PR TITLE
Document message types that can have a default message reference

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -610,6 +610,11 @@ class MessageReference:
         .. versionadded:: 2.5
     message_id: Optional[:class:`int`]
         The id of the message referenced.
+        This can be ``None`` when this message reference was retrieved from
+        a system message of one of the following types:
+
+        - :attr:`MessageType.channel_follow_add`
+        - :attr:`MessageType.thread_created`
     channel_id: :class:`int`
         The channel id of the message referenced.
     guild_id: Optional[:class:`int`]

--- a/discord/message.py
+++ b/discord/message.py
@@ -2010,7 +2010,7 @@ class Message(PartialMessage, Hashable):
         The :class:`TextChannel` or :class:`Thread` that the message was sent from.
         Could be a :class:`DMChannel` or :class:`GroupChannel` if it's a private message.
     reference: Optional[:class:`~discord.MessageReference`]
-        The message that this message references. This is only applicable to message replies,
+        The message that this message references. This is only applicable to message replies (:attr:`MessageType.reply`),
         crossposted messages created by a followed channel integration, and messages of type:
 
         - :attr:`MessageType.pins_add`

--- a/discord/message.py
+++ b/discord/message.py
@@ -2010,9 +2010,15 @@ class Message(PartialMessage, Hashable):
         The :class:`TextChannel` or :class:`Thread` that the message was sent from.
         Could be a :class:`DMChannel` or :class:`GroupChannel` if it's a private message.
     reference: Optional[:class:`~discord.MessageReference`]
-        The message that this message references. This is only applicable to messages of
-        type :attr:`MessageType.pins_add`, crossposted messages created by a
-        followed channel integration, or message replies.
+        The message that this message references. This is only applicable to message replies,
+        crossposted messages created by a followed channel integration, and messages of type:
+
+        - :attr:`MessageType.pins_add`
+        - :attr:`MessageType.channel_follow_add`
+        - :attr:`MessageType.thread_created`
+        - :attr:`MessageType.thread_starter_message`
+        - :attr:`MessageType.poll_result`
+        - :attr:`MessageType.context_menu_command`
 
         .. versionadded:: 1.5
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -2010,8 +2010,9 @@ class Message(PartialMessage, Hashable):
         The :class:`TextChannel` or :class:`Thread` that the message was sent from.
         Could be a :class:`DMChannel` or :class:`GroupChannel` if it's a private message.
     reference: Optional[:class:`~discord.MessageReference`]
-        The message that this message references. This is only applicable to message replies (:attr:`MessageType.reply`),
-        crossposted messages created by a followed channel integration, and messages of type:
+        The message that this message references. This is only applicable to
+        message replies (:attr:`MessageType.reply`), crossposted messages created by
+        a followed channel integration, forwarded messages, and messages of type:
 
         - :attr:`MessageType.pins_add`
         - :attr:`MessageType.channel_follow_add`

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3851,17 +3851,25 @@ of :class:`enum.Enum`.
 
     .. versionadded:: 2.5
 
-    .. attribute:: reply
+    .. attribute:: default
 
-        A message reply.
+        A standard reference used by message replies (:attr:`MessageType.reply`),
+        crossposted messaged created by a followed channel integration, and messages of type:
+
+        - :attr:`MessageType.pins_add`
+        - :attr:`MessageType.channel_follow_add`
+        - :attr:`MessageType.thread_created`
+        - :attr:`MessageType.thread_starter_message`
+        - :attr:`MessageType.poll_result`
+        - :attr:`MessageType.context_menu_command`
 
     .. attribute:: forward
 
         A forwarded message.
 
-    .. attribute:: default
+    .. attribute:: reply
 
-        An alias for :attr:`.reply`.
+        An alias for :attr:`.default`.
 
 .. _discord-api-audit-logs:
 


### PR DESCRIPTION
## Summary

I based the included message types on the following documentation:
https://discord.com/developers/docs/resources/message#message-reference-content-attribution

I changed the documentation such that `reply` is an alias for `default`, not the other way around since this reference type is not only used for message replies.

Additionally, `MessageReference.message_id` was updated because that's why I realized that the message reference of the "reply" type (which is actually the "default" type) can potentially not have a message ID.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
