### PR TITLE
Add support for launch_activity interaction response

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -621,6 +621,7 @@ class InteractionResponseType(Enum):
     autocomplete_result = 8
     modal = 9  # for modals
     # premium_required = 10 (deprecated)
+    launch_activity = 12
 
 
 class VideoQualityMode(Enum):

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -1291,8 +1291,9 @@ class InteractionResponse(Generic[ClientT]):
         """|coro|
 
         Responds to this interaction by launching the activity associated with the app.
-
         Only available for apps with activities enabled.
+
+        .. versionadded:: 2.6
 
         Raises
         -------


### PR DESCRIPTION
## Summary

Activities can now be launched in response to interactions using the LAUNCH_ACTIVITY (type 12) interaction callback type for APPLICATION_COMMAND, MESSAGE_COMPONENT, and MODAL_SUBMIT interaction types.
https://discord.com/developers/docs/change-log#recent-api-updates

- Added the response type launch_activity (12)
https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type

- Created launch_activity method for InteractionResponse

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [/] I have updated the documentation to reflect the changes. (I added docstrings)
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
