### PR TITLE
Create .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Replace Black with Ruff, then format whole project.
+44a44e938fb2bd0bb085d8aa4577abeb01653ad3


### PR DESCRIPTION
## Summary

Add a git-specific file to prevent the ruff format run in 44a44e9 from filling git blame's output with non-semantic changes (both the command-line output and the in-browser GitHub Blame UI). It also establishes a (hopefully helpful) precedent for future big formatting changes.

EDIT: It could even be used for older formatting-related commits if the functionality is deemed useful enough.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
