### PR TITLE
Upstream change in Python

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -160,9 +160,11 @@ class KeepAliveHandler(threading.Thread):
                     f.result()
                 except Exception:
                     _log.exception('An error occurred while stopping the gateway. Ignoring.')
+                except BaseException as exc:
+                    _log.debug('A BaseException was raised while stopping the gateway', exc_info=exc)
                 finally:
                     self.stop()
-                    return
+                return
 
             data = self.get_payload()
             _log.debug(self.msg, self.shard_id, data['d'])


### PR DESCRIPTION
## Summary

This is a pessimistic change in case you'd rather not deal with whatever upstream says should be done here and want it available before you cut the 2.6 release.

## Details

The prior changes (#9984) to use of return in finally are now insufficient. Without disclosing their intent when raising the issue (#9981), the author used this as part of justifying a SyntaxError for working code outside of the normal process for adding errors, with it presenting to end users in a way that [breaks downstream user's existing CI](https://github.com/Rapptz/discord.py/discussions/10240#discussioncomment-14055608)

While making the change, I've continued to not log errors like CancellationError or TimeoutError to users here by default, as it is not an error they need to be aware of during shutdown given the limited kinds of BaseException that could raise in this context, see:  https://github.com/Rapptz/discord.py/issues/9981#issuecomment-2436146333 for prior analysis. I've added a debug log should anyone want access to this kind of failure while debugging gateway close, but due to how asyncio shutdown happens, this is unlikely to ever log anything useful even in a library debugging context.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
