### PR TITLE
Skip GUILD_MEMBER_ADD if member already cached

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -1101,6 +1101,12 @@ class ConnectionState(Generic[ClientT]):
             _log.debug('GUILD_MEMBER_ADD referencing an unknown guild ID: %s. Discarding.', data['guild_id'])
             return
 
+        member_id = int(data['user']['id'])
+        member = guild.get_member(member_id)
+        if member is not None:
+            _log.debug('GUILD_MEMBER_ADD referencing an already cached member ID: %s. Discarding.', member_id)
+            return
+
         member = Member(guild=guild, data=data, state=self)
         if self.member_cache_flags.joined:
             guild._add_member(member)


### PR DESCRIPTION
## Summary

Skips processing `GUILD_MEMBER_ADD` if the member is already present in the guild cache.

This prevents duplicate handling in very specific cases where a `GUILD_MEMBER_ADD` event is received for a member who is already cached - a situation that may occur under specific timing.

Without this check:
- `Guild.member_count` may become inaccurate
- Logic depending on `Guild.chunked` being accurate may break


## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
