### PR TITLE
Store raw values for AttachmentFlags in Embed media properties

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -414,7 +414,7 @@ class Embed:
         """
         # Lying to the type checker for better developer UX.
         data = getattr(self, '_image', {})
-        data['flags'] = AttachmentFlags._from_value(data.get('flags', 0))
+        data['flags'] = data.get('flags', 0)
         return EmbedProxy(data)  # type: ignore
 
     def set_image(self, *, url: Optional[Any]) -> Self:
@@ -459,7 +459,7 @@ class Embed:
         """
         # Lying to the type checker for better developer UX.
         data = getattr(self, '_thumbnail', {})
-        data['flags'] = AttachmentFlags._from_value(data.get('flags', 0))
+        data['flags'] = data.get('flags', 0)
         return EmbedProxy(data)  # type: ignore
 
     def set_thumbnail(self, *, url: Optional[Any]) -> Self:
@@ -504,7 +504,7 @@ class Embed:
         """
         # Lying to the type checker for better developer UX.
         data = getattr(self, '_video', {})
-        data['flags'] = AttachmentFlags._from_value(data.get('flags', 0))
+        data['flags'] = data.get('flags', 0)
         return EmbedProxy(data)  # type: ignore
 
     @property


### PR DESCRIPTION
## Summary

This pull request fixes a JSON serialization error with `AttachmentFlags` in `discord.Embed` media properties (`image`, `thumbnail`, `video`). Previously, attempting to serialize an `Embed` containing these properties resulted in a `TypeError: "Type is not JSON serializable: AttachmentFlags"` because `AttachmentFlags` is not directly serializable.

### **What Changed?**  
- **Replaced `AttachmentFlags._from_value(data.get('flags', 0))` with `data.get('flags', 0)`** in the following properties:  
  - `image`  
  - `thumbnail`  
  - `video`  

### **Why the Change?**  
- The previous implementation attempted to convert `flags` into an `AttachmentFlags` object using `AttachmentFlags._from_value()`, which is not JSON serializable.  
- The new approach directly stores the raw flag values (integers), resolving the serialization issue while preserving API behavior.  

I'm not entirely sure if this is the right fix, but after these changes, the code functions correctly.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
