### PR TITLE
Fix rate limiter window reset and usage timing in GatewayRatelimiter

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -105,14 +105,15 @@ class GatewayRatelimiter:
 
         if current > self.window + self.per:
             self.remaining = self.max
-
-        if self.remaining == self.max:
             self.window = current
 
         if self.remaining == 0:
-            return self.per - (current - self.window)
+            return max(0.0, self.per - (current - self.window))
 
         self.remaining -= 1
+        
+        if self.remaining == self.max - 1:
+            self.window = current
         return 0.0
 
     async def block(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Documentation = "https://discordpy.readthedocs.io/en/latest/"
 dependencies = { file = "requirements.txt" }
 
 [project.optional-dependencies]
-voice = ["PyNaCl>=1.3.0,<1.6"]
+voice = ["PyNaCl>=1.5.0,<1.6"]
 docs = [
     "sphinx==4.4.0",
     "sphinxcontrib_trio==1.1.2",


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This pull request improves the internal logic of the `GatewayRatelimiter` to ensure more accurate and consistent rate-limiting behavior.
**Key Fixes:**
- The rate-limit window (self.window) and token count (self.remaining) now reset together, preventing desync issues.
- The rate-limit window now starts when the first token is consumed, ensuring correct delay calculations.

**Why it matters:**
Previously, if the rate-limit window was not reset properly while `remaining` was, the calculated delay could be incorrectly zero, causing shards to reconnect instantly without actually waiting for the rate limit to reset. This could result in:
This could result in:
- Unintentional rate-limit violations
- Gateway errors or Reconnects
- Unstable shard behavior
This fix ensures the shards respect the intended cooldown window, improving overall stability and compliance with Discord’s Gateway rate limits.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
