### PR TITLE
Fix Select.required not being applied

### DIFF
--- a/discord/components.py
+++ b/discord/components.py
@@ -396,6 +396,7 @@ class SelectMenu(Component):
             'min_values': self.min_values,
             'max_values': self.max_values,
             'disabled': self.disabled,
+            'required': self.required,
         }
         if self.id is not None:
             payload['id'] = self.id


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
`required` key was not included in the component dict making selects always required in modals
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
