### PR TITLE
Add `channel` attribute to automod quarantine user AuditLogAction

### DIFF
--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -720,7 +720,6 @@ class AuditLogEntry(Hashable):
             _AuditLogProxyStageInstanceAction,
             _AuditLogProxyMessageBulkDelete,
             _AuditLogProxyAutoModAction,
-            _AuditLogProxyAutoModActionQuarantineUser,
             _AuditLogProxyMemberKickOrMemberRoleUpdate,
             Member, User, None, PartialIntegration,
             Role, Object

--- a/discord/audit_logs.py
+++ b/discord/audit_logs.py
@@ -630,11 +630,6 @@ class _AuditLogProxyAutoModAction(_AuditLogProxy):
     channel: Optional[Union[abc.GuildChannel, Thread]]
 
 
-class _AuditLogProxyAutoModActionQuarantineUser(_AuditLogProxy):
-    automod_rule_name: str
-    automod_rule_trigger_type: str
-
-
 class _AuditLogProxyMemberKickOrMemberRoleUpdate(_AuditLogProxy):
     integration_type: Optional[str]
 
@@ -766,6 +761,7 @@ class AuditLogEntry(Hashable):
                 self.action is enums.AuditLogAction.automod_block_message
                 or self.action is enums.AuditLogAction.automod_flag_message
                 or self.action is enums.AuditLogAction.automod_timeout_member
+                or self.action is enums.AuditLogAction.automod_quarantine_user
             ):
                 channel_id = utils._get_as_snowflake(extra, 'channel_id')
                 channel = None
@@ -780,13 +776,6 @@ class AuditLogEntry(Hashable):
                         enums.AutoModRuleTriggerType, int(extra['auto_moderation_rule_trigger_type'])
                     ),
                     channel=channel,
-                )
-            elif self.action is enums.AuditLogAction.automod_quarantine_user:
-                self.extra = _AuditLogProxyAutoModActionQuarantineUser(
-                    automod_rule_name=extra['auto_moderation_rule_name'],
-                    automod_rule_trigger_type=enums.try_enum(
-                        enums.AutoModRuleTriggerType, int(extra['auto_moderation_rule_trigger_type'])
-                    ),
                 )
 
             elif self.action.name.startswith('overwrite_'):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3063,10 +3063,11 @@ of :class:`enum.Enum`.
         a :class:`Member` with the ID of the person who triggered the automod rule.
 
         When this is the action, the type of :attr:`~AuditLogEntry.extra` is
-        set to an unspecified proxy object with 2 attributes:
+        set to an unspecified proxy object with 3 attributes:
 
         - ``automod_rule_name``: The name of the automod rule that was triggered.
         - ``automod_rule_trigger_type``: A :class:`AutoModRuleTriggerType` representation of the rule type that was triggered.
+        - ``channel``: The channel of the message sent by the member when they were flagged. `None` if the member was quarantined when they just joined the guild.
 
         When this is the action, :attr:`AuditLogEntry.changes` is empty.
 


### PR DESCRIPTION
## Summary
This PR adds the `channel` attribute to `automod_quarantine_user` for the its extra attributes.
[Docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info)
This attribute is present when a member sends a message and discord detects that 
their profile violates the automod rule. The `channel`, being the channel of the message sent.

Not really sure how to phrase this in the docs, so feedback is appreciated :p

## Checklist


- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
