### PR TITLE
Docs: fix audit log scheduled event action descriptions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2846,7 +2846,7 @@ of :class:`enum.Enum`.
 
     .. attribute:: scheduled_event_update
 
-        A scheduled event was created.
+        A scheduled event was updated.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
         the :class:`ScheduledEvent` or :class:`Object` with the ID of the event
@@ -2866,7 +2866,7 @@ of :class:`enum.Enum`.
 
     .. attribute:: scheduled_event_delete
 
-        A scheduled event was created.
+        A scheduled event was deleted.
 
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
         the :class:`ScheduledEvent` or :class:`Object` with the ID of the event

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -1212,7 +1212,7 @@ This allows you to define a command as both slash and text command without writi
 both counterparts.
 
 
-In order to define a hybrid command, The command callback should be decorated with
+In order to define a hybrid command, the command callback should be decorated with
 :meth:`.Bot.hybrid_command` decorator.
 
 .. code-block:: python3
@@ -1264,11 +1264,11 @@ Apart from that, all other features such as converters, checks, autocomplete, fl
 are supported on hybrid commands. Note that due to a design constraint, decorators related to application commands
 such as :func:`discord.app_commands.autocomplete` should be placed below the :func:`~ext.commands.hybrid_command` decorator.
 
-For convenience and ease in writing code, The :class:`~ext.commands.Context` class implements
+For convenience and ease in writing code, the :class:`~ext.commands.Context` class implements
 some behavioural changes for various methods and attributes:
 
 - :attr:`.Context.interaction` can be used to retrieve the slash command interaction.
-- Since interaction can only be responded to once, The :meth:`.Context.send` automatically
+- Since interaction can only be responded to once, the :meth:`.Context.send` automatically
   determines whether to send an interaction response or a followup response.
 - :meth:`.Context.defer` defers the interaction response for slash commands but shows typing
   indicator for text commands.

--- a/docs/ext/commands/extensions.rst
+++ b/docs/ext/commands/extensions.rst
@@ -10,7 +10,7 @@ There comes a time in the bot development when you want to extend the bot functi
 Primer
 --------
 
-An extension at its core is a python file with an entry point called ``setup``. This setup function must be a Python coroutine. It takes a single parameter -- the :class:`~.commands.Bot` that loads the extension.
+An extension at its core is a Python file with an entry point called ``setup``. This setup function must be a Python coroutine. It takes a single parameter -- the :class:`~.commands.Bot` that loads the extension.
 
 An example extension looks like this:
 

--- a/docs/intents.rst
+++ b/docs/intents.rst
@@ -153,7 +153,7 @@ If the cache is disabled or you disable chunking guilds at startup, we might sti
 - :meth:`Guild.fetch_member`
     - Used to fetch a member by ID through the HTTP API.
 - :meth:`Guild.fetch_members`
-    - used to fetch a large number of members through the HTTP API.
+    - Used to fetch a large number of members through the HTTP API.
 
 It should be noted that the gateway has a strict rate limit of 120 requests per 60 seconds.
 

--- a/docs/interactions/api.rst
+++ b/docs/interactions/api.rst
@@ -533,10 +533,10 @@ Enumerations
 
     .. attribute:: file_upload
 
-       Represents a file upload component, usually in a modal.
+        Represents a file upload component, usually in a modal.
 
-         .. versionadded:: 2.7
-    
+        .. versionadded:: 2.7
+
     .. attribute:: radio_group
 
         Represents a radio group component.
@@ -634,7 +634,7 @@ Enumerations
         A string parameter.
     .. attribute:: integer
 
-        A integer parameter.
+        An integer parameter.
     .. attribute:: boolean
 
         A boolean parameter.

--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -24,9 +24,8 @@ Examples of Non-Breaking Changes
 - Adding or removing private underscored attributes.
 - Adding an element into the ``__slots__`` of a data class.
 - Changing the behaviour of a function to fix a bug.
-- Changes in the typing behaviour of the library
-- Changes in the calling convention of functions that are primarily meant as callbacks
+- Changes in the typing behaviour of the library.
+- Changes in the calling convention of functions that are primarily meant as callbacks.
 - Changes in the documentation.
 - Modifying the internal HTTP handling.
 - Upgrading the dependencies to a new version, major or otherwise.
-


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

noticed that `scheduled_event_update` and `scheduled_event_delete` both say "A scheduled event was created." while it should have been "updated" and "deleted" respectively

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
