### PR TITLE
Add Spoiler channels support

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -62,7 +62,7 @@ from .http import handle_message_parameters
 from .voice_client import VoiceClient, VoiceProtocol
 from .sticker import GuildSticker, StickerItem
 from . import utils
-from .flags import InviteFlags
+from .flags import ChannelFlags, InviteFlags
 import warnings
 
 __all__ = (
@@ -423,10 +423,22 @@ class GuildChannel:
     category_id: Optional[int]
     _state: ConnectionState
     _overwrites: List[_Overwrites]
+    _flags: int
 
     if TYPE_CHECKING:
 
         def __init__(self, *, state: ConnectionState, guild: Guild, data: GuildChannelPayload): ...
+
+    @property
+    def flags(self) -> ChannelFlags:
+        """:class:`~discord.ChannelFlags`: The flags associated with this channel.
+
+        .. versionadded:: 2.1
+
+        .. versionchanged:: 2.8
+            This is now available on all guild channels.
+        """
+        return ChannelFlags._from_value(self._flags)
 
     def __str__(self) -> str:
         return self.name

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -66,7 +66,7 @@ from .errors import ClientException
 from .stage_instance import StageInstance
 from .threads import Thread
 from .partial_emoji import _EmojiTag, PartialEmoji
-from .flags import ChannelFlags, MessageFlags
+from .flags import MessageFlags
 from .http import handle_message_parameters
 from .object import Object
 from .soundboard import BaseSoundboardSound, SoundboardDefaultSound
@@ -129,6 +129,7 @@ if TYPE_CHECKING:
         topic: str
         slowmode_delay: int
         nsfw: bool
+        spoiler: bool
         overwrites: Mapping[Union[Role, Member, Object], PermissionOverwrite]
         default_auto_archive_duration: int
         default_thread_slowmode_delay: int
@@ -138,6 +139,7 @@ if TYPE_CHECKING:
         user_limit: int
         rtc_region: Optional[str]
         video_quality_mode: VideoQualityMode
+        spoiler: bool
         overwrites: Mapping[Union[Role, Member, Object], PermissionOverwrite]
 
     class _CreateStageChannelOptions(_CreateVoiceChannelOptions, total=False):
@@ -350,6 +352,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         'last_message_id',
         'default_auto_archive_duration',
         'default_thread_slowmode_delay',
+        '_flags',
     )
 
     def __init__(self, *, state: ConnectionState, guild: Guild, data: Union[TextChannelPayload, NewsChannelPayload]):
@@ -381,6 +384,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         self.slowmode_delay: int = data.get('rate_limit_per_user', 0)
         self.default_auto_archive_duration: ThreadArchiveDuration = data.get('default_auto_archive_duration', 1440)
         self.default_thread_slowmode_delay: int = data.get('default_thread_rate_limit_per_user', 0)
+        self._flags: int = data.get('flags', 0)
         self._type: Literal[0, 5] = data.get('type', self._type)
         self.last_message_id: Optional[int] = utils._get_as_snowflake(data, 'last_message_id')
         self._fill_overwrites(data)
@@ -430,6 +434,13 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         """:class:`bool`: Checks if the channel is NSFW."""
         return self.nsfw
 
+    def is_spoiler(self) -> bool:
+        """:class:`bool`: Checks if members must opt in before viewing the channel's contents.
+
+        .. versionadded:: 2.8
+        """
+        return self.flags.spoiler
+
     def is_news(self) -> bool:
         """:class:`bool`: Checks if the channel is a news channel."""
         return self._type == ChannelType.news.value
@@ -470,6 +481,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         topic: str = ...,
         position: int = ...,
         nsfw: bool = ...,
+        spoiler: bool = ...,
         sync_permissions: bool = ...,
         category: Optional[CategoryChannel] = ...,
         slowmode_delay: int = ...,
@@ -509,6 +521,8 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             The new channel's position.
         nsfw: :class:`bool`
             To mark the channel as NSFW or not.
+        spoiler: :class:`bool`
+            Whether members must opt in before viewing the channel's contents.
         sync_permissions: :class:`bool`
             Whether to sync permissions with the channel's new or pre-existing
             category. Defaults to ``False``.
@@ -553,6 +567,15 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
             The newly edited text channel. If the edit was only positional
             then ``None`` is returned instead.
         """
+
+        try:
+            spoiler = options.pop('spoiler')
+        except KeyError:
+            pass
+        else:
+            flags = self.flags
+            flags.spoiler = spoiler
+            options['flags'] = flags.value
 
         payload = await self._edit(options, reason=reason)
         if payload is not None:
@@ -1087,6 +1110,7 @@ class VocalGuildChannel(discord.abc.Messageable, discord.abc.Connectable, discor
         'rtc_region',
         'video_quality_mode',
         'last_message_id',
+        '_flags',
     )
 
     def __init__(self, *, state: ConnectionState, guild: Guild, data: Union[VoiceChannelPayload, StageChannelPayload]):
@@ -1115,6 +1139,7 @@ class VocalGuildChannel(discord.abc.Messageable, discord.abc.Connectable, discor
         self.slowmode_delay = data.get('rate_limit_per_user', 0)
         self.bitrate: int = data['bitrate']
         self.user_limit: int = data['user_limit']
+        self._flags: int = data.get('flags', 0)
         self._fill_overwrites(data)
 
     @property
@@ -1127,6 +1152,13 @@ class VocalGuildChannel(discord.abc.Messageable, discord.abc.Connectable, discor
         .. versionadded:: 2.0
         """
         return self.nsfw
+
+    def is_spoiler(self) -> bool:
+        """:class:`bool`: Checks if members must opt in before viewing the channel's contents.
+
+        .. versionadded:: 2.8
+        """
+        return self.flags.spoiler
 
     @property
     def members(self) -> List[Member]:
@@ -1557,6 +1589,7 @@ class VoiceChannel(VocalGuildChannel):
         *,
         name: str = ...,
         nsfw: bool = ...,
+        spoiler: bool = ...,
         bitrate: int = ...,
         user_limit: int = ...,
         position: int = ...,
@@ -1598,6 +1631,8 @@ class VoiceChannel(VocalGuildChannel):
             The new channel's bitrate.
         nsfw: :class:`bool`
             To mark the channel as NSFW or not.
+        spoiler: :class:`bool`
+            Whether members must opt in before viewing the channel's contents.
         user_limit: :class:`int`
             The new channel's user limit.
         position: :class:`int`
@@ -1646,6 +1681,15 @@ class VoiceChannel(VocalGuildChannel):
             The newly edited voice channel. If the edit was only positional
             then ``None`` is returned instead.
         """
+        try:
+            spoiler = options.pop('spoiler')
+        except KeyError:
+            pass
+        else:
+            flags = self.flags
+            flags.spoiler = spoiler
+            options['flags'] = flags.value
+
         payload = await self._edit(options, reason=reason)
         if payload is not None:
             # the payload will always be the proper channel payload
@@ -1919,6 +1963,7 @@ class StageChannel(VocalGuildChannel):
         *,
         name: str = ...,
         nsfw: bool = ...,
+        spoiler: bool = ...,
         bitrate: int = ...,
         user_limit: int = ...,
         position: int = ...,
@@ -1961,6 +2006,8 @@ class StageChannel(VocalGuildChannel):
             The new channel's position.
         nsfw: :class:`bool`
             To mark the channel as NSFW or not.
+        spoiler: :class:`bool`
+            Whether members must opt in before viewing the channel's contents.
         user_limit: :class:`int`
             The new channel's user limit.
         sync_permissions: :class:`bool`
@@ -2000,6 +2047,15 @@ class StageChannel(VocalGuildChannel):
             The newly edited stage channel. If the edit was only positional
             then ``None`` is returned instead.
         """
+
+        try:
+            spoiler = options.pop('spoiler')
+        except KeyError:
+            pass
+        else:
+            flags = self.flags
+            flags.spoiler = spoiler
+            options['flags'] = flags.value
 
         payload = await self._edit(options, reason=reason)
         if payload is not None:
@@ -2049,7 +2105,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
             To check if the channel or the guild of that channel are marked as NSFW, consider :meth:`is_nsfw` instead.
     """
 
-    __slots__ = ('name', 'id', 'guild', 'nsfw', '_state', 'position', '_overwrites', 'category_id')
+    __slots__ = ('name', 'id', 'guild', 'nsfw', '_state', 'position', '_overwrites', 'category_id', '_flags')
 
     def __init__(self, *, state: ConnectionState, guild: Guild, data: CategoryChannelPayload):
         self._state: ConnectionState = state
@@ -2065,6 +2121,7 @@ class CategoryChannel(discord.abc.GuildChannel, Hashable):
         self.category_id: Optional[int] = utils._get_as_snowflake(data, 'parent_id')
         self.nsfw: bool = data.get('nsfw', False)
         self.position: int = data['position']
+        self._flags: int = data.get('flags', 0)
         self._fill_overwrites(data)
 
     @property
@@ -2567,14 +2624,6 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         return [thread for thread in self.guild._threads.values() if thread.parent_id == self.id]
 
     @property
-    def flags(self) -> ChannelFlags:
-        """:class:`ChannelFlags`: The flags associated with this forum.
-
-        .. versionadded:: 2.1
-        """
-        return ChannelFlags._from_value(self._flags)
-
-    @property
     def available_tags(self) -> Sequence[ForumTag]:
         """Sequence[:class:`ForumTag`]: Returns all the available tags for this forum.
 
@@ -2602,6 +2651,13 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
     def is_nsfw(self) -> bool:
         """:class:`bool`: Checks if the forum is NSFW."""
         return self.nsfw
+
+    def is_spoiler(self) -> bool:
+        """:class:`bool`: Checks if members must opt in before viewing the forum's contents.
+
+        .. versionadded:: 2.8
+        """
+        return self.flags.spoiler
 
     def is_media(self) -> bool:
         """:class:`bool`: Checks if the channel is a media channel.
@@ -2655,6 +2711,7 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         topic: str = ...,
         position: int = ...,
         nsfw: bool = ...,
+        spoiler: bool = ...,
         sync_permissions: bool = ...,
         category: Optional[CategoryChannel] = ...,
         slowmode_delay: int = ...,
@@ -2686,6 +2743,8 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
             The new forum's position.
         nsfw: :class:`bool`
             To mark the forum as NSFW or not.
+        spoiler: :class:`bool`
+            Whether members must opt in before viewing the forum's contents.
         sync_permissions: :class:`bool`
             Whether to sync permissions with the forum's new or pre-existing
             category. Defaults to ``False``.
@@ -2777,6 +2836,15 @@ class ForumChannel(discord.abc.GuildChannel, Hashable):
         else:
             flags = self.flags
             flags.require_tag = require_tag
+            options['flags'] = flags.value
+
+        try:
+            spoiler = options.pop('spoiler')
+        except KeyError:
+            pass
+        else:
+            flags = self.flags
+            flags.spoiler = spoiler
             options['flags'] = flags.value
 
         try:

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -1778,6 +1778,14 @@ class ChannelFlags(BaseFlags):
         """
         return 1 << 15
 
+    @flag_value
+    def spoiler(self):
+        """:class:`bool`: Returns ``True`` if the channel requires members to opt in before viewing its contents.
+
+        .. versionadded:: 2.8
+        """
+        return 1 << 21
+
 
 class ArrayFlags(BaseFlags):
     @classmethod

--- a/discord/http.py
+++ b/discord/http.py
@@ -1280,6 +1280,7 @@ class HTTPClient:
             'default_reaction_emoji',
             'default_forum_layout',
             'available_tags',
+            'flags',
         )
         payload.update({k: v for k, v in options.items() if k in valid_keys and v is not None})
 

--- a/discord/types/channel.py
+++ b/discord/types/channel.py
@@ -56,6 +56,7 @@ class _BaseGuildChannel(_BaseChannel):
     permission_overwrites: List[PermissionOverwrite]
     nsfw: bool
     parent_id: Optional[Snowflake]
+    flags: NotRequired[int]
 
 
 class PartialChannel(_BaseChannel):

--- a/tests/test_channel_flags.py
+++ b/tests/test_channel_flags.py
@@ -1,0 +1,114 @@
+import pytest
+
+from discord.channel import StageChannel, TextChannel
+from discord.flags import ChannelFlags
+
+
+def test_spoiler_channel_flag():
+    flags = ChannelFlags()
+
+    assert flags.spoiler is False
+
+    flags.spoiler = True
+
+    assert flags.spoiler is True
+    assert flags.value == 1 << 21
+
+
+def test_spoiler_channel_flag_preserves_other_flags():
+    flags = ChannelFlags._from_value((1 << 4) | (1 << 15))
+    flags.spoiler = True
+
+    assert flags.value == (1 << 4) | (1 << 15) | (1 << 21)
+
+
+class _HTTP:
+    async def edit_channel(self, channel_id, *, reason, **options):
+        self.channel_id = channel_id
+        self.reason = reason
+        self.options = options
+        return {
+            'id': str(channel_id),
+            'type': 0,
+            'name': 'spoilers',
+            'position': 0,
+            'permission_overwrites': [],
+            'flags': options['flags'],
+        }
+
+
+class _State:
+    def __init__(self):
+        self.http = _HTTP()
+
+
+class _Guild:
+    id = 1
+
+
+@pytest.mark.asyncio
+async def test_text_channel_edit_sets_spoiler_flag():
+    state = _State()
+    channel = TextChannel(
+        state=state,
+        guild=_Guild(),
+        data={
+            'id': '1',
+            'type': 0,
+            'name': 'spoilers',
+            'position': 0,
+            'permission_overwrites': [],
+            'flags': 1 << 4,
+        },
+    )
+
+    edited = await channel.edit(spoiler=True)
+
+    assert state.http.options == {'flags': (1 << 4) | (1 << 21)}
+    assert edited is not None
+    assert edited.flags.spoiler is True
+    assert edited.is_spoiler() is True
+
+
+class _StageHTTP(_HTTP):
+    async def edit_channel(self, channel_id, *, reason, **options):
+        self.channel_id = channel_id
+        self.reason = reason
+        self.options = options
+        return {
+            'id': str(channel_id),
+            'type': 13,
+            'name': 'spoilers',
+            'position': 0,
+            'permission_overwrites': [],
+            'bitrate': 64000,
+            'user_limit': 0,
+            'flags': options['flags'],
+        }
+
+
+@pytest.mark.asyncio
+async def test_stage_channel_edit_sets_spoiler_flag():
+    state = _State()
+    state.http = _StageHTTP()
+    channel = StageChannel(
+        state=state,
+        guild=_Guild(),
+        data={
+            'id': '1',
+            'type': 13,
+            'name': 'spoilers',
+            'position': 0,
+            'permission_overwrites': [],
+            'bitrate': 64000,
+            'user_limit': 0,
+            'flags': 1 << 4,
+        },
+    )
+
+    edited = await channel.edit(spoiler=True)
+
+    assert state.http.options == {'flags': (1 << 4) | (1 << 21)}
+    assert edited is not None
+    assert edited.flags.spoiler is True
+    assert edited.is_spoiler() is True


### PR DESCRIPTION
## Previous PR context

This is a restoration of my previous PR #10487, which I opened on July 14 before #10505.

The original PR later became inaccessible after an issue with my GitHub account. A record of it still exists in the official discord.py Discord server:

https://discord.com/channels/336642139381301249/381979045090426881/1526519720235368520

I originally identified the spoiler flag (`1 << 21`, `2097152`) by inspecting Discord's behaviour before it was documented in the Discord API docs.

I would like to re-submit the implementation based on the restored branch and previous maintainer feedback.

## Summary

Adds support for Discord spoiler channels, which require members to opt in before viewing a channel's contents.

Discord exposes this setting through the channel `flags` field. The spoiler flag is `1 << 21` (`2097152`). This PR makes the flag available when fetching, creating, and editing text, voice, and forum channels.

Threads are intentionally not included because Discord does not currently support setting this flag directly on them.

### New API

- `ChannelFlags.spoiler: bool`
- `TextChannel.spoiler: bool`
- `VoiceChannel.spoiler: bool`
- `ForumChannel.spoiler: bool`
- `TextChannel.is_spoiler() -> bool`
- `VoiceChannel.is_spoiler() -> bool`
- `ForumChannel.is_spoiler() -> bool`

### New parameters

- `Guild.create_text_channel(..., spoiler: bool = MISSING)`
- `Guild.create_voice_channel(..., spoiler: bool = MISSING)`
- `Guild.create_forum(..., spoiler: bool = MISSING)`
- `TextChannel.edit(..., spoiler: bool = ...)`
- `VoiceChannel.edit(..., spoiler: bool = ...)`
- `ForumChannel.edit(..., spoiler: bool = ...)`

## Rationale

The API shape follows existing channel APIs such as `channel.nsfw` and `channel.is_nsfw()`:

```py
if channel.is_spoiler():
    ...

channel = await guild.create_text_channel("spoilers", spoiler=True)
await channel.edit(spoiler=False)
```

`spoiler` is exposed through `ChannelFlags` because Discord represents it as a channel flag rather than as a standalone field. When editing a channel, the implementation preserves existing flag bits and only changes the spoiler bit. This avoids unintentionally clearing other current or future channel flags.

The HTTP client now also forwards `flags` when creating channels. Without this change, `spoiler=True` could be accepted by the public creation methods but silently omitted from the API request.

## Testing

- Added unit tests for `ChannelFlags.spoiler`.
- Added a test confirming that editing a text channel preserves existing flags while setting the spoiler flag.
- Manually verified Discord API channel creation and editing with `flags: 2097152`; the API response returned `flags: 2097152`.

## Checklist

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)