### PR TITLE
Move properties transmitted in identify to variable on DiscordWebSocket

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -260,6 +260,13 @@ class DiscordClientWebSocketResponse(aiohttp.ClientWebSocketResponse):
 DWS = TypeVar('DWS', bound='DiscordWebSocket')
 
 
+def _set_identify_properties(properties: dict[str, str]):
+    if not isinstance(properties, dict):
+        raise TypeError(f'expected dict not {properties.__class__.__name__}')
+
+    DiscordWebSocket.IDENTIFY_PROPERTIES = dict(properties)
+
+
 class DiscordWebSocket:
     """Implements a WebSocket for Discord's gateway v10.
 
@@ -327,6 +334,12 @@ class DiscordWebSocket:
     HEARTBEAT_ACK               = 11
     GUILD_SYNC                  = 12
     # fmt: on
+
+    IDENTIFY_PROPERTIES = {
+        'os': sys.platform,
+        'browser': 'discord.py',
+        'device': 'discord.py',
+    }
 
     def __init__(self, socket: aiohttp.ClientWebSocketResponse, *, loop: asyncio.AbstractEventLoop) -> None:
         self.socket: aiohttp.ClientWebSocketResponse = socket
@@ -474,11 +487,7 @@ class DiscordWebSocket:
             'op': self.IDENTIFY,
             'd': {
                 'token': self.token,
-                'properties': {
-                    'os': sys.platform,
-                    'browser': 'discord.py',
-                    'device': 'discord.py',
-                },
+                'properties': self.IDENTIFY_PROPERTIES,
                 'compress': True,
                 'large_threshold': 250,
             },


### PR DESCRIPTION
## Summary

Moves the client properties sent in websocket IDENTIFY to a variable on `DiscordWebSocket`. This makes overriding them easier, and more specifically discourages monkeypatching out the whole identify method, which can break things when the library updates.

Originally suggested by Soheab in [this bikeshedding thread](https://discord.com/channels/336642139381301249/1547282045179265104).

This is intentionally not documented as bots being able to change these properties is not something Discord documents or officially supports.

Snippet for applying mobile status after this change:
```py
import sys
from discord.gateway import _set_identify_properties
_set_identify_properties({
    "os": sys.platform,
    "browser": "Discord Android",
    "device": "Discord Android",
})

# alternatively:
from discord.gateway import DiscordWebSocket
DiscordWebSocket.IDENTIFY_PROPERTIES.update({
    "browser": "Discord Android",
    "device": "Discord Android",
})
```

Snippet for applying VR status after this change:
```py
import sys
from discord.gateway import _set_identify_properties
_set_identify_properties({
    "os": sys.platform,
    "browser": "Discord VR",
    "device": "oculus",
})

# alternatively:
from discord.gateway import DiscordWebSocket
DiscordWebSocket.IDENTIFY_PROPERTIES.update({
    "browser": "Discord VR",
    "device": "oculus",
})
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
