### PR TITLE
Fix docs, manage_roles is not needeed

### DIFF
--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3871,14 +3871,10 @@ class Guild(Hashable):
 
         Retrieves a mapping of roles to the number of members that have it.
 
-        You must have :attr:`~Permissions.manage_roles` to do this.
-
         .. versionadded:: 2.7
 
         Raises
         -------
-        Forbidden
-            You do not have permissions to view the role member counts.
         HTTPException
             Retrieving the role member counts failed.
 


### PR DESCRIPTION
## Summary
This PR fixes the docs for `Guild.role_member_counts`. It states that `manage_roles` is needed but it actually [isn't](https://docs.discord.com/developers/resources/guild#get-guild-role-member-counts)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
