### PR TITLE
Add new UI background colours (Ash, Dark, Onyx)

### DIFF
--- a/discord/colour.py
+++ b/discord/colour.py
@@ -528,7 +528,7 @@ class Colour:
 
         .. colour:: #393a41
 
-        .. versionadded:: 2.4
+        .. versionadded:: 2.5.2
         """
         return cls(0x393A41)
 
@@ -538,7 +538,7 @@ class Colour:
 
         .. colour:: #242429
 
-        .. versionadded:: 2.4
+        .. versionadded:: 2.5.2
         """
         return cls(0x242429)
 
@@ -548,7 +548,7 @@ class Colour:
 
         .. colour:: #131416
 
-        .. versionadded:: 2.4
+        .. versionadded:: 2.5.2
         """
         return cls(0x131416)
 

--- a/discord/colour.py
+++ b/discord/colour.py
@@ -522,5 +522,35 @@ class Colour:
         """
         return cls(0xEB459F)
 
+    @classmethod
+    def ash(cls) -> Self:
+        """A factory method that returns a :class:`Colour` representing the new Discord 'Ash' theme background.
+
+        .. colour:: #393a41
+
+        .. versionadded:: 2.4
+        """
+        return cls(0x393A41)
+
+    @classmethod
+    def discord_dark(cls) -> Self:
+        """A factory method that returns a :class:`Colour` representing the new Discord 'Dark' theme background.
+
+        .. colour:: #242429
+
+        .. versionadded:: 2.4
+        """
+        return cls(0x242429)
+
+    @classmethod
+    def onyx(cls) -> Self:
+        """A factory method that returns a :class:`Colour` representing the new Discord 'Onyx' theme background.
+
+        .. colour:: #131416
+
+        .. versionadded:: 2.4
+        """
+        return cls(0x131416)
+
 
 Color = Colour


### PR DESCRIPTION
## Summary

Adds new colour constants to `discord/colour.py` for the new Discord UI background themes introduced in the recent revamp (Q1 2025). This addresses and closes issue #10151.

Specifically, adds `Colour.ash`, `Colour.discord_dark`, and `Colour.onyx` based on observed hex values for the new base themes.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
