### PR TITLE
fix(http): suppress pyright reportReturnType false positive

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -568,7 +568,7 @@ class HTTPClient:
             'compress': compress,
         }
 
-        return await self.__session.ws_connect(url, **kwargs)
+        return await self.__session.ws_connect(url, **kwargs)  # pyright: ignore[reportReturnType]
 
     def _try_clear_expired_ratelimits(self) -> None:
         if len(self._buckets) < 256:


### PR DESCRIPTION
## Summary

The PR suppresses a pyright false positive in `ws_connect` caused by the latest aiohttp release.  
This caused the all opened PRs to fail the CI lint.

As [previously noted](https://discord.com/channels/336642139381301249/336642776609456130/1524450672320188477) by Sinbad:
> It's statically known that Literal[True] | Literal[False] = bool, and since overloads only differ on that, the effective domain is bool, while the specific resulting type is only known if the input type is known, otherwise the return type is the union of the domains on the overloads.
> aiohttp could work around this by adding more overloads, but that sucks.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
