### PR TITLE
Change join thread from POST to PUT

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -1345,7 +1345,7 @@ class HTTPClient:
             return self.request(r, json=params.payload, params=query, reason=reason)
 
     def join_thread(self, channel_id: Snowflake) -> Response[None]:
-        return self.request(Route('POST', '/channels/{channel_id}/thread-members/@me', channel_id=channel_id))
+        return self.request(Route('PUT', '/channels/{channel_id}/thread-members/@me', channel_id=channel_id))
 
     def add_user_to_thread(self, channel_id: Snowflake, user_id: Snowflake) -> Response[None]:
         return self.request(


### PR DESCRIPTION
## Summary

Fix method of [/channels/{channel.id}/thread-members/@me](https://discord.com/developers/docs/resources/channel#join-thread), which notably moves the rate limit from guild to global.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
