### PR TITLE
Upgrade code by using f-strings and yield from

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -2843,14 +2843,14 @@ class Message(PartialMessage, Hashable):
             if call_ended:
                 duration = utils._format_call_duration(self.call.duration)  # type: ignore # call can't be None here
                 if missed:
-                    return 'You missed a call from {0.author.name} that lasted {1}.'.format(self, duration)
+                    return f'You missed a call from {self.author.name} that lasted {duration}.'
                 else:
-                    return '{0.author.name} started a call that lasted {1}.'.format(self, duration)
+                    return f'{self.author.name} started a call that lasted {duration}.'
             else:
                 if missed:
-                    return '{0.author.name} started a call. \N{EM DASH} Join the call'.format(self)
+                    return f'{self.author.name} started a call. \N{EM DASH} Join the call'
                 else:
-                    return '{0.author.name} started a call.'.format(self)
+                    return f'{self.author.name} started a call.'
 
         if self.type is MessageType.purchase_notification and self.purchase_notification is not None:
             guild_product_purchase = self.purchase_notification.guild_product_purchase

--- a/discord/ui/action_row.py
+++ b/discord/ui/action_row.py
@@ -227,8 +227,7 @@ class ActionRow(Item[V]):
             An item in the action row.
         """
 
-        for child in self.children:
-            yield child
+        yield from self.children
 
     def content_length(self) -> int:
         """:class:`int`: Returns the total length of all text content in this action row."""

--- a/discord/ui/section.py
+++ b/discord/ui/section.py
@@ -137,8 +137,7 @@ class Section(Item[V]):
             An item in this section.
         """
 
-        for child in self.children:
-            yield child
+        yield from self.children
         yield self.accessory
 
     def _update_view(self, view) -> None:


### PR DESCRIPTION
## Summary

This PR upgrades some outdated code patterns that might got missed in the past including:
- f-strings instead of `.format()`
- `yield from` instead of `yield` in a for loop

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
