### PR TITLE
Allow thread=None in Webhook.send()

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1894,7 +1894,7 @@ class Webhook(BaseWebhook):
         ) as params:
             adapter = async_context.get()
             thread_id: Optional[int] = None
-            if thread is not MISSING:
+            if thread:
                 thread_id = thread.id
 
             data = await adapter.execute_webhook(
@@ -1959,7 +1959,7 @@ class Webhook(BaseWebhook):
             raise ValueError('This webhook does not have a token associated with it')
 
         thread_id: Optional[int] = None
-        if thread is not MISSING:
+        if thread:
             thread_id = thread.id
 
         adapter = async_context.get()
@@ -2102,7 +2102,7 @@ class Webhook(BaseWebhook):
             previous_allowed_mentions=previous_mentions,
         ) as params:
             thread_id: Optional[int] = None
-            if thread is not MISSING:
+            if thread:
                 thread_id = thread.id
 
             adapter = async_context.get()
@@ -2164,7 +2164,7 @@ class Webhook(BaseWebhook):
             raise ValueError('This webhook does not have a token associated with it')
 
         thread_id: Optional[int] = None
-        if thread is not MISSING:
+        if thread:
             thread_id = thread.id
 
         adapter = async_context.get()


### PR DESCRIPTION
Fixes https://github.com/Rapptz/discord.py/issues/10313

## Summary

Allow thread=None in Webhook.send() by checking `thread` instead of `thread is MISSING`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
