### PR TITLE
Fix Guild.edit safety_alerts_channel None handling

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2027,7 +2027,7 @@ class Guild(Hashable):
         widget_channel: Optional[Snowflake] = MISSING,
         mfa_level: MFALevel = MISSING,
         raid_alerts_disabled: bool = MISSING,
-        safety_alerts_channel: TextChannel = MISSING,
+        safety_alerts_channel: Optional[TextChannel] = MISSING,
         invites_disabled_until: datetime.datetime = MISSING,
         dms_disabled_until: datetime.datetime = MISSING,
     ) -> Guild:
@@ -2286,7 +2286,7 @@ class Guild(Hashable):
                         f'safety_alerts_channel must be of type TextChannel not {safety_alerts_channel.__class__.__name__}'
                     )
 
-            fields['safety_alerts_channel_id'] = safety_alerts_channel.id
+                fields['safety_alerts_channel_id'] = safety_alerts_channel.id
 
         if owner is not MISSING:
             if self.owner_id != self._state.self_id:


### PR DESCRIPTION
## Summary

`safety_alerts_channel` on `Guild.edit` was typed as
`TextChannel` despite the docstring saying `Optional[TextChannel]`,
and passing `None` crashed because the `.id` assignment ran outside
the `else:` branch. Widens the type and fixes the indent to match
the sibling `rules_channel` / `public_updates_channel` blocks.

Closes #10445

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
