### PR TITLE
Removed random bullet point from changelog

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -63,7 +63,6 @@ New Features
 
 - Add :attr:`PartialWebhookChannel.mention` attribute (:issue:`10101`)
 - Add support for sending stateless views for :class:`SyncWebhook` or webhooks with no state (:issue:`10089`)
-- Add
 - Add richer :meth:`Role.move` interface (:issue:`10100`)
 - Add support for :class:`EmbedFlags` via :attr:`Embed.flags` (:issue:`10085`)
 - Add new flags for :class:`AttachmentFlags` (:issue:`10085`)


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This pull request fixes a typo in the v2.5.0 changelog.
![Screenshot_20250225-225458](https://github.com/user-attachments/assets/31481a5e-63c6-42ed-9d65-9600cd5e66e8)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
