### PR TITLE
Fix ``(Sync)Webhook.edit_message`` missing the ``view`` parameter

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -1871,9 +1871,7 @@ class Webhook(BaseWebhook):
                 raise TypeError(f'expected view parameter to be of type View or LayoutView, not {view.__class__.__name__}')
 
             if isinstance(self._state, _WebhookState) and view.is_dispatchable():
-                raise ValueError(
-                    'Webhook views with interactable components require an associated state with the webhook'
-                )
+                raise ValueError('Webhook views with interactable components require an associated state with the webhook')
 
             if ephemeral is True and view.timeout is None and view.is_dispatchable():
                 view.timeout = 15 * 60.0
@@ -2102,9 +2100,7 @@ class Webhook(BaseWebhook):
                 raise TypeError(f'expected view parameter to be of type View or LayoutView, not {view.__class__.__name__}')
 
             if isinstance(self._state, _WebhookState) and view.is_dispatchable():
-                raise ValueError(
-                    'Webhook views with interactable components require an associated state with the webhook'
-                )
+                raise ValueError('Webhook views with interactable components require an associated state with the webhook')
 
         previous_mentions: Optional[AllowedMentions] = getattr(self._state, 'allowed_mentions', None)
         with handle_message_parameters(

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -1299,9 +1299,7 @@ class SyncWebhook(BaseWebhook):
                 raise TypeError(f'expected view parameter to be of type View or LayoutView, not {view.__class__.__name__}')
 
             if view.is_dispatchable():
-                raise ValueError(
-                    'SyncWebhooks can not send interactable components'
-                )
+                raise ValueError('SyncWebhooks can not send interactable components')
 
         previous_mentions: Optional[AllowedMentions] = getattr(self._state, 'allowed_mentions', None)
         with handle_message_parameters(


### PR DESCRIPTION
## Summary

``SyncWebhook`` and ``Webhook`` both missed the ``view=`` parameter in their ``edit_message`` function. This includes the ``SyncWebhookMessage`` and ``WebhookMessage``'s ``edit`` method.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
