### PR TITLE
Migrate remove_view to walk_children

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -912,7 +912,7 @@ class ViewStore:
         if message_id is not None and not is_fully_dynamic:
             self._synced_message_views[message_id] = view
 
-    def remove_view(self, view: Union[View, LayoutView]) -> None:
+    def remove_view(self, view: BaseView) -> None:
         if view.__discord_ui_modal__:
             self._modals.pop(view.custom_id, None)  # type: ignore
             return


### PR DESCRIPTION
## Summary

Migrate `ViewStore.remove_view` to use `walk_children()` instead of `_children` to ensure nested components in a `LayoutView` are correctly identified and cleared from the `ViewStore` cache on timeout or manual stop. 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
