### PR TITLE
Fix ``.. versionadded::`` strings on Role secondary and tertiary colours

### DIFF
--- a/discord/role.py
+++ b/discord/role.py
@@ -331,6 +331,7 @@ class Role(Hashable):
     @property
     def secondary_colour(self) -> Optional[Colour]:
         """Optional[:class:`Colour`]: The role's secondary colour.
+
         .. versionadded:: 2.6
         """
         return Colour(self._secondary_colour) if self._secondary_colour is not None else None
@@ -338,6 +339,7 @@ class Role(Hashable):
     @property
     def secondary_color(self) -> Optional[Colour]:
         """Optional[:class:`Colour`]: Alias for :attr:`secondary_colour`.
+
         .. versionadded:: 2.6
         """
         return self.secondary_colour
@@ -345,6 +347,7 @@ class Role(Hashable):
     @property
     def tertiary_colour(self) -> Optional[Colour]:
         """Optional[:class:`Colour`]: The role's tertiary colour.
+
         .. versionadded:: 2.6
         """
         return Colour(self._tertiary_colour) if self._tertiary_colour is not None else None
@@ -352,6 +355,7 @@ class Role(Hashable):
     @property
     def tertiary_color(self) -> Optional[Colour]:
         """Optional[:class:`Colour`]: Alias for :attr:`tertiary_colour`.
+
         .. versionadded:: 2.6
         """
         return self.tertiary_colour


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
As the title states: fixes the versionadded strings on Role.secondary_colour and Role.tertiary_colour

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
