### PR TITLE
Fix embed media flags regression

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -46,7 +46,7 @@ class EmbedProxy:
         return len(self.__dict__)
 
     def __repr__(self) -> str:
-        inner = ', '.join((f'{k}={v!r}' for k, v in self.__dict__.items() if not k.startswith('_')))
+        inner = ', '.join((f'{k}={getattr(self, k)!r}' for k in dir(self) if not k.startswith('_')))
         return f'EmbedProxy({inner})'
 
     def __getattr__(self, attr: str) -> None:
@@ -57,10 +57,13 @@ class EmbedProxy:
 
 
 class EmbedMediaProxy(EmbedProxy):
-    def __getattribute__(self, name: str) -> Any:
-        if name == 'flags':
-            return AttachmentFlags._from_value(self.__dict__.get('flags', 0))
-        return super().__getattribute__(name)
+    def __init__(self, layer: Dict[str, Any]):
+        super().__init__(layer)
+        self._flags = self.__dict__.pop('flags', 0)
+
+    @property
+    def flags(self) -> AttachmentFlags:
+        return AttachmentFlags._from_value(self._flags or 0)
 
 
 if TYPE_CHECKING:

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -56,6 +56,13 @@ class EmbedProxy:
         return isinstance(other, EmbedProxy) and self.__dict__ == other.__dict__
 
 
+class EmbedMediaProxy(EmbedProxy):
+    def __getattribute__(self, name: str) -> Any:
+        if name == 'flags':
+            return AttachmentFlags._from_value(self.__dict__.get('flags', 0))
+        return super().__getattribute__(name)
+
+
 if TYPE_CHECKING:
     from typing_extensions import Self
 
@@ -413,9 +420,7 @@ class Embed:
         If the attribute has no value then ``None`` is returned.
         """
         # Lying to the type checker for better developer UX.
-        data = getattr(self, '_image', {})
-        data['flags'] = AttachmentFlags._from_value(data.get('flags', 0))
-        return EmbedProxy(data)  # type: ignore
+        return EmbedMediaProxy(getattr(self, '_image', {}))  # type: ignore
 
     def set_image(self, *, url: Optional[Any]) -> Self:
         """Sets the image for the embed content.
@@ -458,9 +463,7 @@ class Embed:
         If the attribute has no value then ``None`` is returned.
         """
         # Lying to the type checker for better developer UX.
-        data = getattr(self, '_thumbnail', {})
-        data['flags'] = AttachmentFlags._from_value(data.get('flags', 0))
-        return EmbedProxy(data)  # type: ignore
+        return EmbedMediaProxy(getattr(self, '_thumbnail', {}))  # type: ignore
 
     def set_thumbnail(self, *, url: Optional[Any]) -> Self:
         """Sets the thumbnail for the embed content.
@@ -503,9 +506,7 @@ class Embed:
         If the attribute has no value then ``None`` is returned.
         """
         # Lying to the type checker for better developer UX.
-        data = getattr(self, '_video', {})
-        data['flags'] = AttachmentFlags._from_value(data.get('flags', 0))
-        return EmbedProxy(data)  # type: ignore
+        return EmbedMediaProxy(getattr(self, '_video', {}))  # type: ignore
 
     @property
     def provider(self) -> _EmbedProviderProxy:


### PR DESCRIPTION
## Summary

This fixes a regression in embed media parsing where the `flags` attribute would become nested with each access and cause serialization issues, made much worse by me in #10123 🙁

There's a few different ways to fix this, but I don't think any of them are very pretty

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
