### PR TITLE
Fix Interaction.original_response raising when channel is not cached

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -48,7 +48,7 @@ from .webhook.async_ import async_context, Webhook, interaction_response_params,
 from .app_commands.installs import AppCommandContext
 from .app_commands.namespace import Namespace
 from .app_commands.translator import locale_str, TranslationContext, TranslationContextLocation
-from .channel import _threaded_channel_factory
+from .channel import _threaded_channel_factory, PartialMessageable
 
 __all__ = (
     'Interaction',
@@ -489,11 +489,6 @@ class Interaction(Generic[ClientT]):
         if self._original_response is not None:
             return self._original_response
 
-        # TODO: fix later to not raise?
-        channel = self.channel
-        if channel is None:
-            raise ClientException('Channel for message could not be resolved')
-
         adapter = async_context.get()
         http = self._state.http
         data = await adapter.get_original_interaction_response(
@@ -503,6 +498,14 @@ class Interaction(Generic[ClientT]):
             proxy=http.proxy,
             proxy_auth=http.proxy_auth,
         )
+        channel = self.channel
+        if channel is None:
+            channel_id = data.get('channel_id')
+            if channel_id is not None:
+                channel = PartialMessageable(state=self._state, id=int(channel_id), guild_id=self.guild_id)
+            else:
+                raise ClientException('Channel for message could not be resolved')
+
         state = _InteractionMessageState(self, self._state)
         # The state and channel parameters are mocked here
         message = InteractionMessage(state=state, channel=channel, data=data)  # type: ignore
@@ -611,9 +614,13 @@ class Interaction(Generic[ClientT]):
                 files=params.files,
             )
 
+        channel = self.channel
+        if channel is None and 'channel_id' in data:
+            channel = PartialMessageable(state=self._state, id=int(data['channel_id']), guild_id=self.guild_id)
+
         # The message channel types should always match
         state = _InteractionMessageState(self, self._state)
-        message = InteractionMessage(state=state, channel=self.channel, data=data)  # type: ignore
+        message = InteractionMessage(state=state, channel=channel, data=data)  # type: ignore
         if view and not view.is_finished() and view.is_dispatchable():
             self._state.store_view(view, message.id)
         return message

--- a/discord/voice_state.py
+++ b/discord/voice_state.py
@@ -270,7 +270,7 @@ class VoiceConnectionState:
 
     @property
     def can_encrypt(self) -> bool:
-        return self.dave_protocol_version != 0 and self.dave_session != None and self.dave_session.ready
+        return self.dave_protocol_version != 0 and self.dave_session is not None and self.dave_session.ready
 
     async def reinit_dave_session(self) -> None:
         if self.dave_protocol_version > 0:

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import discord
+from discord.webhook.async_ import async_context
+from discord.errors import ClientException
+from discord.channel import PartialMessageable
+
+
+@pytest.mark.asyncio
+async def test_interaction_original_response_channel_fallback():
+    state = MagicMock()
+    data = {
+        'id': '123456',
+        'type': 2,
+        'token': 'mock_token',
+        'version': 1,
+        'application_id': '987654',
+        'user': {'id': '111', 'username': 'testuser', 'discriminator': '0000'},
+        'attachment_size_limit': 10485760,
+    }
+    interaction = discord.Interaction(data=data, state=state)
+    interaction.channel = None
+
+    mock_adapter = AsyncMock()
+    mock_adapter.get_original_interaction_response.return_value = {
+        'id': '55555',
+        'channel_id': '66666',
+        'author': {'id': '111', 'username': 'testuser', 'discriminator': '0000'},
+        'content': 'hello world',
+        'type': 0,
+        'timestamp': '2026-08-07T20:00:00+00:00',
+        'tts': False,
+        'mention_everyone': False,
+        'mentions': [],
+        'role_mentions': [],
+        'attachments': [],
+        'embeds': [],
+        'pinned': False,
+    }
+
+    token = async_context.set(mock_adapter)
+    try:
+        msg = await interaction.original_response()
+        assert isinstance(msg.channel, PartialMessageable)
+        assert msg.channel.id == 66666
+    finally:
+        async_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_interaction_original_response_channel_unresolvable_raises():
+    state = MagicMock()
+    data = {
+        'id': '123456',
+        'type': 2,
+        'token': 'mock_token',
+        'version': 1,
+        'application_id': '987654',
+        'user': {'id': '111', 'username': 'testuser', 'discriminator': '0000'},
+        'attachment_size_limit': 10485760,
+    }
+    interaction = discord.Interaction(data=data, state=state)
+    interaction.channel = None
+
+    mock_adapter = AsyncMock()
+    mock_adapter.get_original_interaction_response.return_value = {
+        'id': '55555',
+        'author': {'id': '111', 'username': 'testuser', 'discriminator': '0000'},
+        'content': 'hello world',
+        'type': 0,
+        'timestamp': '2026-08-07T20:00:00+00:00',
+        'tts': False,
+        'mention_everyone': False,
+        'mentions': [],
+        'role_mentions': [],
+        'attachments': [],
+        'embeds': [],
+        'pinned': False,
+    }
+
+    token = async_context.set(mock_adapter)
+    try:
+        with pytest.raises(ClientException, match='Channel for message could not be resolved'):
+            await interaction.original_response()
+    finally:
+        async_context.reset(token)


### PR DESCRIPTION
## Summary

`original_response()` raises if the channel isn't cached. this falls back to a `PartialMessageable` using channel_id from the response instead, like the webhook code does. did the same for `edit_original_response()` too.

also fixed a `!= None` -> `is not None` in voice_state.py.

## Checklist

- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
