### PR TITLE
Add Deprecation Warn to create_guild

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -67,7 +67,7 @@ from .voice_client import VoiceClient
 from .http import HTTPClient
 from .state import ConnectionState
 from . import utils
-from .utils import MISSING, time_snowflake
+from .utils import MISSING, time_snowflake, deprecated
 from .object import Object
 from .backoff import ExponentialBackoff
 from .webhook import Webhook
@@ -2388,6 +2388,7 @@ class Client:
         data = await self.http.get_guild_preview(guild_id)
         return GuildPreview(data=data, state=self._connection)
 
+    @deprecated()
     async def create_guild(
         self,
         *,
@@ -2407,6 +2408,9 @@ class Client:
         .. versionchanged:: 2.0
             This function will now raise :exc:`ValueError` instead of
             ``InvalidArgument``.
+
+        .. deprecated:: 2.6
+            This function is deprecated and will be removed in a future version.
 
         Parameters
         ----------
@@ -2433,14 +2437,6 @@ class Client:
             The guild created. This is not the same guild that is
             added to cache.
         """
-        import warnings
-
-        msg = (
-            "client.create_guild will be deprecated from July 15, 2025.\n"
-            "Please refer to https://discord.com/developers/docs/change-log?topic=HTTP+API#deprecating-guild-creation-by-apps"
-        )
-        warnings.warn(msg)
-
         if icon is not MISSING:
             icon_base64 = utils._bytes_to_base64_data(icon)
         else:

--- a/discord/client.py
+++ b/discord/client.py
@@ -2433,6 +2433,14 @@ class Client:
             The guild created. This is not the same guild that is
             added to cache.
         """
+        import warnings
+
+        msg = (
+            "client.create_guild will be deprecated from July 15, 2025.\n"
+            "Please refer to https://discord.com/developers/docs/change-log?topic=HTTP+API#deprecating-guild-creation-by-apps"
+        )
+        warnings.warn(msg)
+
         if icon is not MISSING:
             icon_base64 = utils._bytes_to_base64_data(icon)
         else:

--- a/discord/template.py
+++ b/discord/template.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 from typing import Any, Optional, TYPE_CHECKING, List
-from .utils import parse_time, _bytes_to_base64_data, MISSING
+from .utils import parse_time, _bytes_to_base64_data, MISSING, deprecated
 from .guild import Guild
 
 # fmt: off
@@ -164,6 +164,7 @@ class Template:
             f' creator={self.creator!r} source_guild={self.source_guild!r} is_dirty={self.is_dirty}>'
         )
 
+    @deprecated()
     async def create_guild(self, name: str, icon: bytes = MISSING) -> Guild:
         """|coro|
 
@@ -177,6 +178,9 @@ class Template:
         .. versionchanged:: 2.0
             This function will now raise :exc:`ValueError` instead of
             ``InvalidArgument``.
+
+        .. deprecated:: 2.6
+            This function is deprecated and will be removed in a future version.
 
         Parameters
         ----------


### PR DESCRIPTION
## Summary

- Source
https://discord.com/developers/docs/change-log?topic=HTTP+API#deprecating-guild-creation-by-apps

I don't think it's necessary, but I thought it would be nice for developers to be aware of it.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
