### PR TITLE
Exclude category property from CategoryChannel docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5453,6 +5453,7 @@ CategoryChannel
 .. autoclass:: CategoryChannel()
     :members:
     :inherited-members:
+    :exclude-members: category
 
 DMChannel
 ~~~~~~~~~


### PR DESCRIPTION
## Summary

This PR hides the category property from the CategoryChannel documentation.

Since `CategoryChannel` inherits from `abc.GuildChannel`, it currently displays a category attribute in the documentation.  
However, this property always returns None for this class, since there are no nested categories.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
