### PR TITLE
feat(fix): fix comment about inspect replacing inspect

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1545,7 +1545,7 @@ class _RawReprMixin:
         return f'<{self.__class__.__name__} {value}>'
 
 
-# `inspect.iscoroutinefunction()` only became equivalent to (now deprecated) `inspect.iscoroutinefunction()` in Python 3.12
+# `inspect.iscoroutinefunction()` only became equivalent to (now deprecated) `asyncio.iscoroutinefunction()` in Python 3.12
 # https://github.com/python/cpython/issues/122858#issuecomment-2466239748
 if sys.version_info >= (3, 12):
     _iscoroutinefunction = inspect.iscoroutinefunction


### PR DESCRIPTION
## Summary
*Note: this is quite petty, but fixes an inaccurate comment issue introduced in PR #10438*

One of the comments in `discord/utils.py` placed by PR #10438 inaccurately addresses `inspect.iscoroutinefunction` to replace `inspect.iscoroutinefunction`. I have simply just renamed the second `inspect.iscoroutinefunction` in the comment line to `asyncio.iscoroutinefunction`.

*I don't think this counts a code change. Let me know if I need to do any tests regardless.*

## Checklist
- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
