### PR TITLE
Fix heartbeat latency race between keepalive and event loop threads

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -173,8 +173,7 @@ class KeepAliveHandler(threading.Thread):
 
             data = self.get_payload()
             _log.debug(self.msg, self.shard_id, data['d'])
-            coro = self.ws.send_heartbeat(data)
-            f = asyncio.run_coroutine_threadsafe(coro, loop=self.ws.loop)
+            f = asyncio.run_coroutine_threadsafe(self._send_heartbeat(data), loop=self.ws.loop)
             try:
                 # block until sending is complete
                 total = 0
@@ -195,8 +194,6 @@ class KeepAliveHandler(threading.Thread):
 
             except Exception:
                 self.stop()
-            else:
-                self._last_send = time.perf_counter()
 
     def get_payload(self) -> Dict[str, Any]:
         return {
@@ -213,6 +210,10 @@ class KeepAliveHandler(threading.Thread):
     def beat(self) -> Dict[str, Any]:
         self._last_send = time.perf_counter()
         return self.get_payload()
+
+    async def _send_heartbeat(self, data: Any) -> None:
+        self._last_send = time.perf_counter()
+        await self.ws.send_heartbeat(data)
 
     def ack(self) -> None:
         ack_time = time.perf_counter()


### PR DESCRIPTION
## Summary

Fix heartbeat latency race between keepalive and event loop threads. If the gateway responds extremely fast, then the event loop thread can believe it is 41.25s behind, since the _last_send may not have been updated yet. The fix is to set _last_send on the event loop thread before sending so ack() can't read a stale value from the previous heartbeat cycle.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
