### PR TITLE
Add missing fill_with_flags decorator to InviteFlags class

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -2399,6 +2399,7 @@ class EmbedFlags(BaseFlags):
         """
         return 1 << 5
 
+
 @fill_with_flags()
 class InviteFlags(BaseFlags):
     r"""Wraps up the Discord Invite flags

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -2399,7 +2399,7 @@ class EmbedFlags(BaseFlags):
         """
         return 1 << 5
 
-
+@fill_with_flags()
 class InviteFlags(BaseFlags):
     r"""Wraps up the Discord Invite flags
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -2095,15 +2095,6 @@ class MemberFlags(BaseFlags):
         return 1 << 7
 
     @flag_value
-    def automod_quarantined_guild_tag(self):
-        """:class:`bool`: Returns ``True`` if the member's guild tag has been
-        blocked by AutoMod.
-
-        .. versionadded:: 2.6
-        """
-        return 1 << 10
-
-    @flag_value
     def dm_settings_upsell_acknowledged(self):
         """:class:`bool`: Returns ``True`` if the member has dismissed the DM settings upsell.
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -2095,6 +2095,15 @@ class MemberFlags(BaseFlags):
         return 1 << 7
 
     @flag_value
+    def automod_quarantined_guild_tag(self):
+        """:class:`bool`: Returns ``True`` if the member's guild tag has been
+        blocked by AutoMod.
+
+        .. versionadded:: 2.6
+        """
+        return 1 << 10
+
+    @flag_value
     def dm_settings_upsell_acknowledged(self):
         """:class:`bool`: Returns ``True`` if the member has dismissed the DM settings upsell.
 


### PR DESCRIPTION
## Summary

This PR fixes the DEFAULT_VALUE being None for InviteFlags as the fill_with_flags decorator was missing. (Introduced in #10220  )

## Checklist


- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
