### PR TITLE
Update `poll` documentation to list supported poll durations

### DIFF
--- a/discord/poll.py
+++ b/discord/poll.py
@@ -330,7 +330,7 @@ class Poll:
     question: Union[:class:`PollMedia`, :class:`str`]
         The poll's displayed question. The text can be up to 300 characters.
     duration: :class:`datetime.timedelta`
-        The duration of the poll. Duration must be in hours.
+        The duration of the poll. Duration must be 1 hour, 4 hours, 8 hours, 24 hours, 3 days, 1 week, or 2 weeks.
     multiple: :class:`bool`
         Whether users are allowed to select more than one answer.
         Defaults to ``False``.
@@ -341,6 +341,9 @@ class Poll:
     -----------
     duration: :class:`datetime.timedelta`
         The duration of the poll.
+
+        Discord only supports specific durations: 1 hour, 4 hours, 8 hours, 24 hours, 3 days, 1 week, or 2 weeks.
+
     multiple: :class:`bool`
         Whether users are allowed to select more than one answer.
     layout_type: :class:`PollLayoutType`


### PR DESCRIPTION
## Summary

The documentation currently does not specify which duration values are supported by Discord API, which can be confusing.

This PR updates the `duration` parameter documentation to list the duration supported by Discord: 1h, 4h, 8h, 24h, 3d, 1w, 2w.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
