### PR TITLE
Add Interaction.filesize_limit

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -154,6 +154,10 @@ class Interaction(Generic[ClientT]):
         The context of the interaction.
 
         .. versionadded:: 2.4
+    filesize_limit: int
+        The maximum number of bytes a file can have when responding to this interaction.
+
+        .. versionadded:: 2.6
     """
 
     __slots__: Tuple[str, ...] = (
@@ -172,7 +176,8 @@ class Interaction(Generic[ClientT]):
         'command_failed',
         'entitlement_sku_ids',
         'entitlements',
-        "context",
+        'context',
+        'filesize_limit',
         '_integration_owners',
         '_permissions',
         '_app_permissions',
@@ -214,6 +219,7 @@ class Interaction(Generic[ClientT]):
         self.application_id: int = int(data['application_id'])
         self.entitlement_sku_ids: List[int] = [int(x) for x in data.get('entitlement_skus', []) or []]
         self.entitlements: List[Entitlement] = [Entitlement(self._state, x) for x in data.get('entitlements', [])]
+        self.filesize_limit: int = data['attachment_size_limit']
         # This is not entirely useful currently, unsure how to expose it in a way that it is.
         self._integration_owners: Dict[int, Snowflake] = {
             int(k): int(v) for k, v in data.get('authorizing_integration_owners', {}).items()

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -233,6 +233,7 @@ class _BaseInteraction(TypedDict):
     entitlements: NotRequired[List[Entitlement]]
     authorizing_integration_owners: Dict[Literal['0', '1'], Snowflake]
     context: NotRequired[InteractionContextType]
+    attachment_size_limit: int
 
 
 class PingInteraction(_BaseInteraction):

--- a/tests/test_app_commands_invoke.py
+++ b/tests/test_app_commands_invoke.py
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
+
 from __future__ import annotations
 
 
@@ -90,6 +91,7 @@ class MockCommandInteraction(discord.Interaction):
             "version": 1,
             "type": 2,
             "data": self._get_command_data(command, self._get_command_options(**options)),
+            "attachment_size_limit": 0,
         }
         super().__init__(data=data, state=client._connection)
 


### PR DESCRIPTION
## Summary

Adds `Interaction.filesize_limit`, corresponding to the new `attachment_size_limit` key in an interaction payload. [ddocs changelog](https://discord.com/developers/docs/change-log#perattachment-file-upload-behavior-for-apps).

Named it this simply for consistency with `Guild.filesize_limit`


## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
