### PR TITLE
Fix Message.edit() ignoring global allowed mentions

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -1393,12 +1393,7 @@ class PartialMessage(Hashable):
         :class:`Message`
             The newly edited message.
         """
-
-        if content is not MISSING:
-            previous_allowed_mentions = self._state.allowed_mentions
-        else:
-            previous_allowed_mentions = None
-
+        previous_allowed_mentions = self._state.allowed_mentions
         if view is not MISSING:
             self._state.prevent_view_updates_for(self.id)
 
@@ -2964,11 +2959,7 @@ class Message(PartialMessage, Hashable):
         :class:`Message`
             The newly edited message.
         """
-
-        if content is not MISSING:
-            previous_allowed_mentions = self._state.allowed_mentions
-        else:
-            previous_allowed_mentions = None
+        previous_allowed_mentions = self._state.allowed_mentions
 
         if suppress is not MISSING:
             flags = MessageFlags._from_value(self.flags.value)


### PR DESCRIPTION
## Summary

This PR fixes an issue where the allowed mentions configured on the bot did not apply when editing a message via `(Partial)Message.edit()`. As a result, the edit would still ping users etc even when mentions were explicitly disabled, forcing users to reapply the allowed mentions manually. 

From what I can tell, this behavior only happens in `(Partial)Message.edit()`.

Related help post: https://canary.discord.com/channels/336642139381301249/1475259678702440580

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
