### PR TITLE
Make embed flags required and add them to all media fields

### DIFF
--- a/discord/types/embed.py
+++ b/discord/types/embed.py
@@ -38,26 +38,12 @@ class EmbedField(TypedDict):
     inline: NotRequired[bool]
 
 
-class EmbedThumbnail(TypedDict, total=False):
+class EmbedMedia(TypedDict, total=False):
     url: Required[str]
-    proxy_url: str
-    height: int
-    width: int
-
-
-class EmbedVideo(TypedDict, total=False):
-    url: str
     proxy_url: str
     height: int
     width: int
     flags: int
-
-
-class EmbedImage(TypedDict, total=False):
-    url: Required[str]
-    proxy_url: str
-    height: int
-    width: int
 
 
 class EmbedProvider(TypedDict, total=False):
@@ -83,9 +69,9 @@ class Embed(TypedDict, total=False):
     timestamp: str
     color: int
     footer: EmbedFooter
-    image: EmbedImage
-    thumbnail: EmbedThumbnail
-    video: EmbedVideo
+    image: EmbedMedia
+    thumbnail: EmbedMedia
+    video: EmbedMedia
     provider: EmbedProvider
     author: EmbedAuthor
     fields: List[EmbedField]


### PR DESCRIPTION
## Summary

Attachment flags are in all media, not just `image`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
