### PR TITLE
Add silent parameter to ForumChannel.create_thread

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2879,6 +2879,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         applied_tags: Sequence[ForumTag] = ...,
         view: LayoutView,
         suppress_embeds: bool = ...,
+        silent: bool = ...,
         reason: Optional[str] = ...,
     ) -> ThreadWithMessage: ...
 
@@ -2901,6 +2902,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         applied_tags: Sequence[ForumTag] = ...,
         view: View = ...,
         suppress_embeds: bool = ...,
+        silent: bool = ...,
         reason: Optional[str] = ...,
     ) -> ThreadWithMessage: ...
 
@@ -2922,6 +2924,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         applied_tags: Sequence[ForumTag] = MISSING,
         view: BaseView = MISSING,
         suppress_embeds: bool = False,
+        silent: bool = False,
         reason: Optional[str] = None,
     ) -> ThreadWithMessage:
         """|coro|
@@ -2976,6 +2979,11 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
             A list of stickers to upload. Must be a maximum of 3.
         suppress_embeds: :class:`bool`
             Whether to suppress embeds for the message. This sends the message without any embeds if set to ``True``.
+        silent: :class:`bool`
+            Whether to suppress push and desktop notifications for the message. This will increment the mention counter
+            in the UI, but will not actually send a notification.
+
+            .. versionadded:: 2.2
         reason: :class:`str`
             The reason for creating a new thread. Shows up on the audit log.
 
@@ -3008,8 +3016,10 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         if view and not hasattr(view, '__discord_ui_view__'):
             raise TypeError(f'view parameter must be View not {view.__class__.__name__}')
 
-        if suppress_embeds:
-            flags = MessageFlags._from_value(4)
+        if suppress_embeds or silent:
+            flags = MessageFlags._from_value(0)
+            flags.suppress_embeds = suppress_embeds
+            flags.suppress_notifications = silent
         else:
             flags = MISSING
 


### PR DESCRIPTION
## Summary

This pull request adds the silent parameter to ForumChannel.create_thread to use the corresponding MessageFlags.suppress_notifications for the initial message in a Forum thread.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes. (Hope I didn´t forget anything)
- [] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

## Additional question:

In the docstring I have mentioned this has been added since 2.2 because I am sure this just was forgotten somehow or should this be the version when this pr is published and if yes which version number?
