### PR TITLE
Add support for automod_quarantined_guild_tag member flag

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -765,6 +765,7 @@ class AuditLogEntry(Hashable):
                     ),
                     channel=channel,
                 )
+                
             elif self.action is enums.AuditLogAction.automod_quarantine_user:
                 self.extra = _AuditLogProxyAutoModActionQuarantineUser(
                     automod_rule_name=extra['auto_moderation_rule_name'],

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -770,7 +770,7 @@ class AuditLogEntry(Hashable):
                     automod_rule_name=extra['auto_moderation_rule_name'],
                     automod_rule_trigger_type=enums.try_enum(
                         enums.AutoModRuleTriggerType, extra['auto_moderation_rule_trigger_type']
-                    )
+                    ),
                 )
 
             elif self.action.name.startswith('overwrite_'):

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -744,6 +744,7 @@ class AuditLogEntry(Hashable):
                 self.action is enums.AuditLogAction.automod_block_message
                 or self.action is enums.AuditLogAction.automod_flag_message
                 or self.action is enums.AuditLogAction.automod_timeout_member
+                or self.action is enums.AuditLogAction.automod_quarantine_member
             ):
                 channel_id = utils._get_as_snowflake(extra, 'channel_id')
                 channel = None

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -614,6 +614,11 @@ class _AuditLogProxyAutoModAction(_AuditLogProxy):
     channel: Optional[Union[abc.GuildChannel, Thread]]
 
 
+class _AuditLogProxyAutoModActionQuarantineUser(_AuditLogProxy):
+    automod_rule_name: str
+    automod_rule_trigger_type: str
+
+
 class _AuditLogProxyMemberKickOrMemberRoleUpdate(_AuditLogProxy):
     integration_type: Optional[str]
 
@@ -704,6 +709,7 @@ class AuditLogEntry(Hashable):
             _AuditLogProxyStageInstanceAction,
             _AuditLogProxyMessageBulkDelete,
             _AuditLogProxyAutoModAction,
+            _AuditLogProxyAutoModActionQuarantineUser,
             _AuditLogProxyMemberKickOrMemberRoleUpdate,
             Member, User, None, PartialIntegration,
             Role, Object
@@ -744,7 +750,6 @@ class AuditLogEntry(Hashable):
                 self.action is enums.AuditLogAction.automod_block_message
                 or self.action is enums.AuditLogAction.automod_flag_message
                 or self.action is enums.AuditLogAction.automod_timeout_member
-                or self.action is enums.AuditLogAction.automod_quarantine_user
             ):
                 channel_id = utils._get_as_snowflake(extra, 'channel_id')
                 channel = None
@@ -760,7 +765,13 @@ class AuditLogEntry(Hashable):
                     ),
                     channel=channel,
                 )
-
+            elif self.action is enums.AuditLogAction.automod_quarantine_user:
+                self.extra = _AuditLogProxyAutoModActionQuarantineUser(
+                    automod_rule_name=extra['auto_moderation_rule_name'],
+                    automod_rule_trigger_type=enums.try_enum(
+                        enums.AutoModRuleTriggerType, extra['auto_moderation_rule_trigger_type']
+                    )
+                )
             elif self.action.name.startswith('overwrite_'):
                 # the overwrite_ actions have a dict with some information
                 instance_id = int(extra['id'])

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -765,7 +765,7 @@ class AuditLogEntry(Hashable):
                     ),
                     channel=channel,
                 )
-                
+
             elif self.action is enums.AuditLogAction.automod_quarantine_user:
                 self.extra = _AuditLogProxyAutoModActionQuarantineUser(
                     automod_rule_name=extra['auto_moderation_rule_name'],

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -765,7 +765,6 @@ class AuditLogEntry(Hashable):
                     ),
                     channel=channel,
                 )
-
             elif self.action is enums.AuditLogAction.automod_quarantine_user:
                 self.extra = _AuditLogProxyAutoModActionQuarantineUser(
                     automod_rule_name=extra['auto_moderation_rule_name'],
@@ -773,6 +772,7 @@ class AuditLogEntry(Hashable):
                         enums.AutoModRuleTriggerType, extra['auto_moderation_rule_trigger_type']
                     )
                 )
+
             elif self.action.name.startswith('overwrite_'):
                 # the overwrite_ actions have a dict with some information
                 instance_id = int(extra['id'])

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -744,7 +744,7 @@ class AuditLogEntry(Hashable):
                 self.action is enums.AuditLogAction.automod_block_message
                 or self.action is enums.AuditLogAction.automod_flag_message
                 or self.action is enums.AuditLogAction.automod_timeout_member
-                or self.action is enums.AuditLogAction.automod_quarantine_member
+                or self.action is enums.AuditLogAction.automod_quarantine_user
             ):
                 channel_id = utils._get_as_snowflake(extra, 'channel_id')
                 channel = None

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -398,6 +398,7 @@ class AuditLogAction(Enum):
     automod_block_message                             = 143
     automod_flag_message                              = 144
     automod_timeout_member                            = 145
+    automod_quarantine_member                         = 146
     creator_monetization_request_created              = 150
     creator_monetization_terms_accepted               = 151
     # fmt: on
@@ -460,6 +461,7 @@ class AuditLogAction(Enum):
             AuditLogAction.automod_block_message:                    None,
             AuditLogAction.automod_flag_message:                     None,
             AuditLogAction.automod_timeout_member:                   None,
+            AuditLogAction.automod_quarantine_member:                None,
             AuditLogAction.creator_monetization_request_created:     None,
             AuditLogAction.creator_monetization_terms_accepted:      None,
             AuditLogAction.soundboard_sound_create:                  AuditLogActionCategory.create,

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -508,7 +508,7 @@ class AuditLogAction(Enum):
             return 'integration_or_app_command'
         elif 139 < v < 143:
             return 'auto_moderation'
-        elif v < 146:
+        elif v < 147:
             return 'user'
         elif v < 152:
             return 'creator_monetization'

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -398,7 +398,7 @@ class AuditLogAction(Enum):
     automod_block_message                             = 143
     automod_flag_message                              = 144
     automod_timeout_member                            = 145
-    automod_quarantine_member                         = 146
+    automod_quarantine_user                           = 146
     creator_monetization_request_created              = 150
     creator_monetization_terms_accepted               = 151
     # fmt: on
@@ -461,7 +461,7 @@ class AuditLogAction(Enum):
             AuditLogAction.automod_block_message:                    None,
             AuditLogAction.automod_flag_message:                     None,
             AuditLogAction.automod_timeout_member:                   None,
-            AuditLogAction.automod_quarantine_member:                None,
+            AuditLogAction.automod_quarantine_user:                  None,
             AuditLogAction.creator_monetization_request_created:     None,
             AuditLogAction.creator_monetization_terms_accepted:      None,
             AuditLogAction.soundboard_sound_create:                  AuditLogActionCategory.create,

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -2111,6 +2111,7 @@ class MemberFlags(BaseFlags):
         """
         return 1 << 9
 
+
 @fill_with_flags()
 class AttachmentFlags(BaseFlags):
     r"""Wraps up the Discord Attachment flags

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -2095,13 +2095,21 @@ class MemberFlags(BaseFlags):
         return 1 << 7
 
     @flag_value
+    def automod_quarantined_guild_tag(self):
+        """:class:`bool`: Returns ``True`` if the member's guild tag has been
+        blocked by AutoMod.
+
+        .. versionadded:: 2.6
+        """
+        return 1 << 10
+
+    @flag_value
     def dm_settings_upsell_acknowledged(self):
         """:class:`bool`: Returns ``True`` if the member has dismissed the DM settings upsell.
 
         .. versionadded:: 2.5
         """
         return 1 << 9
-
 
 @fill_with_flags()
 class AttachmentFlags(BaseFlags):

--- a/discord/types/audit_log.py
+++ b/discord/types/audit_log.py
@@ -97,6 +97,7 @@ AuditLogEvent = Literal[
     143,
     144,
     145,
+    146,
     150,
     151,
 ]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3055,6 +3055,23 @@ of :class:`enum.Enum`.
 
         .. versionadded:: 2.1
 
+    .. attribute:: automod_quarantine_member
+
+        An automod rule quarantined a member.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.target` is
+        a :class:`Member` with the ID of the person who triggered the automod rule.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
+        set to an unspecified proxy object with 2 attributes:
+
+        - ``automod_rule_name``: The name of the automod rule that was triggered.
+        - ``automod_rule_trigger_type``: A :class:`AutoModRuleTriggerType` representation of the rule type that was triggered.
+
+        When this is the action, :attr:`AuditLogEntry.changes` is empty.
+
+        .. versionadded:: 2.6
+
     .. attribute:: creator_monetization_request_created
 
         A request to monetize the server was created.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3055,7 +3055,7 @@ of :class:`enum.Enum`.
 
         .. versionadded:: 2.1
 
-    .. attribute:: automod_quarantine_member
+    .. attribute:: automod_quarantine_user
 
         An automod rule quarantined a member.
 


### PR DESCRIPTION
## Summary

Adds support for ``automod_quarantined_guild_tag`` member flag.
Discord-api-docs PR: https://github.com/discord/discord-api-docs/pull/7699

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
