### PR TITLE
fix(channel): remove duplicate ForumChannel._flags slot and fix docstring

### DIFF
--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2568,7 +2568,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
 
     @property
     def flags(self) -> ChannelFlags:
-        """:class:`ChannelFlags`: The flags associated with this thread.
+        """:class:`ChannelFlags`: The flags associated with this forum.
 
         .. versionadded:: 2.1
         """

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -2451,7 +2451,6 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         'default_layout',
         'default_sort_order',
         '_available_tags',
-        '_flags',
     )
 
     def __init__(self, *, state: ConnectionState, guild: Guild, data: Union[ForumChannelPayload, MediaChannelPayload]):


### PR DESCRIPTION
## Summary

This PR removes duplicate slotting of `ForumChannel._flags` and a typo in `ForumChannel.flags` docstring.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
