### PR TITLE
fix: safety_alerts_channel accept None in Guild.edit()

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2285,8 +2285,7 @@ class Guild(Hashable):
                     raise TypeError(
                         f'safety_alerts_channel must be of type TextChannel not {safety_alerts_channel.__class__.__name__}'
                     )
-
-            fields['safety_alerts_channel_id'] = safety_alerts_channel.id
+                fields['safety_alerts_channel_id'] = safety_alerts_channel.id
 
         if owner is not MISSING:
             if self.owner_id != self._state.self_id:

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2027,7 +2027,7 @@ class Guild(Hashable):
         widget_channel: Optional[Snowflake] = MISSING,
         mfa_level: MFALevel = MISSING,
         raid_alerts_disabled: bool = MISSING,
-        safety_alerts_channel: TextChannel = MISSING,
+        safety_alerts_channel: Optional[TextChannel] = MISSING,
         invites_disabled_until: datetime.datetime = MISSING,
         dms_disabled_until: datetime.datetime = MISSING,
     ) -> Guild:


### PR DESCRIPTION
## Summary

Fixes #10445. `safety_alerts_channel` in `Guild.edit()` had two bugs:
- typed as `TextChannel` instead of `Optional[TextChannel]`, despite the implementation handling `None` and the docstring documenting it as accepted.
- `safety_alerts_channel.id` assignment was outside the `else` block, causing an `AttributeError` when `None` is passed

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
