### PR TITLE
Deprecate Guild.delete and various parameters for Guild.edit

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1986,11 +1986,15 @@ class Guild(Hashable):
         """
         await self._state.http.leave_guild(self.id)
 
+    @utils.deprecated()
     async def delete(self) -> None:
         """|coro|
 
         Deletes the guild. You must be the guild owner to delete the
         guild.
+
+        .. deprecated:: 2.6
+           This method is deprecated and will be removed in a future version.
 
         Raises
         --------


### PR DESCRIPTION
## Summary

This PR deprecates the following parameters for `Guild.edit`:  

- [`mfa_level`](https://github.com/discord/discord-api-docs/commit/a5cb8e55fbf1193eba62e1fd60b68055ccf7da06)  
- [`owner`](https://github.com/discord/discord-api-docs/commit/1d2b9c2b8db8cbb60616097433aeb797a80c98a4)  
- `vanity_code`  

And method, [`Guild.delete`](https://github.com/discord/discord-api-docs/commit/1d2b9c2b8db8cbb60616097433aeb797a80c98a4).


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
