### PR TITLE
Expand upper bound for TextDisplay.

### DIFF
--- a/discord/ui/text_display.py
+++ b/discord/ui/text_display.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Optional, TypeVar
+from typing import TYPE_CHECKING, Literal, Optional, TypeVar, Union
 
 from .item import Item
 from ..components import TextDisplay as TextDisplayComponent
@@ -34,8 +34,9 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from .view import LayoutView
+    from .modal import Modal
 
-V = TypeVar('V', bound='LayoutView', covariant=True)
+V = TypeVar('V', bound='Union[LayoutView, Modal]', covariant=True)
 
 __all__ = ('TextDisplay',)
 


### PR DESCRIPTION
## Summary

Update the generic type variable V inside `discord.ui.TextDisplay` to accept `Union[LayoutView, Modal]`.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
