### PR TITLE
fix avatar_decoration decorator

### DIFF
--- a/discord/asset.py
+++ b/discord/asset.py
@@ -263,7 +263,7 @@ class Asset(AssetMixin):
             state,
             url=f'{cls.BASE}/avatar-decoration-presets/{avatar_decoration}.png?size=96',
             key=avatar_decoration,
-            animated=True,
+            animated=False,
         )
 
     @classmethod


### PR DESCRIPTION
## Summary

The PR fixes the bug that `_from_avatar_decoration` indicates that a `.png` is animated.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
