### PR TITLE
Fix the escape_mentions return documentation

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1035,7 +1035,7 @@ def escape_mentions(text: str) -> str:
     Returns
     --------
     :class:`str`
-        The text with the mentions removed.
+        The text with mentions escaped using a zero-width space.
     """
     return re.sub(r'@(everyone|here|[!&]?[0-9]{17,20})', '@\u200b\\1', text)
 


### PR DESCRIPTION
## Summary

While looking into the behavior of `escape_mentions`, I noticed that the return documentation does not accurately describe the current implementation.

`escape_mentions` does not remove mention text. It escapes mentions by inserting a zero-width space after `@`.

This updates the return description to match the existing behavior.

## Checklist

* [ ] If code changes were made then they have been tested.

  * [x] I have updated the documentation to reflect the changes.
* [ ] This PR fixes an issue.
* [ ] This PR adds something new (e.g. new method or parameters).
* [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
* [x] This PR is **not** a code change (e.g. documentation, README, ...).

## Details

For example, `@everyone` is escaped by inserting a zero-width space after `@` rather than removing the mention text.

No behavior is changed.

## Tests

Existing `tests/test_utils.py::test_escape_mentions` coverage is unchanged.
