### PR TITLE
Fix poll parameter defaulting to MISSING instead of None for Context.send

### DIFF
--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -924,7 +924,7 @@ class Context(discord.abc.Messageable, Generic[BotT]):
         suppress_embeds: bool = False,
         ephemeral: bool = False,
         silent: bool = False,
-        poll: Poll = MISSING,
+        poll: Optional[Poll] = None,
     ) -> Message:
         """|coro|
 
@@ -1014,10 +1014,12 @@ class Context(discord.abc.Messageable, Generic[BotT]):
 
             .. versionadded:: 2.2
 
-        poll: :class:`~discord.Poll`
+        poll: Optional[:class:`~discord.Poll`]
             The poll to send with this message.
 
             .. versionadded:: 2.4
+            .. versionchanged:: 2.6
+                This can now be ``None`` and defaults to ``None`` instead of ``MISSING``.
 
         Raises
         --------
@@ -1072,7 +1074,7 @@ class Context(discord.abc.Messageable, Generic[BotT]):
             'suppress_embeds': suppress_embeds,
             'ephemeral': ephemeral,
             'silent': silent,
-            'poll': poll,
+            'poll': MISSING if poll is None else poll,
         }
 
         if self.interaction.response.is_done():


### PR DESCRIPTION
## Summary

This is done purely for consistency with all the other parameters.
Context: https://discord.com/channels/336642139381301249/336642776609456130/1353467110537298102

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
