### PR TITLE
Add support for editing attachments

### DIFF
--- a/discord/file.py
+++ b/discord/file.py
@@ -71,10 +71,15 @@ class File:
     spoiler: :class:`bool`
         Whether the attachment is a spoiler. If left unspecified, the :attr:`~File.filename` is used
         to determine if the file is a spoiler.
+
+        .. versionchanged:: 2.8
+            This can now be edited after sending.
     description: Optional[:class:`str`]
         The file description to display, currently only supported for images.
 
         .. versionadded:: 2.0
+        .. versionchanged:: 2.8
+            This can now be edited after sending.
     """
 
     __slots__ = ('fp', '_filename', 'spoiler', 'description', '_original_pos', '_owner', '_closer')
@@ -123,8 +128,13 @@ class File:
         """:class:`str`: The filename to display when uploading to Discord.
         If this is not given then it defaults to ``fp.name`` or if ``fp`` is
         a string then the ``filename`` will default to the string given.
+
+        .. versionchanged:: 2.8
+            This no longer includes the ``SPOILER_`` prefix in the filename, and instead uses
+            the :attr:`spoiler` attribute to determine if the file is a spoiler, which also sets
+            the `is_spoiler` field in the payload sent to Discord.
         """
-        return 'SPOILER_' + self._filename if self.spoiler else self._filename
+        return self._filename
 
     @filename.setter
     def filename(self, value: str) -> None:
@@ -165,6 +175,7 @@ class File:
         payload = {
             'id': index,
             'filename': self.filename,
+            'is_spoiler': self.spoiler,
         }
 
         if self.description is not None:

--- a/discord/message.py
+++ b/discord/message.py
@@ -1350,6 +1350,19 @@ class PartialMessage(Hashable):
 
             .. note::
 
+                You may edit the :attr:`Attachment.description` and spoiler status of existing attachments by passing keyword
+                arguments to the :meth:`Attachment.to_file` method and then passing the returned :class:`File` object here. For
+                example, to edit the spoiler status of all attachments in a message, you can do the following:
+
+                .. code-block:: python3
+
+                    attachments = [await attachment.to_file(spoiler=True) for attachment in message.attachments]
+                    await message.edit(attachments=attachments)
+
+                .. versionadded:: 2.8
+
+            .. note::
+
                 New files will always appear after current attachments.
 
             .. versionadded:: 2.0
@@ -2909,6 +2922,19 @@ class Message(PartialMessage, Hashable):
         attachments: List[Union[:class:`Attachment`, :class:`File`]]
             A list of attachments to keep in the message as well as new files to upload. If ``[]`` is passed
             then all attachments are removed.
+
+            .. note::
+
+                You may edit the :attr:`Attachment.description` and spoiler status of existing attachments by passing keyword
+                arguments to the :meth:`Attachment.to_file` method and then passing the returned :class:`File` object here. For
+                example, to edit the spoiler status of all attachments in a message, you can do the following:
+
+                .. code-block:: python3
+
+                    attachments = [await attachment.to_file(spoiler=True) for attachment in message.attachments]
+                    await message.edit(attachments=attachments)
+
+                .. versionadded:: 2.8
 
             .. note::
 


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/pull/8429/changes
https://docs.discord.com/developers/resources/message#attachment-object-attachment-request-structure

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
