### PR TITLE
Fix key error on role create or delete

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -446,11 +446,9 @@ class AuditLogChanges:
         # add an alias
         if hasattr(self.after, 'colour'):
             self.after.color = self.after.colour
-        if hasattr(self.before, 'colour'):
             self.before.color = self.before.colour
         if hasattr(self.after, 'expire_behavior'):
             self.after.expire_behaviour = self.after.expire_behavior
-        if hasattr(self.before, 'expire_behavior'):
             self.before.expire_behaviour = self.before.expire_behavior
 
     def __repr__(self) -> str:

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -444,9 +444,9 @@ class AuditLogChanges:
             setattr(self.after, attr, after)
 
         # add an alias
-        if hasattr(self.after, 'color'):
+        if hasattr(self.after, 'colour'):
             self.after.color = self.after.colour
-        if hasattr(self.before, 'color'):
+        if hasattr(self.before, 'colour'):
             self.before.color = self.before.colour
         if hasattr(self.after, 'expire_behavior'):
             self.after.expire_behaviour = self.after.expire_behavior

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -409,8 +409,8 @@ class AuditLogChanges:
 
             # special case for colors to set secondary and tertiary colos/colour attributes
             if attr == 'colors':
-                self._handle_colours(self.before, elem['old_value'])  # type: ignore  # should be a RoleColours dict
-                self._handle_colours(self.after, elem['new_value'])  # type: ignore  # should be a RoleColours dict
+                self._handle_colours(self.before, elem.get('old_value'))  # type: ignore  # should be a RoleColours dict
+                self._handle_colours(self.after, elem.get('new_value'))  # type: ignore  # should be a RoleColours dict
                 continue
 
             try:
@@ -446,9 +446,11 @@ class AuditLogChanges:
         # add an alias
         if hasattr(self.after, 'colour'):
             self.after.color = self.after.colour
+        if hasattr(self.before, 'colour'):
             self.before.color = self.before.colour
         if hasattr(self.after, 'expire_behavior'):
             self.after.expire_behaviour = self.after.expire_behavior
+        if hasattr(self.before, 'expire_behavior'):
             self.before.expire_behaviour = self.before.expire_behavior
 
     def __repr__(self) -> str:
@@ -545,13 +547,18 @@ class AuditLogChanges:
         except (AttributeError, TypeError):
             pass
 
-    def _handle_colours(self, diff: AuditLogDiff, colours: RoleColours):
-        # handle colours to multiple colour attributes
-        diff.color = diff.colour = Colour(colours['primary_color'])
+    def _handle_colours(self, diff: AuditLogDiff, colours: Optional[RoleColours]):
+        if colours is not None:
+            # handle colours to multiple colour attributes
+            colour = Colour(colours['primary_color'])
+            secondary_colour = colours['secondary_color']
+            tertiary_colour = colours['tertiary_color']
+        else:
+            colour = None
+            secondary_colour = None
+            tertiary_colour = None
 
-        secondary_colour = colours['secondary_color']
-        tertiary_colour = colours['tertiary_color']
-
+        diff.color = diff.colour = colour
         diff.secondary_color = diff.secondary_colour = Colour(secondary_colour) if secondary_colour is not None else None
         diff.tertiary_color = diff.tertiary_colour = Colour(tertiary_colour) if tertiary_colour is not None else None
 

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -444,9 +444,9 @@ class AuditLogChanges:
             setattr(self.after, attr, after)
 
         # add an alias
-        if hasattr(self.after, 'colour'):
+        if hasattr(self.after, 'color'):
             self.after.color = self.after.colour
-        if hasattr(self.before, 'colour'):
+        if hasattr(self.before, 'color'):
             self.before.color = self.before.colour
         if hasattr(self.after, 'expire_behavior'):
             self.after.expire_behaviour = self.after.expire_behavior


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
create/delete audit logs entries don't have old/new value keys.
potentially fix an issue where aliases for secondary and tertiary colors wouldn't be set
Fixes #10232 
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
