### PR TITLE
Add `channel_type` attr to `Message`

### DIFF
--- a/discord/message.py
+++ b/discord/message.py
@@ -2138,6 +2138,11 @@ class Message(PartialMessage, Hashable):
         The message snapshots attached to this message.
 
         .. versionadded:: 2.5
+    channel_type: Optional[:class:`ChannelType`]
+        The message channel's Discord type.
+        This is only present when received in :func:`on_message`.
+
+        .. versionadded:: 2.8
     """
 
     __slots__ = (
@@ -2177,6 +2182,7 @@ class Message(PartialMessage, Hashable):
         'call',
         'purchase_notification',
         'message_snapshots',
+        'channel_type',
         '_pinned_at',
     )
 
@@ -2218,6 +2224,7 @@ class Message(PartialMessage, Hashable):
         self.stickers: List[StickerItem] = [StickerItem(data=d, state=state) for d in data.get('sticker_items', [])]
         self.message_snapshots: List[MessageSnapshot] = MessageSnapshot._from_value(state, data.get('message_snapshots'))
         self.call: Optional[CallMessage] = None
+        self.channel_type: Optional[ChannelType] = try_enum(ChannelType, data['channel_type']) if 'channel_type' in data else None
         # Set by Messageable.pins
         self._pinned_at: Optional[datetime.datetime] = None
 

--- a/discord/message.py
+++ b/discord/message.py
@@ -2224,7 +2224,9 @@ class Message(PartialMessage, Hashable):
         self.stickers: List[StickerItem] = [StickerItem(data=d, state=state) for d in data.get('sticker_items', [])]
         self.message_snapshots: List[MessageSnapshot] = MessageSnapshot._from_value(state, data.get('message_snapshots'))
         self.call: Optional[CallMessage] = None
-        self.channel_type: Optional[ChannelType] = try_enum(ChannelType, data['channel_type']) if 'channel_type' in data else None
+        self.channel_type: Optional[ChannelType] = (
+            try_enum(ChannelType, data['channel_type']) if 'channel_type' in data else None
+        )
         # Set by Messageable.pins
         self._pinned_at: Optional[datetime.datetime] = None
 

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -228,6 +228,7 @@ class Message(PartialMessage):
     thread: NotRequired[Thread]
     call: NotRequired[CallMessage]
     purchase_notification: NotRequired[PurchaseNotificationResponse]
+    channel_type: NotRequired[int]
 
 
 AllowedMentionType = Literal['roles', 'users', 'everyone']


### PR DESCRIPTION
## Summary
This PR adds the `channel_type` field that is only present in [`message_create`](https://docs.discord.com/developers/events/gateway-events#message-create)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
