### PR TITLE
Add support for new RPC fields

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -78,6 +78,7 @@ __all__ = (
     'VoiceChannelEffectAnimationType',
     'SubscriptionStatus',
     'MessageReferenceType',
+    'StatusDisplayType',
 )
 
 
@@ -910,6 +911,12 @@ class SubscriptionStatus(Enum):
     active = 0
     ending = 1
     inactive = 2
+
+
+class StatusDisplayType(Enum):
+    NAME = 0
+    STATE = 1
+    DETAILS = 2
 
 
 def create_unknown_value(cls: Type[E], val: Any) -> E:

--- a/discord/types/activity.py
+++ b/discord/types/activity.py
@@ -31,6 +31,7 @@ from .snowflake import Snowflake
 
 
 StatusType = Literal['idle', 'dnd', 'online', 'offline']
+StatusDisplayType = Literal[0, 1, 2]
 
 
 class PartialPresenceUpdate(TypedDict):
@@ -62,6 +63,8 @@ class ActivityAssets(TypedDict, total=False):
     large_text: str
     small_image: str
     small_text: str
+    large_url: str
+    small_url: str
 
 
 class ActivitySecrets(TypedDict, total=False):
@@ -104,3 +107,6 @@ class Activity(_BaseActivity, total=False):
     instance: bool
     buttons: List[str]
     sync_id: str
+    state_url: str
+    details_url: str
+    status_display_type: Optional[StatusDisplayType]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3881,6 +3881,25 @@ of :class:`enum.Enum`.
 
         An alias for :attr:`.default`.
 
+.. class:: StatusDisplayType
+
+    Represents which field is of the user's activity is 
+    displayed in the members list.
+
+    .. versionadded:: 2.6
+
+        .. attribute:: NAME
+
+        The name of the activity is displayed.
+
+    .. attribute:: STATE
+
+        The state of the activity is displayed.
+
+    .. attribute:: DETAILS
+
+        The details of the activity are displayed.
+
 .. _discord-api-audit-logs:
 
 Audit Log Data


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/pull/7674/

Enum names are upped cased because `name` is an existing attribute.
Bots don't support any of this, just like before.


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
