### PR TITLE
Remove black config and transition isort config to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,12 +86,11 @@ packages = [
 ]
 include-package-data = true
 
-[tool.black]
-line-length = 125
-skip-string-normalization = true
-
 [tool.ruff]
 line-length = 125
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
 
 [tool.ruff.format]
 line-ending = "lf"
@@ -109,12 +108,6 @@ exclude_lines = [
     "pragma: no cover",
     "@overload",
 ]
-
-[tool.isort]
-profile = "black"
-combine_as_imports = true
-combine_star = true
-line_length = 125
 
 [tool.pyright]
 include = [


### PR DESCRIPTION
## Summary

Since ruff is now the chosen formatter for this project, the old config for black and isort is superfluous.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
