### PR TITLE
docs: fix typos in api reference

### DIFF
--- a/discord/file.py
+++ b/discord/file.py
@@ -137,7 +137,7 @@ class File:
         to an uploaded file via URL.
 
         .. note::
-            Due to Discord's filename processing, the filename must be ASCII aphanumeric
+            Due to Discord's filename processing, the filename must be ASCII alphanumeric
             with underscores, dashes, and periods.
 
         .. versionadded:: 2.6

--- a/discord/message.py
+++ b/discord/message.py
@@ -830,7 +830,7 @@ class MessageInteractionMetadata(Hashable):
     original_response_message_id: Optional[:class:`int`]
         The ID of the original response message if the message is a follow-up.
     interacted_message_id: Optional[:class:`int`]
-        The ID of the message that containes the interactive components, if applicable.
+        The ID of the message that contains the interactive components, if applicable.
     modal_interaction: Optional[:class:`.MessageInteractionMetadata`]
         The metadata of the modal submit interaction that triggered this interaction, if applicable.
     target_user: Optional[:class:`User`]
@@ -922,7 +922,7 @@ class MessageInteractionMetadata(Hashable):
     @property
     def interacted_message(self) -> Optional[Message]:
         """Optional[:class:`~discord.Message`]: The message that
-        containes the interactive components, if applicable and is found in cache.
+        contains the interactive components, if applicable and is found in cache.
         """
         if self.interacted_message_id:
             return self._state._get_message(self.interacted_message_id)

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -313,7 +313,7 @@ class SessionStartLimits:
     total: :class:`int`
         The total number of session starts the current user is allowed
     remaining: :class:`int`
-        Remaining remaining number of session starts the current user is allowed
+        Remaining number of session starts the current user is allowed
     reset_after: :class:`int`
         The number of milliseconds until the limit resets
     max_concurrency: :class:`int`

--- a/discord/sku.py
+++ b/discord/sku.py
@@ -116,7 +116,7 @@ class SKU:
         Raises
         -------
         NotFound
-            An subscription with this ID does not exist.
+            A subscription with this ID does not exist.
         HTTPException
             Fetching the subscription failed.
 

--- a/discord/ui/action_row.py
+++ b/discord/ui/action_row.py
@@ -367,7 +367,7 @@ class ActionRow(Item[V]):
 
             Buttons with a URL or a SKU cannot be created with this function.
             Consider creating a :class:`Button` manually and adding it via
-            :meth:`ActionRow.add_item` instead. This is beacuse these buttons
+            :meth:`ActionRow.add_item` instead. This is because these buttons
             cannot have a callback associated with them since Discord does not
             do any processing with them.
 
@@ -378,7 +378,7 @@ class ActionRow(Item[V]):
             Can only be up to 80 characters.
         custom_id: Optional[:class:`str`]
             The ID of the button that gets received during an interaction.
-            It is recommended to not set this parameters to prevent conflicts.
+            It is recommended to not set this parameter to prevent conflicts.
             Can only be up to 100 characters.
         style: :class:`.ButtonStyle`
             The style of the button. Defaults to :attr:`.ButtonStyle.grey`.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3984,7 +3984,7 @@ of :class:`enum.Enum`.
 
 .. class:: SubscriptionStatus
 
-    Represents the status of an subscription.
+    Represents the status of a subscription.
 
     .. versionadded:: 2.5
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -240,7 +240,7 @@ AutoMod
 
 .. function:: on_automod_rule_create(rule)
 
-    Called when a :class:`AutoModRule` is created.
+    Called when an :class:`AutoModRule` is created.
     You must have :attr:`~Permissions.manage_guild` to receive this.
 
     This requires :attr:`Intents.auto_moderation_configuration` to be enabled.
@@ -252,7 +252,7 @@ AutoMod
 
 .. function:: on_automod_rule_update(rule)
 
-    Called when a :class:`AutoModRule` is updated.
+    Called when an :class:`AutoModRule` is updated.
     You must have :attr:`~Permissions.manage_guild` to receive this.
 
     This requires :attr:`Intents.auto_moderation_configuration` to be enabled.
@@ -264,7 +264,7 @@ AutoMod
 
 .. function:: on_automod_rule_delete(rule)
 
-    Called when a :class:`AutoModRule` is deleted.
+    Called when an :class:`AutoModRule` is deleted.
     You must have :attr:`~Permissions.manage_guild` to receive this.
 
     This requires :attr:`Intents.auto_moderation_configuration` to be enabled.
@@ -276,7 +276,7 @@ AutoMod
 
 .. function:: on_automod_action(execution)
 
-    Called when a :class:`AutoModAction` is created/performed.
+    Called when an :class:`AutoModAction` is created/performed.
     You must have :attr:`~Permissions.manage_guild` to receive this.
 
     This requires :attr:`Intents.auto_moderation_execution` to be enabled.


### PR DESCRIPTION
## Summary

This PR fixes several typos found while reading through the API reference and interactions API reference documentation.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
