### PR TITLE
Fix DeprecationWarning in `escape_markdown()`

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1008,7 +1008,7 @@ def escape_markdown(text: str, *, as_needed: bool = False, ignore_links: bool = 
         regex = _MARKDOWN_STOCK_REGEX
         if ignore_links:
             regex = f'(?:{_URL_REGEX}|{regex})'
-        return re.sub(regex, replacement, text, 0, re.MULTILINE)
+        return re.sub(regex, replacement, text, count=0, flags=re.MULTILINE)
     else:
         text = re.sub(r'\\', r'\\\\', text)
         return _MARKDOWN_ESCAPE_REGEX.sub(r'\\\1', text)


### PR DESCRIPTION
`discord.utils.escape_markdown()` provides `count` as positional argument to `re.sub`, which is deprecated since Python 3.13. This PR provides `count` and `flags` as keyword argument.

See also https://docs.python.org/3.13/library/re.html#re.sub

* I tested this locally with Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14.
* I don't think this change requires a new automated test.
* I don't think this change requires an update to the documentation.

Fixes #10490

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
