### PR TITLE
Fix FFmpeg probing edge cases

### DIFF
--- a/discord/player.py
+++ b/discord/player.py
@@ -641,9 +641,7 @@ class FFmpegOpusAudio(FFmpegAudio):
         loop = asyncio.get_running_loop()
         try:
             codec, bitrate = await loop.run_in_executor(None, lambda: probefunc(source, executable))
-        except (KeyboardInterrupt, SystemExit):
-            raise
-        except BaseException:
+        except Exception:
             if not fallback:
                 _log.exception("Probe '%s' using '%s' failed", method, executable)
                 return None, None
@@ -651,9 +649,7 @@ class FFmpegOpusAudio(FFmpegAudio):
             _log.exception("Probe '%s' using '%s' failed, trying fallback", method, executable)
             try:
                 codec, bitrate = await loop.run_in_executor(None, lambda: fallback(source, executable))
-            except (KeyboardInterrupt, SystemExit):
-                raise
-            except BaseException:
+            except Exception:
                 _log.exception("Fallback probe using '%s' failed", executable)
             else:
                 _log.debug('Fallback probe found codec=%s, bitrate=%s', codec, bitrate)
@@ -683,7 +679,12 @@ class FFmpegOpusAudio(FFmpegAudio):
     def _probe_codec_fallback(source, executable: str = 'ffmpeg') -> Tuple[Optional[str], Optional[int]]:
         args = [executable, '-hide_banner', '-i', source]
         proc = subprocess.Popen(args, creationflags=CREATE_NO_WINDOW, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        out, _ = proc.communicate(timeout=20)
+        try:
+            out, _ = proc.communicate(timeout=20)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+            raise
         output = out.decode('utf8')
         codec = bitrate = None
 

--- a/discord/player.py
+++ b/discord/player.py
@@ -691,7 +691,7 @@ class FFmpegOpusAudio(FFmpegAudio):
         if codec_match:
             codec = codec_match.group(1)
 
-        br_match = re.search(r'(\d+) [kK]b/s', output)
+        br_match = re.search(r'^\s*Stream #\d+:\d+.*?Audio:.*?(\d+)\s+[kK]b/s', output, re.MULTILINE)
         if br_match:
             bitrate = min(int(br_match.group(1)), 512)
 

--- a/discord/player.py
+++ b/discord/player.py
@@ -675,7 +675,7 @@ class FFmpegOpusAudio(FFmpegAudio):
 
             codec = streamdata.get('codec_name')
             bitrate = int(streamdata.get('bit_rate', 0))
-            bitrate = max(round(bitrate / 1000), 512)
+            bitrate = min(round(bitrate / 1000), 512) if bitrate else None
 
         return codec, bitrate
 
@@ -693,7 +693,7 @@ class FFmpegOpusAudio(FFmpegAudio):
 
         br_match = re.search(r'(\d+) [kK]b/s', output)
         if br_match:
-            bitrate = max(int(br_match.group(1)), 512)
+            bitrate = min(int(br_match.group(1)), 512)
 
         return codec, bitrate
 

--- a/tests/test_player_bitrate_cap.py
+++ b/tests/test_player_bitrate_cap.py
@@ -1,0 +1,50 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-present Rapptz
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from discord import player
+
+
+def test_native_probe_preserves_valid_bitrate_and_caps_large_values(monkeypatch):
+    outputs = iter(
+        [
+            b'{"streams": [{"codec_name": "opus", "bit_rate": "128000"}]}',
+            b'{"streams": [{"codec_name": "opus", "bit_rate": "1000000"}]}',
+            b'{"streams": [{"codec_name": "opus"}]}',
+        ]
+    )
+    monkeypatch.setattr(player.subprocess, 'check_output', lambda *args, **kwargs: next(outputs))
+
+    assert player.FFmpegOpusAudio._probe_codec_native('source') == ('opus', 128)
+    assert player.FFmpegOpusAudio._probe_codec_native('source') == ('opus', 512)
+    assert player.FFmpegOpusAudio._probe_codec_native('source') == ('opus', None)
+
+
+def test_fallback_probe_caps_large_bitrate(monkeypatch):
+    class Process:
+        def communicate(self, timeout):
+            return b'    Stream #0:1: Audio: opus, 48000 Hz, stereo, fltp, 1024 kb/s', None
+
+    monkeypatch.setattr(player.subprocess, 'Popen', lambda *args, **kwargs: Process())
+
+    assert player.FFmpegOpusAudio._probe_codec_fallback('source') == ('opus', 512)

--- a/tests/test_player_fallback_audio_bitrate.py
+++ b/tests/test_player_fallback_audio_bitrate.py
@@ -1,0 +1,43 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-present Rapptz
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from discord import player
+
+
+def test_fallback_probe_reads_audio_stream_bitrate(monkeypatch):
+    class Process:
+        def communicate(self, timeout):
+            output = '\n'.join(
+                [
+                    'Input #0, matroska,webm, from source:',
+                    '  Duration: 00:00:01.00, start: 0.000000, bitrate: 2000 kb/s',
+                    '    Stream #0:0: Video: h264, 1920x1080, 1800 kb/s',
+                    '    Stream #0:1: Audio: opus, 48000 Hz, stereo, fltp, 128 kb/s',
+                ]
+            )
+            return output.encode(), None
+
+    monkeypatch.setattr(player.subprocess, 'Popen', lambda *args, **kwargs: Process())
+
+    assert player.FFmpegOpusAudio._probe_codec_fallback('source') == ('opus', 128)

--- a/tests/test_player_probe_lifecycle.py
+++ b/tests/test_player_probe_lifecycle.py
@@ -1,0 +1,99 @@
+import asyncio
+import subprocess
+import sys
+from unittest.mock import Mock, call
+
+import pytest
+
+from discord import FFmpegOpusAudio
+
+
+def test_fallback_timeout_kills_and_reaps_process(monkeypatch):
+    timeout = subprocess.TimeoutExpired('ffmpeg', 20)
+    process = Mock()
+    process.communicate.side_effect = [timeout, (b'', None)]
+    monkeypatch.setattr('discord.player.subprocess.Popen', Mock(return_value=process))
+
+    with pytest.raises(subprocess.TimeoutExpired) as exc:
+        FFmpegOpusAudio._probe_codec_fallback('placeholder')
+
+    assert exc.value is timeout
+    assert process.mock_calls == [call.communicate(timeout=20), call.kill(), call.communicate()]
+
+
+def test_fallback_success_does_not_kill_process(monkeypatch):
+    process = Mock()
+    process.communicate.return_value = (b'Stream #0:0: Audio: opus, 48000 Hz, stereo, 128 kb/s', None)
+    monkeypatch.setattr('discord.player.subprocess.Popen', Mock(return_value=process))
+    assert FFmpegOpusAudio._probe_codec_fallback('placeholder') == ('opus', 128)
+    process.kill.assert_not_called()
+    process.communicate.assert_called_once_with(timeout=20)
+
+
+def test_fallback_reaps_a_real_local_process(monkeypatch):
+    popen = subprocess.Popen
+    processes = []
+
+    def start_process(*args, **kwargs):
+        process = popen([sys.executable, '-c', 'import time; time.sleep(30)'], **kwargs)
+        processes.append(process)
+        communicate = process.communicate
+
+        def short_communicate(*, timeout=None):
+            return communicate(timeout=0.05 if timeout == 20 else timeout)
+
+        process.communicate = short_communicate
+        return process
+
+    monkeypatch.setattr('discord.player.subprocess.Popen', start_process)
+    try:
+        with pytest.raises(subprocess.TimeoutExpired):
+            FFmpegOpusAudio._probe_codec_fallback('unused')
+        assert processes[0].returncode is not None
+        assert processes[0].stdout.closed
+    finally:
+        for process in processes:
+            if process.poll() is None:
+                process.kill()
+                process.communicate()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('cancel_fallback', [False, True])
+async def test_probe_propagates_task_cancellation(monkeypatch, cancel_fallback):
+    loop = asyncio.get_running_loop()
+    entered = asyncio.Event()
+    submissions = []
+
+    def run_in_executor(executor, callback):
+        submissions.append(callback)
+        future = loop.create_future()
+        if cancel_fallback and len(submissions) == 1:
+            future.set_exception(OSError('native failed'))
+        elif len(submissions) == (2 if cancel_fallback else 1):
+            entered.set()
+        else:
+            future.set_result(('opus', 128))
+        return future
+
+    monkeypatch.setattr(loop, 'run_in_executor', run_in_executor)
+    task = asyncio.create_task(FFmpegOpusAudio.probe('placeholder'))
+    await entered.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelled()
+    assert len(submissions) == (2 if cancel_fallback else 1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('fallback_fails', [False, True])
+async def test_probe_retains_error_fallback(monkeypatch, fallback_fails):
+    def fail(*args):
+        raise OSError('probe failed')
+
+    fallback = Mock(side_effect=fail if fallback_fails else None, return_value=('opus', 128))
+    monkeypatch.setattr(FFmpegOpusAudio, '_probe_codec_fallback', fallback)
+    result = await FFmpegOpusAudio.probe('placeholder', method=fail)
+    assert result == ((None, None) if fallback_fails else ('opus', 128))
+    fallback.assert_called_once_with('placeholder', 'ffmpeg')


### PR DESCRIPTION
# Fix FFmpeg probing edge cases

## Summary

This PR fixes several edge cases in `FFmpegOpusAudio.probe` and its fallback implementation:

* caps probed bitrates correctly
* reads fallback bitrates from audio streams rather than unrelated streams
* cleans up fallback subprocesses after a timeout
* propagates task cancellation instead of treating it as a probe failure

## Checklist

* [x] If code changes were made then they have been tested.

  * [ ] I have updated the documentation to reflect the changes.
* [x] This PR fixes an issue.
* [ ] This PR adds something new (e.g. new method or parameters).
* [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
* [ ] This PR is **not** a code change (e.g. documentation, README, ...).

## Details

The probe bitrate is now capped correctly rather than allowing values outside the expected range.

The fallback parser now reads the bitrate from an audio stream instead of potentially picking up a bitrate from another stream in FFmpeg's output.

For fallback probe timeouts, the spawned subprocess is killed and `communicate()` is called again to reap it before the original `subprocess.TimeoutExpired` is re-raised.

Probe error handling also catches `Exception` instead of `BaseException`. This allows `asyncio.CancelledError` to propagate normally instead of causing another fallback probe to be started.

Ordinary probe failures continue to use the existing fallback behavior.

## Tests

Regression tests cover:

* bitrate capping
* audio stream selection in the fallback parser
* subprocess cleanup after fallback timeouts
* successful fallback probes not killing the subprocess
* cleanup of a real local child process
* task cancellation during both primary and fallback probes
* existing fallback behavior for ordinary probe failures

The full test suite passes on Python 3.11 and Python 3.13:

```text
304 passed
```
