### PR TITLE
update PyNaCl minimum version dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Documentation = "https://discordpy.readthedocs.io/en/latest/"
 dependencies = { file = "requirements.txt" }
 
 [project.optional-dependencies]
-voice = ["PyNaCl>=1.3.0,<1.6"]
+voice = ["PyNaCl>=1.5.0,<1.6"]
 docs = [
     "sphinx==4.4.0",
     "sphinxcontrib_trio==1.1.2",


### PR DESCRIPTION
## Summary

PyNaCl's `nacl.secret.Aead` class was only added to PyNaCl in version 1.5. This commit updates the pyproject.toml to ensure that the version is 1.5 since voice_client.py is dependent on this class.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
