### PR TITLE
Fixes a bug introducing a breaking change into Embed

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -46,7 +46,7 @@ class EmbedProxy:
         return len(self.__dict__)
 
     def __repr__(self) -> str:
-        inner = ', '.join((f'{k}={getattr(self, k)!r}' for k in dir(self) if not k.startswith('_')))
+        inner = ', '.join((f'{k}={v!r}' for k, v in self.__dict__.items() if not k.startswith('_')))
         return f'EmbedProxy({inner})'
 
     def __getattr__(self, attr: str) -> None:
@@ -54,16 +54,6 @@ class EmbedProxy:
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, EmbedProxy) and self.__dict__ == other.__dict__
-
-
-class EmbedMediaProxy(EmbedProxy):
-    def __init__(self, layer: Dict[str, Any]):
-        super().__init__(layer)
-        self._flags = self.__dict__.pop('flags', 0)
-
-    @property
-    def flags(self) -> AttachmentFlags:
-        return AttachmentFlags._from_value(self._flags or 0)
 
 
 if TYPE_CHECKING:
@@ -423,7 +413,9 @@ class Embed:
         If the attribute has no value then ``None`` is returned.
         """
         # Lying to the type checker for better developer UX.
-        return EmbedMediaProxy(getattr(self, '_image', {}))  # type: ignore
+        data = getattr(self, '_image', {})
+        data['flags'] = AttachmentFlags._from_value(data.get('flags', 0))
+        return EmbedProxy(data)  # type: ignore
 
     def set_image(self, *, url: Optional[Any]) -> Self:
         """Sets the image for the embed content.
@@ -466,7 +458,9 @@ class Embed:
         If the attribute has no value then ``None`` is returned.
         """
         # Lying to the type checker for better developer UX.
-        return EmbedMediaProxy(getattr(self, '_thumbnail', {}))  # type: ignore
+        data = getattr(self, '_thumbnail', {})
+        data['flags'] = AttachmentFlags._from_value(data.get('flags', 0))
+        return EmbedProxy(data)  # type: ignore
 
     def set_thumbnail(self, *, url: Optional[Any]) -> Self:
         """Sets the thumbnail for the embed content.
@@ -509,7 +503,9 @@ class Embed:
         If the attribute has no value then ``None`` is returned.
         """
         # Lying to the type checker for better developer UX.
-        return EmbedMediaProxy(getattr(self, '_video', {}))  # type: ignore
+        data = getattr(self, '_video', {})
+        data['flags'] = AttachmentFlags._from_value(data.get('flags', 0))
+        return EmbedProxy(data)  # type: ignore
 
     @property
     def provider(self) -> _EmbedProviderProxy:

--- a/discord/types/embed.py
+++ b/discord/types/embed.py
@@ -38,12 +38,26 @@ class EmbedField(TypedDict):
     inline: NotRequired[bool]
 
 
-class EmbedMedia(TypedDict, total=False):
+class EmbedThumbnail(TypedDict, total=False):
     url: Required[str]
     proxy_url: str
     height: int
     width: int
+
+
+class EmbedVideo(TypedDict, total=False):
+    url: str
+    proxy_url: str
+    height: int
+    width: int
     flags: int
+
+
+class EmbedImage(TypedDict, total=False):
+    url: Required[str]
+    proxy_url: str
+    height: int
+    width: int
 
 
 class EmbedProvider(TypedDict, total=False):
@@ -69,9 +83,9 @@ class Embed(TypedDict, total=False):
     timestamp: str
     color: int
     footer: EmbedFooter
-    image: EmbedMedia
-    thumbnail: EmbedMedia
-    video: EmbedMedia
+    image: EmbedImage
+    thumbnail: EmbedThumbnail
+    video: EmbedVideo
     provider: EmbedProvider
     author: EmbedAuthor
     fields: List[EmbedField]


### PR DESCRIPTION
## Summary

This PR reverts earlier commits 8594dd1b309fd66bc2defc1f73540dfa9357e2c7 and cab4732b7ea8008ace32f9bd6285f7d4b3a99299 which have introduced a bug in the truthiness of `Embed`.
After this commits a `Embed` instance will *always* be truthy as it is calculated incorrectly due to the flags always being present.

As the items in these commits are **not** documented on Discord API documentation, I opted to revert the commits rather than try and devise a solution to check each proxy value and correctly report on their truthiness.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
