### PR TITLE
Use compression.zstd for gateway compression on Python 3.14

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -71,12 +71,13 @@ import types
 import typing
 import warnings
 import logging
-import zlib
 
 import yarl
 
 if sys.version_info >= (3, 14):
     import compression.zstd
+else:
+    import zlib
 
 try:
     import orjson  # type: ignore

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -75,6 +75,9 @@ import zlib
 
 import yarl
 
+if sys.version_info >= (3, 14):
+    import compression.zstd
+
 try:
     import orjson  # type: ignore
 except ModuleNotFoundError:
@@ -1432,6 +1435,21 @@ if _HAS_ZSTD:
         def __init__(self) -> None:
             decompressor = zstandard.ZstdDecompressor()
             self.context = decompressor.decompressobj()
+
+        def decompress(self, data: bytes, /) -> str | None:
+            # Each WS message is a complete gateway message
+            return self.context.decompress(data).decode('utf-8')
+
+    _ActiveDecompressionContext: Type[_DecompressionContext] = _ZstdDecompressionContext
+elif sys.version_info >= (3, 14):
+
+    class _ZstdDecompressionContext:
+        __slots__ = ('context',)
+
+        COMPRESSION_TYPE: str = 'zstd-stream'
+
+        def __init__(self) -> None:
+            self.context = compression.zstd.ZstdDecompressor()
 
         def decompress(self, data: bytes, /) -> str | None:
             # Each WS message is a complete gateway message

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ speed = [
     "aiodns>=1.1; sys_platform != 'win32'",
     "Brotli",
     "cchardet==2.1.7; python_version < '3.10'",
-    "zstandard>=0.23.0"
+    "zstandard>=0.23.0; python_version <= '3.13'"
 ]
 test = [
     "coverage[toml]",


### PR DESCRIPTION
## Summary

This PR adds [`compression.zstd`](https://docs.python.org/3.14/library/compression.zstd.html), introduce d in Python 3.14, as a fallback when the `zstandard` module is not available. `zstandard` is still preferred because it might come bundled with a newer zstd version than Python.

The `zstandard` dependency in the `speed` extras has also been limited to Python 3.13 and below.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
