### PR TITLE
discord/ext/commands/core.py fix attachment converter

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -674,10 +674,11 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
         # Try to detect Optional[discord.Attachment] or discord.Attachment special converter
         if converter is discord.Attachment:
-            try:
-                return next(attachments)
-            except StopIteration:
-                raise MissingRequiredAttachment(param)
+            if not attachments.is_empty():
+                try:
+                    return next(attachments)
+                except StopIteration:
+                    raise MissingRequiredAttachment(param)
 
         if self._is_typing_optional(param.annotation) and param.annotation.__args__[0] is discord.Attachment:
             if attachments.is_empty():


### PR DESCRIPTION
if in hybrid command one option are Attachment class its optional and invoket with chat command with no Attachment its raising error in there place

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

PR fixing issue when HybridCommand that has Attachment Class option as 'optional' invokes as chat command without Attachment

Traceback

[Minimal code to reproduce traceback below](https://github.com/dfilvtov/discord-py-sayubot)

```
2025-08-02 12:48:12 ERROR    discord.ext.commands.bot Ignoring exception in command role edit
Traceback (most recent call last):
  File "<PATH>/.local/lib/python3.10/site-packages/discord/ext/commands/core.py", line 285, in __next__
    value = self.data[self.index]
IndexError: list index out of range

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<PATH>/.local/lib/python3.10/site-packages/discord/ext/commands/core.py", line 678, in transform
    return next(attachments)
  File "<PATH>/.local/lib/python3.10/site-packages/discord/ext/commands/core.py", line 287, in __next__
    raise StopIteration
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<PATH>/.local/lib/python3.10/site-packages/discord/ext/commands/bot.py", line 1366, in invoke
    await ctx.command.invoke(ctx)
  File "<PATH>/.local/lib/python3.10/site-packages/discord/ext/commands/core.py", line 1650, in invoke
    await ctx.invoked_subcommand.invoke(ctx)
  File "<PATH>/.local/lib/python3.10/site-packages/discord/ext/commands/core.py", line 1021, in invoke
    await self.prepare(ctx)
  File "<PATH>/.local/lib/python3.10/site-packages/discord/ext/commands/core.py", line 938, in prepare
    await self._parse_arguments(ctx)
  File "<PATH>/.local/lib/python3.10/site-packages/discord/ext/commands/hybrid.py", line 546, in _parse_arguments
    return await super()._parse_arguments(ctx)
  File "<PATH>/.local/lib/python3.10/site-packages/discord/ext/commands/core.py", line 845, in _parse_arguments
    transformed = await self.transform(ctx, param, attachments)
  File "<PATH>/.local/lib/python3.10/site-packages/discord/ext/commands/core.py", line 680, in transform
    raise MissingRequiredAttachment(param)
discord.ext.commands.errors.MissingRequiredAttachment: display_icon is a required argument that is missing an attachment.
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
