### PR TITLE
Add colours for new Discord themes

### DIFF
--- a/discord/colour.py
+++ b/discord/colour.py
@@ -472,7 +472,7 @@ class Colour:
 
     @classmethod
     def dark_theme(cls) -> Self:
-        """A factory method that returns a :class:`Colour` with a value of ``0x313338``.
+        """A factory method that returns a :class:`Colour` with a value of ``0x1A1A1E``.
 
         This will appear transparent on Discord's dark theme.
 

--- a/discord/colour.py
+++ b/discord/colour.py
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
+
 from __future__ import annotations
 
 import colorsys
@@ -458,19 +459,58 @@ class Colour:
         return cls(0x99AAB5)
 
     @classmethod
+    def ash_theme(cls) -> Self:
+        """A factory method that returns a :class:`Colour` with a value of ``0x2E2E34``.
+
+        This will appear transparent on Discord's ash theme.
+
+        .. colour:: #2E2E34
+
+        .. versionadded:: 2.6
+        """
+        return cls(0x2E2E34)
+
+    @classmethod
     def dark_theme(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x313338``.
 
         This will appear transparent on Discord's dark theme.
 
-        .. colour:: #313338
+        .. colour:: #1A1A1E
 
         .. versionadded:: 1.5
 
         .. versionchanged:: 2.2
             Updated colour from previous ``0x36393F`` to reflect discord theme changes.
+
+        .. versionchanged:: 2.6
+            Updated colour from previous ``0x313338`` to reflect discord theme changes.
         """
-        return cls(0x313338)
+        return cls(0x1A1A1E)
+
+    @classmethod
+    def onyx_theme(cls) -> Self:
+        """A factory method that returns a :class:`Colour` with a value of ``0x070709``.
+
+        This will appear transparent on Discord's onyx theme.
+
+        .. colour:: #070709
+
+        .. versionadded:: 2.6
+        """
+        return cls(0x070709)
+
+    @classmethod
+    def light_theme(cls) -> Self:
+        """A factory method that returns a :class:`Colour` with a value of ``0xFBFBFB``.
+
+        This will appear transparent on Discord's light theme.
+
+        .. colour:: #FBFBFB
+
+        .. versionadded:: 2.6
+        """
+        return cls(0xFBFBFB)
 
     @classmethod
     def fuchsia(cls) -> Self:
@@ -493,24 +533,51 @@ class Colour:
         return cls(0xFEE75C)
 
     @classmethod
-    def dark_embed(cls) -> Self:
-        """A factory method that returns a :class:`Colour` with a value of ``0x2B2D31``.
+    def ash_embed(cls) -> Self:
+        """A factory method that returns a :class:`Colour` with a value of ``0x37373E``.
 
-        .. colour:: #2B2D31
+        .. colour:: #37373E
+
+        .. versionadded:: 2.6
+
+        """
+        return cls(0x37373E)
+
+    @classmethod
+    def dark_embed(cls) -> Self:
+        """A factory method that returns a :class:`Colour` with a value of ``0x242429``.
+
+        .. colour:: #242429
 
         .. versionadded:: 2.2
+
+        .. versionchanged:: 2.6
+            Updated colour from previous ``0x2B2D31`` to reflect discord theme changes.
         """
-        return cls(0x2B2D31)
+        return cls(0x242429)
+
+    @classmethod
+    def onyx_embed(cls) -> Self:
+        """A factory method that returns a :class:`Colour` with a value of ``0x131416``.
+
+        .. colour:: #131416
+
+        .. versionadded:: 2.6
+        """
+        return cls(0x131416)
 
     @classmethod
     def light_embed(cls) -> Self:
-        """A factory method that returns a :class:`Colour` with a value of ``0xEEEFF1``.
+        """A factory method that returns a :class:`Colour` with a value of ``0xFFFFFF``.
 
         .. colour:: #EEEFF1
 
         .. versionadded:: 2.2
+
+        .. versionchanged:: 2.6
+            Updated colour from previous ``0xEEEFF1`` to reflect discord theme changes.
         """
-        return cls(0xEEEFF1)
+        return cls(0xFFFFFF)
 
     @classmethod
     def pink(cls) -> Self:

--- a/tests/test_colour.py
+++ b/tests/test_colour.py
@@ -106,18 +106,21 @@ def test_from_str_failures(value):
         (discord.Colour.og_blurple(), 0x7289DA),
         (discord.Colour.blurple(), 0x5865F2),
         (discord.Colour.greyple(), 0x99AAB5),
-        (discord.Colour.dark_theme(), 0x313338),
+        (discord.Colour.ash_theme(), 0x2E2E34),
+        (discord.Colour.dark_theme(), 0x1A1A1E),
+        (discord.Colour.onyx_theme(), 0x070709),
+        (discord.Colour.light_theme(), 0xFBFBFB),
         (discord.Colour.fuchsia(), 0xEB459E),
         (discord.Colour.yellow(), 0xFEE75C),
-        (discord.Colour.dark_embed(), 0x2B2D31),
-        (discord.Colour.light_embed(), 0xEEEFF1),
+        (discord.Colour.ash_embed(), 0x37373E),
+        (discord.Colour.dark_embed(), 0x242429),
+        (discord.Colour.onyx_embed(), 0x131416),
+        (discord.Colour.light_embed(), 0xFFFFFF),
         (discord.Colour.pink(), 0xEB459F),
     ],
 )
 def test_static_colours(value, expected):
     assert value.value == expected
-
-
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Completes #10151 

Adds the following:
- `Colour.ash_theme`
- `Colour.ash_embed`
- `Colour.onyx_theme`
- `Colour.onyx_embed`
- `Colour.light_theme`

Updates the following:
- `Colour.dark_theme`
- `Colour.dark_embed`
- `Colour.light_embed` 

I believe these are all correct, however if you can, please double-check these values.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
