### PR TITLE
Add Interaction.max_attachment_size

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -157,7 +157,7 @@ class Interaction(Generic[ClientT]):
     max_attachment_size: :class:`int`
         The maximum attachments size you can send, in bytes.
 
-        .. versionadded:: 2.7
+        .. versionadded:: 2.6
     """
 
     __slots__: Tuple[str, ...] = (

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -154,6 +154,10 @@ class Interaction(Generic[ClientT]):
         The context of the interaction.
 
         .. versionadded:: 2.4
+    max_attachment_size: :class:`int`
+        The maximum attachments size you can send, in bytes.
+
+        .. versionadded:: 2.7
     """
 
     __slots__: Tuple[str, ...] = (
@@ -172,7 +176,7 @@ class Interaction(Generic[ClientT]):
         'command_failed',
         'entitlement_sku_ids',
         'entitlements',
-        "context",
+        'context',
         '_integration_owners',
         '_permissions',
         '_app_permissions',
@@ -186,6 +190,7 @@ class Interaction(Generic[ClientT]):
         'channel',
         '_cs_namespace',
         '_cs_command',
+        'max_attachment_size',
     )
 
     def __init__(self, *, data: InteractionPayload, state: ConnectionState[ClientT]):
@@ -282,6 +287,8 @@ class Interaction(Generic[ClientT]):
                 self.user = User(state=self._state, data=data['user'])  # type: ignore # The key is optional and handled
             except KeyError:
                 pass
+
+        self.max_attachment_size: int = data['attachment_size_limit']
 
     @property
     def client(self) -> ClientT:

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -233,6 +233,7 @@ class _BaseInteraction(TypedDict):
     entitlements: NotRequired[List[Entitlement]]
     authorizing_integration_owners: Dict[Literal['0', '1'], Snowflake]
     context: NotRequired[InteractionContextType]
+    attachment_size_limit: int
 
 
 class PingInteraction(_BaseInteraction):


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This adds a new attribute and field on Interaction called ``max_attachment_size``.

Docs: [interactions/receiving-and-responding](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
