### PR TITLE
Use keyword arguments for re.sub in remove_markdown

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -968,7 +968,7 @@ def remove_markdown(text: str, *, ignore_links: bool = True) -> str:
     regex = _MARKDOWN_STOCK_REGEX
     if ignore_links:
         regex = f'(?:{_URL_REGEX}|{regex})'
-    return re.sub(regex, replacement, text, 0, re.MULTILINE)
+    return re.sub(regex, replacement, text, count=0, flags=re.MULTILINE)
 
 
 def escape_markdown(text: str, *, as_needed: bool = False, ignore_links: bool = True) -> str:


### PR DESCRIPTION
## Summary

Updates the `re.sub` call in `remove_markdown` to use keyword arguments for `count` and `flags`.

The same change was already made in `escape_markdown`, so this just fixes the remaining call and removes the warning. No behavior changes.

## Checklist

- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)