### PR TITLE
Add defaults for message object parsing

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -571,10 +571,7 @@ class DiscordWebSocket:
         except KeyError:
             _log.debug('Unknown event %s.', event)
         else:
-            try:
-                func(data)
-            except Exception as exc:
-                _log.warning('Parsing event %s encountered an exception.', event, exc_info=exc)
+            func(data)
 
         # remove the dispatched listeners
         removed = []

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -571,7 +571,10 @@ class DiscordWebSocket:
         except KeyError:
             _log.debug('Unknown event %s.', event)
         else:
-            func(data)
+            try:
+                func(data)
+            except Exception as exc:
+                _log.warning('Parsing event %s encountered an exception.', event, exc_info=exc)
 
         # remove the dispatched listeners
         removed = []

--- a/discord/message.py
+++ b/discord/message.py
@@ -2194,15 +2194,15 @@ class Message(PartialMessage, Hashable):
         self._state: ConnectionState = state
         self.webhook_id: Optional[int] = utils._get_as_snowflake(data, 'webhook_id')
         self.reactions: List[Reaction] = [Reaction(message=self, data=d) for d in data.get('reactions', [])]
-        self.attachments: List[Attachment] = [Attachment(data=a, state=self._state) for a in data['attachments']]
-        self.embeds: List[Embed] = [Embed.from_dict(a) for a in data['embeds']]
+        self.attachments: List[Attachment] = [Attachment(data=a, state=self._state) for a in data.get('attachments', [])]
+        self.embeds: List[Embed] = [Embed.from_dict(a) for a in data.get('embeds', [])]
         self.activity: Optional[MessageActivityPayload] = data.get('activity')
-        self._edited_timestamp: Optional[datetime.datetime] = utils.parse_time(data['edited_timestamp'])
+        self._edited_timestamp: Optional[datetime.datetime] = utils.parse_time(data.get('edited_timestamp'))
         self.type: MessageType = try_enum(MessageType, data['type'])
-        self.pinned: bool = data['pinned']
+        self.pinned: bool = data.get('pinned', False)
         self.flags: MessageFlags = MessageFlags._from_value(data.get('flags', 0))
-        self.mention_everyone: bool = data['mention_everyone']
-        self.tts: bool = data['tts']
+        self.mention_everyone: bool = data.get('mention_everyone', False)
+        self.tts: bool = data.get('tts', False)
         self.content: str = data['content']
         self.nonce: Optional[Union[int, str]] = data.get('nonce')
         self.position: Optional[int] = data.get('position')


### PR DESCRIPTION
## Summary

A new feature is leading to some very partial message objects that bots can receive in rare contexts, crashing the library. This PR adds fallbacks in message parsing to account for that. It also catches and logs any errors in event parsing to prevent crashes like this in the future.

Example object:
```json
{
  "id": "1343642713085444138",
  "type": 0,
  "content": "test",
  "channel_id": "852892297661906993",
  "recipient_id": "852892297661906993",
  "flags": 65536,
  "channel": {
    "id": "852892297661906993",
    "type": 18,
    "last_message_id": "1343642713085444138",
    "flags": 0,
    "recipients": [
      ...
    ]
  },
  "author": {
    ...
  },
  "metadata": {
    "stuff": "stuff"
  }
}
```

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
