### PR TITLE
Fix: error when sending non-interactive views via partial webhooks

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1872,7 +1872,7 @@ class Webhook(BaseWebhook):
         if wait:
             msg = self._create_message(data, thread=thread)
 
-        if view is not MISSING and not view.is_finished():
+        if view is not MISSING and not view.is_finished() and view.is_dispatchable():
             message_id = None if msg is None else msg.id
             self._state.store_view(view, message_id)
 


### PR DESCRIPTION
## What’s the fix?

This PR prevents an AttributeError that occurs when sending a `View` with only URL buttons (non-interactive) via a partial webhook.

Previously, the library would attempt to store the view using `_state.store_view()`, which fails if the webhook has a `PartialWebhookState`. However, link-only views don’t require state storage at all.

## What changed?

In `Webhook.send()`, I added a check for `view.is_dispatchable()` before attempting to call `store_view()`:

```py
if view is not MISSING and not view.is_finished() and view.is_dispatchable():
    message_id = None if msg is None else msg.id
    self._state.store_view(view, message_id)
````
This ensures that only views with interactive components (buttons with callbacks, selects, etc.) are stored.

