### PR TITLE
app_commands: handle empty guild_ids list

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -688,9 +688,7 @@ class Command(Generic[GroupT, P, T]):
         self.checks: List[Check] = getattr(callback, '__discord_app_commands_checks__', [])
         self._guild_ids: Optional[List[int]] = guild_ids
         if self._guild_ids is None:
-            self._guild_ids = getattr(
-                callback, '__discord_app_commands_default_guilds__', None
-            )
+            self._guild_ids = getattr(callback, '__discord_app_commands_default_guilds__', None)
         self.default_permissions: Optional[Permissions] = getattr(
             callback, '__discord_app_commands_default_permissions__', None
         )

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -686,9 +686,11 @@ class Command(Generic[GroupT, P, T]):
 
         self._params: Dict[str, CommandParameter] = _extract_parameters_from_callback(callback, callback.__globals__)
         self.checks: List[Check] = getattr(callback, '__discord_app_commands_checks__', [])
-        self._guild_ids: Optional[List[int]] = guild_ids or getattr(
-            callback, '__discord_app_commands_default_guilds__', None
-        )
+        self._guild_ids: Optional[List[int]] = guild_ids
+        if self._guild_ids is None:
+            self._guild_ids = getattr(
+                callback, '__discord_app_commands_default_guilds__', None
+            )
         self.default_permissions: Optional[Permissions] = getattr(
             callback, '__discord_app_commands_default_permissions__', None
         )
@@ -1249,7 +1251,9 @@ class ContextMenu:
         self._param_name = param
         self._annotation = annotation
         self.module: Optional[str] = callback.__module__
-        self._guild_ids = guild_ids or getattr(callback, '__discord_app_commands_default_guilds__', None)
+        self._guild_ids = guild_ids
+        if self._guild_ids is None:
+            self._guild_ids = getattr(callback, '__discord_app_commands_default_guilds__', None)
         self.on_error: Optional[UnboundError] = None
         self.default_permissions: Optional[Permissions] = getattr(
             callback, '__discord_app_commands_default_permissions__', None
@@ -1586,7 +1590,9 @@ class Group:
 
         self._attr: Optional[str] = None
         self._owner_cls: Optional[Type[Any]] = None
-        self._guild_ids: Optional[List[int]] = guild_ids or getattr(cls, '__discord_app_commands_default_guilds__', None)
+        self._guild_ids: Optional[List[int]] = guild_ids
+        if self._guild_ids is None:
+            self._guild_ids = getattr(cls, '__discord_app_commands_default_guilds__', None)
 
         if default_permissions is MISSING:
             if cls.__discord_app_commands_default_permissions__ is MISSING:
@@ -2365,6 +2371,9 @@ def guilds(*guild_ids: Union[Snowflake, int]) -> Callable[[T], T]:
     When the command instance is added to a :class:`CommandTree`, the guilds that are
     specified by this decorator become the default guilds that it's added to rather
     than being a global command.
+
+    If no arguments are given, then the command will not be synced anywhere. This may
+    be modified later using the :meth:`CommandTree.add_command` method.
 
     .. note::
 

--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -656,9 +656,11 @@ class HybridGroup(Group[CogT, P, T]):
         self.fallback_locale: Optional[app_commands.locale_str] = fallback_locale
 
         if self.with_app_command:
-            guild_ids = attrs.pop('guild_ids', None) or getattr(
-                self.callback, '__discord_app_commands_default_guilds__', None
-            )
+            guild_ids = attrs.pop('guild_ids', None)
+            if guild_ids is None:
+                guild_ids = getattr(
+                    self.callback, '__discord_app_commands_default_guilds__', None
+                )
             guild_only = getattr(self.callback, '__discord_app_commands_guild_only__', False)
             default_permissions = getattr(self.callback, '__discord_app_commands_default_permissions__', None)
             nsfw = getattr(self.callback, '__discord_app_commands_is_nsfw__', False)

--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -658,9 +658,7 @@ class HybridGroup(Group[CogT, P, T]):
         if self.with_app_command:
             guild_ids = attrs.pop('guild_ids', None)
             if guild_ids is None:
-                guild_ids = getattr(
-                    self.callback, '__discord_app_commands_default_guilds__', None
-                )
+                guild_ids = getattr(self.callback, '__discord_app_commands_default_guilds__', None)
             guild_only = getattr(self.callback, '__discord_app_commands_guild_only__', False)
             default_permissions = getattr(self.callback, '__discord_app_commands_default_permissions__', None)
             nsfw = getattr(self.callback, '__discord_app_commands_is_nsfw__', False)


### PR DESCRIPTION
## Summary

If an app command has `guild_ids=[]` or `@app_commands.guilds()` with no arguments, I'd expect the command to be detected as non-global command (despite not having guilds). However, this isn't the case and the command will be marked as global and synced everywhere.

When handling a command's `guild_ids`, most of the time an explicit check is made (`if guild_ids is not None`), which makes a difference between `None` and an empty list, but a few places missed this by using `guild_ids or ...`, where both `None` and `[]` will evaluate to false.

I fixed this behavior with an explicit check everywhere, making it possible to have guild commands that don't have a list of guilds yet (which can then be dynamically configured later on).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
