### PR TITLE
fix `guild_only` app command decorator

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -2525,7 +2525,7 @@ def guild_only(func: Optional[T] = None) -> Union[T, Callable[[T], T]]:
             f.__discord_app_commands_contexts__ = allowed_contexts  # type: ignore # Runtime attribute assignment
 
         # Ensure that only Guild context is allowed
-        allowed_contexts.guild = False  # Enable guild context
+        allowed_contexts.guild = True  # Enable guild context
         allowed_contexts.private_channel = False  # Disable private channel context
         allowed_contexts.dm_channel = False  # Disable DM context
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
The last commit mistakenly set `allowed_contexts.guild` to false in `@guild_only()` app command decorator. This PR fixes it.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
