### PR TITLE
Add missing `versionadded` to some `BaseView` items

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -335,7 +335,9 @@ class BaseView:
 
     @property
     def total_children_count(self) -> int:
-        """:class:`int`: The total number of children in this view, including those from nested items."""
+        """:class:`int`: The total number of children in this view, including those from nested items.
+
+        .. versionadded:: 2.6"""
         return self._total_children
 
     @classmethod

--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -655,6 +655,8 @@ class BaseView:
         """An iterator that recursively walks through all the children of this view
         and its children, if applicable.
 
+        .. versionadded:: 2.6
+
         Yields
         ------
         :class:`Item`


### PR DESCRIPTION
## Summary

This PR adds `versionadded` strings to `BaseView.total_children_count` and
`BaseView.walk_children`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
