### PR TITLE
Remove outdated note about having to delete owned guild

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -1977,11 +1977,6 @@ class Guild(Hashable):
 
         Leaves the guild.
 
-        .. note::
-
-            You cannot leave the guild that you own, you must delete it instead
-            via :meth:`delete`.
-
         Raises
         --------
         HTTPException


### PR DESCRIPTION
## Summary

Since bots can no longer own guilds and any leftover ownership has been transferred by Discord already, this note in the `leave` method is no longer relevant

Technically this small change goes alongside #10246 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
