### PR TITLE
fix crash in `Activity.__init__`

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -257,8 +257,8 @@ class Activity(BaseActivity):
         emoji = kwargs.pop('emoji', None)
         self.emoji: Optional[PartialEmoji] = PartialEmoji.from_dict(emoji) if emoji is not None else None
 
-        self.state_url: Optional[str] = kwargs.pop('state_url')
-        self.details_url: Optional[str] = kwargs.pop('details_url')
+        self.state_url: Optional[str] = kwargs.pop('state_url', None)
+        self.details_url: Optional[str] = kwargs.pop('details_url', None)
 
         status_display_type = kwargs.pop('status_display_type', None)
         self.status_display_type: Optional[StatusDisplayType] = (


### PR DESCRIPTION

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This fixes the regression bug from #10227 because not all activity payloads have `state_url` and `details_url` keys present. So without this fix, the bot crashes from unhandled KeyError (trying to pop non-existent key).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
