### PR TITLE
Doc: Mention components needed to be in a Label

### DIFF
--- a/discord/ui/checkbox.py
+++ b/discord/ui/checkbox.py
@@ -59,7 +59,7 @@ V = TypeVar('V', bound='BaseView', covariant=True)
 
 
 class CheckboxGroup(Item[V]):
-    """Represents a checkbox group component within a modal.
+    """Represents a checkbox group component within a modal that can only be used in :class:`Label`.
 
     .. versionadded:: 2.7
 
@@ -281,7 +281,7 @@ class CheckboxGroup(Item[V]):
 
 
 class Checkbox(Item[V]):
-    """Represents a checkbox component within a modal.
+    """Represents a checkbox component within a modal that can only be used in :class:`Label`.
 
     .. versionadded:: 2.7
 

--- a/discord/ui/radio.py
+++ b/discord/ui/radio.py
@@ -54,7 +54,7 @@ V = TypeVar('V', bound='BaseView', covariant=True)
 
 
 class RadioGroup(Item[V]):
-    """Represents a radio group component within a modal.
+    """Represents a radio group component within a modal that can only be used in :class:`Label`.
 
     .. versionadded:: 2.7
 


### PR DESCRIPTION
## Summary
This PR updates the docs to mention what components are needed to be placed inside a `Label`, similary to what [`TextInput`](https://discordpy.readthedocs.io/en/latest/interactions/api.html?highlight=textinput#discord.ui.TextInput) does.

Reference: https://docs.discord.com/developers/components/reference#label

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
