### PR TITLE
Add Discord timestamp converter and transformer

### DIFF
--- a/discord/ext/commands/errors.py
+++ b/discord/ext/commands/errors.py
@@ -79,7 +79,7 @@ __all__ = (
     'SoundboardSoundNotFound',
     'PartialEmojiConversionFailure',
     'BadBoolArgument',
-    'BadDatetimeArgument',
+    'BadTimestampArgument',
     'MissingRole',
     'BotMissingRole',
     'MissingAnyRole',
@@ -603,8 +603,8 @@ class BadBoolArgument(BadArgument):
         super().__init__(f'{argument} is not a recognised boolean option')
 
 
-class BadDatetimeArgument(BadArgument):
-    """Exception raised when a datetime argument was not convertable.
+class BadTimestampArgument(BadArgument):
+    """Exception raised when a timestamp argument was not convertable.
 
     This inherits from :exc:`BadArgument`
 
@@ -613,7 +613,7 @@ class BadDatetimeArgument(BadArgument):
     Attributes
     -----------
     argument: :class:`str`
-        The datetime/timestamp argument supplied by the caller that is not in the predefined list
+        The datetime/timestamp argument supplied by the caller that was not a valid timestamp format.
     """
 
     def __init__(self, argument: str) -> None:

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -536,6 +536,11 @@ Converters
 .. autoclass:: discord.ext.commands.SoundboardSoundConverter
     :members:
 
+.. attributetable:: discord.ext.commands.Timestamp
+
+.. autoclass:: discord.ext.commands.Timestamp
+    :members:
+
 .. attributetable:: discord.ext.commands.clean_content
 
 .. autoclass:: discord.ext.commands.clean_content

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -247,14 +247,6 @@ Unlike the other basic converters, the :class:`bool` converter is treated slight
     elif lowered in ('no', 'n', 'false', 'f', '0', 'disable', 'off'):
         return False
 
-datetime.datetime
-^^^^^^^^^^^^^^^^^^^
-
-Additionally, the :class:`datetime.datetime` converter is also handled differently due to it's support around Discord's ``@time`` timestamp input.
-This converter expects input in the format of a :ddocs:`Discord style timestamp <reference#message-formatting>`.
-
-.. warning:: Due to a Discord limitation, this datetime will not have the timezone information, as such the UTC timezone has been supplanted for ease of conversion.
-
 .. _ext_commands_adv_converters:
 
 Advanced Converters

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -1076,6 +1076,14 @@ Range
 .. autoclass:: discord.app_commands.Range
     :members:
 
+Timestamp
+++++++++++
+
+.. attributetable:: discord.app_commands.Timestamp
+
+.. autoclass:: discord.app_commands.Timestamp
+    :members:
+
 Translations
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary

This PR adds both a converter and transformer for use with Discord's timestamp functionality. This is made easier for the end user with the addition of the `@time` utility in the client, and as such I felt the need to support this.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
