### PR TITLE
Update ruff configuration to exclude docs/tests formatting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,4 +45,4 @@ jobs:
       - name: Run ruff
         if: ${{ always() && steps.install-deps.outcome == 'success' }}
         run: |
-          ruff format --check discord examples
+          ruff format --check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ include-package-data = true
 
 [tool.ruff]
 line-length = 125
+extend-exclude = ["docs", "tests"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true


### PR DESCRIPTION
## Summary

I ran `ruff format` when trying to fix formatting on a PR I'm intending to make, and realised that a lot of files I didn't touch suddenly got modified. As it turns out, only `discord` and `examples` directories are ruff-formatted. I updated the `pyproject.toml` configuration with an exclusion-based approach rather than inclusion-based, though - I simply added `docs` and `tests` directories to `extend-exclude` per https://docs.astral.sh/ruff/settings/#extend-exclude. To make CI consistent with that configuration, I updated the `ruff format --check` call there to not specify the directories to format. `ruff` already has a sensible list of default exclusions: https://docs.astral.sh/ruff/settings/#exclude

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
