### PR TITLE
Remove PublicUserFlag.active_developer

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -574,7 +574,6 @@ class UserFlags(Enum):
     discord_certified_moderator = 262144
     bot_http_interactions = 524288
     spammer = 1048576
-    active_developer = 4194304
 
 
 class ActivityType(Enum):

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -719,14 +719,6 @@ class PublicUserFlags(BaseFlags):
         """
         return UserFlags.spammer.value
 
-    @flag_value
-    def active_developer(self):
-        """:class:`bool`: Returns ``True`` if the user is an active developer.
-
-        .. versionadded:: 2.1
-        """
-        return UserFlags.active_developer.value
-
     def all(self) -> List[UserFlags]:
         """List[:class:`UserFlags`]: Returns all public flags the user has."""
         return [public_flag for public_flag in UserFlags if self._has_flag(public_flag.value)]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2008,12 +2008,6 @@ of :class:`enum.Enum`.
 
         .. versionadded:: 2.0
 
-    .. attribute:: active_developer
-
-        The user is an active developer.
-
-        .. versionadded:: 2.1
-
 .. class:: ActivityType
 
     Specifies the type of :class:`Activity`. This is used to check how to

--- a/docs/locale/ja/LC_MESSAGES/api.po
+++ b/docs/locale/ja/LC_MESSAGES/api.po
@@ -22483,10 +22483,6 @@ msgstr "ユーザーがHTTPインタラクションのみを使用するボッ�
 msgid "Returns ``True`` if the user is flagged as a spammer by Discord."
 msgstr "ユーザーがDiscordによりスパマーとフラグ付けされている場合 ``True`` を返します。"
 
-#: ../../docstring of discord.PublicUserFlags.active_developer:1
-msgid "Returns ``True`` if the user is an active developer."
-msgstr "ユーザーがアクティブな開発者の場合に ``True`` を返します。"
-
 #: ../../../discord/flags.py:docstring of discord.flags.PublicUserFlags.all:1
 msgid "List[:class:`UserFlags`]: Returns all public flags the user has."
 msgstr "List[:class:`UserFlags`]: ユーザーが持つすべての公開フラグを返します。"


### PR DESCRIPTION
## Summary

Remove PublicUserFlag.active_developer because discord has discontinued that flag/badge. Refrerence https://support-dev.discord.com/hc/en-us/articles/10113997751447-Active-Developer-Badge

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
