### PR TITLE
[commands] Fix converters not working with Union for hybrids

### DIFF
--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -256,7 +256,7 @@ def replace_parameter(
                 # Special case Optional[X] where X is a single type that can optionally be a converter
                 inner = args[0]
                 is_inner_transformer = is_transformer(inner)
-                if is_converter(inner) and not is_inner_transformer:
+                if (is_converter(inner) or inner in CONVERTER_MAPPING) and not is_inner_transformer:
                     param = param.replace(annotation=Optional[ConverterTransformer(inner, original)])
             else:
                 raise


### PR DESCRIPTION
## Summary

This PR fixes an issue where command converters did not work correctly with `C | None` or `Optional[C]`. 

Closes #10239


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
