### PR TITLE
Add missing attributes in `AppCommandChannel`

### DIFF
--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -577,21 +577,33 @@ class AppCommandChannel(Hashable):
         The guild ID this channel belongs to.
     category_id: Optional[:class:`int`]
         The category channel ID this channel belongs to, if applicable.
+
+        .. versionadded:: 2.6
     topic: Optional[:class:`str`]
         The channel's topic. ``None`` if it doesn't exist.
+
+        .. versionadded:: 2.6
     position: :class:`int`
         The position in the channel list. This is a number that starts at 0. e.g. the
         top channel is position 0.
+
+        .. versionadded:: 2.6
     last_message_id: Optional[:class:`int`]
         The last message ID of the message sent to this channel. It may
         *not* point to an existing or valid message.
+
+        .. versionadded:: 2.6
     slowmode_delay: :class:`int`
         The number of seconds a member must wait between sending messages
         in this channel. A value of ``0`` denotes that it is disabled.
         Bots and users with :attr:`~discord.Permissions.manage_channels` or
         :attr:`~discord.Permissions.manage_messages` bypass slowmode.
+
+        .. versionadded:: 2.6
     nsfw: :class:`bool`
         If the channel is marked as "not safe for work" or "age restricted".
+
+        .. versionadded:: 2.6
     """
 
     __slots__ = (
@@ -653,11 +665,17 @@ class AppCommandChannel(Hashable):
         return ChannelFlags._from_value(self._flags)
 
     def is_nsfw(self) -> bool:
-        """:class:`bool`: Checks if the channel is NSFW."""
+        """:class:`bool`: Checks if the channel is NSFW.
+
+        .. versionadded:: 2.6
+        """
         return self.nsfw
 
     def is_news(self) -> bool:
-        """:class:`bool`: Checks if the channel is a news channel."""
+        """:class:`bool`: Checks if the channel is a news channel.
+
+        .. versionadded:: 2.6
+        """
         return self.type == ChannelType.news
 
     def resolve(self) -> Optional[GuildChannel]:

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -646,7 +646,7 @@ class AppCommandChannel(Hashable):
 
     @property
     def flags(self) -> ChannelFlags:
-        """:class:`ChannelFlags`: The flags associated with this channel object.
+        """:class:`~discord.ChannelFlags`: The flags associated with this channel object.
 
         .. versionadded:: 2.6
         """

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -588,8 +588,8 @@ class AppCommandChannel(Hashable):
     slowmode_delay: :class:`int`
         The number of seconds a member must wait between sending messages
         in this channel. A value of ``0`` denotes that it is disabled.
-        Bots and users with :attr:`~Permissions.manage_channels` or
-        :attr:`~Permissions.manage_messages` bypass slowmode.
+        Bots and users with :attr:`~discord.Permissions.manage_channels` or
+        :attr:`~discord.Permissions.manage_messages` bypass slowmode.
     nsfw: :class:`bool`
         If the channel is marked as "not safe for work" or "age restricted".
     """

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List, Literal, TypedDict, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, TypedDict, Union, Optional
 from typing_extensions import NotRequired
 
 from .channel import ChannelTypeWithoutThread, GuildChannel, InteractionDMChannel, GroupDMChannel

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -27,9 +27,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Dict, List, Literal, TypedDict, Union
 from typing_extensions import NotRequired
 
-from .channel import ChannelTypeWithoutThread, ThreadMetadata, GuildChannel, InteractionDMChannel, GroupDMChannel
+from .channel import ChannelTypeWithoutThread, GuildChannel, InteractionDMChannel, GroupDMChannel
 from .sku import Entitlement
-from .threads import ThreadType
+from .threads import ThreadType, ThreadMetadata
 from .member import Member
 from .message import Attachment
 from .role import Role
@@ -64,6 +64,14 @@ class _BasePartialChannel(TypedDict):
 
 class PartialChannel(_BasePartialChannel):
     type: ChannelTypeWithoutThread
+    topic: NotRequired[str]
+    position: int
+    nsfw: bool
+    flags: int
+    rate_limit_per_user: int
+    parent_id: Snowflake
+    last_message_id: Snowflake
+    last_pin_timestamp: NotRequired[str]
 
 
 class PartialThread(_BasePartialChannel):

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -69,8 +69,8 @@ class PartialChannel(_BasePartialChannel):
     nsfw: bool
     flags: int
     rate_limit_per_user: int
-    parent_id: Snowflake
-    last_message_id: Snowflake
+    parent_id: Optional[Snowflake]
+    last_message_id: Optional[Snowflake]
     last_pin_timestamp: NotRequired[str]
 
 


### PR DESCRIPTION
## Summary

This PR adds following missing attributes to `AppCommandChannel` class, the underlying payload for which is partial channel object as mentioned in [upstream docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object):
- `category_id`
- `topic`
- `position`
- `last_message_id`
- `slowmode_delay`
- `nsfw` (and `x.is_nsfw()` method)
- `_last_pin`
- `_flags` attr & `flags` @​property
- `x.is_news()` method for consistency because it exists for `TextChannel`

Bikeshedding post: https://discord.com/channels/336642139381301249/1355473537577652234

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
