### PR TITLE
Fix bug in embeds `EmbedMediaProxy` which results in the boolean value of an Embed to always be truthy

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -61,6 +61,12 @@ class EmbedMediaProxy(EmbedProxy):
         super().__init__(layer)
         self._flags = self.__dict__.pop('flags', 0)
 
+    def __bool__(self) -> bool:
+        # This is a nasty check to see if we only have the `_flags` attribute which is created regardless in init.
+        # Had we had any of the other items, like image/video data this would be >1 and therefor
+        # would not be "empty".
+        return len(self.__dict__) > 1
+
     @property
     def flags(self) -> AttachmentFlags:
         return AttachmentFlags._from_value(self._flags or 0)

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -267,3 +267,14 @@ def test_embed_colour_setter_failure(value):
     embed = discord.Embed()
     with pytest.raises(TypeError):
         embed.colour = value
+
+@pytest.mark.parametrize(
+    ('title', 'return_val'),
+    [
+        ('test', True),
+        (None, False)
+    ]
+)
+def test_embed_truthiness(title: str, return_val: bool) -> None:
+    embed = discord.Embed(title=title)
+    assert bool(embed) is return_val


### PR DESCRIPTION
## Summary

This PR fixes an issue in Embed where it's boolean value is always true, due to the existing implementation of `bool` checking the `len` of the internal `__dict__`. Due to how these proxy objects are constructed, they will always have 1 key within `__dict__` making them always truthy.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
