### PR TITLE
fix(commands): discord.Attachment optional arg

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -709,6 +709,8 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
         # Try to detect Optional[discord.Attachment] or discord.Attachment special converter
         if converter is discord.Attachment:
+            if attachments.is_empty():
+                return None if param.default is param.empty else param.default
             try:
                 return next(attachments)
             except StopIteration:


### PR DESCRIPTION
## Summary

This pull request fixes an issue with the discord.Attachment argument raising the MissingRequiredArgument when that argument is actually set as None (optional).

Example:

arg: discord.Attachment = None

Instead it was only possible to bypass the issue it with typing.Optional.
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
