### PR TITLE
Add support for guest invites

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -60,7 +60,7 @@ from .http import handle_message_parameters
 from .voice_client import VoiceClient, VoiceProtocol
 from .sticker import GuildSticker, StickerItem
 from . import utils
-from .flags import GuildInviteFlags
+from .flags import InviteFlags
 
 __all__ = (
     'Snowflake',
@@ -1258,7 +1258,7 @@ class GuildChannel:
         target_type: Optional[InviteTarget] = None,
         target_user: Optional[User] = None,
         target_application_id: Optional[int] = None,
-        guest_invite: bool = False,
+        guest: bool = False,
     ) -> Invite:
         """|coro|
 
@@ -1297,10 +1297,8 @@ class GuildChannel:
             The id of the embedded application for the invite, required if ``target_type`` is :attr:`.InviteTarget.embedded_application`.
 
             .. versionadded:: 2.0
-        guest_invite: :class:`bool`
+        guest: :class:`bool`
             Whether the invite is a guest invite.
-
-            This is only available to guilds that contain ``GUESTS_ENABLED`` in :attr:`.Guild.features`.
 
             .. versionadded:: 2.6
 
@@ -1320,10 +1318,10 @@ class GuildChannel:
         if target_type is InviteTarget.unknown:
             raise ValueError('Cannot create invite with an unknown target type')
 
-        flags: Optional[GuildInviteFlags] = None
-        if guest_invite:
-            flags = GuildInviteFlags._from_value(0)
-            flags.is_guest_invite = True
+        flags: Optional[InviteFlags] = None
+        if guest:
+            flags = InviteFlags._from_value(0)
+            flags.guest = True
 
         data = await self._state.http.create_invite(
             self.id,

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -60,6 +60,7 @@ from .http import handle_message_parameters
 from .voice_client import VoiceClient, VoiceProtocol
 from .sticker import GuildSticker, StickerItem
 from . import utils
+from .flags import GuildInviteFlags
 
 __all__ = (
     'Snowflake',
@@ -1257,6 +1258,7 @@ class GuildChannel:
         target_type: Optional[InviteTarget] = None,
         target_user: Optional[User] = None,
         target_application_id: Optional[int] = None,
+        guest_invite: bool = False,
     ) -> Invite:
         """|coro|
 
@@ -1295,6 +1297,12 @@ class GuildChannel:
             The id of the embedded application for the invite, required if ``target_type`` is :attr:`.InviteTarget.embedded_application`.
 
             .. versionadded:: 2.0
+        guest_invite: :class:`bool`
+            Whether the invite is a guest invite.
+
+            This is only available to guilds that contain ``GUESTS_ENABLED`` in :attr:`.Guild.features`.
+
+            .. versionadded:: 2.6
 
         Raises
         -------
@@ -1312,6 +1320,10 @@ class GuildChannel:
         if target_type is InviteTarget.unknown:
             raise ValueError('Cannot create invite with an unknown target type')
 
+        flags = GuildInviteFlags._from_value(0)
+        if guest_invite:
+            flags.is_guest_invite = True
+
         data = await self._state.http.create_invite(
             self.id,
             reason=reason,
@@ -1322,6 +1334,7 @@ class GuildChannel:
             target_type=target_type.value if target_type else None,
             target_user_id=target_user.id if target_user else None,
             target_application_id=target_application_id,
+            flags=flags.value,
         )
         return Invite.from_incomplete(data=data, state=self._state)
 

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -1320,8 +1320,9 @@ class GuildChannel:
         if target_type is InviteTarget.unknown:
             raise ValueError('Cannot create invite with an unknown target type')
 
-        flags = GuildInviteFlags._from_value(0)
+        flags: Optional[GuildInviteFlags] = None
         if guest_invite:
+            flags = GuildInviteFlags._from_value(0)
             flags.is_guest_invite = True
 
         data = await self._state.http.create_invite(
@@ -1334,7 +1335,7 @@ class GuildChannel:
             target_type=target_type.value if target_type else None,
             target_user_id=target_user.id if target_user else None,
             target_application_id=target_application_id,
-            flags=flags.value,
+            flags=flags.value if flags else None,
         )
         return Invite.from_incomplete(data=data, state=self._state)
 

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -145,8 +145,8 @@ def _transform_applied_forum_tags(entry: AuditLogEntry, data: List[Snowflake]) -
     return [Object(id=tag_id, type=ForumTag) for tag_id in data]
 
 
-def _transform_overloaded_flags(entry: AuditLogEntry, data: int) -> Union[int, flags.ChannelFlags]:
-    # The `flags` key is definitely overloaded. Right now it's for channels and threads but
+def _transform_overloaded_flags(entry: AuditLogEntry, data: int) -> Union[int, flags.ChannelFlags, flags.InviteFlags]:
+    # The `flags` key is definitely overloaded. Right now it's for channels, threads and invites but
     # I am aware of `member.flags` and `user.flags` existing. However, this does not impact audit logs
     # at the moment but better safe than sorry.
     channel_audit_log_types = (
@@ -157,9 +157,16 @@ def _transform_overloaded_flags(entry: AuditLogEntry, data: int) -> Union[int, f
         enums.AuditLogAction.thread_update,
         enums.AuditLogAction.thread_delete,
     )
+    invite_audit_log_types = (
+        enums.AuditLogAction.invite_create,
+        enums.AuditLogAction.invite_update,
+        enums.AuditLogAction.invite_delete,
+    )
 
     if entry.action in channel_audit_log_types:
         return flags.ChannelFlags._from_value(data)
+    elif entry.action in invite_audit_log_types:
+        return flags.InviteFlags._from_value(data)
     return data
 
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -64,6 +64,7 @@ __all__ = (
     'AppInstallationType',
     'SKUFlags',
     'EmbedFlags',
+    'GuildInviteFlags',
 )
 
 BF = TypeVar('BF', bound='BaseFlags')
@@ -2397,3 +2398,59 @@ class EmbedFlags(BaseFlags):
         longer displayed.
         """
         return 1 << 5
+
+
+class GuildInviteFlags(BaseFlags):
+    r"""Wraps up the Discord Guild Invite flags
+
+    .. versionadded:: 2.6
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two GuildInviteFlags are equal.
+
+        .. describe:: x != y
+
+            Checks if two GuildInviteFlags are not equal.
+
+        .. describe:: x | y, x |= y
+
+            Returns a GuildInviteFlags instance with all enabled flags from
+            both x and y.
+
+        .. describe:: x ^ y, x ^= y
+
+            Returns a GuildInviteFlags instance with only flags enabled on
+            only one of x or y, not on both.
+
+        .. describe:: ~x
+
+            Returns a GuildInviteFlags instance with all flags inverted from x.
+
+        .. describe:: hash(x)
+
+            Returns the flag's hash.
+
+        .. describe:: iter(x)
+
+            Returns an iterator of ``(name, value)`` pairs. This allows it
+            to be, for example, constructed as a dict or a list of pairs.
+            Note that aliases are not shown.
+
+        .. describe:: bool(b)
+
+            Returns whether any flag is set to ``True``.
+
+    Attributes
+    ----------
+    value: :class:`int`
+        The raw value. You should query flags via the properties
+        rather than using this raw value.
+    """
+
+    @flag_value
+    def is_guest_invite(self):
+        """:class:`bool`: Returns ``True`` if this is a guest invite for a voice channel."""
+        return 1 << 0

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -64,7 +64,7 @@ __all__ = (
     'AppInstallationType',
     'SKUFlags',
     'EmbedFlags',
-    'GuildInviteFlags',
+    'InviteFlags',
 )
 
 BF = TypeVar('BF', bound='BaseFlags')
@@ -2400,8 +2400,8 @@ class EmbedFlags(BaseFlags):
         return 1 << 5
 
 
-class GuildInviteFlags(BaseFlags):
-    r"""Wraps up the Discord Guild Invite flags
+class InviteFlags(BaseFlags):
+    r"""Wraps up the Discord Invite flags
 
     .. versionadded:: 2.6
 
@@ -2409,25 +2409,25 @@ class GuildInviteFlags(BaseFlags):
 
         .. describe:: x == y
 
-            Checks if two GuildInviteFlags are equal.
+            Checks if two InviteFlags are equal.
 
         .. describe:: x != y
 
-            Checks if two GuildInviteFlags are not equal.
+            Checks if two InviteFlags are not equal.
 
         .. describe:: x | y, x |= y
 
-            Returns a GuildInviteFlags instance with all enabled flags from
+            Returns a InviteFlags instance with all enabled flags from
             both x and y.
 
         .. describe:: x ^ y, x ^= y
 
-            Returns a GuildInviteFlags instance with only flags enabled on
+            Returns a InviteFlags instance with only flags enabled on
             only one of x or y, not on both.
 
         .. describe:: ~x
 
-            Returns a GuildInviteFlags instance with all flags inverted from x.
+            Returns a InviteFlags instance with all flags inverted from x.
 
         .. describe:: hash(x)
 
@@ -2451,6 +2451,6 @@ class GuildInviteFlags(BaseFlags):
     """
 
     @flag_value
-    def is_guest_invite(self):
+    def guest(self):
         """:class:`bool`: Returns ``True`` if this is a guest invite for a voice channel."""
         return 1 << 0

--- a/discord/http.py
+++ b/discord/http.py
@@ -1853,7 +1853,7 @@ class HTTPClient:
         if target_application_id:
             payload['target_application_id'] = str(target_application_id)
 
-        if flags is not None:
+        if flags:
             payload['flags'] = flags
 
         return self.request(r, reason=reason, json=payload)

--- a/discord/http.py
+++ b/discord/http.py
@@ -1834,6 +1834,7 @@ class HTTPClient:
         target_type: Optional[invite.InviteTargetType] = None,
         target_user_id: Optional[Snowflake] = None,
         target_application_id: Optional[Snowflake] = None,
+        flags: Optional[int] = None,
     ) -> Response[invite.Invite]:
         r = Route('POST', '/channels/{channel_id}/invites', channel_id=channel_id)
         payload = {
@@ -1851,6 +1852,9 @@ class HTTPClient:
 
         if target_application_id:
             payload['target_application_id'] = str(target_application_id)
+
+        if flags is not None:
+            payload['flags'] = flags
 
         return self.request(r, reason=reason, json=payload)
 

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -32,6 +32,7 @@ from .mixins import Hashable
 from .enums import ChannelType, NSFWLevel, VerificationLevel, InviteTarget, InviteType, try_enum
 from .appinfo import PartialAppInfo
 from .scheduled_event import ScheduledEvent
+from .flags import GuildInviteFlags
 
 __all__ = (
     'PartialInviteChannel',
@@ -379,6 +380,7 @@ class Invite(Hashable):
         'scheduled_event',
         'scheduled_event_id',
         'type',
+        '_flags',
     )
 
     BASE = 'https://discord.gg'
@@ -432,6 +434,7 @@ class Invite(Hashable):
             else None
         )
         self.scheduled_event_id: Optional[int] = self.scheduled_event.id if self.scheduled_event else None
+        self._flags: int = data.get('flags', 0)
 
     @classmethod
     def from_incomplete(cls, *, state: ConnectionState, data: InvitePayload) -> Self:
@@ -522,6 +525,14 @@ class Invite(Hashable):
         if self.scheduled_event_id is not None:
             url += '?event=' + str(self.scheduled_event_id)
         return url
+
+    @property
+    def flags(self) -> GuildInviteFlags:
+        """:class:`GuildInviteFlags`: Returns the flags for this guild invite.
+
+        .. versionadded:: 2.6
+        """
+        return GuildInviteFlags._from_value(self._flags)
 
     def set_scheduled_event(self, scheduled_event: Snowflake, /) -> Self:
         """Sets the scheduled event for this invite.

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -528,7 +528,7 @@ class Invite(Hashable):
 
     @property
     def flags(self) -> InviteFlags:
-        """:class:`InviteFlags`: Returns the flags for this guild invite.
+        """:class:`InviteFlags`: Returns the flags for this invite.
 
         .. versionadded:: 2.6
         """

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -32,7 +32,7 @@ from .mixins import Hashable
 from .enums import ChannelType, NSFWLevel, VerificationLevel, InviteTarget, InviteType, try_enum
 from .appinfo import PartialAppInfo
 from .scheduled_event import ScheduledEvent
-from .flags import GuildInviteFlags
+from .flags import InviteFlags
 
 __all__ = (
     'PartialInviteChannel',
@@ -527,12 +527,12 @@ class Invite(Hashable):
         return url
 
     @property
-    def flags(self) -> GuildInviteFlags:
-        """:class:`GuildInviteFlags`: Returns the flags for this guild invite.
+    def flags(self) -> InviteFlags:
+        """:class:`InviteFlags`: Returns the flags for this guild invite.
 
         .. versionadded:: 2.6
         """
-        return GuildInviteFlags._from_value(self._flags)
+        return InviteFlags._from_value(self._flags)
 
     def set_scheduled_event(self, scheduled_event: Snowflake, /) -> Self:
         """Sets the scheduled event for this invite.

--- a/discord/member.py
+++ b/discord/member.py
@@ -238,7 +238,8 @@ class Member(discord.abc.Messageable, _UserTag):
     ----------
     joined_at: Optional[:class:`datetime.datetime`]
         An aware datetime object that specifies the date and time in UTC that the member joined the guild.
-        If the member left and rejoined the guild, this will be the latest date. In certain cases, this can be ``None``.
+        If the member left and rejoined the guild, this will be the latest date.
+        This can be ``None``, such as when the member is a guest.
     activities: Tuple[Union[:class:`BaseActivity`, :class:`Spotify`]]
         The activities that the user is currently doing.
 

--- a/discord/types/invite.py
+++ b/discord/types/invite.py
@@ -65,6 +65,7 @@ class Invite(IncompleteInvite, total=False):
     target_application: PartialAppInfo
     guild_scheduled_event: GuildScheduledEvent
     type: InviteType
+    flags: NotRequired[int]
 
 
 class InviteWithCounts(Invite, _GuildPreviewUnique):
@@ -84,6 +85,7 @@ class GatewayInviteCreate(TypedDict):
     target_type: NotRequired[InviteTargetType]
     target_user: NotRequired[PartialUser]
     target_application: NotRequired[PartialAppInfo]
+    flags: NotRequired[int]
 
 
 class GatewayInviteDelete(TypedDict):

--- a/discord/types/member.py
+++ b/discord/types/member.py
@@ -34,7 +34,7 @@ class Nickname(TypedDict):
 
 class PartialMember(TypedDict):
     roles: SnowflakeList
-    joined_at: str
+    joined_at: Optional[str]  # null if guest
     deaf: bool
     mute: bool
     flags: int

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2517,6 +2517,7 @@ of :class:`enum.Enum`.
         - :attr:`~AuditLogDiff.channel`
         - :attr:`~AuditLogDiff.uses`
         - :attr:`~AuditLogDiff.max_uses`
+        - :attr:`~AuditLogDiff.flags`
 
     .. attribute:: invite_update
 
@@ -2541,6 +2542,7 @@ of :class:`enum.Enum`.
         - :attr:`~AuditLogDiff.channel`
         - :attr:`~AuditLogDiff.uses`
         - :attr:`~AuditLogDiff.max_uses`
+        - :attr:`~AuditLogDiff.flags`
 
     .. attribute:: webhook_create
 
@@ -4552,11 +4554,11 @@ AuditLogDiff
 
     .. attribute:: flags
 
-        The channel flags associated with this thread or forum post.
+        The flags associated with this thread, forum post or invite.
 
-        See also :attr:`ForumChannel.flags` and :attr:`Thread.flags`
+        See also :attr:`ForumChannel.flags`, :attr:`Thread.flags` and :attr:`Invite.flags`
 
-        :type: :class:`ChannelFlags`
+        :type: Union[:class:`ChannelFlags`, :class:`InviteFlags`]
 
     .. attribute:: default_thread_slowmode_delay
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5739,7 +5739,7 @@ GuildInviteFlags
 
 .. attributetable:: GuildInviteFlags
 
-.. autoclass:: GuildInviteFlags(
+.. autoclass:: GuildInviteFlags()
     :members:
 
 ForumTag

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5734,6 +5734,14 @@ EmbedFlags
 .. autoclass:: EmbedFlags()
     :members:
 
+GuildInviteFlags
+~~~~~~~~~~~~~~~~
+
+.. attributetable:: GuildInviteFlags
+
+.. autoclass:: GuildInviteFlags(
+    :members:
+
 ForumTag
 ~~~~~~~~~
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5734,12 +5734,12 @@ EmbedFlags
 .. autoclass:: EmbedFlags()
     :members:
 
-GuildInviteFlags
+InviteFlags
 ~~~~~~~~~~~~~~~~
 
-.. attributetable:: GuildInviteFlags
+.. attributetable:: InviteFlags
 
-.. autoclass:: GuildInviteFlags()
+.. autoclass:: InviteFlags()
     :members:
 
 ForumTag


### PR DESCRIPTION
## Summary

This PR adds support for creating (`guest_invite` kwarg in create_invite) and detecting a guest invite (flags).

Also marks `Member.joined_at` as None in the types and mentions it in the doc.

I could not test creating nor getting as I don't have a bot in a guild with the `GUESTS_ENABLED` feature.

Relevant API Docs PR:
- https://github.com/discord/discord-api-docs/pull/6247

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
