### PR TITLE
docs: fix typo in ui.RadioGroup.value docstring

### DIFF
--- a/discord/ui/radio.py
+++ b/discord/ui/radio.py
@@ -113,7 +113,7 @@ class RadioGroup(Item[V]):
 
     @property
     def value(self) -> Optional[str]:
-        """Optional[:class:`str`]: The value have been selected by the user, if any."""
+        """Optional[:class:`str`]: The value that has been selected by the user, if any."""
         return self._value
 
     @property


### PR DESCRIPTION
## Summary

This PR fixes a typo/grammar error in in the documentation for `ui.RadioGroup`.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
