### PR TITLE
Fix aiohttp websocket timeout deprecation warning

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -551,9 +551,10 @@ class HTTPClient:
             self.__session = MISSING
 
     async def ws_connect(self, url: str, *, compress: int = 0) -> aiohttp.ClientWebSocketResponse:
-        timeout: Any = 30.0
-        if hasattr(aiohttp, 'ClientWSTimeout'):
-            timeout = aiohttp.ClientWSTimeout(ws_close=30.0)
+        try:
+            timeout: Any = aiohttp.ClientWSTimeout(ws_close=30.0)  # pyright: ignore[reportCallIssue]
+        except (AttributeError, TypeError):
+            timeout = 30.0
 
         kwargs = {
             'proxy_auth': self.proxy_auth,


### PR DESCRIPTION
## Summary
Fix aiohttp websocket timeout deprecation warning
```
discord/http.py:566: DeprecationWarning: parameter 'timeout' of type 'float' is deprecated, please use 'timeout=ClientWSTimeout(ws_close=...)'\n  return await self.__session.ws_connect(url, **kwargs)\n"
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
