### PR TITLE
Handle asyncio.CancelledError during WebSocket event polling - v2.6.x

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -724,7 +724,11 @@ class Client:
                 self.ws = await asyncio.wait_for(coro, timeout=60.0)
                 ws_params['initial'] = False
                 while True:
-                    await self.ws.poll_event()
+                    try:
+                        await self.ws.poll_event()
+                    except asyncio.CancelledError:
+                        _log.debug("WebSocket poll_event cancelled (likely disconnect).")
+                        return
             except ReconnectWebSocket as e:
                 _log.debug('Got a request to %s the websocket.', e.op)
                 self.dispatch('disconnect')


### PR DESCRIPTION
## Summary

This PR fixes an unhandled asyncio.CancelledError that occurs in Client.connect() when ws.poll_event() is cancelled (e.g., during bot shutdown or disconnects) in Python 3.12. By catching this exception, the bot can shut down cleanly without raising tracebacks, while keeping reconnect logic intact.

## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)