### PR TITLE
Missing word in logging setup page

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -41,7 +41,7 @@ Likewise, configuring the log level to ``logging.DEBUG`` is also possible:
     # Assume client refers to a discord.Client subclass...
     client.run(token, log_handler=handler, log_level=logging.DEBUG)
 
-This is recommended, especially at verbose levels such as ``DEBUG``, as there are a lot of events logged and it would clog the stderr of your program.
+This is not recommended, especially at verbose levels such as ``DEBUG``, as there are a lot of events logged and it would clog the stderr of your program.
 
 If you want the logging configuration the library provides to affect all loggers rather than just the ``discord`` logger, you can pass ``root_logger=True`` inside :meth:`Client.run`:
 


### PR DESCRIPTION
## Summary
Running the log in debug mode should be not recommended, I think the word "not" is missing, its understandable when you think about it but probably can confuse someone who is new to programming.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
