### PR TITLE
Add guild and user context to autocomplete logs

### DIFF
--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -1289,7 +1289,12 @@ class CommandTree(Generic[ClientT]):
                 await command._invoke_autocomplete(interaction, focused, namespace)
             except Exception:
                 # Suppress exception since it can't be handled anyway.
-                _log.exception('Ignoring exception in autocomplete for %r', command.qualified_name)
+                _log.exception(
+                    'Ignoring exception in autocomplete for %r (Guild: %s, User: %s)',
+                    command.qualified_name,
+                    interaction.guild_id,
+                    interaction.user.id,
+                )
 
             return
 


### PR DESCRIPTION
## Summary

This PR improves visibility when autocomplete fails or times out (e.g., `10062: Unknown interaction`) by adding missing context to the logs, as discussed [here](https://discord.com/channels/336642139381301249/1462060008849277009).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
