### PR TITLE
Make description optional & fix emoji display in Guild.create_sticker

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3104,7 +3104,8 @@ class Guild(Hashable):
         name: :class:`str`
             The sticker name. Must be between 2 and 30 characters.
         description: :class:`str`
-            The sticker's description. Must be between 2 and 100 characters.
+            The sticker's description. Can be an empty string or a string between 2 and 100 characters.
+            Defaults to an empty string if not provided.
         emoji: :class:`str`
             The emoji tag associated with the sticker. This corresponds to the
             ``tags`` field in Discord's API, which is used for emoji autocomplete


### PR DESCRIPTION
## Summary

- Made the `description` parameter optional and default to an empty string to match Discord's API behavior
- Removed the Unicode name conversion which causes display issues on the client UI, as Discord doesn't actually validate this input at all, and expects a raw Unicode emoji to render properly

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)