### PR TITLE
 Raise error immediately when voice channel is full or lacks permissions and  add early validation for empty command groups

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -2124,7 +2124,8 @@ class Connectable(Protocol):
         asyncio.TimeoutError
             Could not connect to the voice channel in time.
         ~discord.ClientException
-            You are already connected to a voice channel.
+            You are already connected to a voice channel, or the voice
+            channel is full and the connection was rejected.
         ~discord.opus.OpusNotLoaded
             The opus library has not been loaded.
 
@@ -2146,11 +2147,23 @@ class Connectable(Protocol):
         if not isinstance(voice, VoiceProtocol):
             raise TypeError('Type must meet VoiceProtocol abstract base class.')
 
+        if hasattr(self, 'guild') and hasattr(self, 'permissions_for'):
+            me = self.guild.me  # type: ignore
+            permissions = self.permissions_for(me)  # type: ignore
+
+            if not permissions.connect:
+                raise ClientException('You do not have permission to connect to this voice channel.')
+
+            limit = getattr(self, 'user_limit', 0)
+            if limit > 0 and len(getattr(self, 'members', [])) >= limit:
+                if not permissions.administrator and not permissions.move_members:
+                    raise ClientException('The voice channel is full and you do not have permission to bypass the limit.')
+
         state._add_voice_client(key_id, voice)
 
         try:
             await voice.connect(timeout=timeout, reconnect=reconnect, self_deaf=self_deaf, self_mute=self_mute)
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, ClientException):
             try:
                 await voice.disconnect(force=True)
             except Exception:

--- a/discord/app_commands/tree.py
+++ b/discord/app_commands/tree.py
@@ -380,7 +380,10 @@ class CommandTree(Generic[ClientT]):
         elif not isinstance(command, (Command, Group)):
             raise TypeError(f'Expected an application command, received {command.__class__.__name__} instead')
 
-        # todo: validate application command groups having children (required)
+        if isinstance(command, Group):
+            for child in [command, *command.walk_commands()]:
+                if isinstance(child, Group) and not child.commands:
+                    raise ValueError(f'Application command group {child.qualified_name!r} has no commands')
 
         root = command.root_parent or command
         name = root.name

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -49,7 +49,7 @@ from typing import TYPE_CHECKING, Optional, Dict, List, Callable, Coroutine, Any
 
 from .enums import Enum
 from .utils import MISSING, sane_wait_for
-from .errors import ConnectionClosed
+from .errors import ClientException, ConnectionClosed
 from .backoff import ExponentialBackoff
 from .gateway import DiscordVoiceWebSocket
 
@@ -332,6 +332,15 @@ class VoiceConnectionState:
             # being in the reconnect or disconnect flow, we ignore it.  Otherwise, it probably wasn't from us.
             if self._expecting_disconnect:
                 self._expecting_disconnect = False
+            elif self.state in (
+                ConnectionFlowState.set_guild_voice_state,
+                ConnectionFlowState.got_voice_server_update,
+            ):
+                # We were rejected from the channel before completing the handshake.
+                # This typically happens when the voice channel is full.
+                # Setting the state to disconnected will cause _wait_for_state to abort.
+                _log.info('Disconnected from voice during connection handshake (channel may be full).')
+                self.state = ConnectionFlowState.disconnected
             else:
                 _log.debug('We were externally disconnected from voice.')
                 await self.disconnect()
@@ -626,6 +635,8 @@ class VoiceConnectionState:
         while True:
             if self.state in states:
                 return
+            if self.state is ConnectionFlowState.disconnected:
+                raise ClientException('Failed to connect to voice channel; the channel may be full.')
             await sane_wait_for([self._state_event.wait()], timeout=timeout)
 
     async def _voice_connect(self, *, self_deaf: bool = False, self_mute: bool = False) -> None:


### PR DESCRIPTION
## Summary
This PR fixes an issue where channel.connect() could silently hang for 30 seconds before raising an unhelpful asyncio.TimeoutError when:

- The bot lacks the CONNECT permission.
- The target voice channel is full and the bot lacks MOVE_MEMBERS or ADMINISTRATOR permissions to bypass the user limit.

To address this, pre-connection permission and user limit validation has been added to Connectable.connect() in discord/abc.py, allowing a ClientException to be raised immediately with a clear error message.

Additionally, a fallback has been implemented in discord/voice_state.py to properly abort the voice connection handshake if Discord drops the request during the connection process.

This PR also resolves an existing # TODO in the codebase by validating that application command groups contain at least one child command before being added to the command tree.


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
