### PR TITLE
Fix various TypeDicts for Unpack

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -124,25 +124,25 @@ if TYPE_CHECKING:
     from .flags import MemberCacheFlags
 
     class _ClientOptions(TypedDict, total=False):
-        max_messages: int
-        proxy: str
-        proxy_auth: aiohttp.BasicAuth
-        shard_id: int
-        shard_count: int
+        max_messages: Optional[int]
+        proxy: Optional[str]
+        proxy_auth: Optional[aiohttp.BasicAuth]
+        shard_id: Optional[int]
+        shard_count: Optional[int]
         application_id: int
         member_cache_flags: MemberCacheFlags
         chunk_guilds_at_startup: bool
-        status: Status
-        activity: BaseActivity
-        allowed_mentions: AllowedMentions
+        status: Optional[Status]
+        activity: Optional[BaseActivity]
+        allowed_mentions: Optional[AllowedMentions]
         heartbeat_timeout: float
         guild_ready_timeout: float
         assume_unsync_clock: bool
         enable_debug_events: bool
         enable_raw_presences: bool
         http_trace: aiohttp.TraceConfig
-        max_ratelimit_timeout: float
-        connector: aiohttp.BaseConnector
+        max_ratelimit_timeout: Optional[float]
+        connector: Optional[aiohttp.BaseConnector]
 
 
 # fmt: off

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -89,8 +89,8 @@ if TYPE_CHECKING:
     PrefixType = Union[_Prefix, _PrefixCallable[BotT]]
 
     class _BotOptions(_ClientOptions, total=False):
-        owner_id: int
-        owner_ids: Collection[int]
+        owner_id: Optional[int]
+        owner_ids: Optional[Collection[int]]
         strip_after_prefix: bool
         case_insensitive: bool
 

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -50,23 +50,13 @@ from typing import (
 from ._types import _BaseCommand, BotT
 
 if TYPE_CHECKING:
-    from typing_extensions import Self, Unpack, TypedDict
+    from typing_extensions import Self
     from discord.abc import Snowflake
     from discord._types import ClientT
 
     from .bot import BotBase
     from .context import Context
-    from .core import Command, _GroupDecoratorKwargs
-
-    class _CogKwargs(TypedDict, total=False, extra_items=Any):
-        name: str
-        group_name: Union[str, app_commands.locale_str]
-        description: str
-        group_description: Union[str, app_commands.locale_str]
-        group_nsfw: bool
-        group_auto_locale_strings: bool
-        group_extras: Dict[Any, Any]
-        command_attrs: _GroupDecoratorKwargs
+    from .core import Command
 
 
 __all__ = (
@@ -181,7 +171,7 @@ class CogMeta(type):
     __cog_app_commands__: List[Union[app_commands.Group, app_commands.Command[Any, ..., Any]]]
     __cog_listeners__: List[Tuple[str, str]]
 
-    def __new__(cls, *args: Any, **kwargs: Unpack[_CogKwargs]) -> CogMeta:
+    def __new__(cls, *args: Any, **kwargs: Any) -> CogMeta:
         name, bases, attrs = args
         if any(issubclass(base, app_commands.Group) for base in bases):
             raise TypeError(

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -45,13 +45,12 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    TypedDict,
 )
 
 from ._types import _BaseCommand, BotT
 
 if TYPE_CHECKING:
-    from typing_extensions import Self, Unpack
+    from typing_extensions import Self, Unpack, TypedDict
     from discord.abc import Snowflake
     from discord._types import ClientT
 
@@ -59,7 +58,7 @@ if TYPE_CHECKING:
     from .context import Context
     from .core import Command, _CommandDecoratorKwargs
 
-    class _CogKwargs(TypedDict, total=False):
+    class _CogKwargs(TypedDict, total=False, extra_items=Any):
         name: str
         group_name: Union[str, app_commands.locale_str]
         description: str

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
 
     from .bot import BotBase
     from .context import Context
-    from .core import Command, _CommandDecoratorKwargs
+    from .core import Command, _GroupDecoratorKwargs
 
     class _CogKwargs(TypedDict, total=False, extra_items=Any):
         name: str
@@ -66,7 +66,7 @@ if TYPE_CHECKING:
         group_nsfw: bool
         group_auto_locale_strings: bool
         group_extras: Dict[Any, Any]
-        command_attrs: _CommandDecoratorKwargs
+        command_attrs: _GroupDecoratorKwargs
 
 
 __all__ = (

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -72,7 +72,7 @@ if TYPE_CHECKING:
         brief: Optional[str]
         usage: Optional[str]
         rest_is_raw: bool
-        aliases: List[str]
+        aliases: Union[List[str], Tuple[str, ...]]
         description: str
         hidden: bool
         checks: List[UserCheck[Context[Any]]]

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -68,9 +68,9 @@ if TYPE_CHECKING:
 
     class _CommandDecoratorKwargs(TypedDict, total=False):
         enabled: bool
-        help: str
-        brief: str
-        usage: str
+        help: Optional[str]
+        brief: Optional[str]
+        usage: Optional[str]
         rest_is_raw: bool
         aliases: List[str]
         description: str

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -449,7 +449,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         self.brief: Optional[str] = kwargs.get('brief')
         self.usage: Optional[str] = kwargs.get('usage')
         self.rest_is_raw: bool = kwargs.get('rest_is_raw', False)
-        self.aliases: Union[List[str], Tuple[str]] = kwargs.get('aliases', [])
+        self.aliases: Union[List[str], Tuple[str, ...]] = kwargs.get('aliases', [])
         self.extras: Dict[Any, Any] = kwargs.get('extras', {})
 
         if not isinstance(self.aliases, (list, tuple)):

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -1070,7 +1070,7 @@ class DefaultHelpCommand(HelpCommand):
         self.width: int = options.pop('width', 80)
         self.indent: int = options.pop('indent', 2)
         self.sort_commands: bool = options.pop('sort_commands', True)
-        self.dm_help: bool = options.pop('dm_help', False)
+        self.dm_help: Optional[bool] = options.pop('dm_help', False)
         self.dm_help_threshold: int = options.pop('dm_help_threshold', 1000)
         self.arguments_heading: str = options.pop('arguments_heading', 'Arguments:')
         self.commands_heading: str = options.pop('commands_heading', 'Commands:')

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -75,7 +75,7 @@ if TYPE_CHECKING:
     class _BaseHelpCommandOptions(_HelpCommandOptions, total=False):
         sort_commands: bool
         dm_help: Optional[bool]
-        dm_help_threshold: Optional[int]
+        dm_help_threshold: int
         no_category: str
         paginator: Paginator
         commands_heading: str
@@ -1365,7 +1365,7 @@ class MinimalHelpCommand(HelpCommand):
         self.sort_commands: bool = options.pop('sort_commands', True)
         self.commands_heading: str = options.pop('commands_heading', 'Commands')
         self.dm_help: Optional[bool] = options.pop('dm_help', False)
-        self.dm_help_threshold: Optional[int] = options.pop('dm_help_threshold', 1000)
+        self.dm_help_threshold: int = options.pop('dm_help_threshold', 1000)
         self.aliases_heading: str = options.pop('aliases_heading', 'Aliases:')
         self.no_category: str = options.pop('no_category', 'No Category')
 

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -394,7 +394,7 @@ class HelpCommand:
 
     def __init__(self, **options: Unpack[_HelpCommandOptions]) -> None:
         self.show_hidden: bool = options.pop('show_hidden', False)
-        self.verify_checks: bool = options.pop('verify_checks', True)
+        self.verify_checks: Optional[bool] = options.pop('verify_checks', True)
         self.command_attrs = attrs = options.pop('command_attrs', {})
         attrs.setdefault('name', 'help')
         attrs.setdefault('help', 'Shows this message')

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -69,13 +69,13 @@ if TYPE_CHECKING:
 
     class _HelpCommandOptions(TypedDict, total=False):
         show_hidden: bool
-        verify_checks: bool
+        verify_checks: Optional[bool]
         command_attrs: _CommandKwargs
 
     class _BaseHelpCommandOptions(_HelpCommandOptions, total=False):
         sort_commands: bool
-        dm_help: bool
-        dm_help_threshold: int
+        dm_help: Optional[bool]
+        dm_help_threshold: Optional[int]
         no_category: str
         paginator: Paginator
         commands_heading: str
@@ -1364,8 +1364,8 @@ class MinimalHelpCommand(HelpCommand):
     def __init__(self, **options: Unpack[_MinimalHelpCommandOptions]) -> None:
         self.sort_commands: bool = options.pop('sort_commands', True)
         self.commands_heading: str = options.pop('commands_heading', 'Commands')
-        self.dm_help: bool = options.pop('dm_help', False)
-        self.dm_help_threshold: int = options.pop('dm_help_threshold', 1000)
+        self.dm_help: Optional[bool] = options.pop('dm_help', False)
+        self.dm_help_threshold: Optional[int] = options.pop('dm_help_threshold', 1000)
         self.aliases_heading: str = options.pop('aliases_heading', 'Aliases:')
         self.no_category: str = options.pop('no_category', 'No Category')
 

--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -67,10 +67,12 @@ if TYPE_CHECKING:
         default_permissions: bool
         nsfw: bool
         description: str
+        case_insensitive: bool
 
     class _HybridGroupDecoratorKwargs(_HybridGroupKwargs, total=False):
         description: Union[str, app_commands.locale_str]
-        fallback: Union[str, app_commands.locale_str]
+        fallback: str
+        fallback_locale: Optional[app_commands.locale_str]
 
 
 __all__ = (

--- a/discord/ext/commands/hybrid.py
+++ b/discord/ext/commands/hybrid.py
@@ -71,7 +71,7 @@ if TYPE_CHECKING:
 
     class _HybridGroupDecoratorKwargs(_HybridGroupKwargs, total=False):
         description: Union[str, app_commands.locale_str]
-        fallback: str
+        fallback: Optional[str]
         fallback_locale: Optional[app_commands.locale_str]
 
 


### PR DESCRIPTION
## Summary

- `discord.Client`
  - `max_messages, proxy, proxy_auth, shard_id, shard_count, status, activity, allowed_mentions, max_ratelimit_timeout, and connector` can be None 
 
- `commands.Bot`
  - `owner_id` and `owner_ids` can be None
 
- `commands.Cog`
  - Remove the Unpack + CogKwargs

- `commands.Command`
  - `help, brief, and usage` can be None 
  - `aliases` can be a tuple too
 
- `commands.HelpCommand`
  - `verify_checks` and `dm_help` can be None
 
- `commands.HybridGroup`
  - Added missing `case_insensitive` kwarg
  - Fixed type of `fallback` being `Union[str, app_commands.locale_str]` instead of `Optional[str]`
  - Added missing `fallback_locale` kwarg with a type of `Optional[app_commands.locale_str]`
 
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
