### PR TITLE
fix typo in LabelComponent's `__repr_info__`

### DIFF
--- a/discord/components.py
+++ b/discord/components.py
@@ -1359,7 +1359,7 @@ class LabelComponent(Component):
         'id',
     )
 
-    __repr_info__ = ('label', 'description', 'component', 'id,')
+    __repr_info__ = ('label', 'description', 'component', 'id')
 
     def __init__(self, data: LabelComponentPayload, state: Optional[ConnectionState]) -> None:
         self.component: Component = _component_factory(data['component'], state)  # type: ignore


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This fixes repr() for LabelComponent to properly show `id=`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
