### PR TITLE
fix(tasks): survive external CancelledError during connection reset

### DIFF
--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -258,6 +258,20 @@ class Loop(Generic[LF]):
                         retry_after,
                     )
                     await asyncio.sleep(retry_after)
+                except asyncio.CancelledError:
+                    # If the task was cancelled externally (e.g. during a connection
+                    # reset) but the user did not request a stop or cancel, treat it
+                    # as a retriable failure so the loop survives reconnection.
+                    if self._stop_next_iteration or not self.reconnect:
+                        raise
+                    self._last_iteration_failed = True
+                    retry_after = backoff.delay()
+                    _log.warning(
+                        'Task %s was cancelled externally, likely due to a connection reset. Retrying in %.2fs',
+                        self.coro.__qualname__,
+                        retry_after,
+                    )
+                    await asyncio.sleep(retry_after)
                 else:
                     if self._stop_next_iteration:
                         return


### PR DESCRIPTION
## Summary

fixes #9074

tasks die after a connection reset, been broken for 3 years mate. basically when the websocket resets it cancels the task externally, that `CancelledError` was hitting the outer handler and just killing the loop dead. reconnect logic never even got a chance to run innit

shoved an inner `CancelledError` handler in the try block around `coro()`. if its an external cancel it backs off and retries, if the user actually asked for a stop it raises like normal

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)