### PR TITLE
fix: do not assume Python 3.14 has compression.zstd

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -87,7 +87,7 @@ try:
     _HAS_ZSTD = True
 except ImportError:
     try:
-        from compression.zstd import ZstdDecompressor
+        from compression.zstd import ZstdDecompressor  # type: ignore
     except ImportError:
         import zlib
 


### PR DESCRIPTION
## Summary

It turns out the new `compression.zstd` module in 3.14 is optional.

References: https://github.com/aio-libs/aiohttp/issues/11603 https://github.com/python/cpython/issues/139707

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
