### PR TITLE
feat(locale): add BCP47 unicode tags for Locale enum

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
+
 from __future__ import annotations
 
 import types
@@ -770,7 +771,7 @@ class Locale(Enum):
     @property
     def language_code(self) -> str:
         """Returns the locale's language code in the format of ``language-COUNTRY``.
-        
+
         .. versionadded:: 2.5
         """
         return _UNICODE_LANG_MAP.get(self.value, self.value)

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -694,6 +694,42 @@ class MFALevel(Enum, comparable=True):
     require_2fa = 1
 
 
+_UNICODE_LANG_MAP: Dict[str, str] = {
+    'bg': 'bg-BG',
+    'zh-CN': 'zh-CN',
+    'zh-TW': 'zh-TW',
+    'hr': 'hr-HR',
+    'cs': 'cs-CZ',
+    'da': 'da-DK',
+    'nl': 'nl-NL',
+    'en-US': 'en-US',
+    'en-GB': 'en-GB',
+    'fi': 'fi-FI',
+    'fr': 'fr-FR',
+    'de': 'de-DE',
+    'el': 'el-GR',
+    'hi': 'hi-IN',
+    'hu': 'hu-HU',
+    'id': 'id-ID',
+    'it': 'it-IT',
+    'ja': 'ja-JP',
+    'ko': 'ko-KR',
+    'lt': 'lt-LT',
+    'no': 'no-NO',
+    'pl': 'pl-PL',
+    'pt-BR': 'pt-BR',
+    'ro': 'ro-RO',
+    'ru': 'ru-RU',
+    'es-ES': 'es-ES',
+    'es-419': 'es-419',
+    'sv-SE': 'sv-SE',
+    'th': 'th-TH',
+    'tr': 'tr-TR',
+    'uk': 'uk-UA',
+    'vi': 'vi-VN',
+}
+
+
 class Locale(Enum):
     american_english = 'en-US'
     british_english = 'en-GB'
@@ -730,6 +766,14 @@ class Locale(Enum):
 
     def __str__(self) -> str:
         return self.value
+
+    @property
+    def language_code(self) -> str:
+        """Returns the locale's language code in the format of ``language-COUNTRY``.
+        
+        .. versionadded:: 2.5
+        """
+        return _UNICODE_LANG_MAP.get(self.value, self.value)
 
 
 E = TypeVar('E', bound='Enum')

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -772,6 +772,9 @@ class Locale(Enum):
     def language_code(self) -> str:
         """:class:`str`: Returns the locale's BCP 47 language code in the format of ``language-COUNTRY``.
 
+        This is derived from a predefined mapping based on Discord's supported locales.
+        If no mapping exists for the current locale, this returns the raw locale value as a fallback.
+
         .. versionadded:: 2.6
         """
         return _UNICODE_LANG_MAP.get(self.value, self.value)

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -770,7 +770,7 @@ class Locale(Enum):
 
     @property
     def language_code(self) -> str:
-        """Returns the locale's language code in the format of ``language-COUNTRY``.
+        """:class:`str`: Returns the locale's BCP 47 language code in the format of ``language-COUNTRY``.
 
         .. versionadded:: 2.6
         """

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -772,7 +772,7 @@ class Locale(Enum):
     def language_code(self) -> str:
         """Returns the locale's language code in the format of ``language-COUNTRY``.
 
-        .. versionadded:: 2.5
+        .. versionadded:: 2.6
         """
         return _UNICODE_LANG_MAP.get(self.value, self.value)
 


### PR DESCRIPTION
## Summary
Adds support for BCP 47-style unicode language identifiers to the Locale enum.

This adds a new property, `language_code`, that maps the Discord locale value to its standardized `language-REGION` format (e.g. `de` → `de-DE`, `pt-BR` → `pt-BR`, `es-419` → `es-419`).
This can be useful for integrations that require full locale identifiers (e.g. HTTP headers, system locale matching, external APIs).

## Changes
- Adds `_UNICODE_LANG_MAP` for locale → unicode tag mapping.
- Adds a `language_code` property to `Locale`.
- The property returns the mapped Unicode tag or falls back to the original value.
- Mapping is based on CLDR identifiers matching Discord's locale list.

## Example
```py
Locale.german.language_code  # 'de-DE'
Locale.brazil_portuguese.language_code  # 'pt-BR'
Locale.spanish.language_code  # 'es-ES'
Locale.latin_american_spanish.language_code  # 'es-419'
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue. (#9589)
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
