### PR TITLE
Add `total message sent` attribute to threads

### DIFF
--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -791,6 +791,10 @@ class AppCommandThread(Hashable):
         An approximate number of members in this thread. This caps at 50.
 
         .. versionadded:: 2.6
+    total_message_sent: :class:`int`
+        The total number of messages sent, including deleted messages.
+
+        .. versionadded:: 2.6
     permissions: :class:`~discord.Permissions`
         The resolved permissions of the user who invoked
         the application command in that thread.
@@ -830,6 +834,7 @@ class AppCommandThread(Hashable):
         'member_count',
         'slowmode_delay',
         'last_message_id',
+        'total_message_sent',
         '_applied_tags',
         '_flags',
         '_created_at',
@@ -855,6 +860,7 @@ class AppCommandThread(Hashable):
         self.message_count: int = int(data['message_count'])
         self.last_message_id: Optional[int] = _get_as_snowflake(data, 'last_message_id')
         self.slowmode_delay: int = data.get('rate_limit_per_user', 0)
+        self.total_message_sent : int = data.get('total_message_sent')
         self._applied_tags: array.array[int] = array.array('Q', map(int, data.get('applied_tags', [])))
         self._flags: int = data.get('flags', 0)
         self._unroll_metadata(data['thread_metadata'])

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -109,6 +109,10 @@ class Thread(Messageable, Hashable):
         An approximate number of messages in this thread.
     member_count: :class:`int`
         An approximate number of members in this thread. This caps at 50.
+    total_message_sent: :class:`int`
+        The total number of messages sent, including deleted messages.
+
+        .. versionadded:: 2.6
     me: Optional[:class:`ThreadMember`]
         A thread member representing yourself, if you've joined the thread.
         This could not be available.
@@ -152,6 +156,7 @@ class Thread(Messageable, Hashable):
         'archiver_id',
         'auto_archive_duration',
         'archive_timestamp',
+        'total_message_sent',
         '_created_at',
         '_flags',
         '_applied_tags',
@@ -185,6 +190,7 @@ class Thread(Messageable, Hashable):
         self.slowmode_delay: int = data.get('rate_limit_per_user', 0)
         self.message_count: int = data['message_count']
         self.member_count: int = data['member_count']
+        self.total_message_sent : int = data['total_message_sent']
         self._flags: int = data.get('flags', 0)
         # SnowflakeList is sorted, but this would not be proper for applied tags, where order actually matters.
         self._applied_tags: array.array[int] = array.array('Q', map(int, data.get('applied_tags', [])))

--- a/discord/types/channel.py
+++ b/discord/types/channel.py
@@ -126,6 +126,7 @@ class ThreadChannel(_BaseChannel):
     rate_limit_per_user: int
     message_count: int
     member_count: int
+    total_message_sent : int
     thread_metadata: ThreadMetadata
     member: NotRequired[ThreadMember]
     owner_id: NotRequired[Snowflake]

--- a/discord/types/interactions.py
+++ b/discord/types/interactions.py
@@ -85,6 +85,7 @@ class PartialThread(_BasePartialChannel):
     rate_limit_per_user: int
     last_message_id: NotRequired[Optional[Snowflake]]
     flags: NotRequired[int]
+    total_message_sent : int
 
 
 class ResolvedData(TypedDict, total=False):

--- a/discord/types/threads.py
+++ b/discord/types/threads.py
@@ -51,23 +51,22 @@ class ThreadMetadata(TypedDict):
     create_timestamp: NotRequired[str]
 
 
-class ThreadChannel(_BaseChannel):
-    type: Literal[10, 11, 12]
+class Thread(TypedDict):
+    id: Snowflake
     guild_id: Snowflake
     parent_id: Snowflake
     owner_id: Snowflake
-    nsfw: bool
-    last_message_id: Optional[Snowflake]
-    rate_limit_per_user: int
-    message_count: int
+    name: str
+    type: ThreadType
     member_count: int
-    total_message_sent : int
+    message_count: int
+    total_message_sent: int
+    rate_limit_per_user: int
     thread_metadata: ThreadMetadata
     member: NotRequired[ThreadMember]
-    owner_id: NotRequired[Snowflake]
-    rate_limit_per_user: NotRequired[int]
     last_message_id: NotRequired[Optional[Snowflake]]
-    last_pin_timestamp: NotRequired[str]
+    last_pin_timestamp: NotRequired[Optional[Snowflake]]
+    newly_created: NotRequired[bool]
     flags: NotRequired[int]
     applied_tags: NotRequired[List[Snowflake]]
 

--- a/discord/types/threads.py
+++ b/discord/types/threads.py
@@ -51,21 +51,23 @@ class ThreadMetadata(TypedDict):
     create_timestamp: NotRequired[str]
 
 
-class Thread(TypedDict):
-    id: Snowflake
+class ThreadChannel(_BaseChannel):
+    type: Literal[10, 11, 12]
     guild_id: Snowflake
     parent_id: Snowflake
     owner_id: Snowflake
-    name: str
-    type: ThreadType
-    member_count: int
-    message_count: int
+    nsfw: bool
+    last_message_id: Optional[Snowflake]
     rate_limit_per_user: int
+    message_count: int
+    member_count: int
+    total_message_sent : int
     thread_metadata: ThreadMetadata
     member: NotRequired[ThreadMember]
+    owner_id: NotRequired[Snowflake]
+    rate_limit_per_user: NotRequired[int]
     last_message_id: NotRequired[Optional[Snowflake]]
-    last_pin_timestamp: NotRequired[Optional[Snowflake]]
-    newly_created: NotRequired[bool]
+    last_pin_timestamp: NotRequired[str]
     flags: NotRequired[int]
     applied_tags: NotRequired[List[Snowflake]]
 


### PR DESCRIPTION
## Summary

This PR adds the `total_message_sent` attribute to Threads

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
