### PR TITLE
Fix bitrate limit to treat 512 kbps as upper boundary

### DIFF
--- a/discord/player.py
+++ b/discord/player.py
@@ -675,7 +675,7 @@ class FFmpegOpusAudio(FFmpegAudio):
 
             codec = streamdata.get('codec_name')
             bitrate = int(streamdata.get('bit_rate', 0))
-            bitrate = max(round(bitrate / 1000), 512)
+            bitrate = min(round(bitrate / 1000), 512)
 
         return codec, bitrate
 
@@ -693,7 +693,7 @@ class FFmpegOpusAudio(FFmpegAudio):
 
         br_match = re.search(r'(\d+) [kK]b/s', output)
         if br_match:
-            bitrate = max(int(br_match.group(1)), 512)
+            bitrate = min(int(br_match.group(1)), 512)
 
         return codec, bitrate
 


### PR DESCRIPTION
## Summary

Due to a bug that forced the bitrate to 512 kbps even when the detected value was less than 512 kbps, we have fixed the issue so that 512 kbps is now treated as the upper limit.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
