### PR TITLE
Add generics to Interaction params

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -1802,7 +1802,7 @@ class Group:
                 yield from command.walk_commands()
 
     @mark_overrideable
-    async def on_error(self, interaction: Interaction, error: AppCommandError, /) -> None:
+    async def on_error(self, interaction: Interaction[ClientT], error: AppCommandError, /) -> None:
         """|coro|
 
         A callback that is called when a child's command raises an :exc:`AppCommandError`.
@@ -1850,7 +1850,7 @@ class Group:
         self.on_error = coro  # type: ignore
         return coro
 
-    async def interaction_check(self, interaction: Interaction, /) -> bool:
+    async def interaction_check(self, interaction: Interaction[ClientT], /) -> bool:
         """|coro|
 
         A callback that is called when an interaction happens within the group

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -646,7 +646,9 @@ class Cog(metaclass=CogMeta):
         pass
 
     @_cog_special_method
-    async def cog_app_command_error(self, interaction: discord.Interaction, error: app_commands.AppCommandError) -> None:
+    async def cog_app_command_error(
+        self, interaction: discord.Interaction[ClientT], error: app_commands.AppCommandError
+    ) -> None:
         """|coro|
 
         A special method that is called whenever an error within


### PR DESCRIPTION
## Summary

ty gives this,

<img width="1927" height="551" alt="image" src="https://github.com/user-attachments/assets/97f15cef-d198-4da6-8097-f7bec45b15c1" />

Allows `interaction.client` to narrow to the bot class instead of the basic discord.Client.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
