### PR TITLE
Fix return value of `Invite.delete` & `Client.delete_invite` methods

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -2546,7 +2546,7 @@ class Client:
         )
         return Invite.from_incomplete(state=self._connection, data=data)
 
-    async def delete_invite(self, invite: Union[Invite, str], /) -> None:
+    async def delete_invite(self, invite: Union[Invite, str], /) -> Invite:
         """|coro|
 
         Revokes an :class:`.Invite`, URL, or ID to an invite.
@@ -2574,7 +2574,8 @@ class Client:
         """
 
         resolved = utils.resolve_invite(invite)
-        await self.http.delete_invite(resolved.code)
+        data = await self.http.delete_invite(resolved.code)
+        return Invite.from_incomplete(state=self._connection, data=data)
 
     # Miscellaneous stuff
 

--- a/discord/http.py
+++ b/discord/http.py
@@ -1874,7 +1874,7 @@ class HTTPClient:
     def invites_from_channel(self, channel_id: Snowflake) -> Response[List[invite.Invite]]:
         return self.request(Route('GET', '/channels/{channel_id}/invites', channel_id=channel_id))
 
-    def delete_invite(self, invite_id: str, *, reason: Optional[str] = None) -> Response[None]:
+    def delete_invite(self, invite_id: str, *, reason: Optional[str] = None) -> Response[invite.Invite]:
         return self.request(Route('DELETE', '/invites/{invite_id}', invite_id=invite_id), reason=reason)
 
     # Role management

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -546,7 +546,7 @@ class Invite(Hashable):
 
         return self
 
-    async def delete(self, *, reason: Optional[str] = None) -> None:
+    async def delete(self, *, reason: Optional[str] = None) -> Self:
         """|coro|
 
         Revokes the instant invite.
@@ -568,4 +568,5 @@ class Invite(Hashable):
             Revoking the invite failed.
         """
 
-        await self._state.http.delete_invite(self.code, reason=reason)
+        data = await self._state.http.delete_invite(self.code, reason=reason)
+        return self.from_incomplete(state=self._state, data=data)


### PR DESCRIPTION
## Summary

As per [upstream docs](https://discord.com/developers/docs/resources/invite#delete-invite), deleting an invite does return an invite object on success.

Hence, This PR fixes return value of these methods to `discord.Invite` type to match with the upstream beahviour:
- `Invite.delete()`
- `Client.delete_invite()`

Bikeshedding post: https://discord.com/channels/336642139381301249/1355473537577652234

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
