### PR TITLE
Add env parameter to FFmpegAudio subclasses

### DIFF
--- a/discord/player.py
+++ b/discord/player.py
@@ -300,7 +300,7 @@ class FFmpegPCMAudio(FFmpegAudio):
         to the stdin of ffmpeg. Defaults to ``False``.
     stderr: Optional[:term:`py:file object`]
         A file-like object to pass to the Popen constructor.
-    env: Optional[:class:`Mapping[:class:`str`, :class:`str`]`]
+    env: Optional[Mapping[:class:`str`, :class:`str`]]
         A :class:`Mapping` that defines the environment variables for the Popen constructor.
     before_options: Optional[:class:`str`]
         Extra command line arguments to pass to ffmpeg before the ``-i`` flag.
@@ -413,7 +413,7 @@ class FFmpegOpusAudio(FFmpegAudio):
         to the stdin of ffmpeg. Defaults to ``False``.
     stderr: Optional[:term:`py:file object`]
         A file-like object to pass to the Popen constructor.
-    env: Optional[:class:`Mapping[:class:`str`, :class:`str`]`]
+    env: Optional[Mapping[:class:`str`, :class:`str`]]
         A :class:`Mapping` that defines the environment variables for the Popen constructor.
     before_options: Optional[:class:`str`]
         Extra command line arguments to pass to ffmpeg before the ``-i`` flag.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Add `env` parameter to `FFmpegPCMAudio` and `FFmpegOpusAudio` so that the FFmpeg subprocess can run with custom environment variables.
This is useful for uniquely defining environment variables for each ffmpeg subprocess, such as `FFREPORT`, which controls the file that FFmpeg logs to ([relevant docs](https://www.ffmpeg.org/ffmpeg.html#:~:text=FFREPORT)).

Example:
```python
source = discord.FFmpegPCMAudio(
    "audio.mp3",
    env={"FFREPORT": "file=ffmpeg.log:level=32"}
)
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
