### PR TITLE
Fix guild template available_tags errors

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2330,7 +2330,7 @@ class ForumTag(Hashable):
     def from_data(cls, *, state: ConnectionState, data: ForumTagPayload) -> Self:
         self = cls.__new__(cls)
         self.name = data['name']
-        self.id = int(data['id'])
+        self.id = int(data.get('id', 0))
         self.moderated = data.get('moderated', False)
 
         emoji_name = data['emoji_name'] or ''

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2486,7 +2486,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         self.default_auto_archive_duration: ThreadArchiveDuration = data.get('default_auto_archive_duration', 1440)
         self.last_message_id: Optional[int] = utils._get_as_snowflake(data, 'last_message_id')
         # This takes advantage of the fact that dicts are ordered since Python 3.7
-        tags = [ForumTag.from_data(state=self._state, data=tag) for tag in data.get('available_tags', [])]
+        tags = [ForumTag.from_data(state=self._state, data=tag) for tag in data.get('available_tags', []) or []]
         self.default_thread_slowmode_delay: int = data.get('default_thread_rate_limit_per_user', 0)
         self.default_layout: ForumLayoutType = try_enum(ForumLayoutType, data.get('default_forum_layout', 0))
         self._available_tags: Dict[int, ForumTag] = {tag.id: tag for tag in tags}


### PR DESCRIPTION
## Summary
Fixes two related errors from `Guild.templates()` both caused by inconsistencies in channel `available_tags`:
 - TypeError when `available_tags` is null (happens for all non-forum channels and forum channels which don't have any tags)
 - KeyError when tags in `available_tags` don't have an 'id' key (happens in the opposite case from the above)

Relevant discord api docs issue: discord/discord-api-docs/issues/7798

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
