### PR TITLE
Add guild specific avatar_decoration on Member

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -662,6 +662,17 @@ class Member(discord.abc.Messageable, _UserTag):
         return None
 
     @property
+    def display_avatar_decoration(self) -> Optional[Asset]:
+        """Optional[:class:`Asset`]: Returns the member's displayed avatar decoration, if any.
+
+        This is the member's guild specific avatar decoration if available, otherwise it's their
+        global avatar decoration. If the member has no avatar decoration set ``None`` is returned.
+
+        .. versionadded:: 2.8
+        """
+        return self.guild_avatar_decoration or self._user.avatar_decoration
+
+    @property
     def display_banner(self) -> Optional[Asset]:
         """Optional[:class:`Asset`]: Returns the member's displayed banner, if any.
 

--- a/discord/member.py
+++ b/discord/member.py
@@ -33,7 +33,7 @@ import discord.abc
 
 from . import utils
 from .asset import Asset
-from .utils import MISSING
+from .utils import MISSING, _get_as_snowflake
 from .user import BaseUser, ClientUser, User, _UserTag
 from .permissions import Permissions
 from .enums import Status
@@ -636,6 +636,30 @@ class Member(discord.abc.Messageable, _UserTag):
         if self._avatar is None:
             return None
         return Asset._from_guild_avatar(self._state, self.guild.id, self.id, self._avatar)
+
+    @property
+    def guild_avatar_decoration(self) -> Optional[Asset]:
+        """Optional[:class:`Asset`]: Returns an :class:`Asset` for the guild specific avatar decoration the member has.
+
+        If the member has not set a guild specific avatar decoration, ``None`` is returned.
+
+        .. versionadded:: 2.8
+        """
+        if self._avatar_decoration_data is not None:
+            return Asset._from_avatar_decoration(self._state, self._avatar_decoration_data['asset'])
+        return None
+
+    @property
+    def guild_avatar_decoration_sku_id(self) -> Optional[int]:
+        """Optional[:class:`int`]: Returns the SKU ID of the guild specific avatar decoration the member has.
+
+        If the member has not set a guild specific avatar decoration, ``None`` is returned.
+
+        .. versionadded:: 2.8
+        """
+        if self._avatar_decoration_data is not None:
+            return _get_as_snowflake(self._avatar_decoration_data, 'sku_id')
+        return None
 
     @property
     def display_banner(self) -> Optional[Asset]:


### PR DESCRIPTION
## Summary

This PR adds the missing `Member.guild_avatar_decoration`, `Member.guild_avatar_decoration_sku_id` & `Member.display_avatar_decoration`.

## Note

I did not include a `display_avatar_decoration_sku_id` since there was no existing precedent for exposing a `display_*sku_id` elsewhere in the lib. If anyone think it would be useful, I can add it.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
