### PR TITLE
Add `fetch members named` method to `Guild`

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2465,7 +2465,7 @@ class Guild(Hashable):
     async def fetch_members_named(self, name: str, *, limit: Optional[int] = 1000) -> List[Member]:
         """|coro|
 
-        A List[:class:`Member`] whose username or nickname starts
+        Returns a list of members whose username or nickname starts
         with the provided `name`.
 
         .. versionadded:: 2.?
@@ -2476,17 +2476,17 @@ class Guild(Hashable):
         name: :class:`str`
             The string to match a username and nickname against.
         limit: Optional[:class:`int`]
-            The maximum number of members to return. Defaults to 1000.
+            The maximum number of members to return. Max of 1000.
 
         Raises
         ------
         HTTPException
             Getting the members failed.
-
+s
         Returns
         ------
         List[:class:`Member`]
-            A list of members.
+            A list of matched members.
         """
 
         state = self._state

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2462,6 +2462,40 @@ class Guild(Hashable):
 
         return threads
 
+    async def fetch_members_named(self, name: str, *, limit: Optional[int] = 1) -> List[Member]:
+        """A List[:class:`.Member`] members whose username or nickname starts
+        with the provided `name`.
+
+        .. versionadded:: 2.6
+
+
+        Parameters
+        ----------
+        name: :class:`str`
+            The string to match a username and nickname against.
+        limit: Optional[:class:`int`]
+            The maximum number of members to return. Max of 1000, defaults to 1.
+
+        Raises
+        ------
+        HTTPException
+            Getting the members failed.
+        ValueError
+            Maximum number of members to return of 1000 was exceeded.
+
+        Returns
+        ------
+        List[:class:`.Member`]
+            A list of members.
+        """
+
+        if limit > 1000:
+            raise ValueError('Maximum number of members to return was exceeded')
+
+        state = self._state
+        data = await state.http.search_members(name, self.id, limit)
+        return [Member(data=raw_member, guild=self, state=state) for raw_member in data]
+
     async def fetch_members(self, *, limit: Optional[int] = 1000, after: SnowflakeTime = MISSING) -> AsyncIterator[Member]:
         """Retrieves an :term:`asynchronous iterator` that enables receiving the guild's members. In order to use this,
         :meth:`Intents.members` must be enabled.

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2463,7 +2463,7 @@ class Guild(Hashable):
         return threads
 
     async def fetch_members_named(self, name: str, *, limit: Optional[int] = 1) -> List[Member]:
-        """A List[:class:`.Member`] members whose username or nickname starts
+        """A List[:class:`.Member`] whose username or nickname starts
         with the provided `name`.
 
         .. versionadded:: 2.6

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2462,11 +2462,13 @@ class Guild(Hashable):
 
         return threads
 
-    async def fetch_members_named(self, name: str, *, limit: Optional[int] = 1) -> List[Member]:
-        """A List[:class:`.Member`] whose username or nickname starts
+    async def fetch_members_named(self, name: str, *, limit: Optional[int] = 1000) -> List[Member]:
+        """|coro|
+
+        A List[:class:`Member`] whose username or nickname starts
         with the provided `name`.
 
-        .. versionadded:: 2.6
+        .. versionadded:: 2.?
 
 
         Parameters
@@ -2474,23 +2476,18 @@ class Guild(Hashable):
         name: :class:`str`
             The string to match a username and nickname against.
         limit: Optional[:class:`int`]
-            The maximum number of members to return. Max of 1000, defaults to 1.
+            The maximum number of members to return. Defaults to 1000.
 
         Raises
         ------
         HTTPException
             Getting the members failed.
-        ValueError
-            Maximum number of members to return of 1000 was exceeded.
 
         Returns
         ------
-        List[:class:`.Member`]
+        List[:class:`Member`]
             A list of members.
         """
-
-        if limit > 1000:
-            raise ValueError('Maximum number of members to return was exceeded')
 
         state = self._state
         data = await state.http.search_members(name, self.id, limit)

--- a/discord/http.py
+++ b/discord/http.py
@@ -1616,6 +1616,11 @@ class HTTPClient:
         r = Route('GET', '/guilds/{guild_id}/members', guild_id=guild_id)
         return self.request(r, params=params)
 
+    def search_members(self, query: str, guild_id: Snowflake, limit: int) -> Response[List[member.MemberWithUser]]:
+        params: Dict[str, Any] = {'query': query, 'limit': limit}
+        r = Route('GET', '/guilds/{guild_id}/members/search', guild_id=guild_id)
+        return self.request(r, params=params)
+
     def get_member(self, guild_id: Snowflake, member_id: Snowflake) -> Response[member.MemberWithUser]:
         return self.request(Route('GET', '/guilds/{guild_id}/members/{member_id}', guild_id=guild_id, member_id=member_id))
 


### PR DESCRIPTION
## Summary
This PR adds a `fetch_members_named` method to `Guild`.
Docs: https://discord.com/developers/docs/resources/guild#search-guild-members
Somethings I'm unsure of/Things to note:
- Version added is not set, cuz not sure if it is 2.6 or not
- Not sure what to default to here
- Could perhaps add a note to use the property `members` and query the names themselves?
- Not the same as #9912 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
