### PR TITLE
Add support for sending finished views in stateless application webhooks

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1859,7 +1859,11 @@ class Webhook(BaseWebhook):
             if not hasattr(view, '__discord_ui_view__'):
                 raise TypeError(f'expected view parameter to be of type View not {view.__class__.__name__}')
 
-            if isinstance(self._state, _WebhookState) and view.is_dispatchable():
+            if (
+                isinstance(self._state, _WebhookState)
+                and (not application_webhook or not view.is_finished())
+                and view.is_dispatchable()
+            ):
                 raise ValueError(
                     'Webhook views with any component other than URL buttons require an associated state with the webhook'
                 )


### PR DESCRIPTION
## Summary

As a deferred Discord application command results in an application webhook that can be used to do the follow-up statelessly, it can be used directly by the bot client to offload a deferred interaction to another stateless machine by providing the webhook url (or equivalently, application id + token) and the interaction data:
```py
# ... handle the received interation data just like what the bot client would do ...

# do the interaction.followup.send statelessly
webhook = discord.Webhook.from_url(
    url = ..., # https://discord(app)?.com/api/webhooks/{application_id}/{token}
    session = await get_session() # an existing aiohttp.ClientSession within the machine process
)
webhook.type = discord.WebhookType.application # it would be nice if Webhook.from_url allows specifying so, but as long as it works
return await webhook.send(content, ephemeral=ephemeral, wait=True, **kwargs) # wait = True is set automatically for application webhook anyways
```

A special case is that this stateless machine may send messages with views.
If persistent views are utilized, it is useful to send a stopped view with interactive components with `custom_id` set, so interactions done by users to the components can still be picked up later by the persistent view in the bot client according to the current Discord.py mechanism.

This PR follows the PR #10089 that allows stateless webhooks to send views. That PR only allows views without dispatchable components to be sent via stateless webhooks.

Unlike normal webhooks, Discord API allows deferred application interactions follow-up `send` to act like a direct `send_message` call in most scenarios since it's introduced without restrictions in normal stateless webhooks as addressed in #10089.

The `is_finished` condition followed exactly as the condition that checks whether to do `self._state.store_view` later, i.e.
```py
if view is not MISSING and not view.is_finished() and view.is_dispatchable():
    message_id = None if msg is None else msg.id
    self._state.store_view(view, message_id)
```
, which infers that a "finished" view is already inherently supported by this coroutine method.

Therefore, the current _WebhookState ValueError check done in discord.py does not need to block finished views from being sent, as a "finished" view used this way would not be `store`d or `wait`ed to trigger callbacks anyways. This unlocks the full potential for application webhooks initialized without any client state to work.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
