### PR TITLE
Fixed to_dict() bug for user-defined embed classes implementing __slo…

### DIFF
--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -737,7 +737,7 @@ class Embed:
         # fmt: off
         result = {
             key[1:]: getattr(self, key)
-            for key in self.__slots__
+            for key in Embed.__slots__
             if key[0] == '_' and hasattr(self, key)
         }
         # fmt: on


### PR DESCRIPTION
…ts__


## Summary

<!-- What is this pull request for? Does it fix any issues? -->

The to_dict() method wouldn't work if someone correctly subclasses discord.Embed and implements __slots__ in their custom class. This is because the original to_dict() method accessed self.__slots__, which would return only the subclass’s slots tuple. This hotfix changes self.__slots__ to Embed.__slots__ so that it works for any subclass, even if it implements its own __slots__.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
