### PR TITLE
Update docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -874,6 +874,7 @@ Members
     - avatar
     - username
     - discriminator
+    - primary guild
 
     This requires :attr:`Intents.members` to be enabled.
 


### PR DESCRIPTION
## Summary

Adds primary guilds to the reasons why `on_user_update()` may get called

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
