### PR TITLE
Fix spelling in slots for LabelComp, `commponent` -> `component`

### DIFF
--- a/discord/components.py
+++ b/discord/components.py
@@ -1355,11 +1355,11 @@ class LabelComponent(Component):
     __slots__ = (
         'label',
         'description',
-        'commponent',
+        'component',
         'id',
     )
 
-    __repr_info__ = ('label', 'description', 'commponent', 'id,')
+    __repr_info__ = ('label', 'description', 'component', 'id,')
 
     def __init__(self, data: LabelComponentPayload, state: Optional[ConnectionState]) -> None:
         self.component: Component = _component_factory(data['component'], state)  # type: ignore


### PR DESCRIPTION
## Summary
This PR changes the slot attr name from `commponent` -> `component`. Matching the actual attribute.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
