### PR TITLE
Upgrade outdated syntax with pyupgrade

### DIFF
--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -1164,7 +1164,7 @@ class AppCommandGroup:
         self.name_localizations: Dict[Locale, str] = _to_locale_dict(data.get('name_localizations') or {})
         self.description_localizations: Dict[Locale, str] = _to_locale_dict(data.get('description_localizations') or {})
 
-    def to_dict(self) -> 'ApplicationCommandOption':
+    def to_dict(self) -> ApplicationCommandOption:
         return {
             'name': self.name,
             'type': self.type.value,

--- a/discord/client.py
+++ b/discord/client.py
@@ -963,7 +963,7 @@ class Client:
 
         .. versionadded: 2.0
         """
-        if self._connection._status in set(state.value for state in Status):
+        if self._connection._status in {state.value for state in Status}:
             return Status(self._connection._status)
         return Status.online
 

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -46,7 +46,7 @@ class EmbedProxy:
         return len(self.__dict__)
 
     def __repr__(self) -> str:
-        inner = ', '.join((f'{k}={getattr(self, k)!r}' for k in dir(self) if not k.startswith('_')))
+        inner = ', '.join(f'{k}={getattr(self, k)!r}' for k in dir(self) if not k.startswith('_'))
         return f'EmbedProxy({inner})'
 
     def __getattr__(self, attr: str) -> None:

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 The MIT License (MIT)
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -2843,14 +2843,14 @@ class Message(PartialMessage, Hashable):
             if call_ended:
                 duration = utils._format_call_duration(self.call.duration)  # type: ignore # call can't be None here
                 if missed:
-                    return 'You missed a call from {0.author.name} that lasted {1}.'.format(self, duration)
+                    return f'You missed a call from {self.author.name} that lasted {duration}.'
                 else:
-                    return '{0.author.name} started a call that lasted {1}.'.format(self, duration)
+                    return f'{self.author.name} started a call that lasted {duration}.'
             else:
                 if missed:
-                    return '{0.author.name} started a call. \N{EM DASH} Join the call'.format(self)
+                    return f'{self.author.name} started a call. \N{EM DASH} Join the call'
                 else:
-                    return '{0.author.name} started a call.'.format(self)
+                    return f'{self.author.name} started a call.'
 
         if self.type is MessageType.purchase_notification and self.purchase_notification is not None:
             guild_product_purchase = self.purchase_notification.guild_product_purchase

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -80,9 +80,9 @@ class EventType:
 class EventItem:
     __slots__ = ('type', 'shard', 'error')
 
-    def __init__(self, etype: int, shard: Optional['Shard'], error: Optional[Exception]) -> None:
+    def __init__(self, etype: int, shard: Optional[Shard], error: Optional[Exception]) -> None:
         self.type: int = etype
-        self.shard: Optional['Shard'] = shard
+        self.shard: Optional[Shard] = shard
         self.error: Optional[Exception] = error
 
     def __lt__(self, other: object) -> bool:

--- a/discord/ui/action_row.py
+++ b/discord/ui/action_row.py
@@ -227,8 +227,7 @@ class ActionRow(Item[V]):
             An item in the action row.
         """
 
-        for child in self.children:
-            yield child
+        yield from self.children
 
     def content_length(self) -> int:
         """:class:`int`: Returns the total length of all text content in this action row."""

--- a/discord/ui/section.py
+++ b/discord/ui/section.py
@@ -137,8 +137,7 @@ class Section(Item[V]):
             An item in this section.
         """
 
-        for child in self.children:
-            yield child
+        yield from self.children
         yield self.accessory
 
     def _update_view(self, view) -> None:

--- a/discord/welcome_screen.py
+++ b/discord/welcome_screen.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 The MIT License (MIT)
 


### PR DESCRIPTION
## Summary

This PR updates outdated syntax with pyupgrade. This includes:
- Unnecessary string types while using annotations future
- Usage of `set` instead of curly braces
- Unnecessary parentheses around generator
- Outdated `-*- coding: utf-8 -*-` header
- Usage of f-strings instead of `.format()`
- Usage of `yield from` instead of `yield` in a `for` loop

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
