### PR TITLE
Exposes recurrence_rule endpoint for Scheduled Events

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3201,6 +3201,7 @@ class Guild(Hashable):
         end_time: datetime.datetime = ...,
         description: str = ...,
         image: bytes = ...,
+        recurrence_rule: str = ...,
         reason: Optional[str] = ...,
     ) -> ScheduledEvent:
         ...
@@ -3217,6 +3218,7 @@ class Guild(Hashable):
         end_time: datetime.datetime = ...,
         description: str = ...,
         image: bytes = ...,
+        recurrence_rule: str = ...,
         reason: Optional[str] = ...,
     ) -> ScheduledEvent:
         ...
@@ -3232,6 +3234,7 @@ class Guild(Hashable):
         end_time: datetime.datetime = ...,
         description: str = ...,
         image: bytes = ...,
+        recurrence_rule: str = ...,
         reason: Optional[str] = ...,
     ) -> ScheduledEvent:
         ...
@@ -3247,6 +3250,7 @@ class Guild(Hashable):
         end_time: datetime.datetime = ...,
         description: str = ...,
         image: bytes = ...,
+        recurrence_rule: str = ...,
         reason: Optional[str] = ...,
     ) -> ScheduledEvent:
         ...
@@ -3263,6 +3267,7 @@ class Guild(Hashable):
         end_time: datetime.datetime = MISSING,
         description: str = MISSING,
         image: bytes = MISSING,
+        recurrence_rule: str = MISSING,
         reason: Optional[str] = None,
     ) -> ScheduledEvent:
         r"""|coro|
@@ -3308,6 +3313,9 @@ class Guild(Hashable):
             The location of the scheduled event.
 
             Required if the ``entity_type`` is :attr:`EntityType.external`.
+        recurrence_rule: :class:`str`
+            The recurrence rule for the scheduled event in iCalendar format.
+            This determines how often the event repeats.
         reason: Optional[:class:`str`]
             The reason for creating this scheduled event. Shows up on the audit log.
 
@@ -3376,6 +3384,9 @@ class Guild(Hashable):
         if image is not MISSING:
             image_as_str: str = utils._bytes_to_base64_data(image)
             payload['image'] = image_as_str
+
+        if recurrence_rule is not MISSING:
+            payload['recurrence_rule'] = recurrence_rule
 
         if entity_type in (EntityType.stage_instance, EntityType.voice):
             if channel in (MISSING, None):

--- a/discord/scheduled_event.py
+++ b/discord/scheduled_event.py
@@ -104,6 +104,9 @@ class ScheduledEvent(Hashable):
         .. versionadded:: 2.2
     location: Optional[:class:`str`]
         The location of the scheduled event.
+    recurrence_rule: Optional[:class:`str`]
+        The recurrence rule for the scheduled event in iCalendar format.
+        This determines how often the event repeats.
     """
 
     __slots__ = (
@@ -125,6 +128,7 @@ class ScheduledEvent(Hashable):
         'channel_id',
         'creator_id',
         'location',
+        'recurrence_rule',
     )
 
     def __init__(self, *, state: ConnectionState, data: GuildScheduledEventPayload) -> None:
@@ -145,6 +149,7 @@ class ScheduledEvent(Hashable):
         self._cover_image: Optional[str] = data.get('image', None)
         self.user_count: int = data.get('user_count', 0)
         self.creator_id: Optional[int] = _get_as_snowflake(data, 'creator_id')
+        self.recurrence_rule: Optional[str] = data.get('recurrence_rule')
 
         creator = data.get('creator')
         self.creator: Optional[User] = self._state.store_user(creator) if creator else None
@@ -343,6 +348,7 @@ class ScheduledEvent(Hashable):
         status: EventStatus = ...,
         image: bytes = ...,
         location: str,
+        recurrence_rule: str = ...,
         reason: Optional[str] = ...,
     ) -> ScheduledEvent:
         ...
@@ -359,6 +365,7 @@ class ScheduledEvent(Hashable):
         privacy_level: PrivacyLevel = ...,
         status: EventStatus = ...,
         image: bytes = ...,
+        recurrence_rule: str = ...,
         reason: Optional[str] = ...,
     ) -> ScheduledEvent:
         ...
@@ -375,6 +382,7 @@ class ScheduledEvent(Hashable):
         status: EventStatus = ...,
         image: bytes = ...,
         location: str,
+        recurrence_rule: str = ...,
         reason: Optional[str] = ...,
     ) -> ScheduledEvent:
         ...
@@ -392,6 +400,7 @@ class ScheduledEvent(Hashable):
         status: EventStatus = MISSING,
         image: bytes = MISSING,
         location: str = MISSING,
+        recurrence_rule: str = MISSING,
         reason: Optional[str] = None,
     ) -> ScheduledEvent:
         r"""|coro|
@@ -439,6 +448,9 @@ class ScheduledEvent(Hashable):
             The new location of the scheduled event.
 
             Required if the entity type is :attr:`EntityType.external`.
+        recurrence_rule: :class:`str`
+            The recurrence rule for the scheduled event in iCalendar format.
+            This determines how often the event repeats.
         reason: Optional[:class:`str`]
             The reason for editing the scheduled event. Shows up on the audit log.
 
@@ -493,6 +505,9 @@ class ScheduledEvent(Hashable):
         if image is not MISSING:
             image_as_str: Optional[str] = _bytes_to_base64_data(image) if image is not None else image
             payload['image'] = image_as_str
+
+        if recurrence_rule is not MISSING:
+            payload['recurrence_rule'] = recurrence_rule
 
         entity_type = entity_type or getattr(channel, '_scheduled_event_entity_type', MISSING)
         if entity_type is MISSING:

--- a/discord/types/scheduled_event.py
+++ b/discord/types/scheduled_event.py
@@ -47,6 +47,7 @@ class _BaseGuildScheduledEvent(TypedDict):
     creator: NotRequired[User]
     user_count: NotRequired[int]
     image: NotRequired[Optional[str]]
+    recurrence_rule: NotRequired[Optional[str]]
 
 
 class _VoiceChannelScheduledEvent(_BaseGuildScheduledEvent):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1306,6 +1306,7 @@ Scheduled Events
     - The description is changed.
     - The status is changed.
     - The image is changed.
+    - The recurrence rule is changed.
 
     .. versionadded:: 2.0
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Noticed "recurrence_rule" is missing from the wrapper. See [Developer Docs](https://discord.com/developers/docs/resources/guild-scheduled-event).

## Description
This PR adds support for recurring scheduled events, allowing events to be set up with iCalendar recurrence rules. This enables features like daily, weekly, monthly, and yearly recurring events.

- Added `recurrence_rule` field to `ScheduledEvent` class
- Added support for recurrence rules in `create_scheduled_event` and `edit` methods
- Updated docs where needed

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested. 
    - [ ] I have updated the documentation to reflect the changes.
- [ ] ? This PR fixes an issue. - Might resolve #10114
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
