### PR TITLE
docs: fix: Safari sidebar ul has toolbar cut off

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -388,6 +388,7 @@ aside {
   color: var(--mobile-nav-text);
   z-index: 2;
   max-height: 100vh;
+  max-height: 100dvh;
   overflow-y: auto;
   overscroll-behavior-y: contain;
 }
@@ -1286,6 +1287,7 @@ div.code-block-caption {
     position: sticky;
     top: 1em;
     max-height: calc(100vh - 2em);
+    max-height: calc(100dvh - 2em);
     max-width: 100%;
     overflow-y: auto;
     margin: 1em;

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -387,7 +387,6 @@ aside {
   background-color: var(--mobile-nav-background);
   color: var(--mobile-nav-text);
   z-index: 2;
-  max-height: 100vh;
   max-height: 100dvh;
   overflow-y: auto;
   overscroll-behavior-y: contain;
@@ -1286,7 +1285,6 @@ div.code-block-caption {
     display: inline-block;
     position: sticky;
     top: 1em;
-    max-height: calc(100vh - 2em);
     max-height: calc(100dvh - 2em);
     max-width: 100%;
     overflow-y: auto;


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This Pull Request fixes an issue on mobile Safari where the API reference sidebar table of contents is cut off.

It does so by using dvh (dynamic viewport height) where possible instead of vh.

This closes https://github.com/Rapptz/discord.py/issues/10435

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
