### PR TITLE
Add `__all__` to `primary_guild` module

### DIFF
--- a/discord/primary_guild.py
+++ b/discord/primary_guild.py
@@ -35,6 +35,10 @@ if TYPE_CHECKING:
     from .types.user import PrimaryGuild as PrimaryGuildPayload
     from typing_extensions import Self
 
+__all__ = (
+    'PrimaryGuild',
+)
+
 
 class PrimaryGuild:
     """Represents the primary guild identity of a :class:`User`


### PR DESCRIPTION
prevents star-all exports like `discord.TYPE_CHECKING` etc