### PR TITLE
Detach view from item when removed

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -439,6 +439,7 @@ class BaseView:
             pass
         else:
             self._add_count(-item._total_count)
+            item._update_view(None)
 
         return self
 
@@ -448,6 +449,9 @@ class BaseView:
         This function returns the class instance to allow for fluent-style
         chaining.
         """
+        for child in self._children:
+            child._update_view(None)
+
         self._children.clear()
         self._total_children = 0
         return self
@@ -744,6 +748,8 @@ class View(BaseView):
             pass
         else:
             self.__weights.remove_item(item)
+            item._update_view(None)
+
         return self
 
     def clear_items(self) -> Self:


### PR DESCRIPTION
## Summary

This PR ensures that when an item is removed or cleared from a view, it no longer has an attached view.

This caused issues, particularly with LayoutView and Container. When calling clear_items on both and then adding items only to the container, it would still count as if it was a child of the previously attached view. This resulted in a wrong count and a subsequent error when trying to add the container to the view, as the counts would be added again and thus doubled.

More context: https://discord.com/channels/336642139381301249/1345167602304946206/1437942915568767036
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
