### PR TITLE
Add file type filtering in slash command attachment options and modal's fileupload component

### DIFF
--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -2966,12 +2966,15 @@ def set_file_types(**parameters: Sequence[Union[str, FileType]]) -> Callable[[T]
     Parameters
     -----------
     \*\*parameters: Sequence[Union[:class:`str`, :class:`.FileType`]]
-        The file types of the parameters.
+        A list of up to 10 file types that are allowed to be uploaded for each attachment parameter.
+        The type of the parameter must be :class:`discord.Attachment`.
 
         You can mix and match strings and :class:`.FileType` enums in the list.
 
         If a string is provided, make sure to prefix it with a period (``.``) (e.g. ``.png``).
-        You may provide any string you want.
+        This is required.
+        You may provide any string you want, but (if you are specifying only extensions) you must
+        include ``.jpg`` for image uploads, and both ``.mp4`` and ``.mov`` for video uploads.
 
         Must be between 0 and 10. Defaults to allowing all file types.
 

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -377,6 +377,9 @@ def _populate_autocomplete(params: Dict[str, CommandParameter], autocomplete: Di
 
 def _populate_file_types(params: Dict[str, CommandParameter], file_types: Dict[str, Sequence[Union[str, FileType]]]) -> None:
     for name, param in params.items():
+        if param.type is not AppCommandOptionType.attachment:
+            raise TypeError('file_types is only supported for attachment option types')
+
         types = file_types.pop(name, MISSING)
         if types is MISSING:
             continue

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -36,6 +36,7 @@ from typing import (
     List,
     MutableMapping,
     Optional,
+    Sequence,
     Set,
     TYPE_CHECKING,
     Tuple,
@@ -48,7 +49,7 @@ from typing import (
 import re
 from copy import copy as shallow_copy
 
-from ..enums import AppCommandOptionType, AppCommandType, ChannelType, Locale
+from ..enums import AppCommandOptionType, AppCommandType, ChannelType, Locale, FileType
 from .installs import AppCommandContext, AppInstallationType
 from .models import Choice
 from .transformers import annotation_to_parameter, CommandParameter, NoneType
@@ -107,6 +108,7 @@ __all__ = (
     'user_install',
     'allowed_installs',
     'default_permissions',
+    'set_file_types',
 )
 
 if TYPE_CHECKING:
@@ -373,6 +375,22 @@ def _populate_autocomplete(params: Dict[str, CommandParameter], autocomplete: Di
         raise TypeError(f'unknown parameter given: {first}')
 
 
+def _populate_file_types(params: Dict[str, CommandParameter], file_types: Dict[str, Sequence[Union[str, FileType]]]) -> None:
+    for name, param in params.items():
+        types = file_types.pop(name, MISSING)
+        if types is MISSING:
+            continue
+
+        if not isinstance(types, (list, tuple)) or not all(isinstance(ft, (str, FileType)) for ft in types):
+            raise TypeError('file_types must be a list of strings or FileType enums')
+
+        param.file_types = [ft.value if isinstance(ft, FileType) else ft for ft in types]
+
+    if file_types:
+        first = next(iter(file_types))
+        raise TypeError(f'unknown parameter given: {first}')
+
+
 def _extract_parameters_from_callback(func: Callable[..., Any], globalns: Dict[str, Any]) -> Dict[str, CommandParameter]:
     params = inspect.signature(func).parameters
     cache = {}
@@ -427,6 +445,13 @@ def _extract_parameters_from_callback(func: Callable[..., Any], globalns: Dict[s
         pass
     else:
         _populate_autocomplete(result, autocomplete.copy())
+
+    try:
+        file_types = func.__discord_app_commands_param_file_types__
+    except AttributeError:
+        pass
+    else:
+        _populate_file_types(result, file_types.copy())
 
     return result
 
@@ -497,6 +522,8 @@ class Parameter:
         The minimum supported value for this parameter.
     max_value: Optional[Union[:class:`int`, :class:`float`]]
         The maximum supported value for this parameter.
+    file_types: Optional[Sequence[Union[:class:`str`, :class:`FileType`]]]
+        A list of file types that are allowed to be uploaded for this parameter.
     default: Any
         The default value of the parameter, if given.
         If not given then this is :data:`~discord.utils.MISSING`.
@@ -573,6 +600,10 @@ class Parameter:
     @property
     def max_value(self) -> Optional[Union[int, float]]:
         return self.__parent.max_value
+
+    @property
+    def file_types(self) -> Optional[Sequence[Union[str, FileType]]]:
+        return self.__parent.file_types
 
 
 class Command(Generic[GroupT, P, T]):
@@ -2903,5 +2934,56 @@ def default_permissions(perms_obj: Optional[Permissions] = None, /, **perms: Unp
             func.__discord_app_commands_default_permissions__ = permissions  # type: ignore # Runtime attribute assignment
 
         return func
+
+    return decorator
+
+
+def set_file_types(**parameters: Sequence[Union[str, FileType]]) -> Callable[[T], T]:
+    r"""Sets the file types for the given parameters by their name using the key of the keyword argument
+    as the name.
+
+    .. warning::
+
+        The actual file is not guaranteed to be of the specified type. The client only
+        checks the file extension, so users can easily bypass this check by renaming the file.
+
+    Example:
+
+    .. code-block:: python3
+
+        @app_commands.command(description='Uploads a file')
+        @app_commands.set_file_types(file=['.png', discord.FileType.video])
+        async def upload(interaction: discord.Interaction, file: discord.Attachment):
+            await interaction.response.send_message(f'Uploaded {file.filename}')
+
+    Parameters
+    -----------
+    \*\*parameters: Sequence[Union[:class:`str`, :class:`FileType`]]
+        The file types of the parameters.
+
+        You can mix and match strings and :class:`FileType` enums in the list.
+
+        If a string is provided, make sure to prefix it with a period (``.``) (e.g. ``.png``).
+        You may provide any string you want.
+
+        Must be between 0 and 10. Defaults to allowing all file types.
+
+    Raises
+    --------
+    TypeError
+        The parameter name is not found or the parameter type was incorrect.
+    """
+
+    def decorator(inner: T) -> T:
+        unwrapped = getattr(inner, '__discord_app_commands_unwrap__', inner) or inner
+        if isinstance(unwrapped, Command):
+            _populate_file_types(unwrapped._params, parameters)
+        else:
+            try:
+                inner.__discord_app_commands_param_file_types__.update(parameters)  # type: ignore # Runtime attribute access
+            except AttributeError:
+                inner.__discord_app_commands_param_file_types__ = parameters  # type: ignore # Runtime attribute assignment
+
+        return inner
 
     return decorator

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -68,6 +68,7 @@ from ..utils import (
     _iscoroutinefunction,
     _shorten,
     _to_kebab_case,
+    _validate_discord_file_types,
 )
 
 if TYPE_CHECKING:
@@ -387,7 +388,8 @@ def _populate_file_types(params: Dict[str, CommandParameter], file_types: Dict[s
         if not isinstance(types, (list, tuple)) or not all(isinstance(ft, (str, FileType)) for ft in types):
             raise TypeError('file_types must be a list of strings and FileType enums')
 
-        param.file_types = [ft.value if isinstance(ft, FileType) else ft for ft in types]
+        _validate_discord_file_types(types)
+        param.file_types = types
 
     if file_types:
         first = next(iter(file_types))

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -377,15 +377,15 @@ def _populate_autocomplete(params: Dict[str, CommandParameter], autocomplete: Di
 
 def _populate_file_types(params: Dict[str, CommandParameter], file_types: Dict[str, Sequence[Union[str, FileType]]]) -> None:
     for name, param in params.items():
-        if param.type is not AppCommandOptionType.attachment:
-            raise TypeError('file_types is only supported for attachment option types')
-
         types = file_types.pop(name, MISSING)
         if types is MISSING:
             continue
 
+        if param.type is not AppCommandOptionType.attachment:
+            raise TypeError('file_types is only supported for attachment option types')
+
         if not isinstance(types, (list, tuple)) or not all(isinstance(ft, (str, FileType)) for ft in types):
-            raise TypeError('file_types must be a list of strings or FileType enums')
+            raise TypeError('file_types must be a list of strings and FileType enums')
 
         param.file_types = [ft.value if isinstance(ft, FileType) else ft for ft in types]
 
@@ -527,6 +527,8 @@ class Parameter:
         The maximum supported value for this parameter.
     file_types: Optional[Sequence[Union[:class:`str`, :class:`.FileType`]]]
         A list of file types that are allowed to be uploaded for this parameter.
+
+        Only applicable for :class:`~discord.AppCommandOptionType.attachment` parameters.
 
         .. versionadded:: 2.8
     default: Any
@@ -2981,7 +2983,7 @@ def set_file_types(**parameters: Sequence[Union[str, FileType]]) -> Callable[[T]
     Raises
     --------
     TypeError
-        The parameter name is not found or the parameter type was incorrect.
+        The parameter name is not found or the parameter type is not :class:`discord.Attachment`.
     """
 
     def decorator(inner: T) -> T:

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -2942,6 +2942,8 @@ def set_file_types(**parameters: Sequence[Union[str, FileType]]) -> Callable[[T]
     r"""Sets the file types for the given parameters by their name using the key of the keyword argument
     as the name.
 
+    .. versionadded:: 2.8
+
     .. warning::
 
         The actual file is not guaranteed to be of the specified type. The client only

--- a/discord/app_commands/commands.py
+++ b/discord/app_commands/commands.py
@@ -522,8 +522,10 @@ class Parameter:
         The minimum supported value for this parameter.
     max_value: Optional[Union[:class:`int`, :class:`float`]]
         The maximum supported value for this parameter.
-    file_types: Optional[Sequence[Union[:class:`str`, :class:`FileType`]]]
+    file_types: Optional[Sequence[Union[:class:`str`, :class:`.FileType`]]]
         A list of file types that are allowed to be uploaded for this parameter.
+
+        .. versionadded:: 2.8
     default: Any
         The default value of the parameter, if given.
         If not given then this is :data:`~discord.utils.MISSING`.
@@ -2960,10 +2962,10 @@ def set_file_types(**parameters: Sequence[Union[str, FileType]]) -> Callable[[T]
 
     Parameters
     -----------
-    \*\*parameters: Sequence[Union[:class:`str`, :class:`FileType`]]
+    \*\*parameters: Sequence[Union[:class:`str`, :class:`.FileType`]]
         The file types of the parameters.
 
-        You can mix and match strings and :class:`FileType` enums in the list.
+        You can mix and match strings and :class:`.FileType` enums in the list.
 
         If a string is provided, make sure to prefix it with a period (``.``) (e.g. ``.png``).
         You may provide any string you want.

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -1018,8 +1018,10 @@ class Argument:
         The maximum allowed length for this parameter.
     autocomplete: :class:`bool`
         Whether the argument has autocomplete.
-    file_types: Optional[Sequence[Union[:class:`str`, :class:`FileType`]]]
+    file_types: Sequence[Union[:class:`str`, :class:`FileType`]]
         A list of file types that are allowed to be uploaded for this argument.
+
+        .. versionadded:: 2.8
     """
 
     __slots__ = (
@@ -1065,7 +1067,7 @@ class Argument:
         self.choices: List[Choice[Union[int, float, str]]] = [Choice.from_dict(d) for d in data.get('choices', [])]
         self.name_localizations: Dict[Locale, str] = _to_locale_dict(data.get('name_localizations') or {})
         self.description_localizations: Dict[Locale, str] = _to_locale_dict(data.get('description_localizations') or {})
-        self.file_types: Optional[List[str]] = data.get('file_types')
+        self.file_types: List[str] = data.get('file_types', [])
 
     def to_dict(self) -> ApplicationCommandOption:
         return {

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -1018,6 +1018,8 @@ class Argument:
         The maximum allowed length for this parameter.
     autocomplete: :class:`bool`
         Whether the argument has autocomplete.
+    file_types: Optional[Sequence[Union[:class:`str`, :class:`FileType`]]]
+        A list of file types that are allowed to be uploaded for this argument.
     """
 
     __slots__ = (
@@ -1036,6 +1038,7 @@ class Argument:
         'autocomplete',
         'parent',
         '_state',
+        'file_types',
     )
 
     def __init__(
@@ -1062,6 +1065,7 @@ class Argument:
         self.choices: List[Choice[Union[int, float, str]]] = [Choice.from_dict(d) for d in data.get('choices', [])]
         self.name_localizations: Dict[Locale, str] = _to_locale_dict(data.get('name_localizations') or {})
         self.description_localizations: Dict[Locale, str] = _to_locale_dict(data.get('description_localizations') or {})
+        self.file_types: Optional[List[str]] = data.get('file_types')
 
     def to_dict(self) -> ApplicationCommandOption:
         return {
@@ -1079,6 +1083,7 @@ class Argument:
             'options': [],
             'name_localizations': {str(k): v for k, v in self.name_localizations.items()},
             'description_localizations': {str(k): v for k, v in self.description_localizations.items()},
+            'file_types': self.file_types,
         }  # type: ignore # Type checker does not understand this literal.
 
 

--- a/discord/app_commands/models.py
+++ b/discord/app_commands/models.py
@@ -1018,7 +1018,7 @@ class Argument:
         The maximum allowed length for this parameter.
     autocomplete: :class:`bool`
         Whether the argument has autocomplete.
-    file_types: Sequence[Union[:class:`str`, :class:`FileType`]]
+    file_types: Sequence[Union[:class:`str`, :class:`.FileType`]]
         A list of file types that are allowed to be uploaded for this argument.
 
         .. versionadded:: 2.8

--- a/discord/app_commands/transformers.py
+++ b/discord/app_commands/transformers.py
@@ -39,6 +39,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -52,7 +53,7 @@ from .translator import TranslationContextLocation, TranslationContext, Translat
 from ..channel import StageChannel, VoiceChannel, TextChannel, CategoryChannel, ForumChannel
 from ..abc import GuildChannel
 from ..threads import Thread
-from ..enums import Enum as InternalEnum, AppCommandOptionType, ChannelType, Locale
+from ..enums import Enum as InternalEnum, AppCommandOptionType, ChannelType, Locale, FileType
 from ..utils import MISSING, maybe_coroutine, _human_join, _iscoroutinefunction, TIMESTAMP_PATTERN
 from ..user import User
 from ..role import Role
@@ -91,6 +92,7 @@ class CommandParameter:
     min_value: Optional[Union[int, float]] = None
     max_value: Optional[Union[int, float]] = None
     autocomplete: Optional[Callable[..., Coroutine[Any, Any, Any]]] = None
+    file_types: Optional[Sequence[Union[str, FileType]]] = MISSING
     _rename: Union[str, locale_str] = MISSING
     _annotation: Any = MISSING
 
@@ -143,6 +145,8 @@ class CommandParameter:
             base['channel_types'] = [t.value for t in self.channel_types]
         if self.autocomplete:
             base['autocomplete'] = True
+        if self.file_types:
+            base['file_types'] = [ft.value if isinstance(ft, FileType) else ft for ft in self.file_types]
 
         min_key, max_key = (
             ('min_value', 'max_value') if self.type is not AppCommandOptionType.string else ('min_length', 'max_length')

--- a/discord/components.py
+++ b/discord/components.py
@@ -32,6 +32,7 @@ from typing import (
     TYPE_CHECKING,
     Tuple,
     Union,
+    Sequence,
 )
 
 from .asset import AssetMixin
@@ -44,6 +45,7 @@ from .enums import (
     SelectDefaultValueType,
     SeparatorSpacing,
     MediaItemLoadingState,
+    FileType,
 )
 from .flags import AttachmentFlags
 from .colour import Colour
@@ -1491,7 +1493,7 @@ class FileUploadComponent(Component):
         self.max_values: int = data.get('max_values', 1)
         self.required: bool = data.get('required', True)
         self.id: Optional[int] = data.get('id')
-        self.file_types: List[str] = data.get('file_types', [])
+        self.file_types: Sequence[Union[str, FileType]] = data.get('file_types', [])
 
     @property
     def type(self) -> Literal[ComponentType.file_upload]:
@@ -1509,7 +1511,7 @@ class FileUploadComponent(Component):
         if self.id is not None:
             payload['id'] = self.id
         if self.file_types:
-            payload['file_types'] = self.file_types
+            payload['file_types'] = [ft.value if isinstance(ft, FileType) else ft for ft in self.file_types]
 
         return payload
 

--- a/discord/components.py
+++ b/discord/components.py
@@ -1467,6 +1467,9 @@ class FileUploadComponent(Component):
     required: :class:`bool`
         Whether the component is required.
         Defaults to ``True``.
+    file_types: List[:class:`str`]
+        A list of file types that are allowed to be uploaded for this component.
+        Defaults to allowing all file types.
     """
 
     __slots__: Tuple[str, ...] = (
@@ -1475,6 +1478,7 @@ class FileUploadComponent(Component):
         'max_values',
         'required',
         'id',
+        'file_types',
     )
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
@@ -1485,6 +1489,7 @@ class FileUploadComponent(Component):
         self.max_values: int = data.get('max_values', 1)
         self.required: bool = data.get('required', True)
         self.id: Optional[int] = data.get('id')
+        self.file_types: List[str] = data.get('file_types', [])
 
     @property
     def type(self) -> Literal[ComponentType.file_upload]:
@@ -1501,6 +1506,8 @@ class FileUploadComponent(Component):
         }
         if self.id is not None:
             payload['id'] = self.id
+        if self.file_types:
+            payload['file_types'] = self.file_types
 
         return payload
 

--- a/discord/components.py
+++ b/discord/components.py
@@ -1470,6 +1470,8 @@ class FileUploadComponent(Component):
     file_types: List[:class:`str`]
         A list of file types that are allowed to be uploaded for this component.
         Defaults to allowing all file types.
+
+        .. versionadded:: 2.8
     """
 
     __slots__: Tuple[str, ...] = (

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -87,6 +87,7 @@ __all__ = (
     'MediaItemLoadingState',
     'CollectibleType',
     'NameplatePalette',
+    'FileType',
 )
 
 
@@ -1004,6 +1005,29 @@ class NameplatePalette(Enum):
     clover = 'clover'
     lemon = 'lemon'
     white = 'white'
+
+
+class FileType(Enum):
+    audio = 'audio'
+    video = 'video'
+    image = 'image'
+
+    @property
+    def file_extensions(self) -> tuple[str, ...]:
+        """:class:`tuple[str]`: Returns a tuple of file extensions that belong to this file type.
+
+        .. warning::
+
+            These are subject to change at anytime and should not be relied upon for validation.
+        """
+        # fmt: off
+        lookup: Dict[FileType, tuple[str, ...]] = {
+            FileType.image: ('png', 'gif', 'jpg', 'jpeg', 'jfif', 'webp', 'avif'),
+            FileType.video: ('mp4', 'mov', 'qt', 'webm'),
+            FileType.audio: ('mp3', 'm4a', 'wav', 'ogg', 'opus', 'flac'),
+        }
+        # fmt: on
+        return lookup.get(self, ())
 
 
 def create_unknown_value(cls: Type[E], val: Any) -> E:

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -1013,7 +1013,7 @@ class FileType(Enum):
     image = 'image'
 
     @property
-    def file_extensions(self) -> tuple[str, ...]:
+    def file_extensions(self) -> Tuple[str, ...]:
         """:class:`tuple[str]`: Returns a tuple of file extensions that belong to this file type.
 
         .. warning::
@@ -1021,7 +1021,7 @@ class FileType(Enum):
             These are subject to change at anytime and should not be relied upon for validation.
         """
         # fmt: off
-        lookup: Dict[FileType, tuple[str, ...]] = {
+        lookup: Dict[FileType, Tuple[str, ...]] = {
             FileType.image: ('png', 'gif', 'jpg', 'jpeg', 'jfif', 'webp', 'avif'),
             FileType.video: ('mp4', 'mov', 'qt', 'webm'),
             FileType.audio: ('mp3', 'm4a', 'wav', 'ogg', 'opus', 'flac'),

--- a/discord/types/command.py
+++ b/discord/types/command.py
@@ -118,12 +118,18 @@ class _NumberApplicationCommandOption(_BaseValueApplicationCommandOption, total=
     autocomplete: bool
 
 
+class _AttachmentApplicationCommandOption(_BaseValueApplicationCommandOption):
+    type: Literal[11]
+    file_types: NotRequired[List[str]]
+
+
 _ValueApplicationCommandOption = Union[
     _StringApplicationCommandOption,
     _IntegerApplicationCommandOption,
     _BooleanApplicationCommandOption,
     _SnowflakeApplicationCommandOptionChoice,
     _NumberApplicationCommandOption,
+    _AttachmentApplicationCommandOption,
 ]
 
 ApplicationCommandOption = Union[

--- a/discord/types/components.py
+++ b/discord/types/components.py
@@ -204,6 +204,7 @@ class FileUploadComponent(ComponentBase):
     max_values: NotRequired[int]
     min_values: NotRequired[int]
     required: NotRequired[bool]
+    file_types: NotRequired[List[str]]
 
 
 class RadioGroupComponent(ComponentBase):

--- a/discord/ui/file_upload.py
+++ b/discord/ui/file_upload.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any, List, Literal, Optional, Sequence, Tuple,
 
 import os
 
-from ..utils import MISSING
+from ..utils import MISSING, _validate_discord_file_types
 from ..components import FileUploadComponent
 from ..enums import ComponentType, FileType
 from .item import Item
@@ -116,13 +116,16 @@ class FileUpload(Item[V]):
         if not isinstance(custom_id, str):
             raise TypeError(f'expected custom_id to be str not {custom_id.__class__.__name__}')
 
+        if file_types:
+            _validate_discord_file_types(file_types)
+
         self._underlying: FileUploadComponent = FileUploadComponent._raw_construct(
             id=id,
             custom_id=custom_id,
             max_values=max_values,
             min_values=min_values,
             required=required,
-            file_types=[ft.value if isinstance(ft, FileType) else ft for ft in file_types] if file_types is not None else [],
+            file_types=file_types if file_types else [],
         )
         self.id = id
         self._values: List[Attachment] = []
@@ -186,7 +189,7 @@ class FileUpload(Item[V]):
         self._underlying.required = bool(value)
 
     @property
-    def file_types(self) -> List[str]:
+    def file_types(self) -> List[Union[str, FileType]]:
         """List[:class:`str`]: A list of file types that are allowed to be uploaded for this component.
 
         When setting this property, see the documentation for this parameter in the :class:`.FileUpload`
@@ -194,14 +197,15 @@ class FileUpload(Item[V]):
 
         .. versionadded:: 2.8
         """
-        return self._underlying.file_types
+        return list(self._underlying.file_types)
 
     @file_types.setter
-    def file_types(self, value: List[Union[str, FileType]]) -> None:
-        if not isinstance(value, list) or not all(isinstance(ft, (str, FileType)) for ft in value):
+    def file_types(self, value: Sequence[Union[str, FileType]]) -> None:
+        if not isinstance(value, (list, tuple)) or not all(isinstance(ft, (str, FileType)) for ft in value):
             raise TypeError('file_types must be a list of str or FileType')
 
-        self._underlying.file_types = [ft.value if isinstance(ft, FileType) else ft for ft in value]
+        _validate_discord_file_types(value)
+        self._underlying.file_types = list(value)
 
     @property
     def width(self) -> int:

--- a/discord/ui/file_upload.py
+++ b/discord/ui/file_upload.py
@@ -86,6 +86,8 @@ class FileUpload(Item[V]):
 
             The actual file is not guaranteed to be of the specified type. The client only
             checks the file extension, so users can easily bypass this check by renaming the file.
+
+        .. versionadded:: 2.8
     """
 
     __item_repr_attributes__: Tuple[str, ...] = (
@@ -187,6 +189,8 @@ class FileUpload(Item[V]):
 
         When setting this property, see the documentation for this parameter in the :class:`FileUpload`
         constructor for more information.
+
+        .. versionadded:: 2.8
         """
         return self._underlying.file_types
 

--- a/discord/ui/file_upload.py
+++ b/discord/ui/file_upload.py
@@ -72,10 +72,10 @@ class FileUpload(Item[V]):
     required: :class:`bool`
         Whether this component is required to be filled before submitting the modal.
         Defaults to ``True``.
-    file_types: List[Union[:class:`str`, :class:`FileType`]]
+    file_types: List[Union[:class:`str`, :class:`.FileType`]]
         A list of file types that are allowed to be uploaded for this component.
 
-        You can mix and match strings and :class:`FileType` enums in the list.
+        You can mix and match strings and :class:`.FileType` enums in the list.
 
         If a string is provided, make sure to prefix it with a period (``.``) (e.g. ``.png``).
         You may provide any string you want.
@@ -187,7 +187,7 @@ class FileUpload(Item[V]):
     def file_types(self) -> List[str]:
         """List[:class:`str`]: A list of file types that are allowed to be uploaded for this component.
 
-        When setting this property, see the documentation for this parameter in the :class:`FileUpload`
+        When setting this property, see the documentation for this parameter in the :class:`.FileUpload`
         constructor for more information.
 
         .. versionadded:: 2.8

--- a/discord/ui/file_upload.py
+++ b/discord/ui/file_upload.py
@@ -23,13 +23,13 @@ DEALINGS IN THE SOFTWARE.
 """
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, List, Literal, Optional, Tuple, TypeVar, Dict
+from typing import TYPE_CHECKING, Any, List, Literal, Optional, Sequence, Tuple, TypeVar, Dict, Union
 
 import os
 
 from ..utils import MISSING
 from ..components import FileUploadComponent
-from ..enums import ComponentType
+from ..enums import ComponentType, FileType
 from .item import Item
 
 if TYPE_CHECKING:
@@ -72,6 +72,20 @@ class FileUpload(Item[V]):
     required: :class:`bool`
         Whether this component is required to be filled before submitting the modal.
         Defaults to ``True``.
+    file_types: List[Union[:class:`str`, :class:`FileType`]]
+        A list of file types that are allowed to be uploaded for this component.
+
+        You can mix and match strings and :class:`FileType` enums in the list.
+
+        If a string is provided, make sure to prefix it with a period (``.``) (e.g. ``.png``).
+        You may provide any string you want.
+
+        Must be between 0 and 10. Defaults to allowing all file types.
+
+        .. warning::
+
+            The actual file is not guaranteed to be of the specified type. The client only
+            checks the file extension, so users can easily bypass this check by renaming the file.
     """
 
     __item_repr_attributes__: Tuple[str, ...] = (
@@ -90,6 +104,7 @@ class FileUpload(Item[V]):
         min_values: Optional[int] = None,
         max_values: Optional[int] = None,
         id: Optional[int] = None,
+        file_types: Optional[Sequence[Union[str, FileType]]] = None,
     ) -> None:
         super().__init__()
         self._provided_custom_id = custom_id is not MISSING
@@ -103,6 +118,7 @@ class FileUpload(Item[V]):
             max_values=max_values,
             min_values=min_values,
             required=required,
+            file_types=[ft.value if isinstance(ft, FileType) else ft for ft in file_types] if file_types is not None else [],
         )
         self.id = id
         self._values: List[Attachment] = []
@@ -166,6 +182,22 @@ class FileUpload(Item[V]):
         self._underlying.required = bool(value)
 
     @property
+    def file_types(self) -> List[str]:
+        """List[:class:`str`]: A list of file types that are allowed to be uploaded for this component.
+
+        When setting this property, see the documentation for this parameter in the :class:`FileUpload`
+        constructor for more information.
+        """
+        return self._underlying.file_types
+
+    @file_types.setter
+    def file_types(self, value: List[Union[str, FileType]]) -> None:
+        if not isinstance(value, list) or not all(isinstance(ft, (str, FileType)) for ft in value):
+            raise TypeError('file_types must be a list of str or FileType')
+
+        self._underlying.file_types = [ft.value if isinstance(ft, FileType) else ft for ft in value]
+
+    @property
     def width(self) -> int:
         return 5
 
@@ -188,6 +220,7 @@ class FileUpload(Item[V]):
             max_values=component.max_values,
             min_values=component.min_values,
             required=component.required,
+            file_types=component.file_types,
         )
         return self
 

--- a/discord/ui/file_upload.py
+++ b/discord/ui/file_upload.py
@@ -78,7 +78,9 @@ class FileUpload(Item[V]):
         You can mix and match strings and :class:`.FileType` enums in the list.
 
         If a string is provided, make sure to prefix it with a period (``.``) (e.g. ``.png``).
-        You may provide any string you want.
+        This is required.
+        You may provide any string you want, but (if you are specifying only extensions) you must
+        include ``.jpg`` for image uploads, and both ``.mp4`` and ``.mov`` for video uploads.
 
         Must be between 0 and 10. Defaults to allowing all file types.
 

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1537,6 +1537,34 @@ def _format_call_duration(duration: datetime.timedelta) -> str:
     return formatted
 
 
+if TYPE_CHECKING:
+    from .enums import FileType
+
+DISCORD_FILE_TYPES_RE = re.compile(r'^\.[\w\-\.]+$', re.IGNORECASE)
+
+
+def _validate_discord_file_types(exts: Sequence[Union[FileType, str]], /) -> None:
+    if len(exts) > 10:
+        raise ValueError(
+            f'Too many file extensions provided. Must be 10 or less, got {len(exts)}.',
+        )
+
+    for ext in exts:
+        # don't need to validate the presets (FileType enum) since they are guaranteed to be valid
+        if not isinstance(ext, str):
+            continue
+
+        if len(ext) > 16:
+            raise ValueError(
+                f'File extension {ext!r} is too long. Must be 16 characters or less.',
+            )
+
+        if not DISCORD_FILE_TYPES_RE.match(ext):
+            raise ValueError(
+                f'File extension {ext!r} is invalid. It must start with a dot and contain only alphanumeric characters, hyphens, or underscores.',
+            )
+
+
 class _RawReprMixin:
     __slots__: Tuple[str, ...] = ()
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4154,6 +4154,23 @@ of :class:`enum.Enum`.
 
         The collectible nameplate palette is white.
 
+
+.. class:: FileType
+
+    .. versionadded:: 2.8
+
+    .. attribute:: image
+
+        Only image files are allowed.
+
+    .. attribute:: video
+
+        Only video files are allowed.
+
+    .. attribute:: audio
+
+        Only audio files are allowed.
+
 .. _discord-api-audit-logs:
 
 Audit Log Data

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4161,15 +4161,15 @@ of :class:`enum.Enum`.
 
     .. attribute:: image
 
-        Only image files are allowed.
+        Preset to represent image files.
 
     .. attribute:: video
 
-        Only video files are allowed.
+        Preset to represent video files.
 
     .. attribute:: audio
 
-        Only audio files are allowed.
+        Preset to represent audio files.
 
 .. _discord-api-audit-logs:
 


### PR DESCRIPTION
## Summary

This PR adds supports for the functionality to limit file uploads from a modal or slash commands to certain extensions.

Docs PR: https://github.com/discord/discord-api-docs/pull/8506

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
