### PR TITLE
Add discord.Permissions.apps()

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -364,6 +364,16 @@ class Permissions(BaseFlags):
         return cls(0b0000_0000_0000_0000_0000_0001_0000_0100_0111_0000_0000_0000_0010_0000_0011_1110)
 
     @classmethod
+    def apps(cls) -> Self:
+        """A factory method that creates a :class:`Permissions` with all
+        "Apps" permissions from the official Discord UI set to ``True``.
+
+
+        .. versionadded:: 2.6
+        """
+        return cls(0b0000_0000_0000_0100_0000_0000_1000_0000_1000_0000_0000_0000_0000_0000_0000_0000)
+
+    @classmethod
     def events(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Events" permissions from the official Discord UI set to ``True``.


### PR DESCRIPTION
## Summary

This PR adds an `apps` classmethod to discord.Permissions which creates a permission object with all the permissions in the "Apps" section of the discord permissions UI set to True.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
