### PR TITLE
Add with_components query parameter to webhook message edits

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -364,6 +364,7 @@ class AsyncWebhookAdapter:
         multipart: Optional[List[Dict[str, Any]]] = None,
         files: Optional[Sequence[File]] = None,
         thread_id: Optional[int] = None,
+        with_components: bool = False,
     ) -> Response[MessagePayload]:
         route = Route(
             'PATCH',
@@ -372,7 +373,12 @@ class AsyncWebhookAdapter:
             webhook_token=token,
             message_id=message_id,
         )
-        params = None if thread_id is None else {'thread_id': thread_id}
+        params: Dict[str, Any] = {}
+        if thread_id is not None:
+            params['thread_id'] = thread_id
+        if with_components:
+            params['with_components'] = int(with_components)
+        params = params or None  # type: ignore
         return self.request(
             route,
             session=session,
@@ -2117,6 +2123,7 @@ class Webhook(BaseWebhook):
                 multipart=params.multipart,
                 files=params.files,
                 thread_id=thread_id,
+                with_components=view is not MISSING,
             )
 
         message = self._create_message(data, thread=thread)

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -329,6 +329,7 @@ class WebhookAdapter:
         multipart: Optional[List[Dict[str, Any]]] = None,
         files: Optional[Sequence[File]] = None,
         thread_id: Optional[int] = None,
+        with_components: bool = False,
     ) -> MessagePayload:
         route = Route(
             'PATCH',
@@ -337,8 +338,12 @@ class WebhookAdapter:
             webhook_token=token,
             message_id=message_id,
         )
-        params = None if thread_id is None else {'thread_id': thread_id}
-        return self.request(route, session, payload=payload, multipart=multipart, files=files, params=params)
+        params: Dict[str, Any] = {}
+        if thread_id is not None:
+            params['thread_id'] = thread_id
+        if with_components:
+            params['with_components'] = int(with_components)
+        return self.request(route, session, payload=payload, multipart=multipart, files=files, params=params or None)
 
     def delete_webhook_message(
         self,
@@ -1293,6 +1298,7 @@ class SyncWebhook(BaseWebhook):
                 multipart=params.multipart,
                 files=params.files,
                 thread_id=thread_id,
+                with_components=view is not MISSING,
             )
             return self._create_message(data, thread=thread)
 


### PR DESCRIPTION
## Summary

When editing webhook messages that use `COMPONENTS_V2`, Discord requires the `with_components=true` query parameter for component changes to take effect. This parameter was already correctly included when **sending** webhook messages but was missing from the **edit** path.

## Changes

- Added `with_components` parameter to `edit_webhook_message` in both `AsyncWebhookAdapter` and `WebhookAdapter` (sync)
- Pass `with_components=True` from `Webhook.edit_message` and `SyncWebhook.edit_message` when a `view` is provided

## Checklist

- [x] If code changes were made, they have been tested
- [x] This PR fixes an issue: Closes #10395
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
