### PR TITLE
Add more Attributes to AppCommandChannel/Thread

### DIFF
--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -779,8 +779,8 @@ class AppCommandThread(Hashable):
     slowmode_delay: :class:`int`
         The number of seconds a member must wait between sending messages
         in this thread. A value of ``0`` denotes that it is disabled.
-        Bots and users with :attr:`~Permissions.manage_channels` or
-        :attr:`~Permissions.manage_messages` bypass slowmode.
+        Bots and users with :attr:`~discord.Permissions.manage_channels` or
+        :attr:`~discord.Permissions.manage_messages` bypass slowmode.
 
         .. versionadded:: 2.6
     message_count: :class:`int`
@@ -881,7 +881,7 @@ class AppCommandThread(Hashable):
 
     @property
     def applied_tags(self) -> List[ForumTag]:
-        """List[:class:`ForumTag`]: A list of tags applied to this thread.
+        """List[:class:`~discord.ForumTag`]: A list of tags applied to this thread.
 
         .. versionadded:: 2.6
         """
@@ -904,7 +904,7 @@ class AppCommandThread(Hashable):
 
     @property
     def flags(self) -> ChannelFlags:
-        """:class:`ChannelFlags`: The flags associated with this thread.
+        """:class:`~discord.ChannelFlags`: The flags associated with this thread.
 
         .. versionadded:: 2.6
         """
@@ -912,7 +912,7 @@ class AppCommandThread(Hashable):
 
     @property
     def owner(self) -> Optional[Member]:
-        """Optional[:class:`Member`]: The member this thread belongs to.
+        """Optional[:class:`~discord.Member`]: The member this thread belongs to.
 
         .. versionadded:: 2.6
         """

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -916,7 +916,7 @@ class AppCommandThread(Hashable):
 
         .. versionadded:: 2.6
         """
-        return self.guild.get_member(self.owner_id)
+        return self.guild.get_member(self.owner_id)  # type: ignore
 
     @property
     def mention(self) -> str:

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -720,6 +720,14 @@ class AppCommandChannel(Hashable):
         return f'<#{self.id}>'
 
     @property
+    def jump_url(self) -> str:
+        """:class:`str`: Returns a URL that allows the client to jump to the channel.
+
+        .. versionadded:: 2.6
+        """
+        return f'https://discord.com/channels/{self.guild_id}/{self.id}'
+
+    @property
     def created_at(self) -> datetime:
         """:class:`datetime.datetime`: An aware timestamp of when this channel was created in UTC."""
         return snowflake_time(self.id)
@@ -841,6 +849,14 @@ class AppCommandThread(Hashable):
     def mention(self) -> str:
         """:class:`str`: The string that allows you to mention the thread."""
         return f'<#{self.id}>'
+
+    @property
+    def jump_url(self) -> str:
+        """:class:`str`: Returns a URL that allows the client to jump to the thread.
+
+        .. versionadded:: 2.6
+        """
+        return f'https://discord.com/channels/{self.guild_id}/{self.id}'
 
     @property
     def created_at(self) -> Optional[datetime]:

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -899,7 +899,8 @@ class AppCommandThread(Hashable):
 
     @property
     def parent(self) -> Optional[Union[ForumChannel, TextChannel]]:
-        """Optional[Union[:class:`~discord.ForumChannel`, :class:`~discord.TextChannel`]]: The parent channel this thread belongs to."""
+        """Optional[Union[:class:`~discord.ForumChannel`, :class:`~discord.TextChannel`]]: The parent channel
+        this thread belongs to."""
         return self.guild.get_channel(self.parent_id)  # type: ignore
 
     @property

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -854,8 +854,8 @@ class AppCommandThread(Hashable):
         self.member_count: int = int(data['member_count'])
         self.message_count: int = int(data['message_count'])
         self.last_message_id: Optional[int] = _get_as_snowflake(data, 'last_message_id')
-        self._applied_tags: array.array[int] = array.array('Q', map(int, data.get('applied_tags', [])))
         self.slowmode_delay: int = data.get('rate_limit_per_user', 0)
+        self._applied_tags: array.array[int] = array.array('Q', map(int, data.get('applied_tags', [])))
         self._flags: int = data.get('flags', 0)
         self._unroll_metadata(data['thread_metadata'])
 

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -79,8 +79,8 @@ class PartialThread(_BasePartialChannel):
     thread_metadata: ThreadMetadata
     parent_id: Snowflake
     applied_tags: NotRequired[List[Snowflake]]
-    owner_id : Snowflake
-    message_count : int
+    owner_id: Snowflake
+    message_count: int
     member_count: int
     rate_limit_per_user: int
     last_message_id: NotRequired[Optional[Snowflake]]

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -78,6 +78,13 @@ class PartialThread(_BasePartialChannel):
     type: ThreadType
     thread_metadata: ThreadMetadata
     parent_id: Snowflake
+    applied_tags: NotRequired[List[Snowflake]]
+    owner_id : Snowflake
+    message_count : int
+    member_count: int
+    rate_limit_per_user: int
+    last_message_id: NotRequired[Optional[Snowflake]]
+    flags: NotRequired[int]
 
 
 class ResolvedData(TypedDict, total=False):


### PR DESCRIPTION
## Summary
This PR adds the `jump_url` property to `AppCommandChannel` and `AppCommandThread`

Decided to add more more attributes to `AppCommandChannel` since I realised there were
more data in the payload while testing.

## Checklist


- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
