### PR TITLE
fix(app_commands): detect duplicate param renames correctly

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -297,27 +297,24 @@ def _populate_descriptions(params: Dict[str, CommandParameter], descriptions: Di
 
 
 def _populate_renames(params: Dict[str, CommandParameter], renames: Dict[str, Union[str, locale_str]]) -> None:
-    rename_map: Dict[str, Union[str, locale_str]] = {}
-
-    # original name to renamed name
+    rename_map: Dict[str, str] = {}
 
     for name in params.keys():
         new_name = renames.pop(name, MISSING)
 
         if new_name is MISSING:
-            rename_map[name] = name
-            continue
-
-        if new_name in rename_map.values():
-            raise ValueError(f'{new_name} is already used')
-
-        if isinstance(new_name, str):
-            new_name = validate_name(new_name)
+            display_name = name
+        elif isinstance(new_name, str):
+            display_name = validate_name(new_name)
         else:
-            validate_name(new_name.message)
+            display_name = validate_name(new_name.message)
 
-        rename_map[name] = new_name
-        params[name]._rename = new_name
+        if display_name in rename_map:
+            raise ValueError(f'{display_name} is already used')
+
+        rename_map[display_name] = name
+        if new_name is not MISSING:
+            params[name]._rename = new_name
 
     if renames:
         first = next(iter(renames))

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -308,7 +308,7 @@ def _populate_renames(params: Dict[str, CommandParameter], renames: Dict[str, Un
             rename_map[name] = name
             continue
 
-        if name in rename_map:
+        if new_name in rename_map.values():
             raise ValueError(f'{new_name} is already used')
 
         if isinstance(new_name, str):


### PR DESCRIPTION
## Summary

The code currently checks `if name in rename_map`, but `rename_map` is keyed by original parameter names, which are unique. Hence, this condition can never be true during iteration, so duplicate renames are accepted and later caught by discord api:

```python
from discord import app_commands 

@app_commands.rename(a='x', b='x')  # should raise ValueError("x is already used")
async def cmd(...) -> None: ...

# Raised: CommandSyncFailure (HTTP 400)
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
