### PR TITLE
Fix documentation for `User.display_name`

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -313,9 +313,7 @@ class BaseUser(_UserTag):
     def display_name(self) -> str:
         """:class:`str`: Returns the user's display name.
 
-        For regular users this is just their global name or their username,
-        but if they have a guild specific nickname then that
-        is returned instead.
+        This is the user's global name or username
         """
         if self.global_name:
             return self.global_name


### PR DESCRIPTION
## Summary

The `User.display_name` docstring is a copy of `Member.display_name` one, but it does not actually try to fetch a guild-specific display_name 
https://github.com/Rapptz/discord.py/blob/master/discord/user.py#L313
```python
    @property
    def display_name(self) -> str:
        """:class:`str`: Returns the user's display name.

        For regular users this is just their global name or their username,
        but if they have a guild specific nickname then that
        is returned instead.
        """
        if self.global_name:
            return self.global_name
        return self.name
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
