### PR TITLE
New timestamp format style

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1232,7 +1232,7 @@ def format_dt(dt: datetime.datetime, /, style: Optional[TimestampStyle] = None) 
     This allows for a locale-independent way of presenting data using Discord specific Markdown.
 
     +-------------+--------------------------------+-------------------------+
-    |    Style    |       Example Output           |       Description       |
+    |    Style    |        Example Output          |       Description       |
     +=============+================================+=========================+
     | t           | 22:57                          | Short Time              |
     +-------------+--------------------------------+-------------------------+


### PR DESCRIPTION
## Summary
This PR adds the new `s` and `S` timestamp format styles and updates the example output.
Relevant PR: https://github.com/discord/discord-api-docs/pull/7922

Ion think a version added this needed for this right?

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
