### PR TITLE
Fix inaccurate `total_children_count` property in modals

### DIFF
--- a/discord/ui/label.py
+++ b/discord/ui/label.py
@@ -139,3 +139,8 @@ class Label(Item[V]):
 
     def is_dispatchable(self) -> bool:
         return False
+
+    @property
+    def _total_count(self) -> int:
+        # Count the component and ourselves
+        return 2


### PR DESCRIPTION
## Summary
This PR fixes the `total_children_count` property in modals returning an inaccurate value when
`ui.Label` is added using the `add_item` method.
`ui.Label` should always return 2 items (`ui.Label` + Component), but rn returns only 1 in `_total_count`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
