### PR TITLE
[tasks] reset exponential backoff after task runs successfully

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -245,6 +245,7 @@ class Loop(Generic[LF]):
                 try:
                     await self.coro(*args, **kwargs)
                     self._last_iteration_failed = False
+                    backoff = ExponentialBackoff()
                 except self._valid_exception:
                     self._last_iteration_failed = True
                     if not self.reconnect:


### PR DESCRIPTION
## Summary

Fix unexpected behavior (?) of tasks

The current behaviour of the _loop method (when the reconnect attribute is set to True) is to have the same ExponentialBackoff instance for all of its lifetime. A task that has failed n (when n is less than 11) times over its life-time will thus wait 2**n seconds before retrying, no matter how many successful instances of happened between the failures.

With this commit, the behaviour is to reset the exponential backoff after a succesful execution of the task, so that the backoff only takes place after successive failures.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes (no mention in documentation).
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
