### PR TITLE
ci: pin actions versions with hashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,12 @@ jobs:
 
     name: dists & docs (${{ matrix.python-version }}/${{ matrix.language }})
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Set up CPython ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -35,9 +35,9 @@ jobs:
           python ./setup.py sdist bdist_wheel
 
       # - name: Upload artifacts
-      #   uses: actions/upload-artifact@v2
+      #   uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       #   with:
-      #     name: distributions
+      #     name: distributions-${{ matrix.python-version }}-${{ matrix.language }}
       #     path: dist/*
 
       - name: Install package
@@ -53,8 +53,8 @@ jobs:
           DOCS_LANGUAGE: ${{ matrix.language }}
 
       # - name: Upload docs
-      #   uses: actions/upload-artifact@v2
+      #   uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       #   if: always()
       #   with:
-      #     name: docs-${{ matrix.language }}
+      #     name: docs-${{ matrix.python-version }}-${{ matrix.language }}
       #     path: docs/_build/html/*

--- a/.github/workflows/crowdin_download.yml
+++ b/.github/workflows/crowdin_download.yml
@@ -27,7 +27,7 @@ jobs:
     environment: Crowdin
     name: download
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: master
@@ -49,7 +49,7 @@ jobs:
 
       - name: Create pull request
         id: cpr_crowdin
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Crowdin translations download
@@ -60,7 +60,7 @@ jobs:
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
 
       - name: Close and reopen the PR with different token to trigger CI
-        uses: actions/github-script@v3
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ steps.cpr_crowdin.outputs.pull-request-number }}
           PR_OPERATION: ${{ steps.cpr_crowdin.outputs.pull-request-operation }}

--- a/.github/workflows/crowdin_upload.yml
+++ b/.github/workflows/crowdin_upload.yml
@@ -9,12 +9,12 @@ jobs:
     environment: Crowdin
     name: upload
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Set up CPython 3.x
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.x
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,12 +15,12 @@ jobs:
 
     name: check ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Set up CPython ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -31,12 +31,12 @@ jobs:
           pip install -U -r requirements.txt
 
       - name: Setup node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '16'
 
       - name: Run Pyright
-        uses: jakebailey/pyright-action@v1
+        uses: jakebailey/pyright-action@8ec14b5cfe41f26e5f41686a31eb6012758217ef # v3.0.2
         with:
           version: '1.1.394'
           warnings: false

--- a/.github/workflows/scripts/close_and_reopen_pr.js
+++ b/.github/workflows/scripts/close_and_reopen_pr.js
@@ -12,7 +12,7 @@ module.exports = (async function ({github, context}) {
         await new Promise(r => setTimeout(r, 5000));
 
         // Close the PR
-        github.issues.update({
+        await github.rest.issues.update({
             issue_number: pr_number,
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ jobs:
 
     name: pytest ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Set up CPython ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary

I have pinned the versions of the actions used in the workflows with hashes.

Pinning GitHub Actions to a commit hash is an effective safeguard against supply chain attacks. By referencing a specific and immutable version of an action, you prevent compromised versions from being automatically integrated into your pipelines.

I checked the breaking changes for all actions that had been upgraded, and made the necessary changes.
There were two breaking changes that affected us:
- one for `actions/upload-artifact`, for which I had to update the artifact names to ensure they were unique (since artifacts are immutable since `v4`) (https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)
- one for `actions/github-script`, in the JS script that was launched, where `github.issues.update` was used, which has been replaced by `github.rest.issues.update` (https://github.com/actions/github-script#v5)

Here is the link to the tags for the actions I've pinned, if you want to check the hashes:
- https://github.com/actions/checkout/releases/tag/v6.0.3
- https://github.com/actions/setup-python/releases/tag/v6.2.0
- https://github.com/actions/upload-artifact/releases/tag/v7.0.1 (this action is commented but I fixed the version in the commentary)
- https://github.com/peter-evans/create-pull-request/releases/tag/v8.1.1
- https://github.com/actions/github-script/releases/tag/v9.0.0
- https://github.com/actions/setup-node/releases/tag/v6.4.0
- https://github.com/jakebailey/pyright-action/releases/tag/v3.0.2

Pinning versions requires a bit of maintenance, since you have to perform manual upgrades regularly, but in your case, with workflows that handle secrets (such as `secrets.GITHUB_TOKEN`), it’s a best practice to avoid troubles.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)