### PR TITLE
Fix: `as_chunks` errors upon non-sliceable iterators

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1041,18 +1041,12 @@ def escape_mentions(text: str) -> str:
 
 
 def _chunk(iterator: Iterable[T], max_size: int) -> Iterator[List[T]]:
-    # Specialise iterators that can be sliced as it is much faster
-    if isinstance(iterator, collections.abc.Sequence):
-        for i in range(0, len(iterator), max_size):
-            yield list(iterator[i : i + max_size])
-    else:
-        # Fallback to slower path
-        iterator = iter(iterator)
-        while True:
-            batch = list(islice(iterator, max_size))
-            if not batch:
-                break
-            yield batch
+    iterator = iter(iterator)
+    while True:
+        batch = list(islice(iterator, max_size))
+        if not batch:
+            break
+        yield batch
 
 
 async def _achunk(iterator: AsyncIterable[T], max_size: int) -> AsyncIterator[List[T]]:

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -57,7 +57,6 @@ from typing import (
     TYPE_CHECKING,
 )
 import unicodedata
-import collections.abc
 from itertools import islice
 from base64 import b64encode, b64decode
 from bisect import bisect_left


### PR DESCRIPTION
## Summary
This PR fixes `as_chunks` where the iterator is an `abc.Sequence`, but its `__getitem__` method does not support slicing. (#10351)
An example is `deque`.

The solution is to use `isslice` for all cases which can slice any iterator. It's only slightly slower and memory usage is around the same.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
