### PR TITLE
Fix audit log relating to automod rules

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -761,7 +761,7 @@ class AuditLogEntry(Hashable):
                 self.extra = _AuditLogProxyAutoModAction(
                     automod_rule_name=extra['auto_moderation_rule_name'],
                     automod_rule_trigger_type=enums.try_enum(
-                        enums.AutoModRuleTriggerType, extra['auto_moderation_rule_trigger_type']
+                        enums.AutoModRuleTriggerType, int(extra['auto_moderation_rule_trigger_type'])
                     ),
                     channel=channel,
                 )
@@ -769,7 +769,7 @@ class AuditLogEntry(Hashable):
                 self.extra = _AuditLogProxyAutoModActionQuarantineUser(
                     automod_rule_name=extra['auto_moderation_rule_name'],
                     automod_rule_trigger_type=enums.try_enum(
-                        enums.AutoModRuleTriggerType, extra['auto_moderation_rule_trigger_type']
+                        enums.AutoModRuleTriggerType, int(extra['auto_moderation_rule_trigger_type'])
                     ),
                 )
 


### PR DESCRIPTION
## Summary

This PR fixes an issue in audit logs relating to AutoMod rules.
The `extra` we receive for the trigger type is a string in the payload, even though it is a number.
This causes the `try_enum` lookup to fail, and results in an unknown key.

We correct this by casting to int. This does not use `try` because the documentation says it will always be a enumeration.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
